### PR TITLE
feat(pipeline): add current-head review gate

### DIFF
--- a/.github/workflows/pipeline-review-gate.yml
+++ b/.github/workflows/pipeline-review-gate.yml
@@ -1,0 +1,63 @@
+name: "Pipeline: Review Gate"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+  issue_comment:
+    types: [created, edited]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to evaluate"
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  checks: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  review-gate:
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Resolve pull request number
+        id: pr
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          case "${{ github.event_name }}" in
+            workflow_dispatch)
+              number="${{ inputs.pr_number }}"
+              ;;
+            pull_request|pull_request_review)
+              number="${{ github.event.pull_request.number }}"
+              ;;
+            issue_comment)
+              number="${{ github.event.issue.number }}"
+              ;;
+            *)
+              echo "Unsupported event: ${{ github.event_name }}" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "number=${number}" >> "$GITHUB_OUTPUT"
+
+      - name: Evaluate review gate
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: node scripts/pipeline-review-gate.mjs --pr "$PR_NUMBER"

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -188,7 +188,7 @@ for the pipeline.
 | Discovery publishes via | `pipeline/discovery` branch + auto-PR | labeled `pipeline/discovery`, no direct push to `main` | Workflow |
 | Dispatcher publishes via | `pipeline/dispatcher` branch + auto-PR | labeled `pipeline/dispatcher`, no direct push to `main`; skips duplicate `pipeline/ready` Issues when one is already open | Workflow |
 | PR batch review | Human merge (not auto-merge) | Nothing lands on `main` without review | Workflow + branch protection |
-| Review readiness gate | `pipeline-review-gate.yml` + `pipeline-review-gate.mjs` | Current-head validation for content PRs, current-head AI second review, zero unresolved AI review threads | Live GitHub state |
+| Review readiness gate | `pipeline-review-gate.yml` + `pipeline-review-gate.mjs` | Current-head validation for content PRs, current-head AI second review from Gemini Code Assist or `dangermouse-bot`, zero unresolved AI review threads | Live GitHub state |
 | Editorial queue backpressure (hysteresis) | `pipeline-dispatcher.yml` (via `scripts/pipeline-config.mjs`); state tracked via labeled GitHub Issue (`pipeline/backpressure`) | Pause at 50 pending · stay paused until queue < 40 (auto-resume + Issue auto-close) | `config.yml` (`queues.editorial.max_pending` / `backpressure_resume`) |
 | Stale-lock timeout | `pipeline-dispatcher.yml` (via `scripts/pipeline-config.mjs`) | 30 minutes | `config.yml` (`scheduling.stale_lock_minutes`) |
 | Circuit breaker | `pipeline-dispatcher.yml` (via `scripts/pipeline-config.mjs`) | 3 failures in 120min → Issue + halt; 60min cooldown | `config.yml` (`circuit_breaker.*`) |

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -154,7 +154,21 @@ for the pipeline.
      agent to record a real open PR number, which moves the task to
      `status: pr_open`.
 
