### PR TITLE
Fix malformed TASK-2026-0167 task JSON

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0167.json
+++ b/.github/pipeline/tasks/TASK-2026-0167.json
@@ -5,7 +5,6 @@
   "priority": "P0",
   "status": "pr_open",
   "created": "2026-04-18T00:01:26.101Z",
-<<<<<<< HEAD
   "updated": "2026-04-21T17:38:24Z",
   "source": "auto_discovery",
   "submitted_by": "pipeline-discovery",


### PR DESCRIPTION
## Summary
- remove the stray merge-conflict marker accidentally merged into `TASK-2026-0167.json`
- restore valid JSON for pipeline task bookkeeping on `main`

## Validation
- `python3` JSON parse of `.github/pipeline/tasks/TASK-2026-0167.json`
- `node scripts/pipeline-schema.mjs`
