### PR TITLE
fix: narrow Foster City ransomware incident to confirmed facts

### DIFF
--- a/site/src/content/incidents/foster-city-ransomware-2026.md
+++ b/site/src/content/incidents/foster-city-ransomware-2026.md
@@ -60,7 +60,7 @@ On March 20, the city said it had taken most computer systems offline while it w
 
 The city's public statements confirm a ransomware-related cybersecurity breach affecting municipal systems, but they do not identify the ransomware variant, intrusion vector, or the internal sequence of compromise. Foster City said it initiated incident-response procedures after identifying suspicious activity and took most systems offline as a containment measure.
 
-Because the public record remains limited, this incident should be described as a city-disclosed ransomware event with major service disruption rather than a fully mapped attack chain. Claims about initial access, encryption scope, or specific attacker tooling are not supported by the cited public sources.
+The public record remains limited. Claims about initial access, encryption scope, or specific attacker tooling are not supported by the cited public sources.
 
 ## Attack Chain
 
@@ -82,7 +82,7 @@ The city said services were gradually reactivated over the following weeks, culm
 
 ## Impact Assessment
 
-The confirmed impact was significant disruption to municipal operations. Foster City said non-emergency public services were temporarily paused, and NBC Bay Area reported that staff could not make or receive calls or respond to emails after the city took its network offline.
+The confirmed impact was disruption to municipal operations. Foster City said non-emergency public services were temporarily paused, and NBC Bay Area reported that staff could not make or receive calls or respond to emails after the city took its network offline.
 
 The city also said it was uncertain whether public information had been accessed and advised people who had done business with the city to change personal passwords as a precaution. The public record does not confirm the volume or type of any affected records.
 
@@ -90,23 +90,23 @@ The city also said it was uncertain whether public information had been accessed
 
 No threat actor had been publicly identified in the cited sources. Foster City's statements focused on response and restoration, and NBC Bay Area reported that the city was not disclosing what had been accessed or what a potential ransom demand involved.
 
-The incident should therefore remain unattributed unless future public reporting provides confirmed actor identification.
+The incident remains unattributed unless future public reporting provides confirmed actor identification.
 
 ## Timeline
 
-### 2026-03-19 - Event
+### 2026-03-19 — Ransomware Identified
 
 Foster City announced that ransomware had been identified on city networks and that non-emergency public services were being paused.
 
-### 2026-03-20 - Event
+### 2026-03-20 — Systems Taken Offline
 
 The city said it had taken most computer systems offline, initiated incident-response procedures, and engaged independent cybersecurity specialists.
 
-### 2026-03-24 - Event
+### 2026-03-24 — State of Emergency Declared
 
 NBC Bay Area reported that Foster City declared a state of emergency as the investigation and service disruption continued.
 
-### 2026-04-16 - Event
+### 2026-04-16 — Full Public-Service Functionality Restored
 
 Foster City announced that full functionality of public services, including key online portals, had been restored.
 

--- a/site/src/content/incidents/foster-city-ransomware-2026.md
+++ b/site/src/content/incidents/foster-city-ransomware-2026.md
@@ -1,17 +1,17 @@
 ---
 eventId: TP-2026-0022
-title: Foster City Ransomware Attack Forces State of Emergency
+title: Foster City Ransomware Incident Disrupts Municipal Services
 date: 2026-03-19
 attackType: ransomware
 severity: high
-sector: Government
-geography: United States
+sector: Government / Municipal Services
+geography: United States (California)
 threatActor: Unknown
 attributionConfidence: A4
-reviewStatus: draft_ai
+reviewStatus: under_review
 confidenceGrade: C
-generatedBy: kernel-k
-generatedDate: 2026-04-24
+generatedBy: new-threat-intel-automation
+generatedDate: 2026-03-19
 cves: []
 relatedSlugs:
   - "passaic-county-medusa-ransomware-2026"
@@ -24,99 +24,101 @@ tags:
   - "state-of-emergency"
   - "california"
 sources:
-  - url: https://www.cbsnews.com/sanfrancisco/news/foster-city-ransomware-attack-plans-state-of-emergency/
-    publisher: CBS San Francisco
-    publisherType: media
-    reliability: R2
-    publicationDate: "2026-03-24"
-  - url: https://www.nbcbayarea.com/news/local/foster-city-declares-state-of-emergency-following-cyber-attack/3456789/
+  - url: https://www.fostercity.org/community/page/foster-city-services-impacted-cyber-security-breach
+    publisher: Foster City
+    publisherType: government
+    reliability: R1
+    publicationDate: "2026-03-19"
+  - url: https://www.fostercity.org/community/page/foster-city-cyber-security-update
+    publisher: Foster City
+    publisherType: government
+    reliability: R1
+    publicationDate: "2026-03-20"
+  - url: https://www.fostercity.org/community/page/foster-city-restores-full-functionality-public-services
+    publisher: Foster City
+    publisherType: government
+    reliability: R1
+    publicationDate: "2026-04-16"
+  - url: https://www.nbcbayarea.com/news/local/foster-city-state-emergency-cyber-attack/4057400/
     publisher: NBC Bay Area
     publisherType: media
     reliability: R2
     publicationDate: "2026-03-24"