-9. **Human review + merge**
+9. **Review readiness gate**
+   - `.github/workflows/pipeline-review-gate.yml` runs
+     `node scripts/pipeline-review-gate.mjs --pr <number>` against live
+     GitHub state for public content, site, and pipeline PRs.
+   - For content-collection PRs, the gate requires a successful current-head
+     `validate` check. Green checks from an older head SHA do not count.
+   - For public content/site/pipeline PRs, the gate requires an AI second
+     review on the current head SHA, no unresolved current AI review threads,
+     and no later AI review-error comment without a successful replacement
+     review.
+   - Worker status comments are treated as informational only. A comment that
+     says `merge_ready` does not override current-head checks, review state,
+     unresolved AI threads, or review errors.
+
+10. **Human review + merge**
    - `auto_merge.enabled: false` today — every PR goes to Kernel K for
      review. Merge state is no longer trusted from the local CLI. A GitHub PR
      event records the final task transition after the PR is merged (or reverts
@@ -174,6 +188,7 @@ for the pipeline.
 | Discovery publishes via | `pipeline/discovery` branch + auto-PR | labeled `pipeline/discovery`, no direct push to `main` | Workflow |
 | Dispatcher publishes via | `pipeline/dispatcher` branch + auto-PR | labeled `pipeline/dispatcher`, no direct push to `main`; skips duplicate `pipeline/ready` Issues when one is already open | Workflow |
 | PR batch review | Human merge (not auto-merge) | Nothing lands on `main` without review | Workflow + branch protection |
+| Review readiness gate | `pipeline-review-gate.yml` + `pipeline-review-gate.mjs` | Current-head validation for content PRs, current-head AI second review, zero unresolved AI review threads | Live GitHub state |
 | Editorial queue backpressure (hysteresis) | `pipeline-dispatcher.yml` (via `scripts/pipeline-config.mjs`); state tracked via labeled GitHub Issue (`pipeline/backpressure`) | Pause at 50 pending · stay paused until queue < 40 (auto-resume + Issue auto-close) | `config.yml` (`queues.editorial.max_pending` / `backpressure_resume`) |
 | Stale-lock timeout | `pipeline-dispatcher.yml` (via `scripts/pipeline-config.mjs`) | 30 minutes | `config.yml` (`scheduling.stale_lock_minutes`) |
 | Circuit breaker | `pipeline-dispatcher.yml` (via `scripts/pipeline-config.mjs`) | 3 failures in 120min → Issue + halt; 60min cooldown | `config.yml` (`circuit_breaker.*`) |

--- a/scripts/pipeline-review-gate.mjs
+++ b/scripts/pipeline-review-gate.mjs
@@ -16,7 +16,7 @@ const PIPELINE_FILE_RE = /^(?:scripts\/(?:pipeline-|validate-content-corpus|publ
 function parseArgs(argv) {
   const parsed = {
     pr: process.env.PR_NUMBER ? Number.parseInt(process.env.PR_NUMBER, 10) : null,
-    repo: process.env.GITHUB_REPOSITORY || 'MahdiHedhli/threatpedia',
+    repo: process.env.GITHUB_REPOSITORY || null,
     json: false,
   };
 
@@ -33,6 +33,10 @@ function parseArgs(argv) {
 
   if (!Number.isInteger(parsed.pr) || parsed.pr <= 0) {
     throw new Error('Missing required PR number. Use --pr <number> or PR_NUMBER.');
+  }
+
+  if (!parsed.repo) {
+    throw new Error('Missing required repo. Use --repo <owner/name> or GITHUB_REPOSITORY.');
   }
 
   if (!/^[^/]+\/[^/]+$/.test(parsed.repo)) {
@@ -138,6 +142,39 @@ async function listPaginated(path, token) {
   return results;
 }
 
+async function getReviewThreadComments(threadId, token) {
+  const query = `
+    query($threadId: ID!, $after: String) {
+      node(id: $threadId) {
+        ... on PullRequestReviewThread {
+          comments(first: 100, after: $after) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              author { login }
+              body
+              path
+              line
+              originalLine
+              createdAt
+            }
+          }
+        }
+      }
+    }`;
+
+  const comments = [];
+  let after = null;
+  while (true) {
+    const data = await githubGraphql(query, { threadId, after }, token);
+    const connection = data.node?.comments;
+    if (!connection) break;
+    comments.push(...connection.nodes);
+    if (!connection.pageInfo.hasNextPage) break;
+    after = connection.pageInfo.endCursor;
+  }
+  return comments;
+}
+
 async function getReviewThreads(owner, repo, prNumber, token) {
   const query = `
     query($owner: String!, $repo: String!, $number: Int!, $after: String) {
@@ -149,7 +186,8 @@ async function getReviewThreads(owner, repo, prNumber, token) {
               id
               isResolved
               isOutdated
-              comments(first: 50) {
+              comments(first: 100) {
+                pageInfo { hasNextPage endCursor }
                 nodes {
                   author { login }
                   body
@@ -170,7 +208,12 @@ async function getReviewThreads(owner, repo, prNumber, token) {
   while (true) {
     const data = await githubGraphql(query, { owner, repo, number: prNumber, after }, token);
     const connection = data.repository.pullRequest.reviewThreads;
-    threads.push(...connection.nodes);
+    for (const thread of connection.nodes) {
+      if (thread.comments?.pageInfo?.hasNextPage) {
+        thread.comments.nodes = await getReviewThreadComments(thread.id, token);
+      }
+      threads.push(thread);
+    }
     if (!connection.pageInfo.hasNextPage) break;
     after = connection.pageInfo.endCursor;
   }
@@ -235,9 +278,16 @@ async function evaluate({ repo: repoSlug, pr: prNumber }) {
     && !isAiReviewError(review.body)
   );
 
-  const latestAiErrorCommentAt = latestDate(
-    issueComments.filter((comment) => isAiLogin(comment.user?.login, aiLogins) && isAiReviewError(comment.body)),
-    (comment) => comment.created_at,
+  const latestAiErrorAt = latestDate(
+    [
+      ...issueComments
+        .filter((comment) => isAiLogin(comment.user?.login, aiLogins) && isAiReviewError(comment.body))
+        .map((comment) => ({ createdAt: comment.created_at })),
+      ...reviews
+        .filter((review) => isAiLogin(review.user?.login, aiLogins) && isAiReviewError(review.body))
+        .map((review) => ({ createdAt: review.submitted_at })),
+    ],
+    (item) => item.createdAt,
   );
   const latestCurrentHeadAiReviewAt = latestDate(currentHeadAiReviews, (review) => review.submitted_at);
 
@@ -245,7 +295,7 @@ async function evaluate({ repo: repoSlug, pr: prNumber }) {
     failures.push('No AI second review exists on the current head SHA.');
   }
 
-  if (latestAiErrorCommentAt && (!latestCurrentHeadAiReviewAt || latestCurrentHeadAiReviewAt < latestAiErrorCommentAt)) {
+  if (latestAiErrorAt && (!latestCurrentHeadAiReviewAt || latestCurrentHeadAiReviewAt < latestAiErrorAt)) {
     failures.push('Latest AI review attempt errored and no later current-head AI review is present.');
   }
 
@@ -301,7 +351,7 @@ async function evaluate({ repo: repoSlug, pr: prNumber }) {
         state: review.state,
         submittedAt: review.submitted_at,
       })),
-      latestAiErrorCommentAt,
+      latestAiErrorAt,
       unresolvedAiThreadCount: unresolvedAiThreads.length,
     },
   };

--- a/scripts/pipeline-review-gate.mjs
+++ b/scripts/pipeline-review-gate.mjs
@@ -1,0 +1,346 @@
+#!/usr/bin/env node
+/**
+ * pipeline-review-gate.mjs
+ *
+ * Fails content/pipeline PRs that are structurally green but not publication
+ * ready. This intentionally checks live GitHub state rather than worker
+ * status comments, because worker comments can become stale after a push,
+ * rebase, or failed AI review attempt.
+ */
+
+const DEFAULT_AI_REVIEW_LOGINS = ['gemini-code-assist', 'gemini-code-assist[bot]'];
+const CONTENT_FILE_RE = /^site\/src\/content\/(?:incidents|campaigns|threat-actors|zero-days)\/.+\.mdx?$/;
+const PUBLIC_SITE_FILE_RE = /^site\/src\/(?:content|pages|components|layouts|data)\//;
+const PIPELINE_FILE_RE = /^(?:scripts\/(?:pipeline-|validate-content-corpus|public-prose-guardrails|check-pr-comments)|\.github\/workflows\/pipeline-|\.github\/pipeline\/config\.yml|docs\/PIPELINE\.md|site\/src\/content\.config\.ts)/;
+
+function parseArgs(argv) {
+  const parsed = {
+    pr: process.env.PR_NUMBER ? Number.parseInt(process.env.PR_NUMBER, 10) : null,
+    repo: process.env.GITHUB_REPOSITORY || 'MahdiHedhli/threatpedia',
+    json: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--pr' && argv[i + 1]) parsed.pr = Number.parseInt(argv[++i], 10);
+    else if (arg === '--repo' && argv[i + 1]) parsed.repo = argv[++i];
+    else if (arg === '--json') parsed.json = true;
+    else if (arg === '--help' || arg === '-h') {
+      printHelp();
+      process.exit(0);
+    }
+  }
+
+  if (!Number.isInteger(parsed.pr) || parsed.pr <= 0) {
+    throw new Error('Missing required PR number. Use --pr <number> or PR_NUMBER.');
+  }
+
+  if (!/^[^/]+\/[^/]+$/.test(parsed.repo)) {
+    throw new Error(`Invalid repo "${parsed.repo}". Expected owner/name.`);
+  }
+
+  return parsed;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/pipeline-review-gate.mjs --pr <number> [--repo owner/name] [--json]
+
+Environment:
+  GITHUB_TOKEN or GITHUB_PAT must be present.
+  AI_REVIEW_LOGINS may override the comma-separated AI reviewer login list.
+`);
+}
+
+function getToken() {
+  return process.env.GITHUB_TOKEN || process.env.GITHUB_PAT || null;
+}
+
+function getAiLogins() {
+  const raw = process.env.AI_REVIEW_LOGINS;
+  if (!raw) return new Set(DEFAULT_AI_REVIEW_LOGINS.map((login) => login.toLowerCase()));
+  return new Set(raw.split(',').map((login) => login.trim().toLowerCase()).filter(Boolean));
+}
+
+function isAiLogin(login, aiLogins) {
+  return Boolean(login) && aiLogins.has(login.toLowerCase());
+}
+
+function isRelevantFile(path) {
+  return CONTENT_FILE_RE.test(path) || PUBLIC_SITE_FILE_RE.test(path) || PIPELINE_FILE_RE.test(path);
+}
+
+function isContentFile(path) {
+  return CONTENT_FILE_RE.test(path);
+}
+
+function isAiReviewError(body) {
+  return /encountered an error creating the review/i.test(body || '')
+    || /try again by commenting\s+`?\/gemini review`?/i.test(body || '');
+}
+
+function hasNoFeedbackBody(body) {
+  return /\bno feedback\b/i.test(body || '')
+    || /\bno findings\b/i.test(body || '')
+    || /\bnothing to add\b/i.test(body || '');
+}
+
+async function githubFetch(path, token, options = {}) {
+  const url = path.startsWith('https://') ? path : `https://api.github.com${path}`;
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'User-Agent': 'threatpedia-pipeline-review-gate',
+      'X-GitHub-Api-Version': '2022-11-28',
+      ...(options.headers || {}),
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub API ${response.status} for ${path}: ${body.slice(0, 500)}`);
+  }
+
+  return response.json();
+}
+
+async function githubGraphql(query, variables, token) {
+  const response = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'threatpedia-pipeline-review-gate',
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const payload = await response.json();
+  if (!response.ok || payload.errors?.length) {
+    throw new Error(`GitHub GraphQL error: ${JSON.stringify(payload.errors || payload).slice(0, 800)}`);
+  }
+  return payload.data;
+}
+
+async function listPaginated(path, token) {
+  const results = [];
+  let page = 1;
+  while (true) {
+    const separator = path.includes('?') ? '&' : '?';
+    const items = await githubFetch(`${path}${separator}per_page=100&page=${page}`, token);
+    if (!Array.isArray(items) || items.length === 0) break;
+    results.push(...items);
+    if (items.length < 100) break;
+    page += 1;
+  }
+  return results;
+}
+
+async function getReviewThreads(owner, repo, prNumber, token) {
+  const query = `
+    query($owner: String!, $repo: String!, $number: Int!, $after: String) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          reviewThreads(first: 100, after: $after) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id
+              isResolved
+              isOutdated
+              comments(first: 50) {
+                nodes {
+                  author { login }
+                  body
+                  path
+                  line
+                  originalLine
+                  createdAt
+                }
+              }
+            }
+          }
+        }
+      }
+    }`;
+
+  const threads = [];
+  let after = null;
+  while (true) {
+    const data = await githubGraphql(query, { owner, repo, number: prNumber, after }, token);
+    const connection = data.repository.pullRequest.reviewThreads;
+    threads.push(...connection.nodes);
+    if (!connection.pageInfo.hasNextPage) break;
+    after = connection.pageInfo.endCursor;
+  }
+  return threads;
+}
+
+function latestDate(items, getter) {
+  const dates = items.map(getter).filter(Boolean).map((value) => new Date(value).getTime()).filter(Number.isFinite);
+  if (!dates.length) return null;
+  return new Date(Math.max(...dates)).toISOString();
+}
+
+async function evaluate({ repo: repoSlug, pr: prNumber }) {
+  const token = getToken();
+  if (!token) {
+    throw new Error('GITHUB_TOKEN or GITHUB_PAT is required. Do not read local secret files for this gate.');
+  }
+
+  const [owner, repo] = repoSlug.split('/');
+  const aiLogins = getAiLogins();
+
+  const pr = await githubFetch(`/repos/${owner}/${repo}/pulls/${prNumber}`, token);
+  const [files, reviews, issueComments, checkRunsPayload, threads] = await Promise.all([
+    listPaginated(`/repos/${owner}/${repo}/pulls/${prNumber}/files`, token),
+    listPaginated(`/repos/${owner}/${repo}/pulls/${prNumber}/reviews`, token),
+    listPaginated(`/repos/${owner}/${repo}/issues/${prNumber}/comments`, token),
+    githubFetch(`/repos/${owner}/${repo}/commits/${pr.head.sha}/check-runs?per_page=100`, token),
+    getReviewThreads(owner, repo, prNumber, token),
+  ]);
+
+  const changedPaths = files.map((file) => file.filename);
+  const relevantPaths = changedPaths.filter(isRelevantFile);
+  const contentPaths = changedPaths.filter(isContentFile);
+  const requiresGate = relevantPaths.length > 0;
+  const requiresValidation = contentPaths.length > 0;
+
+  const failures = [];
+  const notes = [];
+
+  if (!requiresGate) {
+    return {
+      pass: true,
+      pr: prNumber,
+      headSha: pr.head.sha,
+      applicable: false,
+      summary: 'No public content, site, or pipeline files changed; review gate not applicable.',
+      failures,
+      notes,
+      files: { changed: changedPaths, relevant: relevantPaths, content: contentPaths },
+    };
+  }
+
+  const validateChecks = (checkRunsPayload.check_runs || []).filter((check) => check.name === 'validate');
+  const passingValidate = validateChecks.find((check) => check.status === 'completed' && check.conclusion === 'success');
+  if (requiresValidation && !passingValidate) {
+    failures.push('No successful Pipeline: Validate Article PR "validate" check exists on the current head SHA.');
+  }
+
+  const currentHeadAiReviews = reviews.filter((review) =>
+    isAiLogin(review.user?.login, aiLogins)
+    && review.commit_id === pr.head.sha
+    && !isAiReviewError(review.body)
+  );
+
+  const latestAiErrorCommentAt = latestDate(
+    issueComments.filter((comment) => isAiLogin(comment.user?.login, aiLogins) && isAiReviewError(comment.body)),
+    (comment) => comment.created_at,
+  );
+  const latestCurrentHeadAiReviewAt = latestDate(currentHeadAiReviews, (review) => review.submitted_at);
+
+  if (!currentHeadAiReviews.length) {
+    failures.push('No AI second review exists on the current head SHA.');
+  }
+
+  if (latestAiErrorCommentAt && (!latestCurrentHeadAiReviewAt || latestCurrentHeadAiReviewAt < latestAiErrorCommentAt)) {
+    failures.push('Latest AI review attempt errored and no later current-head AI review is present.');
+  }
+
+  const unresolvedAiThreads = threads.filter((thread) =>
+    !thread.isResolved
+    && !thread.isOutdated
+    && thread.comments.nodes.some((comment) => isAiLogin(comment.author?.login, aiLogins))
+  );
+
+  if (unresolvedAiThreads.length > 0) {
+    failures.push(`${unresolvedAiThreads.length} unresolved current AI review thread(s) remain.`);
+  }
+
+  const currentHeadAiReviewBodies = currentHeadAiReviews.map((review) => review.body || '').filter(Boolean);
+  const currentHeadNoFeedback = currentHeadAiReviewBodies.some(hasNoFeedbackBody);
+  if (currentHeadAiReviews.length && !currentHeadNoFeedback && unresolvedAiThreads.length === 0) {
+    notes.push('Current-head AI review exists and no unresolved AI threads remain; review body was not a no-feedback summary, so top-level disposition should still be checked by the reviewer.');
+  }
+
+  const staleMergeReadyComments = issueComments.filter((comment) =>
+    /(?:Backlog|Queue|Worker) Status/i.test(comment.body || '')
+    && /Outcome:\s*`?merge_ready`?/i.test(comment.body || '')
+  );
+
+  if (staleMergeReadyComments.length && failures.length) {
+    notes.push('Worker status comments claim merge_ready, but live review gate failed; worker comments are stale/non-authoritative.');
+  }
+
+  return {
+    pass: failures.length === 0,
+    pr: prNumber,
+    headSha: pr.head.sha,
+    applicable: true,
+    summary: failures.length === 0 ? 'Review gate passed.' : 'Review gate failed.',
+    failures,
+    notes,
+    files: {
+      changed: changedPaths,
+      relevant: relevantPaths,
+      content: contentPaths,
+    },
+    checks: {
+      requiresValidation,
+      validateChecks: validateChecks.map((check) => ({
+        name: check.name,
+        status: check.status,
+        conclusion: check.conclusion,
+        startedAt: check.started_at,
+        completedAt: check.completed_at,
+      })),
+      aiReviewsOnHead: currentHeadAiReviews.map((review) => ({
+        author: review.user?.login || 'unknown',
+        state: review.state,
+        submittedAt: review.submitted_at,
+      })),
+      latestAiErrorCommentAt,
+      unresolvedAiThreadCount: unresolvedAiThreads.length,
+    },
+  };
+}
+
+function printHuman(result) {
+  console.log(`Pipeline review gate for PR #${result.pr}`);
+  console.log(`Head: ${result.headSha}`);
+  console.log(`Applicable: ${result.applicable ? 'yes' : 'no'}`);
+  console.log(`Result: ${result.pass ? 'PASS' : 'FAIL'}`);
+  console.log('');
+  console.log(result.summary);
+
+  if (result.failures.length) {
+    console.log('');
+    console.log('Failures:');
+    for (const failure of result.failures) console.log(`- ${failure}`);
+  }
+
+  if (result.notes.length) {
+    console.log('');
+    console.log('Notes:');
+    for (const note of result.notes) console.log(`- ${note}`);
+  }
+
+  if (result.files?.relevant?.length) {
+    console.log('');
+    console.log('Relevant changed files:');
+    for (const path of result.files.relevant) console.log(`- ${path}`);
+  }
+}
+
+try {
+  const args = parseArgs(process.argv.slice(2));
+  const result = await evaluate(args);
+  if (args.json) console.log(JSON.stringify(result, null, 2));
+  else printHuman(result);
+  if (!result.pass) process.exitCode = 1;
+} catch (error) {
+  console.error(`pipeline-review-gate: ${error.message}`);
+  process.exitCode = 2;
+}

