### PR TITLE
fix: narrow FortiClient EMS zero-day article to confirmed facts

### DIFF
--- a/site/src/content/incidents/forticlient-ems-cve-2026-35616.md
+++ b/site/src/content/incidents/forticlient-ems-cve-2026-35616.md
@@ -1,161 +1,125 @@
 ---
-eventId: "TP-2026-0030"
-title: "FortiClient EMS Zero-Day Exploitation (CVE-2026-35616)"
-date: 2026-03-31
-attackType: "Zero-Day Exploitation"
+eventId: TP-2026-0030
+title: FortiClient EMS Zero-Day Exploitation (CVE-2026-35616)
+date: 2026-04-04
+attackType: zero-day-exploitation
 severity: critical
-sector: "Multi-Sector"
-geography: "Global"
-threatActor: "Unknown"
-attributionConfidence: A6
-reviewStatus: draft_ai
-confidenceGrade: B
-generatedBy: kernel-k
-generatedDate: 2026-04-24
+sector: Multi-Sector / Enterprise IT
+geography: Global
+threatActor: Unknown
+attributionConfidence: A4
+reviewStatus: under_review
+confidenceGrade: C
+generatedBy: new-threat-intel
+generatedDate: 2026-04-05
 cves:
   - "CVE-2026-35616"
-relatedSlugs: []
+relatedSlugs:
+  - "chrome-cve-2026-5281-zero-day"
+  - "bluehammer-windows-defender-zero-day-2026"
+  - "chrome-cve-2026-2441-css-zero-day"
+  - "langflow-cve-2026-33017-rce-exploitation"
 tags:
+  - "zero-day"
   - "fortinet"
   - "forticlient-ems"
-  - "zero-day"
-  - "remote-code-execution"
+  - "rce"
   - "cisa-kev"
-  - "improper-access-control"
-  - "endpoint-management"
+  - "pre-auth"
+  - "api-bypass"
+  - "cwe-284"
 sources:
-  - url: "https://fortiguard.fortinet.com/psirt/FG-IR-26-099"
-    publisher: "Fortinet"
+  - url: https://www.fortinet.com/psirt/FG-SN-2026-00016
+    publisher: Fortinet
     publisherType: vendor
     reliability: R1
     publicationDate: "2026-04-04"
-    accessDate: "2026-04-24"
-    archived: false
-  - url: "https://nvd.nist.gov/vuln/detail/CVE-2026-35616"
-    publisher: "National Vulnerability Database"
+  - url: https://watchtowr.com/resources/fortinet-forticlient-ems-zero-day-cve-2026-35616-active-exploitation-underway/
+    publisher: watchTowr
+    publisherType: research
+    reliability: R1
+    publicationDate: "2026-03-31"
+  - url: https://www.cyber.gc.ca/en/alerts-advisories/al26-007-vulnerability-impacting-fortinet-forticlientems-cve-2026-35616
+    publisher: Canadian Centre for Cyber Security
     publisherType: government
     reliability: R1
-    publicationDate: "2026-04-03"
-    accessDate: "2026-04-24"
-    archived: false
-  - url: "https://watchtowr.com/resources/fortinet-forticlient-ems-zero-day-cve-2026-35616-active-exploitation-underway/"
-    publisher: "watchTowr"
-    publisherType: research
-    reliability: R2
     publicationDate: "2026-04-07"
-    accessDate: "2026-04-24"
-    archived: false
-  - url: "https://www.helpnetsecurity.com/2026/04/04/forticlient-ems-zero-day-cve-2026-35616/"
-    publisher: "Help Net Security"
-    publisherType: media
-    reliability: R2
-    publicationDate: "2026-04-04"
-    accessDate: "2026-04-24"
-    archived: false
-  - url: "https://digital.nhs.uk/cyber-alerts/2026/cc-4766"
-    publisher: "NHS England Digital"
+  - url: https://nvd.nist.gov/vuln/detail/CVE-2026-35616
+    publisher: National Vulnerability Database
     publisherType: government
