### PR TITLE
Soft-Launch Corpus Review Queue

### DIFF
--- a/.github/pipeline/CORPUS-REVIEW-QUEUE.md
+++ b/.github/pipeline/CORPUS-REVIEW-QUEUE.md
@@ -1,0 +1,32 @@
+## Soft-Launch Corpus Review Queue
+
+This queue stages the remaining corpus review work needed to make the live site production-ready for soft launch.
+
+Scope:
+- `incidents/` — 55 live articles
+- `threat-actors/` — 33 live articles
+- `zero-days/` — 18 live articles
+
+Review standard for every batch:
+- validate against the latest Astro schema in `site/src/content.config.ts`
+- validate against the ratified private specs and ADRs
+- correct technical inaccuracies, historical inaccuracies, attribution overreach, ATT&CK mapping drift, taxonomy mistakes, section drift, and source-quality gaps
+- if a live article must be removed, merged, or reclassified, create a follow-on pipeline reprocess task before merge so no content is lost
+
+Batch order:
+
+1. `TASK-2026-0153` — Incidents batch 1/6: modern exploit-driven incidents
+2. `TASK-2026-0154` — Incidents batch 2/6: 2026 supply-chain, cloud, and breach cluster
+3. `TASK-2026-0155` — Incidents batch 3/6: 2025-2026 ransomware and extortion cluster
+4. `TASK-2026-0156` — Incidents batch 4/6: landmark enterprise incidents and outages
+5. `TASK-2026-0157` — Incidents batch 5/6: state, espionage, and destructive incidents
+6. `TASK-2026-0158` — Incidents batch 6/6: taxonomy and canonicalization edge cases
+7. `TASK-2026-0159` — Threat actors batch 1/4: PRC state-linked and China-adjacent actors
+8. `TASK-2026-0160` — Threat actors batch 2/4: Russian and FSU-linked actors
+9. `TASK-2026-0161` — Threat actors batch 3/4: DPRK and ransomware-core actors
+10. `TASK-2026-0162` — Threat actors batch 4/4: hybrid, criminal, and emerging actors
+11. `TASK-2026-0163` — Zero-days batch 1/2: modern active exploitation set
+12. `TASK-2026-0164` — Zero-days batch 2/2: historical and canonicalization set
+
+Completion goal:
+- the live corpus should be schema-clean, historically defensible, technically accurate, and free of obvious canonical duplication before soft launch

--- a/.github/pipeline/tasks/TASK-2026-0153.json
+++ b/.github/pipeline/tasks/TASK-2026-0153.json
@@ -38,7 +38,7 @@
     "min_mitre_mappings": 1,
     "review_status": "draft_ai",
     "schema_validation": "pass",
