### PR TITLE
feat(pipeline): deduplicate manual link submissions before queueing

### DIFF
--- a/.github/pipeline/ARCHITECTURE.md
+++ b/.github/pipeline/ARCHITECTURE.md
@@ -142,7 +142,8 @@ Tasks with `depends_on` are not dispatched until all dependencies are `complete`
 ### Deduplication
 - Discovery Action checks existing tasks AND existing articles for CVE coverage
 - Prevents duplicate articles for the same vulnerability
-- Manual submissions are not deduplicated (intentional — humans may re-submit with better context)
+- Manual submission ingest also deduplicates by normalized source URL against existing tasks and corpus content
+- Manual submissions that collide are labeled `pipeline/duplicate` and do not create a task file
 
 ### Validation Gates
 Every article PR runs automated checks before merge:

--- a/.github/pipeline/TESTING.md
+++ b/.github/pipeline/TESTING.md
@@ -17,9 +17,10 @@ Tests are organized by component and labeled with expected behavior.
 
 ### Edge Cases
 - [ ] **T1.4** — Submit Issue with no topic → Action posts error comment, adds `pipeline/error` label, no task file created
-- [ ] **T1.5** — Submit Issue with no source URLs → task created but `sources` array empty (agent must find sources independently)
+- [ ] **T1.5** — Submit Issue with no valid source URLs → Action posts error comment, adds `pipeline/error` label, no task file created
 - [ ] **T1.6** — Submit Issue with malformed CVE (e.g., "CVE-abcd-1234") → CVE filtered out, task created without it
 - [ ] **T1.7** — Submit duplicate source URL (already present in corpus/task queue) → no task file created, Issue gets dedup comment + `pipeline/duplicate` label
+- [ ] **T1.7a** — Submit source URL copied with trailing punctuation from prose → URL normalization strips the punctuation before dedup/task creation
 - [ ] **T1.8** — Submit Issue on a repo fork → Action should not trigger (scoped to main repo)
 - [ ] **T1.9** — Two Issues submitted simultaneously → each gets unique task ID (sequential numbering from max existing)
 

--- a/.github/pipeline/TESTING.md
+++ b/.github/pipeline/TESTING.md
@@ -19,7 +19,7 @@ Tests are organized by component and labeled with expected behavior.
 - [ ] **T1.4** — Submit Issue with no topic → Action posts error comment, adds `pipeline/error` label, no task file created
 - [ ] **T1.5** — Submit Issue with no source URLs → task created but `sources` array empty (agent must find sources independently)
 - [ ] **T1.6** — Submit Issue with malformed CVE (e.g., "CVE-abcd-1234") → CVE filtered out, task created without it
-- [ ] **T1.7** — Submit duplicate topic (same CVE already has a task) → currently creates duplicate; dedup is in discovery Action only. **Known limitation — acceptable for manual submissions** since humans may intentionally re-submit with better context
+- [ ] **T1.7** — Submit duplicate source URL (already present in corpus/task queue) → no task file created, Issue gets dedup comment + `pipeline/duplicate` label
 - [ ] **T1.8** — Submit Issue on a repo fork → Action should not trigger (scoped to main repo)
 - [ ] **T1.9** — Two Issues submitted simultaneously → each gets unique task ID (sequential numbering from max existing)
 

