### PR TITLE
fix(pipeline): stop workflow failure email noise

### DIFF
--- a/.github/workflows/auto-rebase-prs.yml
+++ b/.github/workflows/auto-rebase-prs.yml
@@ -28,6 +28,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DMBOT_PAT }}
           MAIN_SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
         run: |
           echo "Main advanced to ${MAIN_SHA:0:7}. Checking open PRs..."
 
@@ -89,10 +90,14 @@ jobs:
               git push origin HEAD:"${branch}" 2>/dev/null
               if [ $? -eq 0 ]; then
                 echo "  ✅ Merged main and pushed."
-                gh pr comment "${pr_number}" --body "✅ Auto-rebased against main (${MAIN_SHA:0:7}). No conflicts."
+                if ! gh pr comment "${pr_number}" --body "✅ Auto-rebased against main (${MAIN_SHA:0:7}). No conflicts."; then
+                  echo "  ⚠️ Could not post auto-rebase success comment."
+                fi
               else
                 echo "  ⚠️ Merge succeeded but push failed."
-                gh pr comment "${pr_number}" --body "⚠️ Auto-rebase merged cleanly but push failed. Manual push needed."
+                if ! gh pr comment "${pr_number}" --body "⚠️ Auto-rebase merged cleanly but push failed. Manual push needed."; then
+                  echo "  ⚠️ Could not post push-failure comment."
+                fi
               fi
             else
               # Merge failed — extract conflicted files
@@ -101,13 +106,23 @@ jobs:
 
               echo "  ❌ Conflicts detected."
 
-              # Add needs-rebase label (create if it doesn't exist)
-              gh label create "needs-rebase" --description "PR has merge conflicts with main" --color "D93F0B" 2>/dev/null || true
-              gh pr edit "${pr_number}" --add-label "needs-rebase"
+              # Add needs-rebase label via REST so repo-scoped tokens work.
+              if ! gh api -X POST "repos/${REPO}/labels" \
+                -f name='needs-rebase' \
+                -f description='PR has merge conflicts with main' \
+                -f color='D93F0B' >/dev/null 2>&1; then
+                true
+              fi
+
+              if ! gh api -X POST "repos/${REPO}/issues/${pr_number}/labels" \
+                -f labels[]='needs-rebase' >/dev/null; then
+                echo "  ⚠️ Could not apply needs-rebase label."
+              fi
 
               # Comment with conflict details
               conflict_list=$(echo "$conflicts" | sed 's/^/- `/' | sed 's/$/`/')
-              gh pr comment "${pr_number}" --body "$(cat <<EOF
+              if ! gh api -X POST "repos/${REPO}/issues/${pr_number}/comments" \
+                -f body="$(cat <<EOF
           ⚠️ Merge conflicts detected after main advanced to ${MAIN_SHA:0:7}.
 
           **Conflicted files:**
@@ -115,7 +130,9 @@ jobs:
 
           DangerMouse-Bot will resolve on next session, or resolve manually and remove the \`needs-rebase\` label.
           EOF
-              )"
+              )" >/dev/null; then
+                echo "  ⚠️ Could not post conflict comment."
+              fi
             fi
 
             # Reset for next PR

--- a/.github/workflows/pipeline-task-pr-state.yml
+++ b/.github/workflows/pipeline-task-pr-state.yml
@@ -75,7 +75,6 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const core = require('@actions/core');
 
             const TASKS_DIR = '.github/pipeline/tasks';
             const prNumber = Number(process.env.PR_NUMBER);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,11 @@
 # Threatpedia — Public Repository Context
 
-This file provides guidance to Claude Code when working in this repository.
+This file provides guidance to Codex and other OpenAI coding agents when
+working in this repository.
 
 ## Parity rule
 
-This file should stay in parity with the sibling `AGENTS.md` and `GEMINI.md`
+This file should stay in parity with the sibling `CLAUDE.md` and `GEMINI.md`
 for shared security, workflow, repository-boundary, and review-discipline
 guidance. Only agent-specific auto-load notes and explicitly repo-local
 exceptions should differ. If one of these files changes, review the others in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,12 +74,12 @@ Current `reviewStatus` enum values are:
 Useful local commands:
 
 ```bash
-cd scripts && npm ci --no-audit --no-fund
+npm --prefix scripts ci --no-audit --no-fund
 node scripts/pipeline-schema.mjs
 node scripts/pipeline-run-task.mjs --task TASK-2026-0000 --validate
-cd site && npm ci
-cd site && npm run build
-cd site && npm run dev
+npm --prefix site ci
+npm --prefix site run build
+npm --prefix site run dev
 ```
 
 Use the shared validator and task runner paths rather than ad hoc file checks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,12 +73,12 @@ Current `reviewStatus` enum values are:
 Useful local commands:
 
 ```bash
-cd scripts && npm ci --no-audit --no-fund
+npm --prefix scripts ci --no-audit --no-fund
 node scripts/pipeline-schema.mjs
 node scripts/pipeline-run-task.mjs --task TASK-2026-0000 --validate
