### PR TITLE
chore(corpus+docs): finish Yahoo split and campaign linkage follow-up

### DIFF
--- a/docs/bot-automation-processes.md
+++ b/docs/bot-automation-processes.md
@@ -296,7 +296,7 @@ subprocess.run(["git", "push", "origin", source_branch], check=True)
 
 # Step 5: Reply to the actionable comments and resolve them
 for comment in gemini_comments:
-    review_comment = repo.get_pull(target_pr_number).get_review_comment(comment["id"])
+    review_comment = pr.get_review_comment(comment["id"])
     review_comment.reply("Fixed in follow-up commit on this PR branch.")
     # Resolve the review thread via GraphQL / gh if available
 

--- a/docs/bot-automation-processes.md
+++ b/docs/bot-automation-processes.md
@@ -38,7 +38,7 @@ The architecture prioritizes data consistency, security, and uniform operational
 - **Severity Levels**: Critical, High, Medium, Low
 - **Response Time**: Typically posts comments within 1-3 minutes of PR creation
 - **Comment Format**: Includes file path, line number, violation description, and suggested fix
-- **Integration**: Tasks check for Gemini comments post-merge and apply fixes in follow-up PRs
+- **Integration**: PRs are not merge-ready until Gemini comments have been reviewed, actionable findings fixed, replies posted, and actionable threads resolved. Post-merge follow-up is only for late-arriving comments that appear after the merge gate was already cleared.
 
 ## Security Requirements
 
@@ -65,7 +65,9 @@ Security is non-negotiable in all automation processes. The following rules prot
 ### PR Review and Merging
 - **All PRs must pass Gemini Code Assist review** before owner account merges
 - **Critical and high-priority findings** must be fixed before merge
-- **Medium and low findings** should be fixed but can be deferred to next run if blocking
+- **Medium and low findings** should also be reviewed before merge; if one is deferred, the deferment must be explicit and owned by the merger
+- **Reply to actionable Gemini comments** with the fix or disposition before resolving the thread
+- **Resolve actionable Gemini threads** before merge so review state matches the code state
 - **Never merge PRs** with dangling security issues (exposed tokens, hardcoded credentials)
 
 ## Standard PR Workflow
@@ -134,13 +136,14 @@ c. Capture PR number from API response
 d. Log PR URL: https://github.com/MahdiHedhli/threatpedia/pull/{number}
 ```
 
-### 6. Gemini Review Post-Check (see dedicated section below)
+### 6. Gemini Review Gate (see dedicated section below)
 ```
-a. Wait 2 minutes after PR creation/merge
-b. Query GitHub API for Gemini comments on the merged commit
-c. If comments found: apply fixes in follow-up PR (see Gemini resolution template)
-d. Continue checking at 5 min total, then 10 min total
-e. After 10 minutes with no new comments: task complete
+a. Wait 2 minutes after PR creation
+b. Query GitHub API for Gemini comments on the PR branch
+c. If comments found: apply fixes on the same branch or a direct follow-up branch, push, reply, and resolve actionable threads
+d. Re-check at 5 min total, then 10 min total
+e. Merge only after actionable Gemini comments are addressed and threads are resolved
+f. If comments arrive only after merge, handle them in a follow-up PR and document the exception
 ```
 
 ### 7. Finalization (Always)
@@ -214,33 +217,22 @@ else:
     print("No critical/high issues found. Proceeding with main task.")
 ```
 
-### Post-PR Check (AFTER Creating and Merging a PR)
+### Post-PR Check (AFTER Creating A PR, BEFORE MERGE)
 
-After merging a PR, check for Gemini comments and resolve them in follow-up PRs:
+Before merging a PR, check for Gemini comments and resolve them before the branch lands on `main`:
 
 ```python
 import time
 
-# After PR is merged to main
-print(f"PR #{pr_number} merged. Checking for Gemini Code Assist comments...")
+# After PR is opened and ready for review
+print(f"PR #{pr_number} open. Checking for Gemini Code Assist comments before merge...")
 
 # Timeline: check at 2 min, 5 min total, 10 min total
 for wait_cycle, total_wait in [(120, 120), (180, 300), (300, 600)]:
     print(f"Waiting {wait_cycle} seconds (total: {total_wait}s)...")
     time.sleep(wait_cycle)
     
-    # Query for Gemini comments on merged commit
-    commits = repo.get_commits(sha="main")
-    latest_commit = commits[0]
-    
-    # Look for associated PR and its comments
-    prs_for_commit = repo.get_pulls(state="all")
-    target_pr = None
-    for pr in prs_for_commit:
-        if pr.merge_commit_sha == latest_commit.sha:
-            target_pr = pr
-            break
-    
+    target_pr = repo.get_pull(pr_number)
     if target_pr:
         gemini_comments = []
         for comment in target_pr.get_comments():
@@ -254,19 +246,19 @@ for wait_cycle, total_wait in [(120, 120), (180, 300), (300, 600)]:
         
         if gemini_comments:
             print(f"Found {len(gemini_comments)} Gemini comments at {total_wait}s")
-            # Apply fixes (see Fix Procedure below)
+            # Apply fixes, reply to comments, and resolve actionable threads (see Fix Procedure below)
             break
         else:
             print(f"No Gemini comments yet at {total_wait}s")
     
     if total_wait >= 600:  # 10 minutes
-        print("No Gemini comments after 10 minutes. Task complete.")
+        print("No Gemini comments after 10 minutes. PR is clear to merge.")
         break
 ```
 
 ### Gemini Comment Resolution Procedure
 
