### PR TITLE
chore(pipeline): repair TASK-2026-0204 ingest for issue 373

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0204.json
+++ b/.github/pipeline/tasks/TASK-2026-0204.json
@@ -1,0 +1,63 @@
+{
+  "task_id": "TASK-2026-0204",
+  "stage": "draft",
+  "type": "zero-day",
+  "priority": "P0",
+  "status": "pending",
+  "created": "2026-04-29T02:54:44.000Z",
+  "updated": "2026-04-29T17:18:59.509Z",
+  "source": "manual_submission",
+  "submitted_by": "MahdiHedhli",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "GitHub internal Git infrastructure RCE (CVE-2026-3854)",
+    "sources": [
+      "https://www.wiz.io/blog/github-rce-vulnerability-cve-2026-3854",
+      "https://github.blog/security/securing-the-git-push-pipeline-responding-to-a-critical-remote-code-execution-vulnerability"
+    ],
+    "candidate_data": {
+      "severity": "critical",
+      "sector": "Enterprise",
+      "geography": "Global",
+      "threat_actor": "N/A",
+      "cves": [
+        "CVE-2026-3854"
+      ]
+    },
+    "notes": "Manual submission from Issue #373. Draft a zero-day article from the listed Wiz and GitHub sources. Cover affected GitHub.com backend storage nodes and GitHub Enterprise Server, GitHub.com mitigation within six hours, supported GHES patches, and customer upgrade guidance. Treat repository and secret exposure claims as source-attributed and avoid exploit-step reproduction beyond source-supported behavior."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "INGESTION-SPEC.md §2"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 5,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/zero-days/{slug}.md",
+    "branch": "pipeline/TASK-2026-0204",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-04-29T02:54:44.000Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "MahdiHedhli",
+      "note": "Manual submission from Issue #373; repaired via PR after the original ingest push was rejected by main protection."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds the missing `TASK-2026-0204` task file for issue #373 after the ingest workflow failed to push under main branch protection.
- Keeps the task pending so the normal dispatcher can create one article PR from `pipeline/TASK-2026-0204`.
- Uses neutral task notes and reserves this ID ahead of the historical seed range.

## Validation

- `npm --prefix scripts ci --no-audit --no-fund`
- Custom task consistency check for `TASK-2026-0204`
- `node scripts/pipeline-run-task.mjs --list`
- `node scripts/pipeline-run-task.mjs --task TASK-2026-0204`

## Related

- Repairs #373
