### PR TITLE
fix(pipeline): block internal prose leakage

### DIFF
--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -148,8 +148,9 @@ for the pipeline.
    - `--validate` enforces `.github/pipeline/config.yml` `validation.*`
      rules plus exact section/schema normalization: canonical H2 headings,
      exact source-line format, frontmatter/body source URL parity, canonical
-     MITRE tactic casing, canonical publisher aliases, and canonical
-     `generatedBy` values.
+     MITRE tactic casing, canonical publisher aliases, canonical
+     `generatedBy` values, and public-prose guardrails that block internal
+     editorial/process language from article body text.
    - Failure leaves the task locked for agent iteration; success allows the
      agent to record a real open PR number, which moves the task to
      `status: pr_open`.
@@ -179,6 +180,13 @@ for the pipeline.
 | Circuit breaker | `pipeline-dispatcher.yml` (via `scripts/pipeline-config.mjs`) | 3 failures in 120min → Issue + halt; 60min cooldown | `config.yml` (`circuit_breaker.*`) |
 | Dependency blocking | `pipeline-dispatcher.yml` | Per-task `depends_on[]` | Task file |
 | Validation gates | `pipeline-run-task.mjs --validate` | See `config.yml` `validation.*` | `config.yml` |
+
+**Public prose guardrails:** generated article body text must not leak internal
+workflow language such as "this article," "this report," `reviewStatus`,
+`draft_ai`, "attribution confidence," or "confidence grade." Those values can
+exist in frontmatter or operator notes where appropriate, but public article
+prose should describe the evidence basis directly rather than narrating
+Threatpedia's internal scoring or editorial process.
 
 **Config authority:** `pipeline-dispatcher.yml` now reads thresholds from
 `.github/pipeline/config.yml` via the authoritative reader

--- a/scripts/pipeline-run-task.mjs
+++ b/scripts/pipeline-run-task.mjs
@@ -50,6 +50,20 @@ const EDITORIAL_WORDS = [
   'sophisticated', 'unprecedented', 'exceptionally',
 ];
 const EDITORIAL_RE = new RegExp(`\\b(${EDITORIAL_WORDS.join('|')})\\b`, 'gi');
+const PUBLIC_PROSE_GUARDRAILS = [
+  {
+    label: 'internal article/report framing',
+    regex: /\b(this|the)\s+(article|report|assessment|write[- ]?up|entry)\b/i,
+  },
+  {
+    label: 'editorial workflow leakage',
+    regex: /\b(editorial\s+(workflow|process|scor(?:e|ing))|reviewStatus|draft_ai|draft_human|under_review)\b/i,
+  },
+  {
+    label: 'confidence label leakage',
+    regex: /\b(attribution confidence|confidence grade)\b/i,
+  },
+];
 const SOURCE_BODY_LINE_RE = /^\s*-\s+\[(.+?):\s+(.+)\]\((https?:\/\/[^\s)]+)\)\s+([—–-])\s+(.+?),\s+(\d{4}-\d{2}-\d{2})\s*$/;
 
 // ── Stage-aware reviewStatus rule matching ─────────────────────────────────