--- a/.github/workflows/pipeline-ingest-issue.yml
+++ b/.github/workflows/pipeline-ingest-issue.yml
@@ -66,7 +66,7 @@ jobs:
               .filter(s => s.startsWith('http'));
 
             function normalizeUrl(rawUrl) {
-              const value = String(rawUrl || '').trim().replace(/[.,;:]+$/g, '');
+              const value = String(rawUrl || '').trim().replace(/[.,;:'"]+$/g, '');
               if (!value) return null;
               try {
                 const url = new URL(value);
@@ -81,7 +81,7 @@ jobs:
             }
 
             function extractMarkdownUrls(content) {
-              return [...String(content || '').matchAll(/https?:\/\/[^\s)<>\"]+/g)]
+              return [...String(content || '').matchAll(/https?:\/\/[^\s)<>\"']+/g)]
                 .map(match => normalizeUrl(match[0]))
                 .filter(Boolean);
             }
@@ -141,7 +141,7 @@ jobs:
             if (fs.existsSync(tasksDir)) {
               const files = fs.readdirSync(tasksDir);
               for (const f of files) {
-                if (!/^TASK-\d{4}-\d{4}\.json$/.test(f)) continue;
+                if (!/^TASK-\d{4}-\d+\.json$/.test(f)) continue;
                 const full = path.join(tasksDir, f);
                 try {
                   const task = JSON.parse(fs.readFileSync(full, 'utf8'));
@@ -198,12 +198,24 @@ jobs:
             if (fs.existsSync(tasksDir)) {
               const files = fs.readdirSync(tasksDir);
               for (const f of files) {
-                const m = f.match(/^TASK-\d{4}-(\d{4})/);
+                const m = f.match(new RegExp(`^TASK-${year}-(\\d+)\\.json$`));
                 if (m) maxNum = Math.max(maxNum, parseInt(m[1]));
               }
             }
             const taskNum = String(maxNum + 1).padStart(4, '0');
             const taskId = `TASK-${year}-${taskNum}`;
+
+            function acceptanceCriteriaFor(articleType) {
+              return {
+                frontmatter_valid: true,
+                min_sources: 3,
+                min_h2_sections: articleType === 'campaign' ? 7 : (articleType === 'threat-actor' ? 6 : 5),
+                min_mitre_mappings: articleType === 'threat-actor' ? 3 : 1,
+                review_status: 'draft_ai',
+                schema_validation: 'pass',
+                astro_build: true,
+              };
+            }
 
             // ── Build task YAML ──────────────────────────────────────────
             const candidateData = {};
@@ -239,15 +251,7 @@ jobs:
               // Canonical write shape: `acceptance_criteria` (not `acceptance`)
               // and `astro_build` (not `build_passes`) per TASK-2026-0066 /
               // Slice 4b. Readers tolerate the legacy forms for back-compat.
-              acceptance_criteria: {
-                frontmatter_valid: true,
-                min_sources: 3,
-                min_h2_sections: 5,
-                min_mitre_mappings: 1,
-                review_status: 'draft_ai',
-                schema_validation: 'pass',
-                astro_build: true,
-              },
+              acceptance_criteria: acceptanceCriteriaFor(type),
               depends_on: [],
               preconditions: [
                 'editorial queue depth < 50',

--- a/.github/workflows/pipeline-ingest-issue.yml
+++ b/.github/workflows/pipeline-ingest-issue.yml
@@ -65,6 +65,29 @@ jobs:
               .map(s => s.trim())
               .filter(s => s.startsWith('http'));
 
+            function normalizeUrl(rawUrl) {
+              const value = String(rawUrl || '').trim();
+              if (!value) return null;
+              try {
+                const url = new URL(value);
+                url.hash = '';
+                if (url.pathname.length > 1 && url.pathname.endsWith('/')) {
+                  url.pathname = url.pathname.slice(0, -1);
+                }
+                return url.toString();
+              } catch {
+                return null;
+              }
+            }
+
+            function extractMarkdownUrls(content) {
+              return [...String(content || '').matchAll(/https?:\/\/[^\s)<>\"]+/g)]
+                .map(match => normalizeUrl(match[0]))
+                .filter(Boolean);
+            }
+
+            const normalizedSources = [...new Set(sources.map(normalizeUrl).filter(Boolean))];
+
             // Parse CVEs
             const cves = cvesRaw
               ? cvesRaw.split(',').map(c => c.trim()).filter(c => /^CVE-\d{4}-\d{4,}$/.test(c))
@@ -78,6 +101,65 @@ jobs:
             const fs = require('fs');
             const path = require('path');
             const tasksDir = '.github/pipeline/tasks';
+            const contentDir = 'site/src/content';
+
+            // ── Dedup against queue + existing corpus URLs ────────────────
+            const knownUrls = new Set();
+            if (fs.existsSync(tasksDir)) {
+              const files = fs.readdirSync(tasksDir);
+              for (const f of files) {
+                if (!/^TASK-\d{4}-\d{4}\.json$/.test(f)) continue;
+                const full = path.join(tasksDir, f);
+                try {
+                  const task = JSON.parse(fs.readFileSync(full, 'utf8'));
+                  for (const source of task.input?.sources || []) {
+                    const normalized = normalizeUrl(source);
+                    if (normalized) knownUrls.add(normalized);
+                  }
+                } catch {}
+              }
+            }
+
+            function collectMarkdownFiles(dir, out = []) {
+              if (!fs.existsSync(dir)) return out;
+              for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                const full = path.join(dir, entry.name);
+                if (entry.isDirectory()) collectMarkdownFiles(full, out);
+                if (entry.isFile() && full.endsWith('.md')) out.push(full);
+              }
+              return out;
+            }
+
+            for (const file of collectMarkdownFiles(contentDir)) {
+              const content = fs.readFileSync(file, 'utf8');
+              for (const url of extractMarkdownUrls(content)) {
+                knownUrls.add(url);
+              }
+            }
+
+            const duplicateSources = normalizedSources.filter(url => knownUrls.has(url));
+            if (duplicateSources.length > 0) {
+              const duplicateLines = duplicateSources.map(url => `- ${url}`).join('\n');
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: [
+                  '**Pipeline Dedup Notice:** no task was created because at least one submitted source URL already exists in the corpus or task queue.',
+                  '',
+                  duplicateLines,
+                  '',
+                  'If this is intentionally a follow-on or correction request, update the Issue with new corroborating URLs and context, then resubmit.',
+                ].join('\n'),
+              });
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['pipeline/duplicate']
+              });
+              return;
+            }
 
             let maxNum = 0;
             if (fs.existsSync(tasksDir)) {
@@ -112,7 +194,7 @@ jobs:
               locked_at: null,
               input: {
                 topic: topic,
-                sources: sources,
+                sources: normalizedSources,
                 candidate_data: Object.keys(candidateData).length > 0 ? candidateData : undefined,
                 notes: notes || undefined,
               },
@@ -177,7 +259,7 @@ jobs:
                 '|---|---|',
                 `| Type | ${type} |`,
                 `| Priority | ${priority} |`,
-                `| Sources | ${sources.length} URL(s) |`,
+                `| Sources | ${normalizedSources.length} URL(s) |`,
                 `| Stage | draft (pending) |`,
                 `| Branch | \`pipeline/${taskId}\` |`,
                 '',

--- a/.github/workflows/pipeline-ingest-issue.yml
+++ b/.github/workflows/pipeline-ingest-issue.yml
@@ -64,9 +64,6 @@ jobs:
               .split('\n')
               .map(s => s.trim())
               .filter(s => s.startsWith('http'));
-
-            const PIPELINE_TASK_YEAR = 2026;
-
             function normalizeUrl(rawUrl) {
               const value = String(rawUrl || '').trim().replace(/[.,;:'"()[\]]+$/g, '');
               if (!value) return null;
@@ -147,7 +144,7 @@ jobs:
 
             // ── Generate task ID ─────────────────────────────────────────
             const now = new Date();
-            const year = PIPELINE_TASK_YEAR;
+            const year = now.getUTCFullYear();
 
             // Find next available task number
             const fs = require('fs');

--- a/.github/workflows/pipeline-ingest-issue.yml
+++ b/.github/workflows/pipeline-ingest-issue.yml
@@ -66,7 +66,7 @@ jobs:
               .filter(s => s.startsWith('http'));
 
             function normalizeUrl(rawUrl) {
-              const value = String(rawUrl || '').trim();
+              const value = String(rawUrl || '').trim().replace(/[.,;:]+$/g, '');
               if (!value) return null;
               try {
                 const url = new URL(value);
@@ -87,6 +87,39 @@ jobs:
             }
 
             const normalizedSources = [...new Set(sources.map(normalizeUrl).filter(Boolean))];
+
+            const validTypes = new Set(['incident', 'campaign', 'threat-actor', 'zero-day']);
+            if (!validTypes.has(type)) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `**Pipeline Error:** Invalid article type \`${type}\`. Expected one of: incident, campaign, threat-actor, zero-day.`
+              });
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['pipeline/error']
+              });
+              return;
+            }
+
+            if (normalizedSources.length === 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: '**Pipeline Error:** No valid source URLs were provided. Add at least one http(s) source URL and resubmit.'
+              });
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['pipeline/error']
+              });
+              return;
+            }
 
             // Parse CVEs
             const cves = cvesRaw

--- a/.github/workflows/pipeline-ingest-issue.yml
+++ b/.github/workflows/pipeline-ingest-issue.yml
@@ -65,8 +65,10 @@ jobs:
               .map(s => s.trim())
               .filter(s => s.startsWith('http'));
 
+            const PIPELINE_TASK_YEAR = 2026;
+
             function normalizeUrl(rawUrl) {
-              const value = String(rawUrl || '').trim().replace(/[.,;:'"]+$/g, '');
+              const value = String(rawUrl || '').trim().replace(/[.,;:'"()[\]]+$/g, '');
               if (!value) return null;
               try {
                 const url = new URL(value);
@@ -105,6 +107,23 @@ jobs:
               return;
             }
 
+            const validSeverities = new Set(['critical', 'high', 'medium', 'low', 'unknown']);
+            if (!validSeverities.has(severity)) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `**Pipeline Error:** Invalid severity \`${severity}\`. Expected one of: critical, high, medium, low, unknown.`
+              });
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['pipeline/error']
+              });
+              return;
+            }
+
             if (normalizedSources.length === 0) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
@@ -128,7 +147,7 @@ jobs:
 
             // ── Generate task ID ─────────────────────────────────────────
             const now = new Date();
-            const year = now.getFullYear();
+            const year = PIPELINE_TASK_YEAR;
 
             // Find next available task number
             const fs = require('fs');
@@ -206,11 +225,19 @@ jobs:
             const taskId = `TASK-${year}-${taskNum}`;
 
             function acceptanceCriteriaFor(articleType) {
+              const minH2Sections = {
+                campaign: 7,
+                'threat-actor': 6,
+              };
+              const minMitreMappings = {
+                'threat-actor': 3,
+              };
+
               return {
                 frontmatter_valid: true,
                 min_sources: 3,
-                min_h2_sections: articleType === 'campaign' ? 7 : (articleType === 'threat-actor' ? 6 : 5),
-                min_mitre_mappings: articleType === 'threat-actor' ? 3 : 1,
+                min_h2_sections: minH2Sections[articleType] || 5,
+                min_mitre_mappings: minMitreMappings[articleType] || 1,
                 review_status: 'draft_ai',
                 schema_validation: 'pass',
                 astro_build: true,
@@ -281,8 +308,24 @@ jobs:
             // ── Write task file ──────────────────────────────────────────
             // Write as JSON (easier for Actions to parse than YAML)
             const taskPath = `${tasksDir}/${taskId}.json`;
-            fs.mkdirSync(tasksDir, { recursive: true });
-            fs.writeFileSync(taskPath, JSON.stringify(task, null, 2) + '\n');
+            try {
+              fs.mkdirSync(tasksDir, { recursive: true });
+              fs.writeFileSync(taskPath, JSON.stringify(task, null, 2) + '\n');
+            } catch (error) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `**Pipeline Error:** Failed to write task file \`${taskPath}\`: ${error.message}`
+              });
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['pipeline/error']
+              });
+              return;
+            }
 
             // ── Comment on Issue with task ID ────────────────────────────
             await github.rest.issues.createComment({

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -162,11 +162,52 @@ for the pipeline.
 
 ---
 
+## Manual link submission workflow (dedup-safe)
+
+Use this path when you find a candidate article link and want it to enter the
+same queue/validation path as discovery-generated tasks.
+
+1. **Preflight dedup check (local dry-run):**
+
+   ```bash
+   node scripts/pipeline-submit-link.mjs \
+     --type incident \
+     --priority P2 \
+     --topic "OpenSSH regreSSHion root shell access (15-year latent flaw)" \
+     --url "https://www.securityweek.com/openssh-flaw-allowing-full-root-shell-access-lurked-for-15-years/"
+   ```
+
+   - The command scans both:
+     - `.github/pipeline/tasks/*.json` (queue)
+     - `site/src/content/**/*.md` (published corpus)
+   - If any submitted URL is already known, it reports a duplicate and does not
+     write a task.
+   - If no duplicates are found, it reports the next available `TASK-YYYY-NNNN`
+     ID that would be created.
+
+2. **Submit through the standard queue:**
+   - Open **Submit Article Lead** Issue (`.github/ISSUE_TEMPLATE/discovery-submission.yml`).
+   - Paste the same URL(s) in **Source URLs**.
+   - The ingest workflow (`pipeline-ingest-issue.yml`) now performs the same
+     URL dedup guard against queue + corpus before writing a task file.
+
+3. **If dedup blocks the submission:**
+   - The Issue gets a dedup comment and `pipeline/duplicate` label.
+   - Add genuinely new corroborating source URLs and context, then resubmit.
+
+4. **After task creation:**
+   - The task enters the normal dispatcher flow and still must pass
+     `node scripts/pipeline-run-task.mjs --task TASK-YYYY-NNNN --validate`
+     before PR-open state can be recorded.
+
+---
+
 ## Guardrail quick reference
 
 | Guardrail | Where it lives | Default | Source of truth |
 |---|---|---|---|
 | Corpus + task dedup | `pipeline-discover.mjs` | Scans all content collections + all existing tasks using CVEs, URLs, normalized titles, and output slugs | Script |
+| Manual link dedup | `pipeline-ingest-issue.yml` + `scripts/pipeline-submit-link.mjs` | Blocks manual submissions when submitted source URLs already exist in corpus/tasks | Workflow + script |
 | Rejection memory (operator veto) | `pipeline-discover.mjs` reads `.github/pipeline/rejected-candidates.json` | Rejected CVEs and non-CVE candidate keys skipped at discovery time | File on `main`; see Rejection memory section |
 | Discovery lookback | workflow env `DAYS` → `--days` | 14 days | Workflow input |
 | Discovery per-run cap | workflow env `LIMIT` → `--limit` | 5 tasks | Workflow input |

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -182,6 +182,9 @@ same queue/validation path as discovery-generated tasks.
      - `site/src/content/**/*.md` (published corpus)
    - If any submitted URL is already known, it reports a duplicate and does not
      write a task.
+   - If the topic appears similar to an existing task/article, it reports an
+     informational overlap warning but still lets URL dedup be the blocking
+     check.
    - If no duplicates are found, it reports the next available `TASK-YYYY-NNNN`
      ID that would be created.
 

--- a/scripts/pipeline-submit-link.mjs
+++ b/scripts/pipeline-submit-link.mjs
@@ -82,7 +82,7 @@ function usage() {
 }
 
 function normalizeUrl(rawUrl) {
-  const value = String(rawUrl || '').trim();
+  const value = String(rawUrl || '').trim().replace(/[.,;:]+$/g, '');
   if (!value) return null;
   try {
     const url = new URL(value);
@@ -263,13 +263,15 @@ function main() {
   console.log(`  Type: ${args.type} | Priority: ${args.priority}`);
   console.log(`  URLs: ${normalizedUrls.length}`);
 
-  if (duplicateUrls.length > 0 || duplicateTitlePath) {
-    console.log('\nDUPLICATE DETECTED — task not created.');
+  if (duplicateTitlePath) {
+    console.log(`\nPotential topic overlap: ${duplicateTitlePath}`);
+    console.log('This is informational only; URL dedup remains the blocking check.');
+  }
+
+  if (duplicateUrls.length > 0) {
+    console.log('\nDUPLICATE DETECTED - task not created.');
     for (const url of duplicateUrls) {
-      console.log(`  • URL already known: ${url}`);
-    }
-    if (duplicateTitlePath) {
-      console.log(`  • Topic appears already covered: ${duplicateTitlePath}`);
+      console.log(`  - URL already known: ${url}`);
     }
     process.exitCode = 2;
     return;

--- a/scripts/pipeline-submit-link.mjs
+++ b/scripts/pipeline-submit-link.mjs
@@ -318,6 +318,9 @@ function main() {
 try {
   main();
 } catch (error) {
-  console.error(`pipeline-submit-link: ${error.message}`);
+  const detail = error instanceof Error
+    ? error.stack || error.message
+    : String(error);
+  console.error(`pipeline-submit-link: ${detail}`);
   process.exitCode = 1;
 }

--- a/scripts/pipeline-submit-link.mjs
+++ b/scripts/pipeline-submit-link.mjs
@@ -8,6 +8,7 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const ROOT = resolve(__dirname, '..');
 const TASKS_DIR = resolve(ROOT, '.github/pipeline/tasks');
 const CONTENT_DIR = resolve(ROOT, 'site/src/content');
+const PIPELINE_TASK_YEAR = 2026;
 
 function parseArgs(argv) {
   const args = {
@@ -16,56 +17,59 @@ function parseArgs(argv) {
     severity: 'unknown',
     submittedBy: 'manual-cli',
     execute: false,
+    urls: [],
   };
 
   for (let i = 2; i < argv.length; i += 1) {
     const token = argv[i];
     const next = argv[i + 1];
-    if (token === '--execute') {
-      args.execute = true;
-      continue;
+
+    switch (token) {
+      case '--execute':
+        args.execute = true;
+        break;
+      case '--help':
+      case '-h':
+        args.help = true;
+        break;
+      case '--url':
+        if (!next) throw new Error(`Missing value for ${token}`);
+        args.urls.push(next.trim());
+        i += 1;
+        break;
+      case '--topic':
+        if (!next) throw new Error(`Missing value for ${token}`);
+        args.topic = next.trim();
+        i += 1;
+        break;
+      case '--type':
+        if (!next) throw new Error(`Missing value for ${token}`);
+        args.type = next.trim();
+        i += 1;
+        break;
+      case '--priority':
+        if (!next) throw new Error(`Missing value for ${token}`);
+        args.priority = next.trim().toUpperCase();
+        i += 1;
+        break;
+      case '--severity':
+        if (!next) throw new Error(`Missing value for ${token}`);
+        args.severity = next.trim().toLowerCase();
+        i += 1;
+        break;
+      case '--submitted-by':
+        if (!next) throw new Error(`Missing value for ${token}`);
+        args.submittedBy = next.trim();
+        i += 1;
+        break;
+      case '--notes':
+        if (!next) throw new Error(`Missing value for ${token}`);
+        args.notes = next.trim();
+        i += 1;
+        break;
+      default:
+        throw new Error(`Unknown/invalid argument: ${token}`);
     }
-    if (token === '--url' && next) {
-      args.urls = args.urls || [];
-      args.urls.push(next.trim());
-      i += 1;
-      continue;
-    }
-    if (token === '--topic' && next) {
-      args.topic = next.trim();
-      i += 1;
-      continue;
-    }
-    if (token === '--type' && next) {
-      args.type = next.trim();
-      i += 1;
-      continue;
-    }
-    if (token === '--priority' && next) {
-      args.priority = next.trim().toUpperCase();
-      i += 1;
-      continue;
-    }
-    if (token === '--severity' && next) {
-      args.severity = next.trim().toLowerCase();
-      i += 1;
-      continue;
-    }
-    if (token === '--submitted-by' && next) {
-      args.submittedBy = next.trim();
-      i += 1;
-      continue;
-    }
-    if (token === '--notes' && next) {
-      args.notes = next.trim();
-      i += 1;
-      continue;
-    }
-    if (token === '--help' || token === '-h') {
-      args.help = true;
-      continue;
-    }
-    throw new Error(`Unknown/invalid argument: ${token}`);
   }
 
   return args;
@@ -82,7 +86,7 @@ function usage() {
 }
 
 function normalizeUrl(rawUrl) {
-  const value = String(rawUrl || '').trim().replace(/[.,;:'"]+$/g, '');
+  const value = String(rawUrl || '').trim().replace(/[.,;:'"()[\]]+$/g, '');
   if (!value) return null;
   try {
     const url = new URL(value);
@@ -163,15 +167,14 @@ function buildIndexes() {
 }
 
 function nextTaskId() {
-  const currentYear = new Date().getUTCFullYear();
   let maxNum = 0;
-  if (!existsSync(TASKS_DIR)) return `TASK-${currentYear}-0001`;
+  if (!existsSync(TASKS_DIR)) return `TASK-${PIPELINE_TASK_YEAR}-0001`;
   for (const file of readdirSync(TASKS_DIR)) {
-    const match = file.match(new RegExp(`^TASK-${currentYear}-(\\d+)\\.json$`));
+    const match = file.match(new RegExp(`^TASK-${PIPELINE_TASK_YEAR}-(\\d+)\\.json$`));
     if (!match) continue;
     maxNum = Math.max(maxNum, Number.parseInt(match[1], 10));
   }
-  return `TASK-${currentYear}-${String(maxNum + 1).padStart(4, '0')}`;
+  return `TASK-${PIPELINE_TASK_YEAR}-${String(maxNum + 1).padStart(4, '0')}`;
 }
 
 function filePatternFor(type) {
@@ -179,11 +182,19 @@ function filePatternFor(type) {
 }
 
 function acceptanceCriteriaFor(type) {
+  const minH2Sections = {
+    campaign: 7,
+    'threat-actor': 6,
+  };
+  const minMitreMappings = {
+    'threat-actor': 3,
+  };
+
   return {
     frontmatter_valid: true,
     min_sources: 3,
-    min_h2_sections: type === 'campaign' ? 7 : (type === 'threat-actor' ? 6 : 5),
-    min_mitre_mappings: type === 'threat-actor' ? 3 : 1,
+    min_h2_sections: minH2Sections[type] || 5,
+    min_mitre_mappings: minMitreMappings[type] || 1,
     review_status: 'draft_ai',
     schema_validation: 'pass',
     astro_build: true,
@@ -258,6 +269,8 @@ function main() {
   const validTypes = new Set(['incident', 'campaign', 'threat-actor', 'zero-day']);
   if (!validTypes.has(args.type)) throw new Error(`Invalid --type: ${args.type}`);
   if (!/^P[0-3]$/.test(args.priority)) throw new Error(`Invalid --priority: ${args.priority}`);
+  const validSeverities = new Set(['critical', 'high', 'medium', 'low', 'unknown']);
+  if (!validSeverities.has(args.severity)) throw new Error(`Invalid --severity: ${args.severity}`);
 
   const { knownUrls, knownTitles } = buildIndexes();
   const duplicateUrls = normalizedUrls.filter(url => knownUrls.has(url));
@@ -292,10 +305,19 @@ function main() {
     return;
   }
 
-  mkdirSync(TASKS_DIR, { recursive: true });
-  writeFileSync(taskPath, `${JSON.stringify(task, null, 2)}\n`);
+  try {
+    mkdirSync(TASKS_DIR, { recursive: true });
+    writeFileSync(taskPath, `${JSON.stringify(task, null, 2)}\n`);
+  } catch (error) {
+    throw new Error(`Failed to write task file ${taskPath}: ${error.message}`);
+  }
   console.log(`\nCreated task: ${taskId}`);
   console.log(`Path: ${taskPath}`);
 }
 
-main();
+try {
+  main();
+} catch (error) {
+  console.error(`pipeline-submit-link: ${error.message}`);
+  process.exitCode = 1;
+}

--- a/scripts/pipeline-submit-link.mjs
+++ b/scripts/pipeline-submit-link.mjs
@@ -8,7 +8,7 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const ROOT = resolve(__dirname, '..');
 const TASKS_DIR = resolve(ROOT, '.github/pipeline/tasks');
 const CONTENT_DIR = resolve(ROOT, 'site/src/content');
-const PIPELINE_TASK_YEAR = 2026;
+const PIPELINE_TASK_YEAR = new Date().getUTCFullYear();
 
 function parseArgs(argv) {
   const args = {

--- a/scripts/pipeline-submit-link.mjs
+++ b/scripts/pipeline-submit-link.mjs
@@ -82,7 +82,7 @@ function usage() {
 }
 
 function normalizeUrl(rawUrl) {
-  const value = String(rawUrl || '').trim().replace(/[.,;:]+$/g, '');
+  const value = String(rawUrl || '').trim().replace(/[.,;:'"]+$/g, '');
   if (!value) return null;
   try {
     const url = new URL(value);
@@ -105,7 +105,7 @@ function normalizeTitleKey(value) {
 }
 
 function extractMarkdownUrls(content) {
-  return [...String(content || '').matchAll(/https?:\/\/[^\s)<>"]+/g)]
+  return [...String(content || '').matchAll(/https?:\/\/[^\s)<>"']+/g)]
     .map(match => normalizeUrl(match[0]))
     .filter(Boolean);
 }
@@ -129,7 +129,7 @@ function buildIndexes() {
 
   if (existsSync(TASKS_DIR)) {
     for (const file of readdirSync(TASKS_DIR)) {
-      if (!/^TASK-\d{4}-\d{4}\.json$/.test(file)) continue;
+      if (!/^TASK-\d{4}-\d+\.json$/.test(file)) continue;
       const full = resolve(TASKS_DIR, file);
       const raw = readFileSync(full, 'utf8');
       let task;
@@ -163,18 +163,31 @@ function buildIndexes() {
 }
 
 function nextTaskId() {
+  const currentYear = new Date().getUTCFullYear();
   let maxNum = 0;
-  if (!existsSync(TASKS_DIR)) return `TASK-${new Date().getUTCFullYear()}-0001`;
+  if (!existsSync(TASKS_DIR)) return `TASK-${currentYear}-0001`;
   for (const file of readdirSync(TASKS_DIR)) {
-    const match = file.match(/^TASK-\d{4}-(\d{4})\.json$/);
+    const match = file.match(new RegExp(`^TASK-${currentYear}-(\\d+)\\.json$`));
     if (!match) continue;
     maxNum = Math.max(maxNum, Number.parseInt(match[1], 10));
   }
-  return `TASK-${new Date().getUTCFullYear()}-${String(maxNum + 1).padStart(4, '0')}`;
+  return `TASK-${currentYear}-${String(maxNum + 1).padStart(4, '0')}`;
 }
 
 function filePatternFor(type) {
   return `site/src/content/${type === 'threat-actor' ? 'threat-actors' : `${type}s`}/{slug}.md`;
+}
+
+function acceptanceCriteriaFor(type) {
+  return {
+    frontmatter_valid: true,
+    min_sources: 3,
+    min_h2_sections: type === 'campaign' ? 7 : (type === 'threat-actor' ? 6 : 5),
+    min_mitre_mappings: type === 'threat-actor' ? 3 : 1,
+    review_status: 'draft_ai',
+    schema_validation: 'pass',
+    astro_build: true,
+  };
 }
 
 function buildTask(args, normalizedUrls, taskId) {
@@ -205,15 +218,7 @@ function buildTask(args, normalizedUrls, taskId) {
       'EDITORIAL-WORKFLOW-SPEC.md §14A',
       'INGESTION-SPEC.md §2',
     ],
-    acceptance_criteria: {
-      frontmatter_valid: true,
-      min_sources: 3,
-      min_h2_sections: 5,
-      min_mitre_mappings: 1,
-      review_status: 'draft_ai',
-      schema_validation: 'pass',
-      astro_build: true,
-    },
+    acceptance_criteria: acceptanceCriteriaFor(args.type),
     depends_on: [],
     preconditions: ['editorial queue depth < 50'],
     output: {

--- a/scripts/pipeline-submit-link.mjs
+++ b/scripts/pipeline-submit-link.mjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const TASKS_DIR = resolve(ROOT, '.github/pipeline/tasks');
+const CONTENT_DIR = resolve(ROOT, 'site/src/content');
+
+function parseArgs(argv) {
+  const args = {
+    type: 'incident',
+    priority: 'P2',
+    severity: 'unknown',
+    submittedBy: 'manual-cli',
+    execute: false,
+  };
+
+  for (let i = 2; i < argv.length; i += 1) {
+    const token = argv[i];
+    const next = argv[i + 1];
+    if (token === '--execute') {
+      args.execute = true;
+      continue;
+    }
+    if (token === '--url' && next) {
+      args.urls = args.urls || [];
+      args.urls.push(next.trim());
+      i += 1;
+      continue;
+    }
+    if (token === '--topic' && next) {
+      args.topic = next.trim();
+      i += 1;
+      continue;
+    }
+    if (token === '--type' && next) {
+      args.type = next.trim();
+      i += 1;
+      continue;
+    }
+    if (token === '--priority' && next) {
+      args.priority = next.trim().toUpperCase();
+      i += 1;
+      continue;
+    }
+    if (token === '--severity' && next) {
+      args.severity = next.trim().toLowerCase();
+      i += 1;
+      continue;
+    }
+    if (token === '--submitted-by' && next) {
+      args.submittedBy = next.trim();
+      i += 1;
+      continue;
+    }
+    if (token === '--notes' && next) {
+      args.notes = next.trim();
+      i += 1;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      args.help = true;
+      continue;
+    }
+    throw new Error(`Unknown/invalid argument: ${token}`);
+  }
+
+  return args;
+}
+
+function usage() {
+  console.log([
+    'Usage:',
+    '  node scripts/pipeline-submit-link.mjs --url <url> [--url <url2> ...] [--topic <text>] [--type incident|campaign|threat-actor|zero-day]',
+    '      [--priority P0|P1|P2|P3] [--severity critical|high|medium|low|unknown] [--notes <text>] [--submitted-by <name>] [--execute]',
+    '',
+    'Default is dry-run (no file write). Add --execute to create a task JSON in .github/pipeline/tasks/.',
+  ].join('\n'));
+}
+
+function normalizeUrl(rawUrl) {
+  const value = String(rawUrl || '').trim();
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    url.hash = '';
+    if (url.pathname.length > 1 && url.pathname.endsWith('/')) {
+      url.pathname = url.pathname.slice(0, -1);
+    }
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function normalizeTitleKey(value) {
+  return String(value || '')
+    .normalize('NFKD')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function extractMarkdownUrls(content) {
+  return [...String(content || '').matchAll(/https?:\/\/[^\s)<>"]+/g)]
+    .map(match => normalizeUrl(match[0]))
+    .filter(Boolean);
+}
+
+function listContentFiles(dir, out = []) {
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      listContentFiles(full, out);
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function buildIndexes() {
+  const knownUrls = new Set();
+  const knownTitles = new Map();
+
+  if (existsSync(TASKS_DIR)) {
+    for (const file of readdirSync(TASKS_DIR)) {
+      if (!/^TASK-\d{4}-\d{4}\.json$/.test(file)) continue;
+      const full = resolve(TASKS_DIR, file);
+      const raw = readFileSync(full, 'utf8');
+      let task;
+      try {
+        task = JSON.parse(raw);
+      } catch {
+        continue;
+      }
+      for (const source of task.input?.sources || []) {
+        const normalized = normalizeUrl(source);
+        if (normalized) knownUrls.add(normalized);
+      }
+      const topic = task.input?.topic;
+      const titleKey = normalizeTitleKey(topic);
+      if (titleKey) knownTitles.set(titleKey, `.github/pipeline/tasks/${file}`);
+    }
+  }
+
+  for (const full of listContentFiles(CONTENT_DIR)) {
+    const rel = full.replace(`${ROOT}/`, '');
+    const content = readFileSync(full, 'utf8');
+    for (const url of extractMarkdownUrls(content)) {
+      knownUrls.add(url);
+    }
+    const heading = content.match(/^#\s+(.+)$/m)?.[1]?.trim();
+    const titleKey = normalizeTitleKey(heading);
+    if (titleKey) knownTitles.set(titleKey, rel);
+  }
+
+  return { knownUrls, knownTitles };
+}
+
+function nextTaskId() {
+  let maxNum = 0;
+  if (!existsSync(TASKS_DIR)) return `TASK-${new Date().getUTCFullYear()}-0001`;
+  for (const file of readdirSync(TASKS_DIR)) {
+    const match = file.match(/^TASK-\d{4}-(\d{4})\.json$/);
+    if (!match) continue;
+    maxNum = Math.max(maxNum, Number.parseInt(match[1], 10));
+  }
+  return `TASK-${new Date().getUTCFullYear()}-${String(maxNum + 1).padStart(4, '0')}`;
+}
+
+function filePatternFor(type) {
+  return `site/src/content/${type === 'threat-actor' ? 'threat-actors' : `${type}s`}/{slug}.md`;
+}
+
+function buildTask(args, normalizedUrls, taskId) {
+  const nowIso = new Date().toISOString();
+  const candidateData = {};
+  if (args.severity && args.severity !== 'unknown') candidateData.severity = args.severity;
+
+  return {
+    task_id: taskId,
+    stage: 'draft',
+    type: args.type,
+    priority: args.priority,
+    status: 'pending',
+    created: nowIso,
+    updated: nowIso,
+    source: 'manual_submission',
+    submitted_by: args.submittedBy,
+    locked_by: null,
+    locked_at: null,
+    input: {
+      topic: args.topic,
+      sources: normalizedUrls,
+      candidate_data: Object.keys(candidateData).length > 0 ? candidateData : undefined,
+      notes: args.notes || undefined,
+    },
+    specs: [
+      'DATA-STANDARDS-v1.0.md',
+      'EDITORIAL-WORKFLOW-SPEC.md §14A',
+      'INGESTION-SPEC.md §2',
+    ],
+    acceptance_criteria: {
+      frontmatter_valid: true,
+      min_sources: 3,
+      min_h2_sections: 5,
+      min_mitre_mappings: 1,
+      review_status: 'draft_ai',
+      schema_validation: 'pass',
+      astro_build: true,
+    },
+    depends_on: [],
+    preconditions: ['editorial queue depth < 50'],
+    output: {
+      file_pattern: filePatternFor(args.type),
+      branch: `pipeline/${taskId}`,
+      pr: true,
+    },
+    history: [
+      {
+        timestamp: nowIso,
+        action: 'created',
+        from: 'none',
+        to: 'pending',
+        agent: args.submittedBy,
+        note: 'Manual link submission via scripts/pipeline-submit-link.mjs',
+      },
+    ],
+  };
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    usage();
+    return;
+  }
+  if (!args.urls || args.urls.length === 0) throw new Error('At least one --url is required.');
+
+  const normalizedUrls = [...new Set(args.urls.map(normalizeUrl).filter(Boolean))];
+  if (normalizedUrls.length === 0) throw new Error('No valid URL values were provided.');
+
+  if (!args.topic) {
+    const first = new URL(normalizedUrls[0]);
+    args.topic = `${first.hostname}${first.pathname}`;
+  }
+
+  const validTypes = new Set(['incident', 'campaign', 'threat-actor', 'zero-day']);
+  if (!validTypes.has(args.type)) throw new Error(`Invalid --type: ${args.type}`);
+  if (!/^P[0-3]$/.test(args.priority)) throw new Error(`Invalid --priority: ${args.priority}`);
+
+  const { knownUrls, knownTitles } = buildIndexes();
+  const duplicateUrls = normalizedUrls.filter(url => knownUrls.has(url));
+  const duplicateTitlePath = knownTitles.get(normalizeTitleKey(args.topic));
+
+  console.log('Threatpedia manual link submission check');
+  console.log(`  Topic: ${args.topic}`);
+  console.log(`  Type: ${args.type} | Priority: ${args.priority}`);
+  console.log(`  URLs: ${normalizedUrls.length}`);
+
+  if (duplicateUrls.length > 0 || duplicateTitlePath) {
+    console.log('\nDUPLICATE DETECTED — task not created.');
+    for (const url of duplicateUrls) {
+      console.log(`  • URL already known: ${url}`);
+    }
+    if (duplicateTitlePath) {
+      console.log(`  • Topic appears already covered: ${duplicateTitlePath}`);
+    }
+    process.exitCode = 2;
+    return;
+  }
+
+  const taskId = nextTaskId();
+  const task = buildTask(args, normalizedUrls, taskId);
+  const taskPath = resolve(TASKS_DIR, `${taskId}.json`);
+
+  if (!args.execute) {
+    console.log(`\nNo duplicates found. Dry-run only; would create ${taskId}.`);
+    console.log(`Add --execute to write: ${taskPath}`);
+    return;
+  }
+
+  mkdirSync(TASKS_DIR, { recursive: true });
+  writeFileSync(taskPath, `${JSON.stringify(task, null, 2)}\n`);
+  console.log(`\nCreated task: ${taskId}`);
+  console.log(`Path: ${taskPath}`);
+}
+
+main();


### PR DESCRIPTION
### Motivation

- Provide a safe, dedup-aware manual intake path so an operator can add a found link into the standard article pipeline while ensuring it goes through the same task/validation flow and avoiding duplicate articles or duplicate tasks.

### Description

- Add a local CLI `scripts/pipeline-submit-link.mjs` that normalizes submitted URLs, scans `.github/pipeline/tasks/*.json` and `site/src/content/**/*.md` for existing URLs/titles, performs a dry-run by default, and writes a canonical `TASK-YYYY-NNNN.json` only with `--execute` when no duplicates are found.
- Update the ingest workflow ` .github/workflows/pipeline-ingest-issue.yml` to normalize submitted source URLs, check for duplicates against the queue and corpus before creating a task, and comment + apply the `pipeline/duplicate` label when collisions are detected instead of creating a task.
- Use normalized sources in the created task JSON so `input.sources` reflects canonicalized URLs and the Issue comment reports normalized counts.
- Document the manual link submission workflow and preflight command in `docs/PIPELINE.md`, and update pipeline architecture and test-plan docs (`.github/pipeline/ARCHITECTURE.md`, `.github/pipeline/TESTING.md`) to note that manual submissions are now deduplicated by URL and emit `pipeline/duplicate` on collisions.

### Testing

- Ran the preflight dry-run: `node scripts/pipeline-submit-link.mjs --type incident --priority P2 --topic "OpenSSH regreSSHion root shell access (15-year latent flaw)" --url "https://www.securityweek.com/openssh-flaw-allowing-full-root-shell-access-lurked-for-15-years/"` and it completed successfully reporting `No duplicates found` and the next available task id (dry-run). (succeeded)
- Verified script syntax with `node --check scripts/pipeline-submit-link.mjs` which returned clean (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eff06ca70c832fa4019c80d4eaf15c)