### PR TITLE
Reconcile TASK-2026-0101 merged state

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0101.json
+++ b/.github/pipeline/tasks/TASK-2026-0101.json
@@ -10,7 +10,7 @@
     "issues": [
       "missing_sources"
     ],
-    "notes": "No sources in frontmatter; No Sources/References section in body; Zero sources anywhere — needs full source reconstruction"
+    "notes": "No sources in frontmatter; No Sources/References section in body; Zero sources anywhere \u2014 needs full source reconstruction"
   },
   "output": {
     "file_pattern": "site/src/content/incidents/operation-truechaos-trueconf-zero-day-2026.md",
@@ -31,7 +31,7 @@
       "from": "none",
       "to": "pending",
       "agent": "dangermouse-bot",
-      "note": "Corpus reprocessing — source quality enforcement"
+      "note": "Corpus reprocessing \u2014 source quality enforcement"
     },
     {
       "timestamp": "2026-04-29T06:42:02.981Z",
@@ -53,7 +53,7 @@
       "action": "merged",
       "from": "pr_open",
       "to": "complete",
-      "agent": "pipeline-task-state",
+      "agent": "Mahdi Hedhli",
       "note": "Reconciled merged PR #381."
     }
   ],

--- a/.github/pipeline/tasks/TASK-2026-0101.json
+++ b/.github/pipeline/tasks/TASK-2026-0101.json
@@ -2,7 +2,7 @@
   "task_id": "TASK-2026-0101",
   "type": "incident",
   "priority": "P0",
-  "status": "pr_open",
+  "status": "complete",
   "input": {
     "topic": "Operation TrueChaos: TrueConf Zero-Day Supply Chain Attack on Southeast Asian Governments",
     "reprocess": true,
@@ -47,11 +47,20 @@
       "agent": "Mahdi Hedhli",
       "action": "pr_opened",
       "note": "Article generated, validated, and recorded against PR #381"
+    },
+    {
+      "timestamp": "2026-04-29T16:48:10Z",
+      "action": "merged",
+      "from": "pr_open",
+      "to": "complete",
+      "agent": "pipeline-task-state",
+      "note": "Reconciled merged PR #381."
     }
   ],
   "locked_by": null,
   "locked_at": null,
-  "updated": "2026-04-29T06:44:01.156Z",
+  "updated": "2026-04-29T16:48:10Z",
   "pr_number": 381,
-  "pr_url": "https://github.com/MahdiHedhli/threatpedia/pull/381"
+  "pr_url": "https://github.com/MahdiHedhli/threatpedia/pull/381",
+  "merged_at": "2026-04-29T07:53:11Z"
 }


### PR DESCRIPTION
## Summary
- reconcile TASK-2026-0101 from stale `pr_open` to `complete`
- record merged PR #381 and merged timestamp in task history
- keep the public queue aligned with current GitHub state

## Notes
- This is a task-state-only cleanup PR.
- It does not change article content or pipeline logic.