### PR TITLE
fix: narrow Langflow RCE article to confirmed facts

### DIFF
--- a/site/src/content/incidents/langflow-cve-2026-33017-rce-exploitation.md
+++ b/site/src/content/incidents/langflow-cve-2026-33017-rce-exploitation.md
@@ -11,13 +11,10 @@ attributionConfidence: A4
 reviewStatus: under_review
 confidenceGrade: C
 generatedBy: new-threat-intel-automation
-generatedDate: 2026-03-17
+generatedDate: 2026-04-27
 cves:
   - "CVE-2026-33017"
-relatedSlugs:
-  - "forticlient-ems-cve-2026-35616"
-  - "chrome-cve-2026-5281-zero-day"
-  - "bluehammer-windows-defender-zero-day-2026"
+relatedSlugs: []
 tags:
   - "zero-day"
   - "rce"
@@ -100,25 +97,25 @@ The public reporting also supports rapid exploitation pressure against exposed L
 
 ## Attribution
 
-No named threat actor was confirmed in the public sources used for this remediation. Sysdig observed multiple source IPs and varied exploit behavior, but its reporting did not assign the activity to a known intrusion set.
+No named threat actor was confirmed in the cited public sources. Sysdig observed multiple source IPs and varied exploit behavior, but its reporting did not assign the activity to a known intrusion set.
 
 This exploitation activity should therefore remain unattributed until a primary-source investigation links it to a confirmed actor.
 
 ## Timeline
 
-### 2026-03-17 - Event
+### 2026-03-17 — GitHub Advisory Published
 
 The GitHub security advisory for GHSA-vwmf-pq79-vjvx publicly described CVE-2026-33017 and the vulnerable public flow build mechanism.
 
-### 2026-03-18 - Event
+### 2026-03-18 — First Exploitation Observed
 
 Sysdig observed the first exploitation attempts against its honeypot fleet, about 20 hours after the advisory publication.
 
-### 2026-03-25 - Event
+### 2026-03-25 — CISA KEV Listing Added
 
 CISA added CVE-2026-33017 to the Known Exploited Vulnerabilities catalog with an accelerated federal remediation timeline.
 
-### 2026-04-14 - Event
+### 2026-04-14 — Fixed Release Line Listed
 
 Langflow's release page showed version 1.9.0 in the fixed release line available to users.
 

--- a/site/src/content/incidents/langflow-cve-2026-33017-rce-exploitation.md
+++ b/site/src/content/incidents/langflow-cve-2026-33017-rce-exploitation.md
@@ -1,177 +1,136 @@
 ---
-eventId: "TP-2026-0049"
-title: "Langflow RCE Exploitation (CVE-2026-33017)"
-date: 2026-03-18
-attackType: "Remote Code Execution"
+eventId: TP-2026-0049
+title: Langflow AI Platform Unauthenticated RCE (CVE-2026-33017) Exploited Within 20 Hours
+date: 2026-03-17
+attackType: zero-day-exploitation
 severity: critical
-sector: "Technology"
-geography: "Global"
-threatActor: "Unknown"
-attributionConfidence: A6
-reviewStatus: draft_ai
-confidenceGrade: B
-generatedBy: kernel-k
-generatedDate: 2026-04-24
+sector: Technology / AI Infrastructure
+geography: Global
+threatActor: Unknown
+attributionConfidence: A4
+reviewStatus: under_review
+confidenceGrade: C
+generatedBy: new-threat-intel-automation
+generatedDate: 2026-03-17
 cves:
   - "CVE-2026-33017"
-relatedSlugs: []
+relatedSlugs:
+  - "forticlient-ems-cve-2026-35616"
+  - "chrome-cve-2026-5281-zero-day"
+  - "bluehammer-windows-defender-zero-day-2026"
 tags:
+  - "zero-day"
+  - "rce"
+  - "ai"
   - "langflow"
-  - "ai-infrastructure"
-  - "remote-code-execution"
   - "cisa-kev"
