### PR TITLE
fix(pipeline): close pickup issues on pr handoff

### DIFF
--- a/.github/workflows/pipeline-task-pr-state.yml
+++ b/.github/workflows/pipeline-task-pr-state.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
       pull-requests: write
 
     steps:
@@ -161,6 +162,53 @@ jobs:
           git commit -m "chore(pipeline): sync task PR state for #${{ github.event.pull_request.number }}"
           git push --force-with-lease origin "${TASK_STATE_BRANCH}"
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
+
+      - name: Close matching pipeline issues for completed tasks
+        if: steps.commit.outputs.has_changes == 'true'
+        uses: actions/github-script@v8
+        env:
+          CHANGED_TASKS_JSON: ${{ steps.mutate.outputs.changed_tasks }}
+        with:
+          script: |
+            const changedTasks = JSON.parse(process.env.CHANGED_TASKS_JSON || '[]');
+            const completedTaskIds = changedTasks
+              .filter(task => task.to === 'complete')
+              .map(task => task.task_id);
+
+            if (completedTaskIds.length === 0) {
+              console.log('No completed tasks in this sync event.');
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const openIssues = await github.paginate(
+              github.rest.issues.listForRepo,
+              {
+                owner,
+                repo,
+                state: 'open',
+                labels: 'pipeline/ready',
+                per_page: 100,
+              }
+            );
+
+            const matchesTask = (issue, taskId) =>
+              String(issue.title || '').includes(`[PIPELINE] ${taskId}:`) ||
+              String(issue.body || '').includes(`## Pipeline Task: \`${taskId}\``);
+
+            for (const taskId of completedTaskIds) {
+              const matches = openIssues.filter(issue => !issue.pull_request && matchesTask(issue, taskId));
+              for (const issue of matches) {
+                console.log(`Closing pipeline issue #${issue.number} for ${taskId}`);
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+              }
+            }
 
       - name: Create or update task-state PR
         if: steps.commit.outputs.has_changes == 'true'

--- a/scripts/pipeline-run-task.mjs
+++ b/scripts/pipeline-run-task.mjs
@@ -658,6 +658,50 @@ function createPullRequest(task, articleFile) {
   return created;
 }
 
+function findOpenPipelineIssues(taskId) {
+  try {
+    const raw = execFileSync(
+      'gh',
+      ['issue', 'list', '--state', 'open', '--label', 'pipeline/ready', '--limit', '200', '--json', 'number,title,body,url'],
+      { encoding: 'utf8', cwd: ROOT, stdio: ['ignore', 'pipe', 'pipe'] }
+    );
+    const issues = JSON.parse(raw);
+    return issues.filter(issue =>
+      String(issue.title || '').includes(`[PIPELINE] ${taskId}:`) ||
+      String(issue.body || '').includes(`## Pipeline Task: \`${taskId}\``)
+    );
+  } catch (error) {
+    const stderr = error.stderr ? error.stderr.toString().trim() : error.message;
+    console.warn(`  WARNING: Could not inspect open pipeline issues for ${taskId}: ${stderr}`);
+    return [];
+  }
+}
+
+function closeOpenPipelineIssues(task, prNumber) {
+  const issues = findOpenPipelineIssues(task.task_id);
+  if (issues.length === 0) return;
+
+  for (const issue of issues) {
+    try {
+      execFileSync(
+        'gh',
+        [
+          'issue',
+          'close',
+          String(issue.number),
+          '--reason', 'completed',
+          '--comment', `Closing automatically because ${task.task_id} moved to PR #${prNumber}.`,
+        ],
+        { cwd: ROOT, stdio: ['ignore', 'pipe', 'pipe'] }
+      );
+      console.log(`  Closed pipeline issue #${issue.number}: ${issue.url}`);
+    } catch (error) {
+      const stderr = error.stderr ? error.stderr.toString().trim() : error.message;
+      console.warn(`  WARNING: Could not close pipeline issue #${issue.number} for ${task.task_id}: ${stderr}`);
+    }
+  }
+}
+
 function assertPullRequestMatchesTask(task, pr) {
   if (pr.state !== 'OPEN') {
     console.error(`  ERROR: PR #${pr.number} is not open (state: ${pr.state})`);
@@ -1196,6 +1240,7 @@ function openPrTask(task, filePath, prNumber, explicitFile, usedDeprecatedComple
 
   saveTask(task, filePath);
   commitAndPushTaskState(task, filePath, pr.number);
+  closeOpenPipelineIssues(task, pr.number);
   console.log(`  ✓ ${task.task_id} recorded against PR #${pr.number}`);
   console.log(`  Bookkeeping commit pushed to ${task.output.branch}.`);
   console.log('  Final completion is now driven by the PR merge event, not by local CLI state.');


### PR DESCRIPTION
## Summary
- close matching `pipeline/ready` issues immediately when `pipeline-run-task.mjs --open-pr` records a PR
- close any lingering matching pickup issues again when merged tasks are reconciled by `pipeline-task-pr-state.yml`
- grant the task-state sync workflow `issues: write` so it can perform that cleanup

## Verification
- `git diff --check`
- `node --check scripts/pipeline-run-task.mjs`
- YAML parse for `.github/workflows/pipeline-task-pr-state.yml`
- `node --check` on the wrapped GitHub Actions script body for the new issue-closing step