-    reliability: R2
-    publicationDate: "2026-04-07"
-    accessDate: "2026-04-24"
-    archived: false
+    reliability: R1
+    publicationDate: "2026-04-06"
 mitreMappings:
-  - techniqueId: "T1190"
+  - techniqueId: T1190
     techniqueName: "Exploit Public-Facing Application"
-    tactic: "Initial Access"
-    notes: "Public reporting describes unauthenticated exploitation of FortiClient EMS through crafted requests to the management API."
+    tactic: Initial Access
 ---
 
 ## Summary
 
-CVE-2026-35616 is an improper access control vulnerability in Fortinet FortiClient Enterprise Management Server. Fortinet says an unauthenticated attacker may execute unauthorized code or commands through crafted requests, and the advisory marks the issue as known exploited.
+CVE-2026-35616 is an actively exploited improper access control vulnerability in Fortinet FortiClient EMS 7.4.5 through 7.4.6. Fortinet's advisory says the flaw may allow an unauthenticated attacker to execute unauthorized code or commands via crafted requests, making exposed EMS servers a high-priority patch target.
 
-The affected self-managed product range is FortiClient EMS 7.4.5 through 7.4.6. Fortinet provided hotfix instructions for both affected versions and stated that FortiClient EMS 7.4.7 and later include the fix. Fortinet also noted that FortiClient Cloud and FortiSASE were remediated by Fortinet and did not require customer action.
-
-watchTowr reported that its sensors saw exploitation on March 31, 2026, before Fortinet's April 4 advisory. NVD records CISA Known Exploited Vulnerabilities catalog treatment with a federal due date of April 9, 2026, which raised the remediation urgency for exposed environments.
+watchTowr said it observed exploitation on March 31, 2026, before Fortinet published its advisory on April 4. Government follow-up alerts from the Canadian Centre for Cyber Security and entries in the U.S. government vulnerability catalog reinforced that the flaw was under active exploitation and required rapid remediation.
 
 ## Technical Analysis
 
-FortiClient EMS centrally manages FortiClient endpoints, policies, VPN configuration, and endpoint compliance state. That role makes the management server a high-value target because compromise can affect the system that administrators use to control endpoint security posture.
+Fortinet describes CVE-2026-35616 as an improper access control issue in FortiClient EMS. The affected surface is the management server, and the core risk is that crafted requests can bypass intended controls and trigger unauthorized code or command execution without prior authentication.
 
-The Fortinet advisory describes the bug as CWE-284 improper access control in the API component. The available public detail is intentionally limited, but the key condition is direct network access to vulnerable FortiClient EMS versions. An attacker can send crafted requests without valid authentication and reach code or command execution paths that should be restricted.
-
-NVD lists Fortinet as the CNA source and describes the issue as affecting FortiClientEMS 7.4.5 through 7.4.6. NVD also records a critical CNA CVSS v3.1 score and identifies CISA KEV inclusion, while Fortinet's public advisory displays a critical severity rating and a CVSS score of 9.1.
-
-Public sources do not provide reliable evidence of a specific post-exploitation payload, victim list, or named actor. Defensive analysis should therefore focus on exposure, patch state, API access logs, unusual management changes, and endpoint policy changes rather than assuming a particular intrusion set.
+The public source set supports affected versions 7.4.5 and 7.4.6, hotfix guidance from Fortinet, and the availability of a fixed release path. It does not support broader claims about confirmed downstream endpoint compromise, actor tradecraft beyond exploitation of the exposed EMS surface, or the exact operational chain inside victim environments.
 
 ## Attack Chain
 
-### Stage 1: External Discovery
+### Stage 1: Exposure of Vulnerable EMS Instances
 
-Attackers identify FortiClient EMS servers that are reachable from untrusted networks or exposed administrative paths.
+Organizations running FortiClient EMS 7.4.5 or 7.4.6 exposed a management surface vulnerable to crafted unauthenticated requests.
 
-### Stage 2: Crafted API Request
+### Stage 2: Exploitation Observed in the Wild
 