@@ -285,16 +299,17 @@ function buildRules(task) {
   5. EDIT-RULE-030: Do NOT use editorial commentary words:
      ${EDITORIAL_WORDS.join(', ')}
   6. Every H2 heading must have a blank line before it
-  7. exploitId format is TP-EXP-YYYY-NNNN (year-namespaced per ADR 0007)
-  8. H2 headings must match the canonical set for ${task.type}: ${(SCHEMA_REQUIRED_H2_BY_TYPE[task.type] || []).join(' | ')}
-  9. Sources & References body section must use markdown hyperlinks that exactly match frontmatter:
+  7. Public article prose must not mention internal article/report framing, editorial workflow, reviewStatus values, attribution confidence labels, or confidence grades
+  8. exploitId format is TP-EXP-YYYY-NNNN (year-namespaced per ADR 0007)
+  9. H2 headings must match the canonical set for ${task.type}: ${(SCHEMA_REQUIRED_H2_BY_TYPE[task.type] || []).join(' | ')}
+  10. Sources & References body section must use markdown hyperlinks that exactly match frontmatter:
      — Format: - [Publisher: Title](https://...) — Publisher, YYYY-MM-DD
      — Every frontmatter source URL must appear in the body exactly once
      — No orphan sources: every body source entry must have a matching frontmatter source object
      — No plain-text sources: every body entry must be a markdown hyperlink
-  10. MITRE tactic casing must use the canonical ATT&CK vocabulary
-  11. Canonical publisher aliases must be normalized in frontmatter and body
-  12. The Astro build must pass: cd site && npm run build`;
+  11. MITRE tactic casing must use the canonical ATT&CK vocabulary
+  12. Canonical publisher aliases must be normalized in frontmatter and body
+  13. The Astro build must pass: cd site && npm run build`;
 }
 
 // ── CLI Parsing ─────────────────────────────────────────────────────────────
@@ -393,6 +408,46 @@ function getSourcesSection(body) {
   const afterHeading = body.slice(start + headingMatch[0].length);
   const nextH2 = afterHeading.search(/^## /m);
   return nextH2 === -1 ? afterHeading : afterHeading.slice(0, nextH2);
+}
+
+function stripCodeBlocks(body) {
+  return body.replace(/```[\s\S]*?```/g, (match) => ' '.repeat(match.length));
+}
+
+function getAuthoredBodyWithoutSources(body) {
+  const headingMatch = body.match(/^## Sources & References\s*$/m);
+  if (!headingMatch) return stripCodeBlocks(body);
+
+  const start = body.indexOf(headingMatch[0]);
+  const afterHeading = body.slice(start + headingMatch[0].length);
+  const nextH2 = afterHeading.search(/^## /m);
+  const end = nextH2 === -1 ? body.length : start + headingMatch[0].length + nextH2;
+
+  return stripCodeBlocks(`${body.slice(0, start)}${' '.repeat(end - start)}${body.slice(end)}`);
+}
+
+function getPublicProseGuardrailIssues(body) {
+  const authoredBody = getAuthoredBodyWithoutSources(body);
+  const issues = [];
+  const lines = authoredBody.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.trim() || line.startsWith('#')) continue;
+
+    for (const guardrail of PUBLIC_PROSE_GUARDRAILS) {
+      const match = guardrail.regex.exec(line);
+      if (match) {
+        issues.push({
+          line: i + 1,
+          label: guardrail.label,
+          phrase: match[0],
+        });
+      }
+    }
+  }
+
+  return issues;
 }
 
 function parseBodySourceEntries(sourcesBody) {
@@ -1317,7 +1372,19 @@ function validateOutput(task, explicitFile) {
       }
     }
 
-    // ── 11. EDIT-RULE-030: blank lines before headings ────────────────────
+    // ── 11. Public prose guardrails ───────────────────────────────────────
+    const publicProseIssues = getPublicProseGuardrailIssues(body);
+    if (publicProseIssues.length > 0) {
+      issues.push(`Public prose guardrails: ${publicProseIssues.length} internal process/scoring phrase(s) found:`);
+      for (const hit of publicProseIssues.slice(0, 5)) {
+        issues.push(`  → line ${hit.line}: ${hit.label} (${hit.phrase})`);
+      }
+      if (publicProseIssues.length > 5) {
+        issues.push(`  → ...and ${publicProseIssues.length - 5} more`);
+      }
+    }
+
+    // ── 12. EDIT-RULE-030: blank lines before headings ────────────────────
     const allLines = content.split('\n');
     for (let i = 1; i < allLines.length; i++) {
       if (allLines[i].match(/^#{2,3} /) && allLines[i - 1].trim() !== '' && !allLines[i - 1].startsWith('---')) {
@@ -1327,7 +1394,7 @@ function validateOutput(task, explicitFile) {
     }
   }
 
-  // ── 11. Astro build ─────────────────────────────────────────────────────
+  // ── 13. Astro build ─────────────────────────────────────────────────────
   console.log('  Running Astro build...');
   try {
     execSync('npm run build', { cwd: resolve(ROOT, 'site'), stdio: 'pipe' });

--- a/scripts/pipeline-run-task.mjs
+++ b/scripts/pipeline-run-task.mjs
@@ -36,6 +36,7 @@ import {
   SCHEMA_REQUIRED_H2_BY_TYPE,
   SCHEMA_REVIEW_STATUSES,
 } from './pipeline-schema.mjs';
+import { getPublicProseGuardrailIssues } from './public-prose-guardrails.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -50,20 +51,6 @@ const EDITORIAL_WORDS = [
   'sophisticated', 'unprecedented', 'exceptionally',
 ];
 const EDITORIAL_RE = new RegExp(`\\b(${EDITORIAL_WORDS.join('|')})\\b`, 'gi');
-const PUBLIC_PROSE_GUARDRAILS = [
-  {
-    label: 'internal article/report framing',
-    regex: /\b(this|the)\s+(article|report|assessment|write[- ]?up|entry)\b/i,
-  },
-  {
-    label: 'editorial workflow leakage',
-    regex: /\b(editorial\s+(workflow|process|scor(?:e|ing))|reviewStatus|draft_ai|draft_human|under_review)\b/i,
-  },
-  {
-    label: 'confidence label leakage',
-    regex: /\b(attribution confidence|confidence grade)\b/i,
-  },
-];
 const SOURCE_BODY_LINE_RE = /^\s*-\s+\[(.+?):\s+(.+)\]\((https?:\/\/[^\s)]+)\)\s+([—–-])\s+(.+?),\s+(\d{4}-\d{2}-\d{2})\s*$/;
 
 // ── Stage-aware reviewStatus rule matching ─────────────────────────────────
@@ -408,46 +395,6 @@ function getSourcesSection(body) {
   const afterHeading = body.slice(start + headingMatch[0].length);
   const nextH2 = afterHeading.search(/^## /m);
   return nextH2 === -1 ? afterHeading : afterHeading.slice(0, nextH2);
-}
-
-function stripCodeBlocks(body) {
-  return body.replace(/```[\s\S]*?```/g, (match) => ' '.repeat(match.length));
-}
-
-function getAuthoredBodyWithoutSources(body) {
-  const headingMatch = body.match(/^## Sources & References\s*$/m);
-  if (!headingMatch) return stripCodeBlocks(body);
-
-  const start = body.indexOf(headingMatch[0]);
-  const afterHeading = body.slice(start + headingMatch[0].length);
-  const nextH2 = afterHeading.search(/^## /m);
-  const end = nextH2 === -1 ? body.length : start + headingMatch[0].length + nextH2;
-
-  return stripCodeBlocks(`${body.slice(0, start)}${' '.repeat(end - start)}${body.slice(end)}`);
-}
-
-function getPublicProseGuardrailIssues(body) {
-  const authoredBody = getAuthoredBodyWithoutSources(body);
-  const issues = [];
-  const lines = authoredBody.split('\n');
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (!line.trim() || line.startsWith('#')) continue;
-
-    for (const guardrail of PUBLIC_PROSE_GUARDRAILS) {
-      const match = guardrail.regex.exec(line);
-      if (match) {
-        issues.push({
-          line: i + 1,
-          label: guardrail.label,
-          phrase: match[0],
-        });
-      }
-    }
-  }
-
-  return issues;
 }
 
 function parseBodySourceEntries(sourcesBody) {

--- a/scripts/public-prose-guardrails.mjs
+++ b/scripts/public-prose-guardrails.mjs
@@ -1,15 +1,15 @@
 const PUBLIC_PROSE_GUARDRAILS = [
   {
     label: 'internal article/report framing',
-    regex: /\bthis\s+(article|report|assessment|write[- \u2013\u2014]?up)\b|\bthis\s+Threatpedia\s+entry\b/i,
+    regex: /\b(?:this\s+(?:article|report|assessment|write[- \u2013\u2014]?up)|these\s+(?:articles|reports|assessments|write[- \u2013\u2014]?ups))\b|\b(?:this\s+Threatpedia\s+entry|these\s+Threatpedia\s+entries)\b/i,
   },
   {
     label: 'editorial workflow leakage',
-    regex: /\b(editorial\s+(workflow|process|scor(?:e|ing))|reviewStatus|draft_ai|draft_human|under_review)\b/i,
+    regex: /\b(editorial\s+(workflow|process|scores?|scoring)|reviewStatus|draft_ai|draft_human|under_review)\b/i,
   },
   {
     label: 'confidence label leakage',
-    regex: /\b(attribution confidence|confidence grade)\b/i,
+    regex: /\b(attribution confidences?|confidence grades?)\b/i,
   },
 ];
 

--- a/scripts/public-prose-guardrails.mjs
+++ b/scripts/public-prose-guardrails.mjs
@@ -1,0 +1,80 @@
+const PUBLIC_PROSE_GUARDRAILS = [
+  {
+    label: 'internal article/report framing',
+    regex: /\bthis\s+(article|report|assessment|write[- \u2013\u2014]?up)\b|\bthis\s+Threatpedia\s+entry\b/i,
+  },
+  {
+    label: 'editorial workflow leakage',
+    regex: /\b(editorial\s+(workflow|process|scor(?:e|ing))|reviewStatus|draft_ai|draft_human|under_review)\b/i,
+  },
+  {
+    label: 'confidence label leakage',
+    regex: /\b(attribution confidence|confidence grade)\b/i,
+  },
+];
+
+export function maskTextPreservingNewlines(value) {
+  return value.replace(/[^\n]/g, ' ');
+}
+
+export function stripCodeBlocksPreservingLines(body) {
+  return body.replace(/```[\s\S]*?```/g, maskTextPreservingNewlines);
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function findH2Section(bodyWithoutCodeBlocks, heading) {
+  const headingRegex = new RegExp(`^## ${escapeRegex(heading)}\\s*$`, 'm');
+  const headingMatch = headingRegex.exec(bodyWithoutCodeBlocks);
+  if (!headingMatch) return null;
+
+  const start = headingMatch.index;
+  const contentStart = start + headingMatch[0].length;
+  const afterHeading = bodyWithoutCodeBlocks.slice(contentStart);
+  const nextH2 = afterHeading.search(/^## /m);
+  const end = nextH2 === -1 ? bodyWithoutCodeBlocks.length : contentStart + nextH2;
+
+  return { start, end };
+}
+
+export function getAuthoredBodyWithoutSources(body) {
+  const bodyWithoutCodeBlocks = stripCodeBlocksPreservingLines(body);
+  const sourcesSection = findH2Section(bodyWithoutCodeBlocks, 'Sources & References');
+  if (!sourcesSection) return bodyWithoutCodeBlocks;
+
+  const maskedSources = maskTextPreservingNewlines(
+    bodyWithoutCodeBlocks.slice(sourcesSection.start, sourcesSection.end),
+  );
+
+  return [
+    bodyWithoutCodeBlocks.slice(0, sourcesSection.start),
+    maskedSources,
+    bodyWithoutCodeBlocks.slice(sourcesSection.end),
+  ].join('');
+}
+
+export function getPublicProseGuardrailIssues(body) {
+  const authoredBody = getAuthoredBodyWithoutSources(body);
+  const issues = [];
+  const lines = authoredBody.split('\n');
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (!line.trim() || line.startsWith('#')) continue;
+
+    for (const guardrail of PUBLIC_PROSE_GUARDRAILS) {
+      const match = guardrail.regex.exec(line);
+      if (match) {
+        issues.push({
+          line: i + 1,
+          label: guardrail.label,
+          phrase: match[0],
+        });
+      }
+    }
+  }
+
+  return issues;
+}

--- a/scripts/validate-content-corpus.mjs
+++ b/scripts/validate-content-corpus.mjs
@@ -40,6 +40,20 @@ const ZERO_DAY_US_SPELLING_MAP = new Map([
   ['weaponisation', 'weaponization'],
   ['weaponised', 'weaponized'],
 ]);
+const PUBLIC_PROSE_GUARDRAILS = [
+  {
+    label: 'internal article/report framing',
+    regex: /\b(this|the)\s+(article|report|assessment|write[- ]?up|entry)\b/i,
+  },
+  {
+    label: 'editorial workflow leakage',
+    regex: /\b(editorial\s+(workflow|process|scor(?:e|ing))|reviewStatus|draft_ai|draft_human|under_review)\b/i,
+  },
+  {
+    label: 'confidence label leakage',
+    regex: /\b(attribution confidence|confidence grade)\b/i,
+  },
+];
 
 function usage() {
   console.log(`Usage:
@@ -162,6 +176,39 @@ function findH2Section(body, heading) {
 
 function getSourcesSection(body) {
   return findH2Section(body, 'Sources & References')?.content || null;
+}
+
+function getAuthoredBodyWithoutSources(body) {
+  const sourcesSection = findH2Section(body, 'Sources & References');
+  if (!sourcesSection) return stripCodeBlocks(body);
+
+  return stripCodeBlocks(
+    `${body.slice(0, sourcesSection.start)}${' '.repeat(sourcesSection.end - sourcesSection.start)}${body.slice(sourcesSection.end)}`,
+  );
+}
+
+function getPublicProseGuardrailIssues(body) {
+  const authoredBody = getAuthoredBodyWithoutSources(body);
+  const issues = [];
+  const lines = authoredBody.split('\n');
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (!line.trim() || line.startsWith('#')) continue;
+
+    for (const guardrail of PUBLIC_PROSE_GUARDRAILS) {
+      const match = guardrail.regex.exec(line);
+      if (match) {
+        issues.push({
+          line: i + 1,
+          label: guardrail.label,
+          phrase: match[0],
+        });
+      }
+    }
+  }
+
+  return issues;
 }
 
 function getZeroDaySeverityIssues(body) {
@@ -355,6 +402,19 @@ function validateFile(file, newFiles) {
     detail: blankLineIssues > 0 ? `${blankLineIssues} issue(s)` : undefined,
   });
   if (blankLineIssues > 0) pass = false;
+
+  const publicProseIssues = getPublicProseGuardrailIssues(body);
+  checks.push({
+    name: 'Public prose guardrails',
+    pass: publicProseIssues.length === 0,
+    detail: publicProseIssues.length === 0
+      ? 'No internal process or scoring language detected'
+      : publicProseIssues
+        .slice(0, 3)
+        .map((issue) => `line ${issue.line}: ${issue.label} (${issue.phrase})`)
+        .join(' | '),
+  });
+  if (publicProseIssues.length > 0) pass = false;
 
   if (type === 'zero-day') {
     const severityIssues = getZeroDaySeverityIssues(body);

--- a/scripts/validate-content-corpus.mjs
+++ b/scripts/validate-content-corpus.mjs
@@ -12,6 +12,10 @@ import {
   SCHEMA_REQUIRED_H2_BY_TYPE,
   SCHEMA_REVIEW_STATUSES,
 } from './pipeline-schema.mjs';
+import {
+  getPublicProseGuardrailIssues,
+  maskTextPreservingNewlines,
+} from './public-prose-guardrails.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -40,21 +44,6 @@ const ZERO_DAY_US_SPELLING_MAP = new Map([
   ['weaponisation', 'weaponization'],
   ['weaponised', 'weaponized'],
 ]);
-const PUBLIC_PROSE_GUARDRAILS = [
-  {
-    label: 'internal article/report framing',
-    regex: /\b(this|the)\s+(article|report|assessment|write[- ]?up|entry)\b/i,
-  },
-  {
-    label: 'editorial workflow leakage',
-    regex: /\b(editorial\s+(workflow|process|scor(?:e|ing))|reviewStatus|draft_ai|draft_human|under_review)\b/i,
-  },
-  {
-    label: 'confidence label leakage',
-    regex: /\b(attribution confidence|confidence grade)\b/i,
-  },
-];
-
 function usage() {
   console.log(`Usage:
   node scripts/validate-content-corpus.mjs --files-file <path> [--new-files-file <path>] [--json-out <path>]
@@ -151,7 +140,7 @@ function escapeRegex(value) {
 
 function stripCodeBlocks(body) {
   const codeBlockRegex = /```[\s\S]*?```/g;
-  return body.replace(codeBlockRegex, (match) => ' '.repeat(match.length));
+  return body.replace(codeBlockRegex, maskTextPreservingNewlines);
 }
 
 function findH2Section(body, heading) {
@@ -176,39 +165,6 @@ function findH2Section(body, heading) {
 
 function getSourcesSection(body) {
   return findH2Section(body, 'Sources & References')?.content || null;
-}
-
-function getAuthoredBodyWithoutSources(body) {
-  const sourcesSection = findH2Section(body, 'Sources & References');
-  if (!sourcesSection) return stripCodeBlocks(body);
-
-  return stripCodeBlocks(
-    `${body.slice(0, sourcesSection.start)}${' '.repeat(sourcesSection.end - sourcesSection.start)}${body.slice(sourcesSection.end)}`,
-  );
-}
-
-function getPublicProseGuardrailIssues(body) {
-  const authoredBody = getAuthoredBodyWithoutSources(body);
-  const issues = [];
-  const lines = authoredBody.split('\n');
-
-  for (let i = 0; i < lines.length; i += 1) {
-    const line = lines[i];
-    if (!line.trim() || line.startsWith('#')) continue;
-
-    for (const guardrail of PUBLIC_PROSE_GUARDRAILS) {
-      const match = guardrail.regex.exec(line);
-      if (match) {
-        issues.push({
-          line: i + 1,
-          label: guardrail.label,
-          phrase: match[0],
-        });
-      }
-    }
-  }
-
-  return issues;
 }
 
 function getZeroDaySeverityIssues(body) {


### PR DESCRIPTION
## Summary
- add public-prose guardrails to the shared content validator and task runner
- block internal article/report framing, editorial workflow leakage, reviewStatus values, attribution confidence labels, and confidence-grade language in article body text
- document the new validation gate in docs/PIPELINE.md

## Validation
- node --check scripts/validate-content-corpus.mjs
- node --check scripts/pipeline-run-task.mjs
- git diff --check
- node scripts/validate-content-corpus.mjs --files-file /tmp/tp-public-prose-good-files.txt
- node scripts/validate-content-corpus.mjs --files-file /tmp/tp-public-prose-negative-files.txt (expected failure; confirmed new guardrail catches attribution-confidence leakage)
- node scripts/pipeline-schema.mjs
- npm run build (site)

## Notes
- This is Workstream 1 sprint hardening for the recent backlog failure class where public article prose leaked internal editorial/scoring language.