### PR TITLE
chore(ci): upgrade GitHub action runtimes

### DIFF
--- a/.github/workflows/auto-rebase-prs.yml
+++ b/.github/workflows/auto-rebase-prs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.DMBOT_PAT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/incident-review.yml
+++ b/.github/workflows/incident-review.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Detect content type and auto-label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create review labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const labels = [

--- a/.github/workflows/pipeline-discovery.yml
+++ b/.github/workflows/pipeline-discovery.yml
@@ -61,12 +61,12 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: main
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -155,7 +155,7 @@ jobs:
 
       - name: Create or update discovery PR
         if: ${{ inputs.execute != 'false' && steps.commit.outputs.has_changes == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { execSync } = require('child_process');

--- a/.github/workflows/pipeline-dispatcher.yml
+++ b/.github/workflows/pipeline-dispatcher.yml
@@ -23,12 +23,12 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: main
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"
@@ -102,7 +102,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Check preconditions and dispatch tasks
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           CONFIG_JSON: ${{ steps.config.outputs.json }}
         with:
@@ -492,7 +492,7 @@ jobs:
 
       - name: Create or update dispatcher PR
         if: ${{ steps.commit.outputs.has_changes == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { execSync } = require('child_process');

--- a/.github/workflows/pipeline-ingest-issue.yml
+++ b/.github/workflows/pipeline-ingest-issue.yml
@@ -14,10 +14,10 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Parse Issue and create task
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/pipeline-post-merge-audit.yml
+++ b/.github/workflows/pipeline-post-merge-audit.yml
@@ -29,11 +29,11 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"
@@ -101,7 +101,7 @@ jobs:
 
       - name: Publish audit result
         if: steps.changed.outputs.count != '0'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PIPELINE_VALIDATION_JSON: ${{ runner.temp }}/pipeline_validation.json
           BUILD_OUTCOME: ${{ steps.build.outcome }}

--- a/.github/workflows/pipeline-reject.yml
+++ b/.github/workflows/pipeline-reject.yml
@@ -36,7 +36,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Full history is not needed; shallow is fine.
           fetch-depth: 1
@@ -64,7 +64,7 @@ jobs:
           echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
 
       - name: Handle stale remote branch (durable retry path)
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             // Mirrors the discovery workflow's stale-branch handling in
@@ -148,7 +148,7 @@ jobs:
           git push -u origin "$BRANCH"
 
       - name: Open PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const cve = process.env.CVE_UPPER;

--- a/.github/workflows/pipeline-task-pr-state.yml
+++ b/.github/workflows/pipeline-task-pr-state.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: main
@@ -65,7 +65,7 @@ jobs:
 
       - name: Apply task PR state transition
         id: mutate
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
@@ -160,7 +160,7 @@ jobs:
 
       - name: Create or update task-state PR
         if: steps.commit.outputs.has_changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           CHANGED_TASKS_JSON: ${{ steps.mutate.outputs.changed_tasks }}
           DISPOSITION: ${{ steps.mutate.outputs.disposition }}

--- a/.github/workflows/pipeline-validate.yml
+++ b/.github/workflows/pipeline-validate.yml
@@ -15,11 +15,11 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"
@@ -68,7 +68,7 @@ jobs:
 
       - name: Publish validation report
         if: steps.changed.outputs.count != '0'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PIPELINE_VALIDATION_JSON: ${{ runner.temp }}/pipeline_validation.json
           BUILD_OUTCOME: ${{ steps.build.outcome }}


### PR DESCRIPTION
## Summary
- upgrade GitHub-managed actions to the current Node 24-capable major versions
- remove Node 20 deprecation warning noise from pipeline and deploy workflows
- keep workflow logic and permissions unchanged

## Verification
- parsed all `.github/workflows/*.yml` with Python `yaml.safe_load`
- `git diff --check`
- confirmed no remaining `actions/checkout@v4`, `actions/setup-node@v4`, or `actions/github-script@v7` pins

## Scope
This is a mechanical workflow-version bump only:
- `actions/checkout@v4` -> `@v6`
- `actions/setup-node@v4` -> `@v6`
- `actions/github-script@v7` -> `@v8`