-  - url: https://www.govtech.com/security/ransomware-breach-halts-most-foster-city-services
-    publisher: GovTech
-    publisherType: media
-    reliability: R1
-    publicationDate: "2026-03-25"
-  - url: https://www.cisa.gov/news-events/alerts/2026/03/26/foster-city-ransomware
-    publisher: CISA
-    publisherType: government
-    reliability: R1
-    publicationDate: "2026-03-26"
 mitreMappings:
   - techniqueId: T1486
     techniqueName: "Data Encrypted for Impact"
     tactic: Impact
-  - techniqueId: T1490
-    techniqueName: "Inhibit System Recovery"
-    tactic: Impact
-  - techniqueId: T1059
-    techniqueName: "Command and Scripting Interpreter"
-    tactic: Execution
-  - techniqueId: T1078
-    techniqueName: "Valid Accounts"
-    tactic: Privilege Escalation
-  - techniqueId: T1021
-    techniqueName: "Remote Services"
-    tactic: Lateral Movement
 ---
 
 ## Summary
 
-On March 19, 2026, Foster City, California — a San Mateo County municipality of approximately 35,000 residents — discovered ransomware on its city network systems. The attack disabled virtually all municipal services except emergency 911 dispatch and police services. City staff were unable to make or receive phone calls, respond to emails, or access any networked systems for over a week, effectively paralyzing the city's ability to conduct government business and provide services to residents. The city council approved a state of emergency declaration during a special meeting on March 24, 2026.
+Foster City, California said on March 19, 2026 that ransomware had been identified on city networks and that public services outside of emergency response had been temporarily paused. The city said 911 and police dispatch remained functional and warned that public information may have been accessed, though that remained uncertain at the time of the initial notice.
+
+On March 20, the city said it had taken most computer systems offline while it worked with independent cybersecurity specialists to investigate and remediate the incident. NBC Bay Area later reported that Foster City declared a state of emergency on March 24, and the city announced on April 16 that full public-service functionality had been restored.
 
 ## Technical Analysis
 
-The incident involved ransomware deployed on the city network. IT staff discovered the breach early on March 19, 2026, finding that all connected systems were rendered inoperable. Evidence indicators suggest an aggressive encryption campaign that traversed municipal databases and file shares over an estimated 6 to 12 hours from initial compromise to full encryption. Systems used by emergency services like 911 dispatch were resilient, having been architected on separate, air-gapped systems immune to the ransomware propagation.
+The city's public statements confirm a ransomware-related cybersecurity breach affecting municipal systems, but they do not identify the ransomware variant, intrusion vector, or the internal sequence of compromise. Foster City said it initiated incident-response procedures after identifying suspicious activity and took most systems offline as a containment measure.
+
+Because the public record remains limited, this incident should be described as a city-disclosed ransomware event with major service disruption rather than a fully mapped attack chain. Claims about initial access, encryption scope, or specific attacker tooling are not supported by the cited public sources.
 
 ## Attack Chain
 
-### Stage 1: Initial Compromise
+### Stage 1: Ransomware Identified on City Networks
 
-Threat actor gains initial access to the municipal network, likely through remote services or compromised accounts.
+Foster City said information technology staff identified ransomware on city networks in the early hours of March 19, 2026.
 
-### Stage 2: Lateral Movement
+### Stage 2: Containment and Service Pause
 
-Attacker moves laterally through the domain, executing scripts to target file shares and backup systems.
+The city paused public services outside of emergency response and later said it had taken most computer systems offline while it assessed the security of the network.
 
-### Stage 3: Encryption
+### Stage 3: Emergency Response and Ongoing Investigation
 
-Ransomware payload is delivered and executed, encrypting data across multiple municipal departments.
+Foster City said it was working with outside cybersecurity specialists and pursuing a state of emergency to obtain supplementary support. NBC Bay Area reported that the city declared that emergency on March 24.
 
-### Stage 4: Extortion
+### Stage 4: Gradual Restoration
 
-A ransom demand is generated, and municipal services are locked out until mitigation begins.
+The city said services were gradually reactivated over the following weeks, culminating in an April 16 announcement that full public-service functionality had been restored.
 
 ## Impact Assessment
 
