### PR TITLE
[pipeline] Close P1 soft-launch reprocess tasks

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0170.json
+++ b/.github/pipeline/tasks/TASK-2026-0170.json
@@ -2,9 +2,9 @@
   "task_id": "TASK-2026-0170",
   "type": "incident",
   "priority": "P1",
-  "status": "pending",
+  "status": "complete",
   "created": "2026-04-18T04:55:00Z",
-  "updated": "2026-04-18T04:55:00Z",
+  "updated": "2026-04-19T00:55:00Z",
   "source": "backfill",
   "submitted_by": "kernel-k",
   "input": {
@@ -38,6 +38,14 @@
       "to": "pending",
       "agent": "kernel-k",
       "note": "Queued follow-on canonical reconciliation for duplicate TrueConf incident coverage discovered during soft-launch corpus review batch 1."
+    },
+    {
+      "timestamp": "2026-04-19T00:55:00Z",
+      "action": "completed",
+      "from": "pending",
+      "to": "complete",
+      "agent": "dangermouse-bot",
+      "note": "TrueConf canonical reconciliation completed via PR #70 (merge 2bf529d)."
     }
   ]
 }

--- a/.github/pipeline/tasks/TASK-2026-0171.json
+++ b/.github/pipeline/tasks/TASK-2026-0171.json
@@ -2,9 +2,9 @@
   "task_id": "TASK-2026-0171",
   "type": "incident",
   "priority": "P1",
-  "status": "pending",
+  "status": "complete",
   "created": "2026-04-18T04:56:00Z",
-  "updated": "2026-04-18T04:56:00Z",
+  "updated": "2026-04-19T00:55:00Z",
   "source": "backfill",
   "submitted_by": "kernel-k",
   "input": {
@@ -38,6 +38,14 @@
       "to": "pending",
       "agent": "kernel-k",
       "note": "Queued follow-on evidence rebuild for BlueHammer after corpus review found discoverer attribution conflation and source-quality overreach."
+    },
+    {
+      "timestamp": "2026-04-19T00:55:00Z",
+      "action": "completed",
+      "from": "pending",
+      "to": "complete",
+      "agent": "dangermouse-bot",
+      "note": "BlueHammer evidence and taxonomy rebuild completed via PR #70 (merge 2bf529d)."
     }
   ]
 }

--- a/.github/pipeline/tasks/TASK-2026-0172.json
+++ b/.github/pipeline/tasks/TASK-2026-0172.json
@@ -2,9 +2,9 @@
   "task_id": "TASK-2026-0172",
   "type": "campaign",
   "priority": "P1",
-  "status": "pending",
+  "status": "complete",
   "created": "2026-04-18T06:40:00Z",
-  "updated": "2026-04-18T06:40:00Z",
+  "updated": "2026-04-19T00:55:00Z",
   "source": "backfill",
   "submitted_by": "kernel-k",
   "input": {
@@ -38,6 +38,14 @@
       "to": "pending",
       "agent": "kernel-k",
       "note": "Queued follow-on reclassification after corpus review identified DragonForce multi-victim coverage as a campaign-taxonomy issue, not a pure incident article."
+    },
+    {
+      "timestamp": "2026-04-19T00:55:00Z",
+      "action": "completed",
+      "from": "pending",
+      "to": "complete",
+      "agent": "dangermouse-bot",
+      "note": "DragonForce campaign reclassification completed via PR #70 (merge 2bf529d)."
     }
   ]
 }

--- a/.github/pipeline/tasks/TASK-2026-0173.json
+++ b/.github/pipeline/tasks/TASK-2026-0173.json
@@ -2,9 +2,9 @@
   "task_id": "TASK-2026-0173",
   "type": "campaign",
   "priority": "P1",
-  "status": "pending",
+  "status": "complete",
   "created": "2026-04-18T07:25:00Z",
-  "updated": "2026-04-18T07:25:00Z",
+  "updated": "2026-04-19T00:55:00Z",
   "source": "backfill",
   "submitted_by": "kernel-k",
   "input": {
@@ -38,6 +38,14 @@
       "to": "pending",
       "agent": "kernel-k",
       "note": "Queued follow-on reclassification after corpus review confirmed FrostArmada is campaign-shaped coverage living in the incidents collection."
+    },
+    {
+      "timestamp": "2026-04-19T00:55:00Z",
+      "action": "completed",
+      "from": "pending",
+      "to": "complete",
+      "agent": "dangermouse-bot",
+      "note": "FrostArmada campaign reclassification completed via PR #70 (merge 2bf529d)."
     }
   ]
 }

--- a/.github/pipeline/tasks/TASK-2026-0174.json
+++ b/.github/pipeline/tasks/TASK-2026-0174.json
@@ -2,9 +2,9 @@
   "task_id": "TASK-2026-0174",
   "type": "campaign",
   "priority": "P1",
-  "status": "pending",
+  "status": "complete",
   "created": "2026-04-18T07:26:00Z",
-  "updated": "2026-04-18T07:26:00Z",
+  "updated": "2026-04-19T00:55:00Z",
   "source": "backfill",
   "submitted_by": "kernel-k",
   "input": {
@@ -38,6 +38,14 @@
       "to": "pending",
       "agent": "kernel-k",
       "note": "Queued follow-on reclassification after corpus review confirmed the Microsoft 365 device-code article is campaign-shaped coverage living in the incidents collection."
+    },
+    {
+      "timestamp": "2026-04-19T00:55:00Z",
+      "action": "completed",
+      "from": "pending",
+      "to": "complete",
+      "agent": "dangermouse-bot",
+      "note": "Microsoft 365 device code phishing campaign reclassification completed via PR #70 (merge 2bf529d)."
     }
   ]
 }

--- a/.github/pipeline/tasks/TASK-2026-0179.json
+++ b/.github/pipeline/tasks/TASK-2026-0179.json
@@ -2,9 +2,9 @@
   "task_id": "TASK-2026-0179",
   "type": "threat-actor",
   "priority": "P1",
-  "status": "pending",
+  "status": "complete",
   "created": "2026-04-18T10:10:00Z",
-  "updated": "2026-04-18T10:10:00Z",
+  "updated": "2026-04-19T00:55:00Z",
   "source": "backfill",
   "submitted_by": "kernel-k",
   "input": {
@@ -39,6 +39,14 @@
       "to": "pending",
       "agent": "kernel-k",
       "note": "Queued rebuild after removing a placeholder Qilin incident stub from the live incidents collection."
+    },
+    {
+      "timestamp": "2026-04-19T00:55:00Z",
+      "action": "completed",
+      "from": "pending",
+      "to": "complete",
+      "agent": "dangermouse-bot",
+      "note": "Qilin canonical actor rebuild completed via PR #70 (merge 2bf529d)."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- mark TASK-2026-0170, 0171, 0172, 0173, 0174, and 0179 complete after PR #70
- preserve canonical task shape and append completion history entries only
- keep queue state honest before triaging PR #61

## Validation
- git diff --check
- python3 status count audit (84 complete / 42 pending after this change)