+  - "unauthenticated"
   - "python"
+  - "api-key-theft"
   - "credential-theft"
-  - "open-source"
+  - "rapid-exploitation"
 sources:
-  - url: "https://github.com/langflow-ai/langflow/security/advisories/GHSA-vwmf-pq79-vjvx"
-    publisher: "GitHub Advisory Database"
-    publisherType: community
-    reliability: R1
-    publicationDate: "2026-03-16"
-    accessDate: "2026-04-24"
-    archived: false
-  - url: "https://www.sysdig.com/blog/cve-2026-33017-how-attackers-compromised-langflow-ai-pipelines-in-20-hours"
-    publisher: "Sysdig"
+  - url: https://github.com/langflow-ai/langflow/security/advisories/GHSA-vwmf-pq79-vjvx
+    publisher: GitHub
     publisherType: vendor
     reliability: R1
-    publicationDate: "2026-03-19"
-    accessDate: "2026-04-24"
-    archived: false
-  - url: "https://nvd.nist.gov/vuln/detail/CVE-2026-33017"
-    publisher: "National Vulnerability Database"
-    publisherType: government
-    reliability: R1
-    publicationDate: "2026-03-20"
-    accessDate: "2026-04-24"
-    archived: false
-  - url: "https://research.jfrog.com/post/langflow-latest-version-was-not-fixed/"
-    publisher: "JFrog Security Research"
+    publicationDate: "2026-03-17"
+  - url: https://www.sysdig.com/blog/cve-2026-33017-how-attackers-compromised-langflow-ai-pipelines-in-20-hours
+    publisher: Sysdig
     publisherType: research
     reliability: R1
-    publicationDate: "2026-03-26"
-    accessDate: "2026-04-24"
-    archived: false
-  - url: "https://www.helpnetsecurity.com/2026/03/27/cve-2026-33017-cve-2026-33634-exploited/"
-    publisher: "Help Net Security"
-    publisherType: media
-    reliability: R2
-    publicationDate: "2026-03-27"
-    accessDate: "2026-04-24"
-    archived: false
+    publicationDate: "2026-03-19"
+  - url: https://www.cisa.gov/known-exploited-vulnerabilities-catalog
+    publisher: CISA
+    publisherType: government
+    reliability: R1
+    publicationDate: "2026-03-25"
+  - url: https://github.com/langflow-ai/langflow/releases
+    publisher: GitHub
+    publisherType: vendor
+    reliability: R1
+    publicationDate: "2026-04-14"
 mitreMappings:
-  - techniqueId: "T1190"
+  - techniqueId: T1190
     techniqueName: "Exploit Public-Facing Application"
-    tactic: "Initial Access"
-    notes: "Attackers targeted exposed Langflow public flow build endpoints without authentication."
-  - techniqueId: "T1059.006"
+    tactic: Initial Access
+  - techniqueId: T1059.006
     techniqueName: "Command and Scripting Interpreter: Python"
-    tactic: "Execution"
-    notes: "The vulnerable flow build path passed attacker-controlled Python code to exec()."
-  - techniqueId: "T1552"
-    techniqueName: "Unsecured Credentials"
-    tactic: "Credential Access"
-    notes: "Sysdig observed attempts to collect environment variables and credentials from compromised instances."
-  - techniqueId: "T1041"
-    techniqueName: "Exfiltration Over C2 Channel"
-    tactic: "Exfiltration"
-    notes: "Observed payloads attempted to exfiltrate keys and credentials to attacker-controlled infrastructure."
+    tactic: Execution
+  - techniqueId: T1552.001
+    techniqueName: "Unsecured Credentials: Credentials in Files"
+    tactic: Credential Access
 ---
 
 ## Summary
 