-    "build_passes": true
+    "astro_build": true
   },
   "depends_on": [],
   "preconditions": [

--- a/.github/pipeline/tasks/TASK-2026-0153.json
+++ b/.github/pipeline/tasks/TASK-2026-0153.json
@@ -1,0 +1,62 @@
+{
+  "task_id": "TASK-2026-0153",
+  "stage": "review",
+  "type": "incident",
+  "priority": "P1",
+  "status": "pending",
+  "created": "2026-04-17T20:30:00Z",
+  "updated": "2026-04-17T20:30:00Z",
+  "locked_by": null,
+  "locked_at": null,
+  "source": "backfill",
+  "submitted_by": "kernel-k",
+  "input": {
+    "topic": "Soft-launch corpus review — incident batch 1/6: modern exploit-driven incidents",
+    "sources": [
+      "https://threatpedia.wiki/incidents/"
+    ],
+    "candidate_data": {
+      "collection": "incidents",
+      "batch_index": 1,
+      "batch_total": 6,
+      "batch_size": 10,
+      "review_scope": "schema compliance, technical accuracy, historical accuracy, attribution, ATT&CK mappings, source quality"
+    },
+    "notes": "Review the scoped live incident articles against the latest Astro schema in `site/src/content.config.ts`, the ratified private specs, and primary-source technical and historical evidence.\n\nScoped files:\n- adobe-mr-raccoon-breach-2026.md\n- axios-unc1069-compromise.md\n- bluehammer-windows-defender-zero-day-2026.md\n- chrome-cve-2026-2441-css-zero-day.md\n- chrome-cve-2026-5281-zero-day.md\n- drift-protocol-dprk-exploit-2026.md\n- forticlient-ems-cve-2026-35616.md\n- langflow-cve-2026-33017-rce-exploitation.md\n- operation-truechaos-trueconf-zero-day-2026.md\n- trueconf-cve-2026-3502-zero-day.md\n\nRequired outcome:\n- correct schema drift, source drift, section drift, ATT&CK mapping issues, attribution overreach, and factual inaccuracies\n- keep fixes within this batch unless a shared schema or validator issue must be corrected centrally\n- if any live article must be removed, merged, or reclassified, create a follow-on pipeline reprocess task before merge so the content is not lost"
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "MANIFEST-SPEC.md",
+    "ADR 0007 — Entity ID Format Convention",
+    "site/src/content.config.ts"
+  ],
+  "acceptance": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 7,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "build_passes": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "Work from a dedicated review branch and keep changes scoped to the batch unless a shared validator or schema fix is required.",
+    "Queue follow-on reprocess tasks for any article that must be removed, merged, or reclassified."
+  ],
+  "output": {
+    "file_pattern": "site/src/content/incidents/{slug}.md",
+    "branch": "pipeline/TASK-2026-0153",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-04-17T20:30:00Z",
+      "from": "none",
+      "to": "pending",
+      "agent": "kernel-k",
+      "note": "Soft-launch corpus review queue — incident batch 1 of 6"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0154.json
+++ b/.github/pipeline/tasks/TASK-2026-0154.json
@@ -38,7 +38,7 @@
     "min_mitre_mappings": 1,
     "review_status": "draft_ai",
     "schema_validation": "pass",
-    "build_passes": true
+    "astro_build": true
   },
   "depends_on": [],
   "preconditions": [

--- a/.github/pipeline/tasks/TASK-2026-0154.json
+++ b/.github/pipeline/tasks/TASK-2026-0154.json
@@ -1,0 +1,62 @@
+{
+  "task_id": "TASK-2026-0154",
+  "stage": "review",
+  "type": "incident",
+  "priority": "P1",
+  "status": "pending",
+  "created": "2026-04-17T20:30:00Z",
+  "updated": "2026-04-17T20:30:00Z",
+  "locked_by": null,
+  "locked_at": null,
+  "source": "backfill",
+  "submitted_by": "kernel-k",
+  "input": {
+    "topic": "Soft-launch corpus review — incident batch 2/6: 2026 supply-chain, cloud, and breach cluster",
+    "sources": [
+      "https://threatpedia.wiki/incidents/"
+    ],
+    "candidate_data": {
+      "collection": "incidents",
+      "batch_index": 2,
+      "batch_total": 6,
+      "batch_size": 10,
+      "review_scope": "schema compliance, technical accuracy, historical accuracy, taxonomy, source quality"
+    },
+    "notes": "Review the scoped live incident articles against the latest Astro schema in `site/src/content.config.ts`, the ratified private specs, and primary-source technical and historical evidence.\n\nScoped files:\n- carecloud-healthcare-breach-2026.md\n- cisco-trivy-supply-chain-breach-2026.md\n- cegedim-sante-health-breach-2026.md\n- conduent-data-breach-2026.md\n- european-commission-trivy-breach-2026.md\n- hims-hers-shinyhunters-breach-2026.md\n- lexisnexis-react2shell-breach-2026.md\n- mercor-litellm-supply-chain-breach-2026.md\n- patriot-regional-emergency-comms-attack-2026.md\n- teampcp-supply-chain-attack.md\n\nRequired outcome:\n- correct schema drift, source drift, section drift, ATT&CK mapping issues, attribution overreach, and factual inaccuracies\n- check cross-links between incident, campaign, threat-actor, and zero-day articles where the cluster spans multiple collections\n- if any live article must be removed, merged, or reclassified, create a follow-on pipeline reprocess task before merge so the content is not lost"
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "MANIFEST-SPEC.md",
+    "ADR 0007 — Entity ID Format Convention",
+    "site/src/content.config.ts"
+  ],
+  "acceptance": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 7,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "build_passes": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "Work from a dedicated review branch and keep changes scoped to the batch unless a shared validator or schema fix is required.",
+    "Queue follow-on reprocess tasks for any article that must be removed, merged, or reclassified."
+  ],
+  "output": {
+    "file_pattern": "site/src/content/incidents/{slug}.md",
+    "branch": "pipeline/TASK-2026-0154",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-04-17T20:30:00Z",
+      "from": "none",
+      "to": "pending",
+      "agent": "kernel-k",
+      "note": "Soft-launch corpus review queue — incident batch 2 of 6"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0155.json
+++ b/.github/pipeline/tasks/TASK-2026-0155.json
@@ -1,0 +1,62 @@
+{
+  "task_id": "TASK-2026-0155",
+  "stage": "review",
+  "type": "incident",
+  "priority": "P1",
+  "status": "pending",
+  "created": "2026-04-17T20:30:00Z",
+  "updated": "2026-04-17T20:30:00Z",
+  "locked_by": null,
+  "locked_at": null,
+  "source": "backfill",
+  "submitted_by": "kernel-k",
+  "input": {
+    "topic": "Soft-launch corpus review — incident batch 3/6: 2025-2026 ransomware and extortion cluster",
+    "sources": [
+      "https://threatpedia.wiki/incidents/"
+    ],
+    "candidate_data": {
+      "collection": "incidents",
+      "batch_index": 3,
+      "batch_total": 6,
+      "batch_size": 10,
+      "review_scope": "schema compliance, technical accuracy, historical accuracy, actor linkage, source quality"
+    },
+    "notes": "Review the scoped live incident articles against the latest Astro schema in `site/src/content.config.ts`, the ratified private specs, and primary-source technical and historical evidence.\n\nScoped files:\n- chipsoft-ransomware-dutch-healthcare-2026.md\n- die-linke-qilin-ransomware-2026.md\n- docketwise-immigration-data-breach-2026.md\n- dragonforce-ransomware-campaign-april-2026.md\n- foster-city-ransomware-2026.md\n- marks-spencer-scattered-spider-2025.md\n- passaic-county-medusa-ransomware-2026.md\n- ummc-medusa-ransomware-2026.md\n- vivaticket-ransomhouse-2026.md\n- winona-county-ransomware-2026.md\n\nRequired outcome:\n- correct schema drift, source drift, section drift, ATT&CK mapping issues, attribution overreach, and factual inaccuracies\n- ensure actor linkage, ransomware naming, and cluster boundaries are historically defensible\n- if any live article must be removed, merged, or reclassified, create a follow-on pipeline reprocess task before merge so the content is not lost"
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "MANIFEST-SPEC.md",
+    "ADR 0007 — Entity ID Format Convention",
+    "site/src/content.config.ts"
+  ],
+  "acceptance": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 7,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "build_passes": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "Work from a dedicated review branch and keep changes scoped to the batch unless a shared validator or schema fix is required.",
+    "Queue follow-on reprocess tasks for any article that must be removed, merged, or reclassified."
+  ],
+  "output": {
+    "file_pattern": "site/src/content/incidents/{slug}.md",
+    "branch": "pipeline/TASK-2026-0155",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-04-17T20:30:00Z",
+      "from": "none",
+      "to": "pending",
+      "agent": "kernel-k",
+      "note": "Soft-launch corpus review queue — incident batch 3 of 6"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0155.json
+++ b/.github/pipeline/tasks/TASK-2026-0155.json
@@ -38,7 +38,7 @@
     "min_mitre_mappings": 1,
     "review_status": "draft_ai",
     "schema_validation": "pass",
-    "build_passes": true
+    "astro_build": true
   },
   "depends_on": [],
   "preconditions": [

--- a/.github/pipeline/tasks/TASK-2026-0156.json
+++ b/.github/pipeline/tasks/TASK-2026-0156.json
@@ -38,7 +38,7 @@
     "min_mitre_mappings": 1,
     "review_status": "draft_ai",
     "schema_validation": "pass",
-    "build_passes": true
+    "astro_build": true
   },
   "depends_on": [],
   "preconditions": [

--- a/.github/pipeline/tasks/TASK-2026-0156.json
+++ b/.github/pipeline/tasks/TASK-2026-0156.json
@@ -1,0 +1,62 @@
+{
+  "task_id": "TASK-2026-0156",
+  "stage": "review",
+  "type": "incident",
+  "priority": "P2",
+  "status": "pending",
+  "created": "2026-04-17T20:30:00Z",
+  "updated": "2026-04-17T20:30:00Z",
+  "locked_by": null,
+  "locked_at": null,
+  "source": "backfill",
+  "submitted_by": "kernel-k",
+  "input": {
+    "topic": "Soft-launch corpus review — incident batch 4/6: landmark enterprise incidents and outages",
+    "sources": [
+      "https://threatpedia.wiki/incidents/"
+    ],
+    "candidate_data": {
+      "collection": "incidents",
+      "batch_index": 4,
+      "batch_total": 6,
+      "batch_size": 10,
+      "review_scope": "schema compliance, technical accuracy, historical accuracy, impact framing, source quality"
+    },
+    "notes": "Review the scoped live incident articles against the latest Astro schema in `site/src/content.config.ts`, the ratified private specs, and primary-source technical and historical evidence.\n\nScoped files:\n- anthem-health-data-breach-2015.md\n- colonial-pipeline-darkside-ransomware-2021.md\n- crowdstrike-falcon-global-bsod-outage-2024.md\n- equifax-data-breach-2017.md\n- jbs-foods-ransomware-2021.md\n- kaseya-vsa-supply-chain-attack-2021.md\n- log4shell-mass-exploitation-2021.md\n- marriott-starwood-data-breach-2018.md\n- moveit-transfer-clop-mass-exploitation-2023.md\n- yahoo-data-breaches-2013.md\n\nRequired outcome:\n- correct schema drift, source drift, section drift, ATT&CK mapping issues, attribution overreach, and factual inaccuracies\n- ensure the landmark incidents are historically framed with accurate scope, chronology, and impact language\n- if any live article must be removed, merged, or reclassified, create a follow-on pipeline reprocess task before merge so the content is not lost"
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "MANIFEST-SPEC.md",
+    "ADR 0007 — Entity ID Format Convention",
+    "site/src/content.config.ts"
+  ],
+  "acceptance": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 7,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "build_passes": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "Work from a dedicated review branch and keep changes scoped to the batch unless a shared validator or schema fix is required.",
+    "Queue follow-on reprocess tasks for any article that must be removed, merged, or reclassified."
+  ],
+  "output": {
+    "file_pattern": "site/src/content/incidents/{slug}.md",
+    "branch": "pipeline/TASK-2026-0156",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-04-17T20:30:00Z",
+      "from": "none",
+      "to": "pending",
+      "agent": "kernel-k",
+      "note": "Soft-launch corpus review queue — incident batch 4 of 6"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0157.json
+++ b/.github/pipeline/tasks/TASK-2026-0157.json
@@ -38,7 +38,7 @@
     "min_mitre_mappings": 1,
     "review_status": "draft_ai",
     "schema_validation": "pass",
-    "build_passes": true
+    "astro_build": true
   },
   "depends_on": [],
   "preconditions": [

--- a/.github/pipeline/tasks/TASK-2026-0157.json
+++ b/.github/pipeline/tasks/TASK-2026-0157.json
@@ -1,0 +1,62 @@
+{
+  "task_id": "TASK-2026-0157",
+  "stage": "review",
+  "type": "incident",
+  "priority": "P1",
+  "status": "pending",
+  "created": "2026-04-17T20:30:00Z",
+  "updated": "2026-04-17T20:30:00Z",
+  "locked_by": null,
+  "locked_at": null,
+  "source": "backfill",
+  "submitted_by": "kernel-k",
+  "input": {
+    "topic": "Soft-launch corpus review — incident batch 5/6: state, espionage, and destructive incidents",
+    "sources": [
+      "https://threatpedia.wiki/incidents/"
+    ],
+    "candidate_data": {
+      "collection": "incidents",
+      "batch_index": 5,
+      "batch_total": 6,
+      "batch_size": 8,
+      "review_scope": "schema compliance, technical accuracy, historical accuracy, attribution, ATT&CK mappings, source quality"
+    },
+    "notes": "Review the scoped live incident articles against the latest Astro schema in `site/src/content.config.ts`, the ratified private specs, and primary-source technical and historical evidence.\n\nScoped files:\n- fbi-dcsnet-salt-typhoon-2026.md\n- frostarmada-soho-dns-hijacking-2026.md\n- m365-oauth-device-code-phishing-2026.md\n- notpetya-wiper-attack-2017.md\n- solarwinds-orion-supply-chain-compromise-2020.md\n- stryker-handala-wiper-2026.md\n- stuxnet-iran-nuclear-sabotage-2010.md\n- ukraine-power-grid-attack-2015.md\n\nRequired outcome:\n- correct schema drift, source drift, section drift, ATT&CK mapping issues, attribution overreach, and factual inaccuracies\n- validate that destructive or espionage framing is supported by primary evidence and not just vendor shorthand\n- if any live article must be removed, merged, or reclassified, create a follow-on pipeline reprocess task before merge so the content is not lost"
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "MANIFEST-SPEC.md",
+    "ADR 0007 — Entity ID Format Convention",
+    "site/src/content.config.ts"
+  ],
+  "acceptance": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 7,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "build_passes": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "Work from a dedicated review branch and keep changes scoped to the batch unless a shared validator or schema fix is required.",
+    "Queue follow-on reprocess tasks for any article that must be removed, merged, or reclassified."
+  ],
+  "output": {
+    "file_pattern": "site/src/content/incidents/{slug}.md",
+    "branch": "pipeline/TASK-2026-0157",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-04-17T20:30:00Z",
+      "from": "none",
+      "to": "pending",
+      "agent": "kernel-k",
+      "note": "Soft-launch corpus review queue — incident batch 5 of 6"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0158.json
+++ b/.github/pipeline/tasks/TASK-2026-0158.json
@@ -1,0 +1,62 @@
+{
+  "task_id": "TASK-2026-0158",
+  "stage": "review",
+  "type": "incident",
+  "priority": "P2",
+  "status": "pending",
+  "created": "2026-04-17T20:30:00Z",
+  "updated": "2026-04-17T20:30:00Z",
+  "locked_by": null,
+  "locked_at": null,
+  "source": "backfill",
+  "submitted_by": "kernel-k",
+  "input": {
+    "topic": "Soft-launch corpus review — incident batch 6/6: taxonomy and canonicalization edge cases",
+    "sources": [
+      "https://threatpedia.wiki/incidents/"
+    ],
+    "candidate_data": {
+      "collection": "incidents",
+      "batch_index": 6,
+      "batch_total": 6,
+      "batch_size": 7,
+      "review_scope": "schema compliance, technical accuracy, historical accuracy, taxonomy, canonicalization"
+    },
+    "notes": "Review the scoped live incident articles against the latest Astro schema in `site/src/content.config.ts`, the ratified private specs, and primary-source technical and historical evidence.\n\nScoped files:\n- ransomhouse-operations.md\n- shiny-hunters-leak-site.md\n- tp-article-qilin-edr-killer.md\n- trivy-cve-2026-33634.md\n- twitter-bitcoin-scam-hack-2020.md\n- twitter-social-engineering-attack-2020.md\n- wannacry-ransomware-2017.md\n\nRequired outcome:\n- resolve taxonomy mistakes, canonical duplication, incomplete editorial placeholders, and historical framing drift\n- if an article belongs in a different collection or should collapse into another canonical entry, create a follow-on pipeline reprocess task before merge so the content is not lost\n- keep shared schema or validator fixes in the same branch only when needed to make the reviewed corpus valid"
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "MANIFEST-SPEC.md",
+    "ADR 0007 — Entity ID Format Convention",
+    "site/src/content.config.ts"
+  ],
+  "acceptance": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 7,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "build_passes": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "Work from a dedicated review branch and keep changes scoped to the batch unless a shared validator or schema fix is required.",
+    "Queue follow-on reprocess tasks for any article that must be removed, merged, or reclassified."
+  ],
+  "output": {
+    "file_pattern": "site/src/content/incidents/{slug}.md",
+    "branch": "pipeline/TASK-2026-0158",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-04-17T20:30:00Z",
+      "from": "none",
+      "to": "pending",
+      "agent": "kernel-k",
+      "note": "Soft-launch corpus review queue — incident batch 6 of 6"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0158.json
+++ b/.github/pipeline/tasks/TASK-2026-0158.json
@@ -38,7 +38,7 @@
     "min_mitre_mappings": 1,
     "review_status": "draft_ai",
     "schema_validation": "pass",
-    "build_passes": true
+    "astro_build": true
   },
   "depends_on": [],
   "preconditions": [

--- a/.github/pipeline/tasks/TASK-2026-0159.json
+++ b/.github/pipeline/tasks/TASK-2026-0159.json
@@ -38,7 +38,7 @@
     "min_mitre_mappings": 3,
     "review_status": "draft_ai",
     "schema_validation": "pass",
-    "build_passes": true
+    "astro_build": true
   },
   "depends_on": [],
   "preconditions": [

--- a/.github/pipeline/tasks/TASK-2026-0159.json
+++ b/.github/pipeline/tasks/TASK-2026-0159.json
@@ -1,0 +1,62 @@
+{
+  "task_id": "TASK-2026-0159",
+  "stage": "review",
+  "type": "threat-actor",
+  "priority": "P2",
+  "status": "pending",
+  "created": "2026-04-17T20:30:00Z",
+  "updated": "2026-04-17T20:30:00Z",
+  "locked_by": null,
+  "locked_at": null,
+  "source": "backfill",
+  "submitted_by": "kernel-k",
+  "input": {
+    "topic": "Soft-launch corpus review — threat actor batch 1/4: PRC state-linked and China-adjacent actors",
+    "sources": [
+      "https://threatpedia.wiki/threat-actors/"
+    ],
+    "candidate_data": {
+      "collection": "threat-actors",
+      "batch_index": 1,
+      "batch_total": 4,
+      "batch_size": 8,
+      "review_scope": "schema compliance, attribution quality, alias normalization, targeting history, source quality"
+    },
+    "notes": "Review the scoped live threat actor profiles against the latest Astro schema in `site/src/content.config.ts`, the ratified private specs, and primary-source technical and historical evidence.\n\nScoped files:\n- apt1.md\n- apt10.md\n- apt27.md\n- apt31.md\n- apt40.md\n- apt41.md\n- salt-typhoon.md\n- volt-typhoon.md\n\nRequired outcome:\n- correct alias drift, attribution overreach, target-sector drift, tool overlap confusion, and source-quality gaps\n- ensure each profile is historically defensible and aligned to the latest schema for actor metadata\n- if any actor profile must be merged, split, or reclassified, create a follow-on pipeline reprocess task before merge so the content is not lost"
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "MANIFEST-SPEC.md",
+    "ADR 0007 — Entity ID Format Convention",
+    "site/src/content.config.ts"
+  ],
+  "acceptance": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 5,
+    "min_mitre_mappings": 3,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "build_passes": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "Work from a dedicated review branch and keep changes scoped to the batch unless a shared validator or schema fix is required.",
+    "Queue follow-on reprocess tasks for any actor profile that must be removed, merged, or reclassified."
+  ],
+  "output": {
+    "file_pattern": "site/src/content/threat-actors/{slug}.md",
+    "branch": "pipeline/TASK-2026-0159",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-04-17T20:30:00Z",
+      "from": "none",
+      "to": "pending",
+      "agent": "kernel-k",
+      "note": "Soft-launch corpus review queue — threat actor batch 1 of 4"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0160.json
+++ b/.github/pipeline/tasks/TASK-2026-0160.json
@@ -1,0 +1,62 @@
+{
+  "task_id": "TASK-2026-0160",
+  "stage": "review",
+  "type": "threat-actor",
+  "priority": "P2",
+  "status": "pending",
+  "created": "2026-04-17T20:30:00Z",
+  "updated": "2026-04-17T20:30:00Z",
+  "locked_by": null,
+  "locked_at": null,
+  "source": "backfill",
+  "submitted_by": "kernel-k",
+  "input": {
+    "topic": "Soft-launch corpus review — threat actor batch 2/4: Russian and FSU-linked actors",
+    "sources": [
+      "https://threatpedia.wiki/threat-actors/"
+    ],
+    "candidate_data": {
+      "collection": "threat-actors",
+      "batch_index": 2,
+      "batch_total": 4,
+      "batch_size": 8,
+      "review_scope": "schema compliance, attribution quality, alias normalization, targeting history, source quality"
+    },
+    "notes": "Review the scoped live threat actor profiles against the latest Astro schema in `site/src/content.config.ts`, the ratified private specs, and primary-source technical and historical evidence.\n\nScoped files:\n- apt28.md\n- apt29.md\n- cl0p-group.md\n- evil-corp.md\n- sandworm.md\n- ta505.md\n- turla.md\n- wizard-spider.md\n\nRequired outcome:\n- correct alias drift, attribution overreach, target-sector drift, tool overlap confusion, and source-quality gaps\n- ensure sanctioned or indicted actor claims are supported with primary or near-primary evidence\n- if any actor profile must be merged, split, or reclassified, create a follow-on pipeline reprocess task before merge so the content is not lost"
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "MANIFEST-SPEC.md",
+    "ADR 0007 — Entity ID Format Convention",
+    "site/src/content.config.ts"
+  ],
+  "acceptance": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 5,
+    "min_mitre_mappings": 3,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "build_passes": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "Work from a dedicated review branch and keep changes scoped to the batch unless a shared validator or schema fix is required.",
+    "Queue follow-on reprocess tasks for any actor profile that must be removed, merged, or reclassified."
+  ],
+  "output": {
+    "file_pattern": "site/src/content/threat-actors/{slug}.md",
+    "branch": "pipeline/TASK-2026-0160",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-04-17T20:30:00Z",
+      "from": "none",
+      "to": "pending",
+      "agent": "kernel-k",
+      "note": "Soft-launch corpus review queue — threat actor batch 2 of 4"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0160.json
+++ b/.github/pipeline/tasks/TASK-2026-0160.json
@@ -38,7 +38,7 @@
     "min_mitre_mappings": 3,
     "review_status": "draft_ai",
     "schema_validation": "pass",
-    "build_passes": true
+    "astro_build": true
   },
   "depends_on": [],
   "preconditions": [

--- a/.github/pipeline/tasks/TASK-2026-0161.json
+++ b/.github/pipeline/tasks/TASK-2026-0161.json
@@ -1,0 +1,62 @@
+{
+  "task_id": "TASK-2026-0161",
+  "stage": "review",
+  "type": "threat-actor",
+  "priority": "P2",
+  "status": "pending",
+  "created": "2026-04-17T20:30:00Z",
+  "updated": "2026-04-17T20:30:00Z",
+  "locked_by": null,
+  "locked_at": null,
+  "source": "backfill",
+  "submitted_by": "kernel-k",
+  "input": {
+    "topic": "Soft-launch corpus review — threat actor batch 3/4: DPRK and ransomware-core actors",
+    "sources": [
+      "https://threatpedia.wiki/threat-actors/"
+    ],
+    "candidate_data": {
+      "collection": "threat-actors",
+      "batch_index": 3,
+      "batch_total": 4,
+      "batch_size": 8,
+      "review_scope": "schema compliance, attribution quality, alias normalization, targeting history, source quality"
+    },
+    "notes": "Review the scoped live threat actor profiles against the latest Astro schema in `site/src/content.config.ts`, the ratified private specs, and primary-source technical and historical evidence.\n\nScoped files:\n- apt38.md\n- blackbasta.md\n- blackcat-alphv.md\n- fin7.md\n- fin11.md\n- fin12.md\n- lazarus-group.md\n- lockbit.md\n\nRequired outcome:\n- correct alias drift, attribution overreach, target-sector drift, tool overlap confusion, and source-quality gaps\n- ensure financially motivated, DPRK-linked, and ransomware ecosystem boundaries are historically defensible\n- if any actor profile must be merged, split, or reclassified, create a follow-on pipeline reprocess task before merge so the content is not lost"
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "MANIFEST-SPEC.md",
+    "ADR 0007 — Entity ID Format Convention",
+    "site/src/content.config.ts"
+  ],
+  "acceptance": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 5,
+    "min_mitre_mappings": 3,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "build_passes": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "Work from a dedicated review branch and keep changes scoped to the batch unless a shared validator or schema fix is required.",
+    "Queue follow-on reprocess tasks for any actor profile that must be removed, merged, or reclassified."
+  ],
+  "output": {
+    "file_pattern": "site/src/content/threat-actors/{slug}.md",
+    "branch": "pipeline/TASK-2026-0161",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-04-17T20:30:00Z",
+      "from": "none",
+      "to": "pending",
+      "agent": "kernel-k",
+      "note": "Soft-launch corpus review queue — threat actor batch 3 of 4"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0161.json
+++ b/.github/pipeline/tasks/TASK-2026-0161.json
@@ -38,7 +38,7 @@
     "min_mitre_mappings": 3,
     "review_status": "draft_ai",
     "schema_validation": "pass",
-    "build_passes": true
+    "astro_build": true
   },
   "depends_on": [],
   "preconditions": [

--- a/.github/pipeline/tasks/TASK-2026-0162.json
+++ b/.github/pipeline/tasks/TASK-2026-0162.json
@@ -38,7 +38,7 @@
     "min_mitre_mappings": 3,
     "review_status": "draft_ai",
     "schema_validation": "pass",
-    "build_passes": true
+    "astro_build": true
   },
   "depends_on": [],
   "preconditions": [

--- a/.github/pipeline/tasks/TASK-2026-0162.json
+++ b/.github/pipeline/tasks/TASK-2026-0162.json
@@ -1,0 +1,62 @@
+{
+  "task_id": "TASK-2026-0162",
+  "stage": "review",
+  "type": "threat-actor",
+  "priority": "P2",
+  "status": "pending",
+  "created": "2026-04-17T20:30:00Z",
+  "updated": "2026-04-17T20:30:00Z",
+  "locked_by": null,
+  "locked_at": null,
+  "source": "backfill",
+  "submitted_by": "kernel-k",
+  "input": {
+    "topic": "Soft-launch corpus review — threat actor batch 4/4: hybrid, criminal, and emerging actors",
+    "sources": [
+      "https://threatpedia.wiki/threat-actors/"
+    ],
+    "candidate_data": {
+      "collection": "threat-actors",
+      "batch_index": 4,
+      "batch_total": 4,
+      "batch_size": 9,
+      "review_scope": "schema compliance, attribution quality, alias normalization, targeting history, source quality"
+    },
+    "notes": "Review the scoped live threat actor profiles against the latest Astro schema in `site/src/content.config.ts`, the ratified private specs, and primary-source technical and historical evidence.\n\nScoped files:\n- dragonforce.md\n- eviltokens.md\n- handala.md\n- lockbit-black.md\n- medusa.md\n- play-ransomware.md\n- scattered-spider.md\n- shinyhunters.md\n- teampcp.md\n\nRequired outcome:\n- correct alias drift, attribution overreach, target-sector drift, tool overlap confusion, and source-quality gaps\n- ensure emerging, hybrid, or loosely tracked actor profiles are not overstated beyond the evidence\n- if any actor profile must be merged, split, or reclassified, create a follow-on pipeline reprocess task before merge so the content is not lost"
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "MANIFEST-SPEC.md",
+    "ADR 0007 — Entity ID Format Convention",
+    "site/src/content.config.ts"
+  ],
+  "acceptance": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 5,
+    "min_mitre_mappings": 3,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "build_passes": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "Work from a dedicated review branch and keep changes scoped to the batch unless a shared validator or schema fix is required.",
+    "Queue follow-on reprocess tasks for any actor profile that must be removed, merged, or reclassified."
+  ],
+  "output": {
+    "file_pattern": "site/src/content/threat-actors/{slug}.md",
+    "branch": "pipeline/TASK-2026-0162",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-04-17T20:30:00Z",
+      "from": "none",
+      "to": "pending",
+      "agent": "kernel-k",
+      "note": "Soft-launch corpus review queue — threat actor batch 4 of 4"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0163.json
+++ b/.github/pipeline/tasks/TASK-2026-0163.json
@@ -38,7 +38,7 @@
     "min_mitre_mappings": 1,
     "review_status": "draft_ai",
     "schema_validation": "pass",
-    "build_passes": true
+    "astro_build": true
   },
   "depends_on": [],
   "preconditions": [

--- a/.github/pipeline/tasks/TASK-2026-0163.json
+++ b/.github/pipeline/tasks/TASK-2026-0163.json
@@ -1,0 +1,62 @@
+{
+  "task_id": "TASK-2026-0163",
+  "stage": "review",
+  "type": "zero-day",
+  "priority": "P1",
+  "status": "pending",
+  "created": "2026-04-17T20:30:00Z",
+  "updated": "2026-04-17T20:30:00Z",
+  "locked_by": null,
+  "locked_at": null,
+  "source": "backfill",
+  "submitted_by": "kernel-k",
+  "input": {
+    "topic": "Soft-launch corpus review — zero-day batch 1/2: modern active exploitation set",
+    "sources": [
+      "https://threatpedia.wiki/zero-days/"
+    ],
+    "candidate_data": {
+      "collection": "zero-days",
+      "batch_index": 1,
+      "batch_total": 2,
+      "batch_size": 9,
+      "review_scope": "schema compliance, technical accuracy, exploit chronology, KEV status, source quality"
+    },
+    "notes": "Review the scoped live zero-day articles against the latest Astro schema in `site/src/content.config.ts`, the ratified private specs, and primary-source technical and historical evidence.\n\nScoped files:\n- adobe-acrobat-and-reader-cve-2026-34621.md\n- bluehammer-windows-defender-lpe-2026.md\n- chrome-dawn-cve-2026-5281.md\n- cisco-fmc-cve-2026-20131.md\n- forticlient-ems-cve-2026-35616.md\n- fortinet-forticlient-ems-cve-2026-21643.md\n- ivanti-epmm-cve-2026-1340.md\n- palo-alto-pan-os-cve-2024-3400.md\n- trueconf-cve-2026-3502.md\n\nRequired outcome:\n- correct schema drift, exploit chronology errors, CVE and KEV status drift, ATT&CK mapping issues, and factual inaccuracies\n- ensure disclosure date, patch date, days-in-the-wild, and exploitation claims are all defensible from primary evidence\n- if any live article must be removed, merged, or reclassified, create a follow-on pipeline reprocess task before merge so the content is not lost"
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "MANIFEST-SPEC.md",
+    "ADR 0007 — Entity ID Format Convention",
+    "site/src/content.config.ts"
+  ],
+  "acceptance": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 7,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "build_passes": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "Work from a dedicated review branch and keep changes scoped to the batch unless a shared validator or schema fix is required.",
+    "Queue follow-on reprocess tasks for any zero-day article that must be removed, merged, or reclassified."
+  ],
+  "output": {
+    "file_pattern": "site/src/content/zero-days/{slug}.md",
+    "branch": "pipeline/TASK-2026-0163",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-04-17T20:30:00Z",
+      "from": "none",
+      "to": "pending",
+      "agent": "kernel-k",
+      "note": "Soft-launch corpus review queue — zero-day batch 1 of 2"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0164.json
+++ b/.github/pipeline/tasks/TASK-2026-0164.json
@@ -38,7 +38,7 @@
     "min_mitre_mappings": 1,
     "review_status": "draft_ai",
     "schema_validation": "pass",
-    "build_passes": true
+    "astro_build": true
   },
   "depends_on": [],
   "preconditions": [

--- a/.github/pipeline/tasks/TASK-2026-0164.json
+++ b/.github/pipeline/tasks/TASK-2026-0164.json
@@ -1,0 +1,62 @@
+{
+  "task_id": "TASK-2026-0164",
+  "stage": "review",
+  "type": "zero-day",
+  "priority": "P2",
+  "status": "pending",
+  "created": "2026-04-17T20:30:00Z",
+  "updated": "2026-04-17T20:30:00Z",
+  "locked_by": null,
+  "locked_at": null,
+  "source": "backfill",
+  "submitted_by": "kernel-k",
+  "input": {
+    "topic": "Soft-launch corpus review — zero-day batch 2/2: historical and canonicalization set",
+    "sources": [
+      "https://threatpedia.wiki/zero-days/"
+    ],
+    "candidate_data": {
+      "collection": "zero-days",
+      "batch_index": 2,
+      "batch_total": 2,
+      "batch_size": 9,
+      "review_scope": "schema compliance, technical accuracy, exploit chronology, canonicalization, source quality"
+    },
+    "notes": "Review the scoped live zero-day articles against the latest Astro schema in `site/src/content.config.ts`, the ratified private specs, and primary-source technical and historical evidence.\n\nScoped files:\n- apache-struts-rce-cve-2017-5638.md\n- eternalblue-ms17-010-cve-2017-0144.md\n- heartbleed-openssl-cve-2014-0160.md\n- heartbleed-openssl-tls-cve-2014-0160.md\n- log4shell-apache-log4j-cve-2021-44228.md\n- microsoft-exchange-server-cve-2023-21529.md\n- microsoft-office-cve-2009-0238.md\n- microsoft-visual-basic-for-applications-vba--cve-2012-1854.md\n- stuxnet-lnk-shortcut-cve-2010-2568.md\n\nRequired outcome:\n- correct schema drift, exploit chronology errors, CVE and KEV status drift, ATT&CK mapping issues, and factual inaccuracies\n- explicitly check canonical duplication and naming drift, especially where multiple live articles may describe the same vulnerability family or disclosure event\n- if any live article must be removed, merged, or reclassified, create a follow-on pipeline reprocess task before merge so the content is not lost"
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "MANIFEST-SPEC.md",
+    "ADR 0007 — Entity ID Format Convention",
+    "site/src/content.config.ts"
+  ],
+  "acceptance": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 7,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "build_passes": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "Work from a dedicated review branch and keep changes scoped to the batch unless a shared validator or schema fix is required.",
+    "Queue follow-on reprocess tasks for any zero-day article that must be removed, merged, or reclassified."
+  ],
+  "output": {
+    "file_pattern": "site/src/content/zero-days/{slug}.md",
+    "branch": "pipeline/TASK-2026-0164",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-04-17T20:30:00Z",
+      "from": "none",
+      "to": "pending",
+      "agent": "kernel-k",
+      "note": "Soft-launch corpus review queue — zero-day batch 2 of 2"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- queue the remaining soft-launch corpus review work for incidents, threat actors, and zero-days in bounded batches
- add a single tracker document that explains the batch order and review rules
- require removed, merged, or reclassified live content to be requeued as follow-on pipeline tasks rather than dropped

## What this adds
- 6 incident review batches covering all 55 live incident articles
- 4 threat-actor review batches covering all 33 live actor profiles
- 2 zero-day review batches covering all 18 live zero-day articles
- `.github/pipeline/CORPUS-REVIEW-QUEUE.md` as the human-readable tracker

## Queue design
- tasks are staged as `review` to avoid flooding the dispatcher while we work the corpus deliberately batch by batch
- each task is self-contained and names the exact scoped files
- each task requires latest-schema review, technical accuracy review, historical accuracy review, and reprocess-task creation for any content that must be removed or retyped

## Validation
- `jq` parse check across TASK-2026-0153 through TASK-2026-0164
- required-field and enum sanity check against the task schema shape
- `git diff --check`