-When Gemini comments are found, clone the PR branch, apply fixes, and push a new PR:
+When Gemini comments are found, update the PR branch, then reply to and resolve the actionable comments before merge:
 
 ```python
 # Step 1: Get PR branch name
@@ -302,26 +294,23 @@ subprocess.run([
 
 subprocess.run(["git", "push", "origin", source_branch], check=True)
 
-# Step 5: Create new PR (or update existing)
-new_pr = repo.create_pull(
-    title=f"[GEMINI FIX] {pr.title}",
-    body=f"Resolves Gemini Code Assist findings:\n" + 
-         "\n".join([f"- {c['severity']}: {c['file']}:{c['line']}" for c in gemini_comments]),
-    head=source_branch,
-    base="main"
-)
+# Step 5: Reply to the actionable comments and resolve them
+for comment in gemini_comments:
+    review_comment = repo.get_pull(target_pr_number).get_review_comment(comment["id"])
+    review_comment.reply("Fixed in follow-up commit on this PR branch.")
+    # Resolve the review thread via GraphQL / gh if available
 
-# Step 6: Approve and merge (using owner token)
+# Step 6: Approve and merge (using owner token) only after actionable threads are resolved
 with open(os.path.expanduser("~/Documents/Coding/Threatpedia/.env.owner")) as f:
     owner_token = f.read().strip()
 
 owner_g = Github(auth=Auth.Token(owner_token))
 owner_repo = owner_g.get_repo("MahdiHedhli/threatpedia")
-owner_pr = owner_repo.get_pull(new_pr.number)
+owner_pr = owner_repo.get_pull(target_pr_number)
 owner_pr.create_review(event="APPROVE")
 owner_pr.merge()
 
-print(f"Gemini fixes merged in PR #{new_pr.number}")
+print(f"Gemini findings resolved and PR #{target_pr_number} merged")
 ```
 
 ### Common Gemini Findings to Watch For
@@ -400,11 +389,12 @@ Every new scheduled task should follow this structure in its prompt or runbook:
 
 ### Post-PR: Gemini Review Check
 1. Wait 2 minutes
-2. Query GitHub API for Gemini comments on merged commit
-3. If found: apply fixes using Comment Resolution Procedure, push new PR
-4. Wait 3 more minutes (5 min total), check again — fix if needed
-5. Wait 5 more minutes (10 min total), final check — fix if needed
-6. If no new comments after 10 min: task complete
+2. Query GitHub API for Gemini comments on the open PR
+3. If found: apply fixes using Comment Resolution Procedure on the PR branch
+4. Reply to actionable comments and resolve actionable threads
+5. Wait 3 more minutes (5 min total), check again — fix if needed
+6. Wait 5 more minutes (10 min total), final check — fix if needed
+7. Merge only after the actionable review state is clean
 
 ### Finalization
 1. Release lock: activeLocks[{task-name}].locked = false

--- a/site/src/content/campaigns/solarwinds-supply-chain-campaign.md
+++ b/site/src/content/campaigns/solarwinds-supply-chain-campaign.md
@@ -18,7 +18,6 @@ cves: []
 relatedIncidents:
   - "solarwinds-orion-supply-chain-compromise-2020"
   - "fireeye-red-team-tools-breach-2020"
-  - "fireeye-red-team-tools-breach-2020"
 tags:
   - "solarwinds"
   - "supply-chain"

--- a/site/src/content/campaigns/solarwinds-supply-chain-campaign.md
+++ b/site/src/content/campaigns/solarwinds-supply-chain-campaign.md
@@ -18,6 +18,7 @@ cves: []
 relatedIncidents:
   - "solarwinds-orion-supply-chain-compromise-2020"
   - "fireeye-red-team-tools-breach-2020"
