### PR TITLE
fix(workflow): serialize task-state sync resets

### DIFF
--- a/.github/workflows/pipeline-task-pr-state.yml
+++ b/.github/workflows/pipeline-task-pr-state.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [closed]
 
+concurrency:
+  group: pipeline-task-pr-state
+  cancel-in-progress: false
+
 env:
   TASK_STATE_BRANCH: pipeline/task-state
   TASK_STATE_LABEL: pipeline/task-state
@@ -45,9 +49,10 @@ jobs:
 
             if [ "$OPEN_PRS" = "0" ]; then
               echo "No open PR on $BRANCH — resetting to origin/main"
-              git fetch origin main
+              git fetch origin main "$BRANCH"
+              REMOTE_BRANCH_SHA="$(git rev-parse --verify "refs/remotes/origin/$BRANCH")"
               git checkout -B "$BRANCH" origin/main
-              git push --force-with-lease origin "$BRANCH"
+              git push --force-with-lease="$BRANCH:$REMOTE_BRANCH_SHA" origin "$BRANCH"
             else
               echo "Open PR exists on $BRANCH — accumulating onto existing branch"
               git fetch origin "$BRANCH"


### PR DESCRIPTION
## Summary
- serialize task-state sync runs to avoid overlapping branch mutations
- fetch the `pipeline/task-state` remote ref before resetting it to `origin/main`
- use an explicit `--force-with-lease` value based on the fetched remote SHA

## Verification
- `git diff --check`
- `python3` YAML parse for `.github/workflows/pipeline-task-pr-state.yml`