-The attacker sends crafted requests to the vulnerable EMS API. Fortinet describes the vulnerability as an authentication and authorization bypass caused by improper access control.
+watchTowr reported seeing exploitation activity against the vulnerable EMS surface on March 31, 2026, before the vendor advisory was publicly released.
 
-### Stage 3: Unauthorized Command Execution
+### Stage 3: Vendor and Government Response
 
-Successful exploitation may allow unauthorized code or command execution on the EMS server. That gives the attacker a path to act through a management system rather than through a single endpoint.
-
-### Stage 4: Management Plane Abuse
-
-If the EMS server is compromised, the attacker may be able to review endpoint inventory, change security policies, or use the management relationship to support follow-on activity. Public sources confirm the potential impact class but do not confirm a specific follow-on campaign for this CVE.
-
-### Stage 5: Response and Containment
-
-Organizations validate FortiClient EMS version exposure, apply Fortinet hotfixes or upgrade to a fixed version, restrict EMS access, and review logs from at least March 31, 2026 forward.
+Fortinet published its advisory and patch guidance on April 4, and government alerts followed with instructions to remediate affected systems on an accelerated timeline.
 
 ## Impact Assessment
 
-The highest-risk deployments are internet-reachable or broadly reachable FortiClient EMS 7.4.5 and 7.4.6 instances. Because exploitation is unauthenticated, exposed management surfaces have little margin for compensating controls unless network access is tightly restricted.
+The confirmed impact is the risk of unauthorized code or command execution on the FortiClient EMS server itself. Because EMS is an administrative system for managed endpoints, compromise of the server creates a serious trust and control problem for organizations that rely on it for endpoint management.
 
-The practical impact is management-plane compromise. EMS holds endpoint-management authority, so unauthorized command execution on that server may affect endpoint policy, VPN configuration, and administrative visibility. The issue is not a single-server risk when EMS controls a large endpoint fleet.
-
-CISA KEV inclusion means U.S. federal civilian agencies had a short remediation deadline under BOD 22-01 treatment. NHS England also published an alert advising affected organizations to apply relevant hotfixes and prepare for further exploitation.
+At the same time, the public reporting reviewed here does not confirm a specific number of victim organizations, a named actor, or a verified sequence of downstream endpoint abuse in real-world incidents. The article should therefore emphasize critical exposure and urgent patching rather than asserted enterprise-wide compromise outcomes.
 
 ## Attribution
 
-Public reporting does not attribute CVE-2026-35616 exploitation to a named threat actor. Fortinet confirmed exploitation in the wild, and watchTowr reported sensor-observed activity beginning March 31, but neither establishes actor identity.
+No public source in this review set identified a named threat actor for CVE-2026-35616 exploitation. The incident remains an actively exploited vulnerability event with unknown actor attribution.
 
-Attribution confidence is A6. Exploitation status and the affected product range are supported by Fortinet, NVD, and government alerting, while actor identity remains unknown.
+Until a vendor, government, or other primary-source investigation publishes confirmed actor information, this exploitation activity should remain unattributed.
 
 ## Timeline
 
-### 2026-03-31 — Exploitation Observed
+### 2026-03-31 - Event
 
-watchTowr reported that its Attacker Eye sensors identified exploitation of CVE-2026-35616 against FortiClient EMS before Fortinet published its advisory.
+watchTowr reported exploitation of the zero-day vulnerability against FortiClient EMS before public vendor disclosure.
 
-### 2026-04-03 — CVE Published
+### 2026-04-04 - Event
 
-NVD records CVE-2026-35616 with Fortinet as the CNA source and describes the vulnerable FortiClientEMS 7.4.5 through 7.4.6 range.
+Fortinet published advisory FG-SN-2026-00016 with affected-version and patch guidance for CVE-2026-35616.
 
-### 2026-04-04 — Fortinet Advisory Published
+### 2026-04-06 - Event
 
-Fortinet published FG-IR-26-099, confirmed exploitation in the wild, and instructed affected customers to install hotfixes for FortiClient EMS 7.4.5 and 7.4.6.
+The U.S. government vulnerability catalog reflected CVE-2026-35616 as a known exploited issue with accelerated remediation requirements.
 