+  - "fireeye-red-team-tools-breach-2020"
 tags:
   - "solarwinds"
   - "supply-chain"

--- a/site/src/content/incidents/fireeye-red-team-tools-breach-2020.md
+++ b/site/src/content/incidents/fireeye-red-team-tools-breach-2020.md
@@ -1,15 +1,13 @@
 ---
 eventId: "TP-2020-0002"
-articleType: "incident"
 title: "FireEye Red Team Tools Breach"
-date_start: 2020-11-01
-date_disclosed: 2020-12-08
+date: 2020-12-08
 attackType: "Espionage"
 severity: critical
 sector: "Technology"
 geography: "Global"
+threatActor: "APT29"
 attributionConfidence: A1
-attributionRationale: "Linked unequivocally to the broader SVR/APT29 SolarWinds campaign by government attribution."
 reviewStatus: "certified"
 confidenceGrade: A
 generatedBy: "dangermouse-bot"
@@ -22,6 +20,7 @@ tags:
   - "apt29"
   - "fireeye"
   - "svr"
+  - "red-team"
 sources:
   - url: "https://www.mandiant.com/resources/blog/fireeye-cyber-attack"
     publisher: "Mandiant"
@@ -48,14 +47,12 @@ mitreMappings:
   - techniqueId: "T1195.002"
     techniqueName: "Supply Chain Compromise: Compromise Software Supply Chain"
     tactic: "Initial Access"
-    attackVersion: "v15.1"
-    confidence: "confirmed"
-    evidence: "APT29 accessed FireEye through the trojanized SolarWinds Orion build."
+    notes: "APT29 accessed FireEye through the trojanized SolarWinds Orion build."
 ---
 
 ## Executive Summary
 
-On December 8, 2020, FireEye (now Mandiant) publicly disclosed that it had been breached by a highly sophisticated state-sponsored adversary. The attackers explicitly targeted and successfully exfiltrated the company's proprietary Red Team assessment tools. This breach served as the precipitating discovery event for the massive SolarWinds supply chain compromise. The actors gained initial access through the trojanized SolarWinds Orion software (SUNBURST), making FireEye one of the most critical victims in the broader SVR espionge campaign.
+On December 8, 2020, FireEye (now Mandiant) publicly disclosed that it had been breached by a highly sophisticated state-sponsored adversary. The attackers explicitly targeted and successfully exfiltrated the company's proprietary Red Team assessment tools. This breach served as the precipitating discovery event for the massive SolarWinds supply chain compromise. The actors gained initial access through the trojanized SolarWinds Orion software (SUNBURST), making FireEye one of the most critical victims in the broader SVR espionage campaign.
 
 ## Technical Analysis
 

--- a/site/src/content/incidents/operation-aurora-espionage-2009.md
+++ b/site/src/content/incidents/operation-aurora-espionage-2009.md
@@ -1,10 +1,7 @@
 ---
 eventId: "TP-2009-0001"
-articleType: "incident"
 title: "Operation Aurora Cyber Espionage"
-startDate: 2009-06-01
-endDate: 2010-01-31
-ongoing: false
+date: 2009-06-01
 attackType: "Espionage"
 severity: critical
 sector: "Technology"
@@ -17,7 +14,7 @@ generatedBy: "kernel-k"
 generatedDate: 2026-04-17
 cves:
   - "CVE-2010-0249"
-relatedIncidents: []
+relatedSlugs: []
 tags:
   - "operation-aurora"
   - "china"

--- a/site/src/content/incidents/ukraine-power-grid-industroyer-2016.md
+++ b/site/src/content/incidents/ukraine-power-grid-industroyer-2016.md
@@ -1,14 +1,13 @@
 ---
 eventId: "TP-2016-0001"
-articleType: "incident"
 title: "Kyiv Power Grid Attack (Industroyer)"
-date_start: 2016-12-17
+date: 2016-12-17
 attackType: "Sabotage"
 severity: critical
 sector: "Energy & Utilities"
 geography: "Ukraine"
+threatActor: "Sandworm"
 attributionConfidence: A1
-attributionRationale: "U.S. DOJ indicted GRU Unit 74455 (Sandworm) for this and the 2015 power grid attacks."
 reviewStatus: "certified"
 confidenceGrade: A
 generatedBy: "dangermouse-bot"
@@ -48,9 +47,7 @@ mitreMappings:
   - techniqueId: "T0831"
     techniqueName: "Manipulation of Control"
     tactic: "Impact"
