### PR TITLE
chore(pipeline): close stale TASK-2026-0095

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0095.json
+++ b/.github/pipeline/tasks/TASK-2026-0095.json
@@ -2,7 +2,7 @@
   "task_id": "TASK-2026-0095",
   "type": "incident",
   "priority": "P0",
-  "status": "pending",
+  "status": "complete",
   "input": {
     "topic": "FrostArmada: SOHO Router DNS Hijacking & AiTM Campaign (APT28)",
     "reprocess": true,
@@ -32,6 +32,15 @@
       "to": "pending",
       "agent": "dangermouse-bot",
       "note": "Corpus reprocessing \u2014 source quality enforcement"
+    },
+    {
+      "timestamp": "2026-04-24T18:05:40Z",
+      "action": "completed",
+      "from": "pending",
+      "to": "complete",
+      "agent": "MahdiHedhli",
+      "note": "No article changes required. Stale incident reprocess task was superseded by TASK-2026-0173, which reclassified FrostArmada into the campaign collection via PR #70. Canonical content now lives at site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md; the legacy incident target is absent by design."
     }
-  ]
+  ],
+  "updated": "2026-04-24T18:05:40Z"
 }


### PR DESCRIPTION
## Summary

- marks stale incident reprocess task `TASK-2026-0095` complete without creating a duplicate incident article
- records that FrostArmada canonicalization was already completed by `TASK-2026-0173` via PR #70
- leaves the canonical campaign article at `site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md`

## Validation

- `node -e "const fs=require('fs'); const t=JSON.parse(fs.readFileSync('.github/pipeline/tasks/TASK-2026-0095.json','utf8')); if(t.status!== 'complete') process.exit(1);"`
- `git diff --check`

## Notes

The normal article runner cannot open this PR because the legacy incident target is intentionally absent after campaign reclassification. This PR is task-state cleanup only.