### PR TITLE
chore(pipeline): seed actor and campaign test tranche

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0191.json
+++ b/.github/pipeline/tasks/TASK-2026-0191.json
@@ -1,0 +1,63 @@
+{
+  "task_id": "TASK-2026-0191",
+  "stage": "draft",
+  "type": "threat-actor",
+  "priority": "P1",
+  "status": "pending",
+  "created": "2026-04-21T18:58:17Z",
+  "updated": "2026-04-21T18:58:17Z",
+  "source": "backfill",
+  "submitted_by": "kernel-k",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "FulcrumSec threat actor profile build from LexisNexis React2Shell intrusion",
+    "sources": [
+      "https://www.scworld.com/brief/lexisnexis-legal-professional-confirms-data-breach-after-react2shell-exploit",
+      "https://www.theregister.com/2026/03/04/lexisnexis_legal_professional_confirms_data/",
+      "https://www.lawnext.com/2026/03/lexisnexis-confirms-data-breach-reports-say-hackers-claim-access-to-government-and-law-firm-user-data.html"
+    ],
+    "candidate_data": {
+      "actor_name": "FulcrumSec",
+      "aliases": [],
+      "origin": "Unknown",
+      "affiliation": "Criminal",
+      "motivation": "Data Theft / Extortion",
+      "active_since": "2026"
+    },
+    "notes": "Create a canonical actor profile for FulcrumSec based on the LexisNexis React2Shell intrusion and any defensible adjacent reporting. Keep the profile tightly evidence-bound: the corpus currently supports one named intrusion cluster and public breach claims, not a broad campaign history. If the evidence does not support a durable standalone actor profile, create the most conservative profile possible and avoid inflating maturity, victim count, or attribution confidence."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "site/src/content.config.ts"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 6,
+    "min_mitre_mappings": 3,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/threat-actors/fulcrumsec.md",
+    "branch": "pipeline/TASK-2026-0191",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-04-21T18:58:17Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "kernel-k",
+      "note": "Manual pipeline seed for actor-lane testing from the LexisNexis / React2Shell cluster."
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0192.json
+++ b/.github/pipeline/tasks/TASK-2026-0192.json
@@ -1,0 +1,65 @@
+{
+  "task_id": "TASK-2026-0192",
+  "stage": "draft",
+  "type": "threat-actor",
+  "priority": "P2",
+  "status": "pending",
+  "created": "2026-04-21T18:58:17Z",
+  "updated": "2026-04-21T18:58:17Z",
+  "source": "backfill",
+  "submitted_by": "kernel-k",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "Mr. Raccoon persona profile and UNC6783 linkage assessment",
+    "sources": [
+      "https://ankura.com/insights/ankura-ctix-flash-update-april-10-2026/",
+      "https://www.securityweek.com/google-warns-of-new-campaign-targeting-bpos-to-steal-corporate-data/",
+      "https://www.bleepingcomputer.com/news/security/google-new-unc6783-hackers-steal-corporate-zendesk-support-tickets/"
+    ],
+    "candidate_data": {
+      "actor_name": "Mr. Raccoon",
+      "aliases": [
+        "Raccoon"
+      ],
+      "origin": "Unknown",
+      "affiliation": "Criminal Persona",
+      "motivation": "Data Theft / Extortion",
+      "active_since": "2026"
+    },
+    "notes": "Build a conservative actor-persona profile for Mr. Raccoon rooted in the Adobe BPO breach claims and later reporting that suggests a possible UNC6783 link. Treat this as a provenance and attribution hygiene task as much as a profile build: if the evidence only supports a criminal handle or persona-level alias, say so clearly. Do not overstate that Mr. Raccoon is a fully distinct threat actor if the stronger defensible reading is 'persona possibly linked to UNC6783'."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "site/src/content.config.ts"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 6,
+    "min_mitre_mappings": 3,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/threat-actors/mr-raccoon.md",
+    "branch": "pipeline/TASK-2026-0192",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-04-21T18:58:17Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "kernel-k",
+      "note": "Manual pipeline seed for persona-vs-actor attribution testing around the Adobe / UNC6783 reporting cluster."
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0193.json
+++ b/.github/pipeline/tasks/TASK-2026-0193.json
@@ -1,0 +1,63 @@
+{
+  "task_id": "TASK-2026-0193",
+  "stage": "draft",
+  "type": "threat-actor",
+  "priority": "P1",
+  "status": "pending",
+  "created": "2026-04-21T18:58:17Z",
+  "updated": "2026-04-21T18:58:17Z",
+  "source": "backfill",
+  "submitted_by": "kernel-k",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "UNC6783 threat actor profile build from BPO and helpdesk intrusion reporting",
+    "sources": [
+      "https://www.securityweek.com/google-warns-of-new-campaign-targeting-bpos-to-steal-corporate-data/",
+      "https://www.bleepingcomputer.com/news/security/google-new-unc6783-hackers-steal-corporate-zendesk-support-tickets/",
+      "https://www.infosecurity-magazine.com/news/google-warns-group-targeting-bpos/"
+    ],
+    "candidate_data": {
+      "actor_name": "UNC6783",
+      "aliases": [],
+      "origin": "Unknown",
+      "affiliation": "Criminal",
+      "motivation": "Data Theft / Extortion",
+      "active_since": "2026"
+    },
+    "notes": "Create a canonical UNC6783 actor profile focused on BPO compromise, helpdesk-targeting tradecraft, credential theft, device enrollment abuse, and extortion operations. Public reporting currently supports a financially motivated cluster with possible ties to the Raccoon persona; preserve that distinction carefully and do not collapse persona and actor identity without evidence."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "site/src/content.config.ts"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 6,
+    "min_mitre_mappings": 3,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/threat-actors/unc6783.md",
+    "branch": "pipeline/TASK-2026-0193",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-04-21T18:58:17Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "kernel-k",
+      "note": "Manual pipeline seed for the BPO / helpdesk intrusion cluster now tracked as UNC6783."
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0194.json
+++ b/.github/pipeline/tasks/TASK-2026-0194.json
@@ -1,0 +1,64 @@
+{
+  "task_id": "TASK-2026-0194",
+  "stage": "draft",
+  "type": "threat-actor",
+  "priority": "P1",
+  "status": "pending",
+  "created": "2026-04-21T18:58:17Z",
+  "updated": "2026-04-21T18:58:17Z",
+  "source": "backfill",
+  "submitted_by": "kernel-k",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "Storm-2372 threat actor profile build from device-code phishing reporting",
+    "sources": [
+      "https://www.microsoft.com/en-us/security/blog/2025/02/13/storm-2372-conducts-device-code-phishing-campaign/",
+      "https://www.aha.org/system/files/media/file/2025/02/h-isac-tlp-white-threat-bulletin-storm-2372-conducts-device-code-phishing-campaign--2-14-2025.pdf",
+      "https://www.dc3.mil/Portals/100/Documents/DC3/Missions/DCISE/DCISE%20Cyber%20Threat%20Roundup/2025/february/20250218%20Cyber%20Threat%20Roundup.pdf"
+    ],
+    "candidate_data": {
+      "actor_name": "Storm-2372",
+      "aliases": [],
+      "origin": "Russia-aligned",
+      "affiliation": "Suspected nation-state",
+      "motivation": "Espionage",
+      "active_since": "2024",
+      "status": "active"
+    },
+    "notes": "Create a canonical Storm-2372 profile grounded in Microsoft's device-code phishing reporting and conservative secondary corroboration. Preserve Microsoft's 'Storm' naming semantics: this is an emerging activity cluster label, not a final real-world organization name. Keep attribution at the confidence supported by the reporting and link the profile back to the existing Microsoft 365 device-code phishing campaign coverage."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "site/src/content.config.ts"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 6,
+    "min_mitre_mappings": 3,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/threat-actors/storm-2372.md",
+    "branch": "pipeline/TASK-2026-0194",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-04-21T18:58:17Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "kernel-k",
+      "note": "Manual pipeline seed for a strongly sourced emerging actor profile tied to the device-code phishing campaign lane."
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0195.json
+++ b/.github/pipeline/tasks/TASK-2026-0195.json
@@ -1,0 +1,62 @@
+{
+  "task_id": "TASK-2026-0195",
+  "stage": "draft",
+  "type": "campaign",
+  "priority": "P1",
+  "status": "pending",
+  "created": "2026-04-21T18:58:17Z",
+  "updated": "2026-04-21T18:58:17Z",
+  "source": "backfill",
+  "submitted_by": "kernel-k",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "TeamPCP / LiteLLM supply-chain campaign canonicalization",
+    "reprocess": true,
+    "target_file": "site/src/content/incidents/teampcp-supply-chain-attack.md",
+    "sources": [
+      "https://techcrunch.com/2026/03/31/mercor-says-it-was-hit-by-cyberattack-tied-to-compromise-of-open-source-litellm-project/",
+      "https://www.theregister.com/2026/04/02/mercor_supply_chain_attack/",
+      "https://www.bankinfosecurity.com/mercor-breach-linked-to-litellm-supply-chain-attack-a-31340"
+    ],
+    "issues": [
+      "incident_campaign_taxonomy_drift",
+      "multi_victim_cluster_requires_campaign_handling",
+      "actor_campaign_boundary_cleanup"
+    ],
+    "notes": "The live `teampcp-supply-chain-attack.md` article is campaign-shaped coverage living in the incidents collection and overlaps with the canonical `threat-actors/teampcp.md` actor profile plus downstream Mercor, Cisco, and European Commission victim articles. Reprocess it into the campaign collection with campaign semantics, preserve victim-specific detail for incident pages, and keep actor-vs-campaign boundaries explicit so the TeamPCP actor profile remains canonical for the group itself."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "site/src/content.config.ts"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 7,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/{collection}/{slug}.md",
+    "branch": "pipeline/TASK-2026-0195",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-04-21T18:58:17Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "kernel-k",
+      "note": "Manual pipeline seed to deepen the campaign lane with a multi-victim supply-chain cluster already represented in the corpus."
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0196.json
+++ b/.github/pipeline/tasks/TASK-2026-0196.json
@@ -1,0 +1,63 @@
+{
+  "task_id": "TASK-2026-0196",
+  "stage": "draft",
+  "type": "campaign",
+  "priority": "P1",
+  "status": "pending",
+  "created": "2026-04-21T18:58:17Z",
+  "updated": "2026-04-21T18:58:17Z",
+  "source": "backfill",
+  "submitted_by": "kernel-k",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "Operation TrueChaos campaign build from TrueConf intrusion cluster",
+    "sources": [
+      "https://research.checkpoint.com/2026/operation-truechaos-0-day-exploitation-against-southeast-asian-government-targets/",
+      "https://nvd.nist.gov/vuln/detail/CVE-2026-3502",
+      "https://www.bleepingcomputer.com/news/security/hackers-exploit-trueconf-zero-day-to-push-malicious-software-updates/"
+    ],
+    "candidate_data": {
+      "campaign_name": "Operation TrueChaos",
+      "related_incident": "operation-truechaos-trueconf-zero-day-2026",
+      "related_zero_day": "trueconf-cve-2026-3502",
+      "suspected_affiliation": "Chinese-nexus (unattributed)"
+    },
+    "notes": "Create a campaign article for Operation TrueChaos as a named multi-victim intrusion cluster while keeping the canonical TrueConf incident article focused on the concrete compromise event and CVE chain. Preserve the current conservative attribution posture: reporting supports a Chinese-nexus assessment with moderate confidence, not a hard public APT attribution."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "site/src/content.config.ts"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 7,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [
+    "TASK-2026-0170"
+  ],
+  "preconditions": [
+    "editorial queue depth < 50"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/campaigns/operation-truechaos.md",
+    "branch": "pipeline/TASK-2026-0196",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-04-21T18:58:17Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "kernel-k",
+      "note": "Manual pipeline seed to add a named campaign slice on top of the existing TrueConf incident and zero-day coverage."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- seed a manual actor and campaign tranche to test non-zero-day pipeline execution
- keep the queue under the editorial cap while filling the thin actor and campaign lanes
- use the existing incident backlog as the incident handoff set instead of creating duplicate incident work

## Added Tasks
- `TASK-2026-0191` FulcrumSec actor profile build
- `TASK-2026-0192` Mr. Raccoon persona / UNC6783 linkage assessment
- `TASK-2026-0193` UNC6783 actor profile build
- `TASK-2026-0194` Storm-2372 actor profile build
- `TASK-2026-0195` TeamPCP / LiteLLM campaign canonicalization
- `TASK-2026-0196` Operation TrueChaos campaign build

## Incident Handoff Set
These existing pending incident tasks form the incident side of the tranche without increasing queue pressure:
- `TASK-2026-0077` Adobe BPO Supply Chain Breach by Mr. Raccoon
- `TASK-2026-0098` LexisNexis AWS Cloud Breach via React2Shell Exploit
- `TASK-2026-0099` Microsoft 365 OAuth Device Code Phishing Campaign
- `TASK-2026-0100` Mercor AI Supply Chain Breach via LiteLLM Compromise
- `TASK-2026-0101` Operation TrueChaos: TrueConf Zero-Day Supply Chain Attack on Southeast Asian Governments

## Validation
- JSON parse pass for all new task files
- `node scripts/pipeline-run-task.mjs --list`
- pending queue after seeding: `45` total (`22 incident`, `15 zero-day`, `4 campaign`, `4 threat-actor`)