-### 2026-04-06 — CISA KEV Treatment Recorded
+### 2026-04-07 - Event
 
-NVD records CISA KEV addition for CVE-2026-35616 with an April 9, 2026 due date and required action to apply vendor mitigations or discontinue use if mitigations are unavailable.
-
-### 2026-04-07 — Public Alerting Broadened
-
-watchTowr and NHS England Digital published public guidance summarizing active exploitation, affected versions, and remediation expectations for exposed organizations.
+The Canadian Centre for Cyber Security published an alert noting active exploitation and directing defenders to Fortinet's remediation guidance.
 
 ## Remediation & Mitigation
 
-Apply Fortinet's hotfixes for FortiClient EMS 7.4.5 and 7.4.6 or upgrade to FortiClient EMS 7.4.7 or later. Fortinet's advisory says the hotfixes are sufficient to prevent the issue, and the fixed release line contains the remediation.
+Fortinet's guidance is the primary remediation path: identify FortiClient EMS instances on affected versions, apply the appropriate hotfix or upgrade path, and restrict exposure of the management surface while patching is underway. Government alerts also reinforce rapid remediation or discontinuation of vulnerable exposure if mitigations cannot be applied quickly.
 
-Restrict access to FortiClient EMS administrative and API surfaces to trusted administrative networks. If an affected server was reachable from the internet or a broad internal network before patching, treat the system as exposed and review API, admin, and endpoint policy activity from March 31, 2026 onward.
-
-Review EMS logs for crafted request patterns, unexpected administrative changes, endpoint policy pushes, new or changed service accounts, and management actions that do not align with normal administrator activity. Correlate those events with endpoint telemetry for unexpected FortiClient policy changes or command execution.
-
-If compromise is suspected, rotate EMS administrator credentials and service credentials, validate FortiClient deployment integrity, preserve relevant logs, and consider endpoint fleet review where EMS policy control may have been abused.
+Defenders should review EMS access logs and server activity for suspicious crafted requests, then treat the server as a high-value administrative asset in any follow-up investigation. The public guidance supports urgent containment and patching, but it does not justify claiming specific compromise artifacts beyond what incident responders actually observe in their own environment.
 
 ## Sources & References
 
