### PR TITLE
fix(pipeline): skip dispatch for tasks with open PRs

### DIFF
--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -136,6 +136,9 @@ for the pipeline.
    - If a task already has an open `pipeline/ready` Issue, the dispatcher
      does **not** open a duplicate Issue on the next tick. It records the
      existing Issue number in task history once and moves on.
+   - If a task is still `pending` on `main` but an open PR already exists for
+     the task branch, the dispatcher treats that PR as covering the task,
+     closes any stale `pipeline/ready` Issue, and skips redispatch.
 
 7. **Agent execution** (under the agent's own subscription)
    - Agent reads the task brief, drafts the article into

--- a/scripts/pipeline-dispatcher-dispatch-step.cjs
+++ b/scripts/pipeline-dispatcher-dispatch-step.cjs
@@ -79,7 +79,7 @@ module.exports = async function runDispatcherDispatchStep({ github, context }) {
   }
 
   function parseTaskIdFromIssue(issue) {
-    const titleMatch = String(issue.title || '').match(/\[PIPELINE\]\s+(TASK-\d{4}-\d+):/);
+    const titleMatch = String(issue.title || '').match(/\[PIPELINE\]\s+(TASK-\d{4}-\d{4}):/);
     if (titleMatch) return titleMatch[1];
     const bodyMatch = String(issue.body || '').match(/## Pipeline Task: `([^`]+)`/);
     return bodyMatch ? bodyMatch[1] : null;
@@ -160,6 +160,7 @@ module.exports = async function runDispatcherDispatchStep({ github, context }) {
   async function loadOpenPrForTask(task) {
     const knownPr = await loadPrForTask(task);
     if (knownPr?.state === 'open') return knownPr;
+    if (!task.pr_number) return null;
 
     const headRef = task.output?.branch;
     if (!headRef) return null;
@@ -171,7 +172,7 @@ module.exports = async function runDispatcherDispatchStep({ github, context }) {
       head: `${context.repo.owner}:${headRef}`,
       sort: 'updated',
       direction: 'desc',
-      per_page: 5,
+      per_page: 1,
     });
     return data[0] || null;
   }
@@ -268,7 +269,12 @@ module.exports = async function runDispatcherDispatchStep({ github, context }) {
       }
 
       const readyForPickup = task.status === 'pending' && task.stage === 'draft';
-      const coveringPr = await loadOpenPrForTask(task);
+      let coveringPr = null;
+      if (readyForPickup) {
+        coveringPr = await loadOpenPrForTask(task);
+      } else if (task.status === 'pr_open' && task.pr_number) {
+        coveringPr = { state: 'open', number: task.pr_number };
+      }
 
       if (coveringPr?.state === 'open') {
         for (const issue of issues) {

--- a/scripts/pipeline-dispatcher-dispatch-step.cjs
+++ b/scripts/pipeline-dispatcher-dispatch-step.cjs
@@ -154,13 +154,14 @@ module.exports = async function runDispatcherDispatchStep({ github, context }) {
       direction: 'desc',
       per_page: 5,
     });
-    return data[0] || null;
+    return data.find((pr) => pr.state === 'open') || data[0] || null;
   }
 
   async function loadOpenPrForTask(task) {
-    const knownPr = await loadPrForTask(task);
-    if (knownPr?.state === 'open') return knownPr;
-    if (!task.pr_number) return null;
+    if (task.pr_number) {
+      const knownPr = await loadPrForTask(task);
+      if (knownPr?.state === 'open') return knownPr;
+    }
 
     const headRef = task.output?.branch;
     if (!headRef) return null;

--- a/scripts/pipeline-dispatcher-dispatch-step.cjs
+++ b/scripts/pipeline-dispatcher-dispatch-step.cjs
@@ -79,7 +79,7 @@ module.exports = async function runDispatcherDispatchStep({ github, context }) {
   }
 
   function parseTaskIdFromIssue(issue) {
-    const titleMatch = String(issue.title || '').match(/\[PIPELINE\]\s+(TASK-\d{4}-\d{4}):/);
+    const titleMatch = String(issue.title || '').match(/\[PIPELINE\]\s+(TASK-\d{4}-\d+):/);
     if (titleMatch) return titleMatch[1];
     const bodyMatch = String(issue.body || '').match(/## Pipeline Task: `([^`]+)`/);
     return bodyMatch ? bodyMatch[1] : null;
@@ -149,6 +149,25 @@ module.exports = async function runDispatcherDispatchStep({ github, context }) {
       owner: context.repo.owner,
       repo: context.repo.repo,
       state: 'all',
+      head: `${context.repo.owner}:${headRef}`,
+      sort: 'updated',
+      direction: 'desc',
+      per_page: 5,
+    });
+    return data[0] || null;
+  }
+
+  async function loadOpenPrForTask(task) {
+    const knownPr = await loadPrForTask(task);
+    if (knownPr?.state === 'open') return knownPr;
+
+    const headRef = task.output?.branch;
+    if (!headRef) return null;
+
+    const { data } = await github.rest.pulls.list({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      state: 'open',
       head: `${context.repo.owner}:${headRef}`,
       sort: 'updated',
       direction: 'desc',
@@ -249,6 +268,18 @@ module.exports = async function runDispatcherDispatchStep({ github, context }) {
       }
 
       const readyForPickup = task.status === 'pending' && task.stage === 'draft';
+      const coveringPr = await loadOpenPrForTask(task);
+
+      if (coveringPr?.state === 'open') {
+        for (const issue of issues) {
+          await closePipelineIssue(
+            issue,
+            `${taskId} is already covered by open PR #${coveringPr.number}`
+          );
+        }
+        continue;
+      }
+
       if (!readyForPickup) {
         for (const issue of issues) {
           await closePipelineIssue(
@@ -429,6 +460,36 @@ module.exports = async function runDispatcherDispatchStep({ github, context }) {
         note: `Blocked by: ${unmet.join(', ')}`,
       });
       saveTask(task);
+      continue;
+    }
+
+    const coveringPr = await loadOpenPrForTask(task);
+    if (coveringPr?.state === 'open') {
+      console.log(`Task ${task.task_id} already has open PR #${coveringPr.number} — skipping dispatch`);
+      const existingIssue = findOpenPipelineIssue(task.task_id);
+      if (existingIssue) {
+        await closePipelineIssue(
+          existingIssue,
+          `${task.task_id} is already covered by open PR #${coveringPr.number}`
+        );
+      }
+
+      const alreadyRecorded = task.history?.some((entry) =>
+        entry.agent === 'dispatcher' &&
+        String(entry.note || '').includes(`open PR #${coveringPr.number}`)
+      );
+      if (!alreadyRecorded) {
+        task.updated = nowIso;
+        appendHistory(task, {
+          timestamp: nowIso,
+          action: 'dispatch_skipped',
+          from: 'pending',
+          to: 'pending',
+          agent: 'dispatcher',
+          note: `Dispatch skipped because open PR #${coveringPr.number} already covers this task.`,
+        });
+        saveTask(task);
+      }
       continue;
     }
 


### PR DESCRIPTION
## Summary

- Prevent dispatcher redispatch for tasks that are still pending on main but already have an open PR on the task branch.
- Close stale pipeline/ready issues when a covering PR exists.
- Document the PR-backed skip behavior in docs/PIPELINE.md.

## Validation

- npm --prefix scripts ci --no-audit --no-fund
- node --check scripts/pipeline-dispatcher-dispatch-step.cjs
- node --check scripts/pipeline-dispatcher-pr-step.cjs
- git diff --check
- mocked dispatcher run covering: pending task + open PR without ready issue, and pending task + open PR + stale ready issue

## Context

This fixes the duplicate ready issue observed for TASK-2026-0106 while PR #347 was already open.