-    attackVersion: "v15.1"
-    confidence: "confirmed"
-    evidence: "Industroyer was designed to directly manipulate industrial control processes."
+    notes: "Industroyer was designed to directly manipulate industrial control processes."
 ---
 
 ## Executive Summary

--- a/site/src/content/incidents/volt-typhoon-critical-infrastructure-2023.md
+++ b/site/src/content/incidents/volt-typhoon-critical-infrastructure-2023.md
@@ -1,9 +1,7 @@
 ---
 eventId: "TP-2023-0001"
-articleType: "incident"
 title: "Volt Typhoon Critical Infrastructure Pre-positioning"
-startDate: 2021-06-01
-ongoing: true
+date: 2021-06-01
 attackType: "Espionage / Pre-positioning"
 severity: critical
 sector: "Critical Infrastructure"
@@ -15,7 +13,7 @@ confidenceGrade: A
 generatedBy: "kernel-k"
 generatedDate: 2026-04-17
 cves: []
-relatedIncidents: []
+relatedSlugs: []
 tags:
   - "volt-typhoon"
   - "china"

--- a/site/src/content/incidents/yahoo-data-breach-2013.md
+++ b/site/src/content/incidents/yahoo-data-breach-2013.md
@@ -1,25 +1,27 @@
 ---
 eventId: TP-2013-0002
-articleType: "incident"
 title: "Yahoo 2013 Data Breach"
-date_start: 2013-08-01
-date_disclosed: 2016-12-14
+date: 2013-08-01
 attackType: Data Breach
 severity: critical
 sector: Technology
 geography: United States
-attributionConfidence: A6
+threatActor: Unknown
+attributionConfidence: A4
 reviewStatus: "certified"
 confidenceGrade: A
-generatedBy: dangermouse-bot
+generatedBy: penfold-bot
 generatedDate: 2026-04-19
 cves: []
 relatedSlugs:
   - "yahoo-data-breach-2014"
 tags:
   - data-breach
+  - yahoo
   - email
   - technology
+  - credentials
+  - consumer
 sources:
   - url: https://blog.yahoo.net/post/154309897759/important-security-information-for-yahoo-users
     publisher: Yahoo
@@ -28,71 +30,65 @@ sources:
     publicationDate: "2016-12-14"
     accessDate: "2026-04-19"
     archived: false
-  - url: https://www.sec.gov/litigation/press/2018/2018-71.htm
-    publisher: U.S. Securities and Exchange Commission
-    publisherType: government
+  - url: https://www.yahoo.com/news/yahoo-says-3-billion-accounts-205639389.html
+    publisher: Reuters
+    publisherType: media
     reliability: R1
-    publicationDate: "2018-04-24"
+    publicationDate: "2017-10-03"
     accessDate: "2026-04-19"
     archived: false
-  - url: https://www.justice.gov/opa/pr/us-charges-russian-fsb-officers-and-their-criminal-conspirators-hacking-yahoo-and-millions
-    publisher: U.S. Department of Justice
-    publisherType: government
-    reliability: R1
-    publicationDate: "2017-03-15"
+  - url: https://www.cnbc.com/2017/10/03/yahoo-every-single-account-3-billion-people-affected-in-2013-attack.html
+    publisher: CNBC
+    publisherType: media
+    reliability: R2
+    publicationDate: "2017-10-03"
     accessDate: "2026-04-19"
     archived: false
-mitreMappings:
-  - techniqueId: T1114
-    techniqueName: Email Collection
-    tactic: Collection
-    attackVersion: "v15.1"
-    confidence: "confirmed"
-    evidence: "Attacker accessed user databases to steal metadata and hashed passwords."
 ---
 
 ## Executive Summary
 
-In August 2013, an unknown actor breached Yahoo's internal network and exfiltrated user data for all 3 billion accounts on the platform—representing the largest data breach in history. The breach went undiscovered for over three years until late 2016. Because of the size and scope, the incident exposed names, email addresses, telephone numbers, dates of birth, MD5 hashed passwords, and security questions for every Yahoo user at that time.
+In August 2013, an unknown actor breached Yahoo's internal network and exfiltrated user data for all 3 billion accounts on the platform, making it one of the largest data breaches in history. The breach went undiscovered for over three years and was first disclosed publicly in December 2016 before being revised in 2017 to reflect the full 3 billion-account scope.
 
-Unlike the separate 2014 Yahoo breach orchestrated by the Russian FSB, the perpetrator of the 2013 breach was never publicly identified (A6 attribution). However, this incident compounded the structural, reputational, and financial damage to Yahoo during its pending acquisition by Verizon.
+This page covers the separate, unattributed 2013 breach. The distinct 2014 FSB-directed intrusion is tracked in [Yahoo 2014 Data Breach](/incidents/yahoo-data-breach-2014/).
 
 ## Technical Analysis
 
