### PR TITLE
Block TASK-2026-0151 pending Operation Aurora canonical decision

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0151.json
+++ b/.github/pipeline/tasks/TASK-2026-0151.json
@@ -2,7 +2,7 @@
   "task_id": "TASK-2026-0151",
   "type": "campaign",
   "priority": "P2",
-  "status": "pending",
+  "status": "blocked",
   "input": {
     "topic": "Operation Aurora campaign canonical reconciliation",
     "reprocess": true,
@@ -49,7 +49,24 @@
       "to": "pending",
       "agent": "dispatcher",
       "note": "Dispatched as Issue #379"
+    },
+    {
+      "timestamp": "2026-04-29T15:42:54.059Z",
+      "from": "pending",
+      "to": "locked",
+      "agent": "Mahdi Hedhli",
+      "note": "Locked for execution"
+    },
+    {
+      "timestamp": "2026-04-29T15:43:10Z",
+      "action": "blocked",
+      "from": "locked",
+      "to": "blocked",
+      "agent": "Mahdi Hedhli",
+      "note": "Blocked in place: target campaign file site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md does not exist on main, and the only live public Operation Aurora content currently exists as the incident article site/src/content/incidents/operation-aurora-espionage-2009.md. This needs a canonical content-shape decision before the task can be drafted or closed as complete."
     }
   ],
-  "updated": "2026-04-29T06:42:15.962Z"
+  "updated": "2026-04-29T15:43:10Z",
+  "locked_by": null,
+  "locked_at": null
 }

--- a/.github/pipeline/tasks/TASK-2026-0151.json
+++ b/.github/pipeline/tasks/TASK-2026-0151.json
@@ -52,6 +52,7 @@
     },
     {
       "timestamp": "2026-04-29T15:42:54.059Z",
+      "action": "locked",
       "from": "pending",
       "to": "locked",
       "agent": "Mahdi Hedhli",


### PR DESCRIPTION
## Summary
- mark TASK-2026-0151 blocked on its own task branch
- record that the campaign target file does not exist on main
- document that current public Operation Aurora content lives as an incident article pending a canonical content-shape decision

## Why
The task is currently queued as a campaign rewrite, but `site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md` does not exist on `main`. Drafting against a nonexistent canonical target would create a misleading queue path. This PR blocks the task in public state until the campaign-vs-incident canonical decision is made.