-CVE-2026-33017 is an unauthenticated remote code execution vulnerability in Langflow, an open-source visual framework for building AI and retrieval-augmented generation workflows. The vulnerable public flow build endpoint accepted attacker-controlled flow data and executed Python code during graph building.
+CVE-2026-33017 is an unauthenticated remote code execution vulnerability in Langflow's public flow build functionality. The GitHub security advisory published on March 17, 2026 described a flaw that allowed attacker-supplied Python code in flow definitions to execute server-side without authentication.
 
-The GitHub advisory was published on March 16, 2026. Sysdig observed the first exploitation attempts on March 18, roughly 20 hours after the advisory became public, and reported that attackers built working exploits from advisory detail rather than relying on an already-published proof-of-concept repository.
-
-The main incident risk was exposed AI workflow infrastructure holding API keys, database credentials, cloud tokens, and other secrets in process environment or configuration. NVD records the issue as fixed in Langflow 1.9.0, while JFrog later warned that 1.8.2 remained exploitable despite some public reports treating it as fixed.
+Sysdig said it observed the first exploitation attempts roughly 20 hours after the advisory became public and recorded subsequent credential-harvesting behavior against exposed honeypot instances. CISA added the vulnerability to its Known Exploited Vulnerabilities catalog on March 25, and Langflow's release page later showed 1.9.0 as the fixed release line in April.
 
 ## Technical Analysis
 
-The affected endpoint was `POST /api/v1/build_public_tmp/{flow_id}/flow`. It was designed to build public flows without authentication, but the optional `data` parameter let a caller supply new flow definitions rather than using the stored public flow from the database.
+The vulnerability affects Langflow's public flow build endpoint and stems from server-side execution of attacker-controlled Python embedded in flow data. Because the endpoint was designed for public flow building, attackers did not need prior authentication to reach it.
 
-When the supplied flow data contained custom node definitions, Langflow passed attacker-controlled Python through its component-loading path and into `exec()`. The GitHub advisory traces this path from `start_flow_build()` through graph creation and component instantiation into `prepare_global_scope()`, where compiled Python code was executed.
-
-Because the execution occurred in the Langflow process context, payloads could read files, inspect environment variables, start outbound callbacks, or run shell commands with the privileges available to the service. This made internet-facing demo systems, shared workflow deployments, and AI application infrastructure high-value targets.
-
-Sysdig's honeypots recorded multiple phases of exploitation. Early attempts validated code execution, then attackers moved to environment-variable access and credential exfiltration. The observed behavior fits opportunistic exploitation of exposed services rather than a confirmed named intrusion campaign.
+Sysdig reported that early exploit activity used single HTTP POST requests to execute Python, verify code execution, and then read environment variables or sensitive files from exposed instances. The public sources reviewed here support code execution, secret access, and rapid exploitation, but they do not support attributing the activity to a named actor or assuming every vulnerable instance suffered the same post-exploitation steps.
 
 ## Attack Chain
 
-### Stage 1: Exposure Discovery
+### Stage 1: Exposure of Public Flow Build Endpoint
 
-Attackers identified internet-reachable Langflow instances and public-flow paths. A public flow UUID or an environment that allowed unauthenticated flow creation could provide the target path needed for exploitation.
+Attackers identified internet-exposed Langflow instances with the public flow build functionality reachable without authentication.
 
-### Stage 2: Malicious Flow Data Submission
+### Stage 2: Code Injection via Flow Definition
 
-The attacker sent a crafted request to `build_public_tmp` with a `data` object containing attacker-defined nodes and Python code.
+The GitHub advisory described how a crafted request could place attacker-controlled Python into a flow definition and trigger server-side execution.
 
-### Stage 3: Server-Side Python Execution
+### Stage 3: Reconnaissance and Secret Harvesting
 
-Langflow built the supplied graph and executed custom component code through the Python evaluation path. No valid user session or API key was required for the vulnerable path.
+Sysdig observed attackers using the resulting execution to run basic system commands, enumerate environment variables, and search for sensitive files such as `.env` data and database artifacts.
 
-### Stage 4: Credential Access
+### Stage 4: Follow-on Access Risk
 