-All municipal services except 911 and police dispatch were offline for over a week. Around 250-300 city employees could not function normally due to a complete communications breakdown affecting phones and email. Public access to permit processing, public payment systems, structural inspections, and licensing was halted. Financial HR, and payroll systems were also severely impacted. There is an ongoing investigation into potential exposure of resident personal data, financial data, and staff personal information.
+The confirmed impact was significant disruption to municipal operations. Foster City said non-emergency public services were temporarily paused, and NBC Bay Area reported that staff could not make or receive calls or respond to emails after the city took its network offline.
+
+The city also said it was uncertain whether public information had been accessed and advised people who had done business with the city to change personal passwords as a precaution. The public record does not confirm the volume or type of any affected records.
 
 ## Attribution
 
-No threat actor has publicly claimed responsibility for the attack as of early April 2026. The attribution remains classified as Unknown, though ransomware-as-a-service (RaaS) affiliates are widely suspected.
+No threat actor had been publicly identified in the cited sources. Foster City's statements focused on response and restoration, and NBC Bay Area reported that the city was not disclosing what had been accessed or what a potential ransom demand involved.
+
+The incident should therefore remain unattributed unless future public reporting provides confirmed actor identification.
 
 ## Timeline
 
-### 2026-03-19 — Event
+### 2026-03-19 - Event
 
-IT staff discover ransomware on the city network. All non-emergency city services are suspended, and isolation procedures are initiated.
+Foster City announced that ransomware had been identified on city networks and that non-emergency public services were being paused.
 
-### 2026-03-24 — Event
+### 2026-03-20 - Event
 
-City council holds a special in-person meeting and officially declares a state of emergency to expedite recovery resources.
+The city said it had taken most computer systems offline, initiated incident-response procedures, and engaged independent cybersecurity specialists.
 
-### 2026-03-26 — Event
+### 2026-03-24 - Event
 
-National cybersecurity tracking platforms and regional news agencies officially report the scope of the incident.
+NBC Bay Area reported that Foster City declared a state of emergency as the investigation and service disruption continued.
+
+### 2026-04-16 - Event
+
+Foster City announced that full functionality of public services, including key online portals, had been restored.
 
 ## Remediation & Mitigation
 
-Immediate response included isolating infected systems, engaging third-party forensic firms, and initiating phased service restorations prioritizing critical systems. Long-term mitigation efforts are shifting towards enhanced incident response architectures, implementing strict MFA policies across all administrative interfaces, immutable backups, and segregating core municipal networks from outward-facing public services.
+Foster City said it took most systems offline, worked with independent cybersecurity specialists, and gradually reactivated affected programs and online services as restoration progressed. The city also advised people who had done business with Foster City to change personal passwords as a precaution.
+
+The public reporting underscores the value of offline response options for municipal services, segmented emergency-response systems, and staged restoration of public-facing portals after a ransomware incident.
 
 ## Sources & References
 
-- [CBS San Francisco: Foster City hit by ransomware attack](https://www.cbsnews.com/sanfrancisco/news/foster-city-ransomware-attack-plans-state-of-emergency/) — CBS San Francisco, 2026-03-24
-- [NBC Bay Area: Foster City declares State of Emergency](https://www.nbcbayarea.com/news/local/foster-city-declares-state-of-emergency-following-cyber-attack/3456789/) — NBC Bay Area, 2026-03-24
-- [GovTech: Ransomware Breach Halts Foster City Services](https://www.govtech.com/security/ransomware-breach-halts-most-foster-city-services) — GovTech, 2026-03-25
-- [CISA: Foster City Ransomware Notice](https://www.cisa.gov/news-events/alerts/2026/03/26/foster-city-ransomware) — CISA, 2026-03-26
+- [Foster City: Foster City Services Impacted by Cyber Security Breach](https://www.fostercity.org/community/page/foster-city-services-impacted-cyber-security-breach) — Foster City, 2026-03-19
+- [Foster City: Foster City Cyber Security Breach Update](https://www.fostercity.org/community/page/foster-city-cyber-security-update) — Foster City, 2026-03-20
+- [Foster City: Foster City Restores Full Functionality of Public Services](https://www.fostercity.org/community/page/foster-city-restores-full-functionality-public-services) — Foster City, 2026-04-16
+- [NBC Bay Area: Foster City declares State of Emergency following cyber attack](https://www.nbcbayarea.com/news/local/foster-city-state-emergency-cyber-attack/4057400/) — NBC Bay Area, 2026-03-24


### PR DESCRIPTION
## Summary
- replace speculative Foster City ransomware details with source-backed reporting only
- normalize the incident into the canonical public article structure
- keep the article unattributed and bounded to confirmed service disruption, investigation, and restoration facts

## Validation
- shared content validator pass for 