-The exact intrusion pathway for the 2013 breach was never disclosed in exhaustive technical detail like the 2014 incident. What was eventually confirmed in 2017 was the total compromise of Yahoo's user account database. The unknown adversaries bypassed perimeter security, accessed the database layer, and extracted the raw information representing the entirety of Yahoo's user base.
+The exact intrusion pathway for the 2013 breach was never disclosed in exhaustive technical detail. What was eventually confirmed in 2017 was the total compromise of Yahoo's user account database. The unknown adversaries bypassed perimeter security, accessed the database layer, and extracted the raw information representing the entirety of Yahoo's user base.
 
-The compromised data included names, email addresses, telephone numbers, dates of birth, hashed passwords (using the outdated and vulnerable MD5 algorithm), and encrypted or unencrypted security questions and answers. Financial information (credit cards, bank accounts) was stored symmetrically on different systems and was reportedly unaffected. The failure of Yahoo's internal discovery meant the attackers had uncontested retention of 3 billion identities for years prior to the forced password reset.
+The compromised data included names, email addresses, telephone numbers, dates of birth, hashed passwords, and security questions and answers. The failure of Yahoo's internal discovery meant the attackers had uncontested retention of 3 billion identities for years prior to the forced password reset.
 
 ## Attack Chain
 
 ### Stage 1: Initial Compromise
+
 An unknown actor gained unauthorized access to Yahoo's corporate network through an unidentified vector in August 2013.
 
 ### Stage 2: Database Exfiltration
-The attackers extracted the core user database containing account metadata for 3 billion users, including identifying information and MD5-hashed passwords.
+
+The attackers extracted the core user database containing account metadata for 3 billion users, including identifying information and hashed passwords.
 
 ## Impact Assessment
 
-The 2013 breach was unprecedented in volume, affecting 3 billion accounts. The combination of this incident and the 2014 incident resulted in significant financial depreciation for Yahoo, reducing the purchase price of its core assets by Verizon by $350 million. Furthermore, the SEC fined Yahoo's successor entity $35 million for failing to disclose the breaches to investors in a timely manner. Millions were spent settling class-action lawsuits.
+The 2013 breach was unprecedented in volume, affecting 3 billion accounts. The breach exposed personal identifiers, password hashes, and security questions for nearly every Yahoo user at the time. It also forced broad password resets and heightened scrutiny of Yahoo's account-security practices.
 
-## MITRE ATT&CK Mapping
+## Historical Context
 
-### Collection
-T1114 - Email Collection: The attacker successfully collected internal database resources representing the entire email and user environment.
+Attribution for the 2013 breach was never publicly assigned, even after Yahoo revised the incident to its full 3 billion-account scope. The event remains an important historical marker because it demonstrated how long a major account-compromise can go undetected when database access is not aggressively monitored.
 
 ## Timeline
 
 ### 2013-08-01 — Breach Occurs
-Unknown attackers breach Yahoo systems and exfiltrate data for 3 billion accounts.
 
-### 2016-12-14 — Initial Disclosure (1 Billion)
-Yahoo publicly discloses the 2013 breach, initially estimating the affected count at 1 billion users.
+Unknown attackers breach Yahoo's systems and exfiltrate data for all Yahoo user accounts.
+
+### 2016-12-14 — Initial Disclosure
+
+Yahoo publicly discloses the 2013 breach, initially reporting 1 billion accounts compromised.
 
 ### 2017-10-03 — 3 Billion Accounts Revised
-Oath (Verizon Media) revises the impact of the 2013 breach to include all 3 billion Yahoo accounts.
 
-### 2018-04-24 — SEC Fine
-The SEC fines Altaba $35 million for failing to disclose the breaches quickly to investors.
+Yahoo revises the 2013 breach total to 3 billion accounts, representing every Yahoo account in existence at the time.
 
 ## Remediation & Mitigation
 