-cd site && npm ci
-cd site && npm run build
-cd site && npm run dev
+npm --prefix site ci
+npm --prefix site run build
+npm --prefix site run dev
 ```
 
 Use the shared validator and task runner paths rather than ad hoc file checks

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -74,12 +74,12 @@ Current `reviewStatus` enum values are:
 Useful local commands:
 
 ```bash
-cd scripts && npm ci --no-audit --no-fund
+npm --prefix scripts ci --no-audit --no-fund
 node scripts/pipeline-schema.mjs
 node scripts/pipeline-run-task.mjs --task TASK-2026-0000 --validate
-cd site && npm ci
-cd site && npm run build
-cd site && npm run dev
+npm --prefix site ci
+npm --prefix site run build
+npm --prefix site run dev
 ```
 
 Use the shared validator and task runner paths rather than ad hoc file checks
@@ -94,7 +94,7 @@ when working on corpus or pipeline integrity.
 - do not call a PR merge-ready based only on local state; live GitHub PR state
   is the source of truth
 
-## Gemini execution discipline
+## Task isolation discipline
 
 For pipeline tasks and task-scoped content work:
 
@@ -102,9 +102,9 @@ For pipeline tasks and task-scoped content work:
 - run `node scripts/pipeline-run-task.mjs --task ... --lock` only from that
   clean task-scoped checkout
 - if you hit a branch mismatch, unrelated dirty paths, or unexpected spillover,
-  stop immediately and rebuild from clean state
-- do not rename branches mid-flight to fit the task
-- do not use local task-runner success as a proxy for live PR readiness
+  stop and rebuild from clean state rather than renaming branches mid-flight or
+  carrying cleanup commits
+- do not broaden the PR beyond the task scope just to recover local state
 
 Before reporting a task PR as ready, verify all of the following:
 
@@ -113,9 +113,6 @@ Before reporting a task PR as ready, verify all of the following:
 - local validation passes for every modified article or task file in the branch
 - `gh pr checks` is green
 - unresolved Gemini review threads are actually zero on the live PR
-
-If any of those checks fail, report the blocker rather than a clean completion
-state.
 
 ## Security expectations
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,12 +1,13 @@
 # Threatpedia — Public Repository Context
 
-This file provides guidance to Claude Code when working in this repository.
+This file provides guidance to Gemini CLI and future Gemini-based agents when
+working in this repository.
 
 ## Parity rule
 
-This file should stay in parity with the sibling `AGENTS.md` and `GEMINI.md`
+This file should stay in parity with the sibling `AGENTS.md` and `CLAUDE.md`
 for shared security, workflow, repository-boundary, and review-discipline
-guidance. Only agent-specific auto-load notes and explicitly repo-local
+guidance. Only Gemini-specific startup notes and explicitly repo-local
 exceptions should differ. If one of these files changes, review the others in
 the same change.
 
@@ -93,7 +94,7 @@ when working on corpus or pipeline integrity.
 - do not call a PR merge-ready based only on local state; live GitHub PR state
   is the source of truth
 
-## Task isolation discipline
+## Gemini execution discipline
 
 For pipeline tasks and task-scoped content work:
 
@@ -101,9 +102,9 @@ For pipeline tasks and task-scoped content work:
 - run `node scripts/pipeline-run-task.mjs --task ... --lock` only from that
   clean task-scoped checkout
 - if you hit a branch mismatch, unrelated dirty paths, or unexpected spillover,
-  stop and rebuild from clean state rather than renaming branches mid-flight or
-  carrying cleanup commits
-- do not broaden the PR beyond the task scope just to recover local state
+  stop immediately and rebuild from clean state
+- do not rename branches mid-flight to fit the task
+- do not use local task-runner success as a proxy for live PR readiness
 
 Before reporting a task PR as ready, verify all of the following:
 
@@ -112,6 +113,9 @@ Before reporting a task PR as ready, verify all of the following:
 - local validation passes for every modified article or task file in the branch
 - `gh pr checks` is green
 - unresolved Gemini review threads are actually zero on the live PR
+
+If any of those checks fail, report the blocker rather than a clean completion
+state.
 
 ## Security expectations
 


### PR DESCRIPTION
## Summary
- fix the two workflow paths currently generating GitHub Actions failure email noise
- refresh the public repo agent startup docs to current Astro/pipeline reality
- add explicit task-isolation and live-PR verification guidance for future Gemini work

## Details
- remove the `@actions/core` redeclaration that breaks `actions/github-script@v8` in `Pipeline: Sync Task PR State`
- switch auto-rebase conflict labeling/commenting to REST endpoints so repo-scoped PATs stop failing on GraphQL scope requirements
- refresh `CLAUDE.md` and add `AGENTS.md` / `GEMINI.md` in the public repo with current pipeline/build/task guidance

## Validation
- `git diff --check`
- YAML parse of `.github/workflows/auto-rebase-prs.yml`
- YAML parse of `.github/workflows/pipeline-task-pr-state.yml`