--- a/scripts/pipeline-review-gate.mjs
+++ b/scripts/pipeline-review-gate.mjs
@@ -224,13 +224,14 @@ async function getReviewThreads(owner, repo, prNumber, token) {
   while (true) {
     const data = await githubGraphql(query, { owner, repo, number: prNumber, after }, token);
     const connection = data.repository.pullRequest.reviewThreads;
-    for (const thread of connection.nodes) {
+    const pageThreads = await Promise.all(connection.nodes.map(async (thread) => {
       if (thread.comments?.pageInfo?.hasNextPage) {
         const allComments = await getReviewThreadComments(thread.id, token);
         if (thread.comments) thread.comments.nodes = allComments;
       }
-      threads.push(thread);
-    }
+      return thread;
+    }));
+    threads.push(...pageThreads);
     if (!connection.pageInfo.hasNextPage) break;
     after = connection.pageInfo.endCursor;
   }
@@ -253,13 +254,7 @@ async function evaluate({ repo: repoSlug, pr: prNumber }) {
   const aiLogins = getAiLogins();
 
   const pr = await githubFetch(`/repos/${owner}/${repo}/pulls/${prNumber}`, token);
-  const [files, reviews, issueComments, checkRunsPayload, threads] = await Promise.all([
-    listPaginated(`/repos/${owner}/${repo}/pulls/${prNumber}/files`, token),
-    listPaginated(`/repos/${owner}/${repo}/pulls/${prNumber}/reviews`, token),
-    listPaginated(`/repos/${owner}/${repo}/issues/${prNumber}/comments`, token),
-    listCheckRuns(owner, repo, pr.head.sha, token),
-    getReviewThreads(owner, repo, prNumber, token),
-  ]);
+  const files = await listPaginated(`/repos/${owner}/${repo}/pulls/${prNumber}/files`, token);
 
   const changedPaths = files.map((file) => file.filename);
   const relevantPaths = changedPaths.filter(isRelevantFile);
@@ -282,6 +277,13 @@ async function evaluate({ repo: repoSlug, pr: prNumber }) {
       files: { changed: changedPaths, relevant: relevantPaths, content: contentPaths },
     };
   }
+
+  const [reviews, issueComments, checkRunsPayload, threads] = await Promise.all([
+    listPaginated(`/repos/${owner}/${repo}/pulls/${prNumber}/reviews`, token),
+    listPaginated(`/repos/${owner}/${repo}/issues/${prNumber}/comments`, token),
+    listCheckRuns(owner, repo, pr.head.sha, token),
+    getReviewThreads(owner, repo, prNumber, token),
+  ]);
 
   const validateChecks = (checkRunsPayload.check_runs || []).filter((check) => check.name === 'validate');
   const passingValidate = validateChecks.find((check) => check.status === 'completed' && check.conclusion === 'success');

--- a/scripts/pipeline-review-gate.mjs
+++ b/scripts/pipeline-review-gate.mjs
@@ -152,7 +152,7 @@ async function listCheckRuns(owner, repo, ref, token) {
   return { check_runs: results };
 }
 
-async function getReviewThreadComments(threadId, token) {
+async function getReviewThreadComments(threadId, token, after = null) {
   const query = `
     query($threadId: ID!, $after: String) {
       node(id: $threadId) {
@@ -173,14 +173,14 @@ async function getReviewThreadComments(threadId, token) {
     }`;
 
   const comments = [];
-  let after = null;
+  let cursor = after;
   while (true) {
-    const data = await githubGraphql(query, { threadId, after }, token);
+    const data = await githubGraphql(query, { threadId, after: cursor }, token);
     const connection = data.node?.comments;
     if (!connection) break;
     comments.push(...connection.nodes);
     if (!connection.pageInfo.hasNextPage) break;
-    after = connection.pageInfo.endCursor;
+    cursor = connection.pageInfo.endCursor;
   }
   return comments;
 }
@@ -220,8 +220,12 @@ async function getReviewThreads(owner, repo, prNumber, token) {
     const connection = data.repository.pullRequest.reviewThreads;
     const pageThreads = await Promise.all(connection.nodes.map(async (thread) => {
       if (thread.comments?.pageInfo?.hasNextPage) {
-        const allComments = await getReviewThreadComments(thread.id, token);
-        if (thread.comments) thread.comments.nodes = allComments;
+        const additionalComments = await getReviewThreadComments(
+          thread.id,
+          token,
+          thread.comments.pageInfo.endCursor,
+        );
+        if (thread.comments) thread.comments.nodes.push(...additionalComments);
       }
       return thread;
     }));

--- a/scripts/pipeline-review-gate.mjs
+++ b/scripts/pipeline-review-gate.mjs
@@ -10,8 +10,8 @@
 
 const DEFAULT_AI_REVIEW_LOGINS = ['gemini-code-assist', 'gemini-code-assist[bot]'];
 const CONTENT_FILE_RE = /^site\/src\/content\/(?:incidents|campaigns|threat-actors|zero-days)\/.+\.mdx?$/;
-const PUBLIC_SITE_FILE_RE = /^site\/src\/(?:content|pages|components|layouts|data)\//;
-const PIPELINE_FILE_RE = /^(?:scripts\/(?:pipeline-|validate-content-corpus|public-prose-guardrails|check-pr-comments)|\.github\/workflows\/pipeline-|\.github\/pipeline\/config\.yml|docs\/PIPELINE\.md|site\/src\/content\.config\.ts)/;
+const PUBLIC_SITE_FILE_RE = /^site\/(?:src\/|package(?:-lock)?\.json$|astro\.config\.)/;
+const PIPELINE_FILE_RE = /^(?:scripts\/|\.github\/workflows\/|\.github\/pipeline\/config\.yml|docs\/PIPELINE\.md|site\/src\/content\.config\.ts)/;
 
 function parseArgs(argv) {
   const parsed = {

--- a/scripts/pipeline-review-gate.mjs
+++ b/scripts/pipeline-review-gate.mjs
@@ -215,21 +215,25 @@ async function getReviewThreads(owner, repo, prNumber, token) {
 
   const threads = [];
   let after = null;
+  const THREAD_COMMENT_BATCH_SIZE = 10;
   while (true) {
     const data = await githubGraphql(query, { owner, repo, number: prNumber, after }, token);
     const connection = data.repository.pullRequest.reviewThreads;
-    const pageThreads = await Promise.all(connection.nodes.map(async (thread) => {
-      if (thread.comments?.pageInfo?.hasNextPage) {
-        const additionalComments = await getReviewThreadComments(
-          thread.id,
-          token,
-          thread.comments.pageInfo.endCursor,
-        );
-        if (thread.comments) thread.comments.nodes.push(...additionalComments);
-      }
-      return thread;
-    }));
-    threads.push(...pageThreads);
+    for (let index = 0; index < connection.nodes.length; index += THREAD_COMMENT_BATCH_SIZE) {
+      const batch = connection.nodes.slice(index, index + THREAD_COMMENT_BATCH_SIZE);
+      const pageThreads = await Promise.all(batch.map(async (thread) => {
+        if (thread.comments?.pageInfo?.hasNextPage) {
+          const additionalComments = await getReviewThreadComments(
+            thread.id,
+            token,
+            thread.comments.pageInfo.endCursor,
+          );
+          if (thread.comments) thread.comments.nodes.push(...additionalComments);
+        }
+        return thread;
+      }));
+      threads.push(...pageThreads);
+    }
     if (!connection.pageInfo.hasNextPage) break;
     after = connection.pageInfo.endCursor;
   }
@@ -237,9 +241,14 @@ async function getReviewThreads(owner, repo, prNumber, token) {
 }
 
 function latestDate(items, getter) {
-  const dates = items.map(getter).filter(Boolean).map((value) => new Date(value).getTime()).filter(Number.isFinite);
+  const dates = items
+    .map(getter)
+    .filter(Boolean)
+    .map((value) => (value instanceof Date ? value.getTime() : new Date(value).getTime()))
+    .filter(Number.isFinite);
   if (!dates.length) return null;
-  return new Date(Math.max(...dates)).toISOString();
+  const latest = dates.reduce((max, value) => Math.max(max, value), -Infinity);
+  return new Date(latest).toISOString();
 }
 
 async function evaluate({ repo: repoSlug, pr: prNumber }) {

--- a/scripts/pipeline-review-gate.mjs
+++ b/scripts/pipeline-review-gate.mjs
@@ -8,7 +8,11 @@
  * rebase, or failed AI review attempt.
  */
 
-const DEFAULT_AI_REVIEW_LOGINS = ['gemini-code-assist', 'gemini-code-assist[bot]'];
+const DEFAULT_AI_REVIEW_LOGINS = [
+  'gemini-code-assist',
+  'gemini-code-assist[bot]',
+  'dangermouse-bot',
+];
 const CONTENT_FILE_RE = /^site\/src\/content\/(?:incidents|campaigns|threat-actors|zero-days)\/.+\.mdx?$/;
 const PUBLIC_SITE_FILE_RE = /^site\/(?:src\/|package(?:-lock)?\.json$|astro\.config\.)/;
 const PIPELINE_FILE_RE = /^(?:scripts\/|\.github\/workflows\/|\.github\/pipeline\/config\.yml|docs\/PIPELINE\.md|site\/src\/content\.config\.ts)/;

--- a/scripts/pipeline-review-gate.mjs
+++ b/scripts/pipeline-review-gate.mjs
@@ -142,6 +142,22 @@ async function listPaginated(path, token) {
   return results;
 }
 
+async function listCheckRuns(owner, repo, ref, token) {
+  const results = [];
+  let page = 1;
+  while (true) {
+    const payload = await githubFetch(
+      `/repos/${owner}/${repo}/commits/${ref}/check-runs?per_page=100&page=${page}`,
+      token,
+    );
+    const checkRuns = payload.check_runs || [];
+    results.push(...checkRuns);
+    if (checkRuns.length < 100) break;
+    page += 1;
+  }
+  return { check_runs: results };
+}
+
 async function getReviewThreadComments(threadId, token) {
   const query = `
     query($threadId: ID!, $after: String) {
@@ -210,7 +226,8 @@ async function getReviewThreads(owner, repo, prNumber, token) {
     const connection = data.repository.pullRequest.reviewThreads;
     for (const thread of connection.nodes) {
       if (thread.comments?.pageInfo?.hasNextPage) {
-        thread.comments.nodes = await getReviewThreadComments(thread.id, token);
+        const allComments = await getReviewThreadComments(thread.id, token);
+        if (thread.comments) thread.comments.nodes = allComments;
       }
       threads.push(thread);
     }
@@ -240,7 +257,7 @@ async function evaluate({ repo: repoSlug, pr: prNumber }) {
     listPaginated(`/repos/${owner}/${repo}/pulls/${prNumber}/files`, token),
     listPaginated(`/repos/${owner}/${repo}/pulls/${prNumber}/reviews`, token),
     listPaginated(`/repos/${owner}/${repo}/issues/${prNumber}/comments`, token),
-    githubFetch(`/repos/${owner}/${repo}/commits/${pr.head.sha}/check-runs?per_page=100`, token),
+    listCheckRuns(owner, repo, pr.head.sha, token),
     getReviewThreads(owner, repo, prNumber, token),
   ]);
 
@@ -275,6 +292,7 @@ async function evaluate({ repo: repoSlug, pr: prNumber }) {
   const currentHeadAiReviews = reviews.filter((review) =>
     isAiLogin(review.user?.login, aiLogins)
     && review.commit_id === pr.head.sha
+    && review.state !== 'DISMISSED'
     && !isAiReviewError(review.body)
   );
 

--- a/scripts/pipeline-review-gate.mjs
+++ b/scripts/pipeline-review-gate.mjs
@@ -128,12 +128,13 @@ async function githubGraphql(query, variables, token) {
   return payload.data;
 }
 
-async function listPaginated(path, token) {
+async function listPaginated(path, token, dataExtractor = (payload) => payload) {
   const results = [];
   let page = 1;
   while (true) {
     const separator = path.includes('?') ? '&' : '?';
-    const items = await githubFetch(`${path}${separator}per_page=100&page=${page}`, token);
+    const payload = await githubFetch(`${path}${separator}per_page=100&page=${page}`, token);
+    const items = dataExtractor(payload);
     if (!Array.isArray(items) || items.length === 0) break;
     results.push(...items);
     if (items.length < 100) break;
@@ -143,18 +144,11 @@ async function listPaginated(path, token) {
 }
 
 async function listCheckRuns(owner, repo, ref, token) {
-  const results = [];
-  let page = 1;
-  while (true) {
-    const payload = await githubFetch(
-      `/repos/${owner}/${repo}/commits/${ref}/check-runs?per_page=100&page=${page}`,
-      token,
-    );
-    const checkRuns = payload.check_runs || [];
-    results.push(...checkRuns);
-    if (checkRuns.length < 100) break;
-    page += 1;
-  }
+  const results = await listPaginated(
+    `/repos/${owner}/${repo}/commits/${ref}/check-runs`,
+    token,
+    (payload) => payload.check_runs || [],
+  );
   return { check_runs: results };
 }
 


### PR DESCRIPTION
## Summary

- add a Pipeline: Review Gate workflow for content/site/pipeline PRs
- add scripts/pipeline-review-gate.mjs to check live GitHub state instead of worker status comments
- require current-head article validation for content PRs, current-head AI review, no unresolved AI threads, and no unresolved AI review-error state
- document the readiness gate in docs/PIPELINE.md

## Validation

- npm --prefix scripts ci --no-audit --no-fund
- npm --prefix site ci
- node --check scripts/pipeline-review-gate.mjs
- git diff --check
- workflow YAML parse via js-yaml
- live gate probe: PR #347 fails as expected for Gemini review errors/no current-head AI review
- live gate probe: PR #334 passes with current-head Gemini review and no content validation requirement
- live gate probe: PR #348 fails as expected after new head commit while awaiting fresh current-head AI review
- node scripts/pipeline-schema.mjs
- npm --prefix site run build

## Notes

This does not enable auto-merge. It adds a visible readiness check so green validation and stale worker comments cannot be mistaken for publication readiness.