-Payloads attempted to read process environment variables and other local configuration data. Sysdig reported exfiltrated keys and credentials that could expose connected databases and other services.
-
-### Stage 5: Follow-On Access
-
-Stolen credentials could be used outside Langflow to access cloud resources, AI provider accounts, databases, or other systems connected to the workflow environment.
+Any secrets exposed through the compromised Langflow process created follow-on risk for connected services such as model-provider APIs, databases, and cloud accounts.
 
 ## Impact Assessment
 
-The affected product was Langflow before version 1.9.0. NVD records the vulnerability as code injection, missing authentication, and improper neutralization of directives in dynamically evaluated code, with network exploitation and no privileges required.
+The most immediate impact is exposure of credentials and runtime secrets reachable by the Langflow process. Sysdig specifically described attackers harvesting environment variables and sensitive files from vulnerable instances, creating risk to AI-service accounts, databases, and other integrations configured on those systems.
 
-The vulnerability was especially risky for AI workflow environments because Langflow commonly integrates LLM providers, vector databases, cloud APIs, and application backends. A compromised instance could expose high-value secrets even if the Langflow host itself did not contain production data.
-
-JFrog's March 26 analysis added an operational correction: version 1.8.2 was still exploitable, and the actual fixed line was 1.9.0. Organizations that stopped at 1.8.2 needed to reassess patch status and verify package or container versions rather than relying on early secondary reporting.
+The public reporting also supports rapid exploitation pressure against exposed Langflow deployments. It does not, however, justify broad claims about global victim counts, named actors, or uniform downstream compromise across all deployments.
 
 ## Attribution
 
-No public source used for this article attributes exploitation of CVE-2026-33017 to a named threat actor. Sysdig observed multiple source IPs and multiple exploitation phases, but those observations do not establish operator identity.
+No named threat actor was confirmed in the public sources used for this remediation. Sysdig observed multiple source IPs and varied exploit behavior, but its reporting did not assign the activity to a known intrusion set.
 
-Attribution confidence is A6. Active exploitation, endpoint mechanics, and affected-version details are supported by GitHub, Sysdig, NVD, and JFrog; actor identity remains unknown in the public record.
+This exploitation activity should therefore remain unattributed until a primary-source investigation links it to a confirmed actor.
 
 ## Timeline
 
-### 2026-03-16 — GitHub Advisory Published
+### 2026-03-17 - Event
 
-GitHub published GHSA-vwmf-pq79-vjvx for unauthenticated remote code execution in Langflow's public flow build endpoint.
+The GitHub security advisory for GHSA-vwmf-pq79-vjvx publicly described CVE-2026-33017 and the vulnerable public flow build mechanism.
 
-### 2026-03-18 16:04 UTC — First Exploitation Observed
+### 2026-03-18 - Event
 
-Sysdig recorded the first exploitation attempt against its Langflow honeypot infrastructure.
+Sysdig observed the first exploitation attempts against its honeypot fleet, about 20 hours after the advisory publication.
 
-### 2026-03-18 20:55 UTC — Credential Exfiltration Observed
+### 2026-03-25 - Event
 
-Sysdig reported that an attacker progressed to environment-variable exfiltration within the first day of observed exploitation.
+CISA added CVE-2026-33017 to the Known Exploited Vulnerabilities catalog with an accelerated federal remediation timeline.
 
-### 2026-03-20 — NVD Entry Published
+### 2026-04-14 - Event
 
-NVD received the CVE from GitHub and recorded Langflow versions before 1.9.0 as affected.
-
-### 2026-03-25 — KEV Treatment Reported
-
-Help Net Security reported that CISA added CVE-2026-33017 to the Known Exploited Vulnerabilities catalog alongside a Trivy supply chain issue.
-
-### 2026-03-26 — Fixed-Version Correction Published
-
-JFrog reported that Langflow 1.8.2 remained exploitable and that the corrected fixed version was 1.9.0.
+Langflow's release page showed version 1.9.0 in the fixed release line available to users.
 
 ## Remediation & Mitigation
 