-- [Fortinet: API authentication and authorization bypass](https://fortiguard.fortinet.com/psirt/FG-IR-26-099) — Fortinet, 2026-04-04
-- [National Vulnerability Database: CVE-2026-35616 Detail](https://nvd.nist.gov/vuln/detail/CVE-2026-35616) — National Vulnerability Database, 2026-04-03
-- [watchTowr: Fortinet FortiClient EMS Zero-Day: CVE-2026-35616 (Active Exploitation Underway)](https://watchtowr.com/resources/fortinet-forticlient-ems-zero-day-cve-2026-35616-active-exploitation-underway/) — watchTowr, 2026-04-07
-- [Help Net Security: FortiClient EMS zero-day exploited, emergency hotfixes available (CVE-2026-35616)](https://www.helpnetsecurity.com/2026/04/04/forticlient-ems-zero-day-cve-2026-35616/) — Help Net Security, 2026-04-04
-- [NHS England Digital: Exploitation of Zero-Day Vulnerability in FortiClient EMS](https://digital.nhs.uk/cyber-alerts/2026/cc-4766) — NHS England Digital, 2026-04-07
+- [Fortinet: FortiClient EMS Improper Access Control Vulnerability (FG-SN-2026-00016)](https://www.fortinet.com/psirt/FG-SN-2026-00016) — Fortinet, 2026-04-04
+- [watchTowr: FortiClient EMS Zero-Day - CVE-2026-35616 (Active Exploitation Underway)](https://watchtowr.com/resources/fortinet-forticlient-ems-zero-day-cve-2026-35616-active-exploitation-underway/) — watchTowr, 2026-03-31
+- [Canadian Centre for Cyber Security: AL26-007 - Vulnerability impacting Fortinet FortiClientEMS - CVE-2026-35616](https://www.cyber.gc.ca/en/alerts-advisories/al26-007-vulnerability-impacting-fortinet-forticlientems-cve-2026-35616) — Canadian Centre for Cyber Security, 2026-04-07
+- [National Vulnerability Database: CVE-2026-35616](https://nvd.nist.gov/vuln/detail/CVE-2026-35616) — National Vulnerability Database, 2026-04-06

--- a/site/src/content/incidents/forticlient-ems-cve-2026-35616.md
+++ b/site/src/content/incidents/forticlient-ems-cve-2026-35616.md
@@ -65,7 +65,7 @@ watchTowr said it observed exploitation on March 31, 2026, before Fortinet publi
 
 Fortinet describes CVE-2026-35616 as an improper access control issue in FortiClient EMS. The affected surface is the management server, and the core risk is that crafted requests can bypass intended controls and trigger unauthorized code or command execution without prior authentication.
 
-The public source set supports affected versions 7.4.5 and 7.4.6, hotfix guidance from Fortinet, and the availability of a fixed release path. It does not support broader claims about confirmed downstream endpoint compromise, actor tradecraft beyond exploitation of the exposed EMS surface, or the exact operational chain inside victim environments.
+Affected versions include 7.4.5 and 7.4.6. Fortinet has provided hotfix guidance and a fixed release path. There is currently no confirmed evidence of downstream endpoint compromise or specific actor tradecraft beyond the initial exploitation of the EMS surface.
 
 ## Attack Chain
 
@@ -85,11 +85,11 @@ Fortinet published its advisory and patch guidance on April 4, and government al
 
 The confirmed impact is the risk of unauthorized code or command execution on the FortiClient EMS server itself. Because EMS is an administrative system for managed endpoints, compromise of the server creates a serious trust and control problem for organizations that rely on it for endpoint management.
 
-At the same time, the public reporting reviewed here does not confirm a specific number of victim organizations, a named actor, or a verified sequence of downstream endpoint abuse in real-world incidents. The article should therefore emphasize critical exposure and urgent patching rather than asserted enterprise-wide compromise outcomes.
+There is no confirmed data regarding the number of victim organizations, the identity of the threat actor, or the specific sequence of post-exploitation activity. Organizations should prioritize patching and exposure reduction.
 
 ## Attribution
 
-No public source in this review set identified a named threat actor for CVE-2026-35616 exploitation. The incident remains an actively exploited vulnerability event with unknown actor attribution.
+No public source identified a named threat actor for CVE-2026-35616 exploitation. The incident remains an actively exploited vulnerability event with unknown actor attribution.
 
 Until a vendor, government, or other primary-source investigation publishes confirmed actor information, this exploitation activity should remain unattributed.
 
@@ -115,7 +115,7 @@ The Canadian Centre for Cyber Security published an alert noting active exploita
 
 Fortinet's guidance is the primary remediation path: identify FortiClient EMS instances on affected versions, apply the appropriate hotfix or upgrade path, and restrict exposure of the management surface while patching is underway. Government alerts also reinforce rapid remediation or discontinuation of vulnerable exposure if mitigations cannot be applied quickly.
 
-Defenders should review EMS access logs and server activity for suspicious crafted requests, then treat the server as a high-value administrative asset in any follow-up investigation. The public guidance supports urgent containment and patching, but it does not justify claiming specific compromise artifacts beyond what incident responders actually observe in their own environment.
+Defenders should review EMS access logs and server activity for suspicious crafted requests, then treat the server as a high-value administrative asset in any follow-up investigation. Investigation should focus on observed artifacts within the specific environment, as generalized post-exploitation patterns have not been established.
 
 ## Sources & References
 


### PR DESCRIPTION
## Summary
- replace speculative impact and disclosure-narrative claims with advisory-backed facts
- keep the article focused on affected versions, active exploitation, and patch guidance
- preserve unattributed status pending primary-source actor reporting

## Validation
- shared content validator pass for site/src/content/incidents/forticlient-ems-cve-2026-35616.md