### PR TITLE
ci: skip auto-rebase on failing PRs

### DIFF
--- a/.github/workflows/auto-rebase-prs.yml
+++ b/.github/workflows/auto-rebase-prs.yml
@@ -48,6 +48,26 @@ jobs:
             echo ""
             echo "=== PR #${pr_number} (${branch}) ==="
 
+            # Skip PRs that are not currently healthy. Rebase churn on failing
+            # branches only retriggers validation noise without moving them
+            # toward merge readiness.
+            pr_status=$(gh pr view "${pr_number}" --json statusCheckRollup)
+            failing_or_pending_checks=$(echo "$pr_status" | jq '
+              [
+                .statusCheckRollup[]?
+                | select(
+                    (has("status") and .status != "COMPLETED")
+                    or (has("conclusion") and ((.conclusion // "PENDING") != "SUCCESS"))
+                    or (has("state") and .state != "SUCCESS")
+                  )
+              ] | length
+            ')
+
+            if [ "${failing_or_pending_checks}" -gt 0 ]; then
+              echo "  ⏭️ Skipping auto-rebase because the PR has failing or pending checks."
+              continue
+            fi
+
             # Fetch the PR branch
             git fetch origin "${branch}" 2>/dev/null
             if [ $? -ne 0 ]; then


### PR DESCRIPTION
## Summary
- stop auto-rebasing PRs whose latest checks are failing or still pending
- keep healthy and no-check PRs eligible for the existing auto-rebase behavior
- reduce repeated validation email noise from stale failing PRs whenever `main` advances

## Verification
- python3 YAML parse of `.github/workflows/auto-rebase-prs.yml`
- local check-count probe against PR #163, #129, and #120