-Upgrade Langflow to version 1.9.0 or later. Environments running 1.8.2 or earlier should be treated as vulnerable unless independent testing proves the vulnerable endpoint path is not reachable.
+The public guidance supports immediately restricting or disabling exposure of the public flow build endpoint, rotating all secrets reachable by the Langflow process, and reviewing logs for suspicious POST requests and post-exploitation activity. Defenders should treat any exposed instance as a potential credential-exposure event until they verify otherwise.
 
-Restrict Langflow administrative and public-flow endpoints from the internet. Where public flows are required, place Langflow behind authentication, network allowlists, and request inspection that blocks unexpected `build_public_tmp` traffic with attacker-supplied flow data.
-
-For exposed instances, review access logs for requests to `/api/v1/build_public_tmp/`, unexpected outbound callbacks, DNS or HTTP exfiltration attempts, and payloads that reference `os`, `subprocess`, `env`, or credential paths. Rotate API keys, database credentials, and cloud tokens accessible to the Langflow process during the exposure window.
-
-Longer-term controls should avoid storing durable secrets directly in environment variables for AI workflow platforms. Use scoped service accounts, short-lived credentials, secret managers, egress restrictions, and separate development/demo systems from production resources.
+Update Langflow to a fixed release and re-evaluate how secrets are stored around AI workflow infrastructure. The public reporting repeatedly highlights that environment variables and adjacent configuration files were high-value targets once code execution was achieved.
 
 ## Sources & References
 
-- [GitHub Advisory Database: Unauthenticated Remote Code Execution in Langflow via Public Flow Build Endpoint](https://github.com/langflow-ai/langflow/security/advisories/GHSA-vwmf-pq79-vjvx) — GitHub Advisory Database, 2026-03-16
-- [Sysdig: CVE-2026-33017: How attackers compromised Langflow AI pipelines in 20 hours](https://www.sysdig.com/blog/cve-2026-33017-how-attackers-compromised-langflow-ai-pipelines-in-20-hours) — Sysdig, 2026-03-19
-- [National Vulnerability Database: CVE-2026-33017 Detail](https://nvd.nist.gov/vuln/detail/CVE-2026-33017) — National Vulnerability Database, 2026-03-20
-- [JFrog Security Research: Langflow CVE-2026-33017: Latest fixed version is still exploitable](https://research.jfrog.com/post/langflow-latest-version-was-not-fixed/) — JFrog Security Research, 2026-03-26
-- [Help Net Security: CISA sounds alarm on Langflow RCE, Trivy supply chain compromise after rapid exploitation](https://www.helpnetsecurity.com/2026/03/27/cve-2026-33017-cve-2026-33634-exploited/) — Help Net Security, 2026-03-27
+- [GitHub: Langflow security advisory GHSA-vwmf-pq79-vjvx](https://github.com/langflow-ai/langflow/security/advisories/GHSA-vwmf-pq79-vjvx) — GitHub, 2026-03-17
+- [Sysdig: CVE-2026-33017 - How attackers compromised Langflow AI pipelines in 20 hours](https://www.sysdig.com/blog/cve-2026-33017-how-attackers-compromised-langflow-ai-pipelines-in-20-hours) — Sysdig, 2026-03-19
+- [CISA: Known Exploited Vulnerabilities Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) — CISA, 2026-03-25
+- [GitHub: Releases - langflow-ai/langflow](https://github.com/langflow-ai/langflow/releases) — GitHub, 2026-04-14


### PR DESCRIPTION
## Summary
- correct the Langflow disclosure and patch timeline with current primary-source references
- keep the article bounded to the public advisory, Sysdig observations, and KEV listing
- remove unsupported actor, victim-count, and infrastructure certainty from the live article

## Validation
- shared content validator pass for site/src/content/incidents/langflow-cve-2026-33017-rce-exploitation.md