@@ -101,5 +97,5 @@ Following the disclosure, Yahoo forced password resets and invalidated unencrypt
 ## Sources & References
 
 - [Yahoo: Important Security Information for Yahoo Users](https://blog.yahoo.net/post/154309897759/important-security-information-for-yahoo-users) — Yahoo, 2016-12-14
-- [U.S. Securities and Exchange Commission: Altaba Fined $35 Million](https://www.sec.gov/litigation/press/2018/2018-71.htm) — SEC, 2018-04-24
-- [U.S. Department of Justice: U.S. Charges Russian FSB Officers and Criminal Conspirators for Hacking Yahoo](https://www.justice.gov/opa/pr/us-charges-russian-fsb-officers-and-their-criminal-conspirators-hacking-yahoo-and-millions) — U.S. Department of Justice, 2017-03-15
+- [Yahoo/Reuters: Yahoo Says 3 Billion Accounts Were Affected by 2013 Breach](https://www.yahoo.com/news/yahoo-says-3-billion-accounts-205639389.html) — Reuters, 2017-10-03
+- [CNBC: Yahoo Every Single Account Affected in 2013 Attack](https://www.cnbc.com/2017/10/03/yahoo-every-single-account-3-billion-people-affected-in-2013-attack.html) — CNBC, 2017-10-03

--- a/site/src/content/incidents/yahoo-data-breach-2014.md
+++ b/site/src/content/incidents/yahoo-data-breach-2014.md
@@ -1,18 +1,17 @@
 ---
 eventId: TP-2014-0001
-articleType: "incident"
 title: "Yahoo 2014 FSB Data Breach"
-date_start: 2014-01-01
-date_disclosed: 2016-09-22
+date: 2014-01-01
 attackType: Espionage
 severity: critical
 sector: Technology
 geography: United States
+threatActor: "FSB-directed actors"
 attributionConfidence: A1
-attributionRationale: "Official US DOJ indictment charged two FSB officers (Dokuchaev and Sushchin) and two criminal hackers (Belan and Baratov)."
+attributionRationale: "2017 DOJ charges identified FSB officers Dmitry Dokuchaev and Igor Sushchin, with Alexsey Belan and Karim Baratov as the technical operators in the 2014 intrusion."
 reviewStatus: "certified"
 confidenceGrade: A
-generatedBy: dangermouse-bot
+generatedBy: penfold-bot
 generatedDate: 2026-04-19
 cves: []
 relatedSlugs:
@@ -46,94 +45,97 @@ sources:
     publicationDate: "2016-12-14"
     accessDate: "2026-04-19"
     archived: false
+  - url: https://www.sec.gov/litigation/press/2018/2018-71.htm
+    publisher: U.S. Securities and Exchange Commission
+    publisherType: government
+    reliability: R1
+    publicationDate: "2018-04-24"
+    accessDate: "2026-04-19"
+    archived: false
 mitreMappings:
   - techniqueId: T1566.001
     techniqueName: "Phishing: Spearphishing Attachment"
     tactic: "Initial Access"
-    attackVersion: "v15.1"
-    confidence: "confirmed"
-    evidence: "FSB officers directed criminal hackers to send spearphishing emails to targeted Yahoo employees to obtain credentials and initial network access."
+    notes: "FSB officers directed criminal hackers to send spearphishing emails to targeted Yahoo employees to obtain credentials and initial network access."
   - techniqueId: T1539
     techniqueName: "Steal Web Session Cookie"
     tactic: "Credential Access"
-    attackVersion: "v15.1"
-    confidence: "confirmed"
-    evidence: "The attackers stole Yahoo's proprietary Account Management Tool database and used it to forge authentication cookies, enabling access to any Yahoo account without the account password."
+    notes: "The attackers stole Yahoo's proprietary Account Management Tool database and used it to forge authentication cookies, enabling access to any Yahoo account without the account password."
   - techniqueId: T1114
     techniqueName: "Email Collection"
     tactic: "Collection"
-    attackVersion: "v15.1"
-    confidence: "confirmed"
-    evidence: "Using forged cookies, the attackers accessed and searched the email content of targeted accounts belonging to Russian journalists, US government officials, and financial industry employees."
+    notes: "Using forged cookies, the attackers accessed and searched the email content of targeted accounts belonging to Russian journalists, US government officials, and financial industry employees."
 ---
 
 ## Executive Summary
 
-In 2014, Yahoo suffered a severe, state-sponsored data breach affecting approximately 500 million user accounts. The operation was directed by officers of the Russian Federal Security Service (FSB)—Dmitry Dokuchaev and Igor Sushchin of Center 18—who recruited cybercriminals Alexsey Belan and Karim Baratov to carry out the highly technical intrusion.
+In 2014, Yahoo suffered a severe, state-sponsored data breach affecting approximately 500 million user accounts. The operation was directed by officers of the Russian Federal Security Service (FSB), who recruited criminal hackers Alexsey Belan and Karim Baratov to carry out the technical intrusion.
 
-Unlike the separate, unattributed 2013 mega-breach of 3 billion accounts, the 2014 FSB incident was a targeted espionage and financial crime operation. The attackers exfiltrated Yahoo's User Database (UDB) and the cryptographic values from the Account Management Tool (AMT), allowing them to forge authentication cookies. Using these "nonce cookies," they bypassed MFA and password checks, selectively monitoring the email accounts of intelligence targets and extracting personal financial data. The operation represents a landmark example of Russian intelligence co-opting cybercriminal talent for state-directed campaigns.
+Unlike the separate, unattributed 2013 breach of 3 billion accounts, the 2014 FSB incident was a targeted espionage operation. The attackers exfiltrated Yahoo's User Database (UDB) and the cryptographic values from the Account Management Tool (AMT), allowing them to forge authentication cookies and selectively monitor the email accounts of intelligence targets. The operation is a landmark example of Russian intelligence co-opting cybercriminal talent for state-directed activity.
 
 ## Technical Analysis
 
-The 2014 state-sponsored breach was technically complex. The attackers gained initial access to Yahoo's corporate network through spearphishing emails targeting Yahoo employees. Once inside, they escalated privileges until they obtained access to Yahoo's User Database (UDB), which contained user account information including names, email addresses, phone numbers, dates of birth, hashed passwords, and security questions and answers.
+The 2014 state-sponsored breach was technically complex. The attackers gained initial access to Yahoo's corporate network through spearphishing emails targeting Yahoo employees. Once inside, they escalated privileges until they obtained access to Yahoo's User Database (UDB), which contained account information including names, email addresses, phone numbers, dates of birth, hashed passwords, and security questions and answers.
 
 More importantly, the attackers obtained a copy of Yahoo's Account Management Tool (AMT), which contained the cryptographic values needed to generate authentication cookies. With these values, the attackers minted forged cookies that authenticated to any Yahoo account without requiring the account password. This technique provided persistent, stealthy access to targeted accounts.
 
-The FSB officers directed the criminal hackers to use the forged cookie access to search and monitor the email accounts of specific targets of intelligence interest, including Russian journalists, US and Russian government officials, and employees of financial services companies. Simultaneously, Alexsey Belan used his access for personal financial gain, searching Yahoo email accounts for gift card and credit card information and manipulating Yahoo's search engine results to drive traffic to a pharmaceutical spam affiliate program.
+The FSB officers directed the criminal hackers to use the forged cookie access to search and monitor the email accounts of specific targets of intelligence interest, including Russian journalists, U.S. and Russian government officials, and employees of financial services companies. Simultaneously, Alexsey Belan used his access for personal financial gain, searching Yahoo email accounts for gift card and credit card information and manipulating Yahoo's search engine results to drive traffic to a pharmaceutical spam affiliate program.
 
 ## Attack Chain
 
 ### Stage 1: Spearphishing Campaign
+
 FSB officers directed criminal hackers to send targeted spearphishing emails to Yahoo employees. The emails contained attachments or links designed to steal employee credentials for Yahoo's internal systems.
 
 ### Stage 2: Internal System Access
+
 Using stolen employee credentials, the attackers accessed Yahoo's corporate network and navigated to systems hosting the User Database and Account Management Tool. The lateral movement exploited insufficient internal access controls.
 
 ### Stage 3: Database Exfiltration
+
 The attackers copied Yahoo's User Database containing hashed passwords and account metadata for hundreds of millions of users. They also exfiltrated the Account Management Tool data needed to forge authentication cookies.
 
 ### Stage 4: Cookie Forging
+
 Using the stolen AMT data, the attackers generated forged authentication cookies that allowed access to any Yahoo account. This technique bypassed password-based authentication entirely.
 
 ### Stage 5: Targeted Email Surveillance
+
 The FSB officers used the forged cookie access to monitor the email accounts of intelligence targets, while the criminal hackers simultaneously exploited the access for financial crimes.
 
 ## Impact Assessment
 
-The 2014 breach impacted a reported 500 million user accounts, though its severity was heavily dictated by the intelligence value of the targeted compromise rather than raw numbers. Targeted email surveillance provided the FSB with access to the private communications of journalists, government officials, and business executives, with severe consequences for source protection and diplomatic intelligence.
+The 2014 breach impacted a reported 500 million user accounts, though its severity was heavily shaped by the intelligence value of the targeted compromise rather than raw numbers. Targeted email surveillance provided the FSB with access to private communications belonging to journalists, government officials, and business executives.
 
-Financially, alongside the 2013 breach, the 2014 incident forced the renegotiation of Yahoo's acquisition by Verizon, dropping the price by $350 million. It also led to the SEC's first-ever fine against a public company ($35 million) for failing to disclose a cybersecurity incident to investors in a timely manner.
-
-## MITRE ATT&CK Mapping
-
-### Initial Access
-T1566.001 - Phishing: Spearphishing Attachment: Attackers breached the internal corporate network via spearphishing employees.
-
-### Credential Access
-T1539 - Steal Web Session Cookie: The core operational success was the use of the Account Management Tool to mint valid, forged "nonce cookies" to bypass Yahoo's authentication mechanisms.
-
-### Collection
-T1114 - Email Collection: The primary objective was accessing the email inboxes of high-value geo-political and financial targets.
+Financially, the incident contributed to the renegotiation of Yahoo's acquisition by Verizon and later supported the SEC's enforcement action for failure to disclose the breach to investors in a timely manner.
 
 ## Historical Context
 
 The U.S. Department of Justice indicted four individuals in March 2017 in connection with the 2014 Yahoo breach: FSB officers Dmitry Dokuchaev and Igor Sushchin, and criminal hackers Alexsey Belan and Karim Baratov. Baratov was arrested in Canada and extradited to the United States, where he pleaded guilty and was sentenced to five years in prison. Belan, a Latvian national on the FBI's Cyber Most Wanted list, remained at large in Russia. The two FSB officers were also not arrested.
 
-The indictment detailed a direct relationship between Russian intelligence officers and criminal hackers, with the FSB providing direction and protection to the criminals in exchange for their technical capabilities. This represented a public confirmation of the widely observed model in which Russian intelligence services leverage and protect cybercriminal talent.
+The indictment detailed a direct relationship between Russian intelligence officers and criminal hackers, with the FSB providing direction and protection to the criminals in exchange for their technical capabilities. This represented public confirmation of the model in which Russian intelligence services leverage cybercriminal talent.
 
 ## Timeline
 
 ### 2014-01-01 — FSB-Directed Breach Begins
+
 FSB officers Dokuchaev and Sushchin initiate the operation to compromise Yahoo's systems through directed spearphishing and credential theft.
 
 ### 2014-09-01 — Database Exfiltration Complete
+
 The attackers exfiltrate Yahoo's User Database and Account Management Tool, enabling the forging of authentication cookies for targeted account access.
 
-### 2016-09-22 — 2014 Breach Disclosed
+### 2016-09-22 — Breach Disclosed
+
 Yahoo publicly discloses the 2014 breach, initially reporting 500 million accounts affected and attributing the attack to a state-sponsored actor.
 
 ### 2017-03-15 — DOJ Indictment
+
 The U.S. Department of Justice indicts two FSB officers and two criminal hackers for their roles in the 2014 breach.
+
+### 2018-04-24 — SEC Fine
+
+The SEC fines Altaba $35 million for failing to disclose the breach to investors in a timely manner.
 
 ## Remediation & Mitigation
 
@@ -144,3 +146,4 @@ Organizations should treat authentication cookie-signing keys and account manage
 - [U.S. Department of Justice: U.S. Charges Russian FSB Officers and Criminal Conspirators for Hacking Yahoo](https://www.justice.gov/opa/pr/us-charges-russian-fsb-officers-and-their-criminal-conspirators-hacking-yahoo-and-millions) — U.S. Department of Justice, 2017-03-15
 - [FBI: Alexsey Belan Cyber Most Wanted](https://www.fbi.gov/wanted/cyber/alexsey-belan) — FBI, 2017-03-15
 - [Yahoo: Important Security Information for Yahoo Users](https://blog.yahoo.net/post/154309897759/important-security-information-for-yahoo-users) — Yahoo, 2016-12-14
+- [U.S. Securities and Exchange Commission: Altaba Fined $35 Million](https://www.sec.gov/litigation/press/2018/2018-71.htm) — SEC, 2018-04-24

--- a/site/src/pages/incidents/yahoo-data-breaches-2013.astro
+++ b/site/src/pages/incidents/yahoo-data-breaches-2013.astro
@@ -1,0 +1,8 @@
+---
+import LegacyRedirect from '../../components/LegacyRedirect.astro';
+---
+
+<LegacyRedirect
+  destination="/incidents/yahoo-data-breach-2013/"
+  label="Yahoo 2013 Data Breach"
+/>


### PR DESCRIPTION
## Summary
- split Yahoo 2013 and 2014 into separate canonical incident pages with a compatibility redirect
- strengthen SolarWinds campaign linkage with a second confirmed related incident
- normalize the supporting Aurora, Volt Typhoon, and 2016 Industroyer incident drafts to the current public schema
- codify Gemini Code Assist as a pre-merge gate in the project process docs

## Validation
- git diff --check
- npm run build
