### PR TITLE
fix(incident): restore M365 device-code incident route

### DIFF
--- a/site/src/pages/incidents/m365-oauth-device-code-phishing-2026.astro
+++ b/site/src/pages/incidents/m365-oauth-device-code-phishing-2026.astro
@@ -1,8 +1,0 @@
----
-import LegacyRedirect from '../../components/LegacyRedirect.astro';
----
-
-<LegacyRedirect
-  destination="/campaigns/m365-oauth-device-code-phishing-2026/"
-  label="Microsoft 365 Device Code Phishing Campaign"
-/>


### PR DESCRIPTION
## Summary
- remove the hard-coded incident redirect that shadows the merged M365 incident article
- let the standard incidents dynamic route serve `site/src/content/incidents/m365-oauth-device-code-phishing-2026.md`
- keep the campaign page intact at `/campaigns/m365-oauth-device-code-phishing-2026/`

## Validation
- `npm --prefix site run build`
