### PR TITLE
fix(pipeline): make review-gate comment trigger explicit

### DIFF
--- a/.github/workflows/pipeline-review-gate.yml
+++ b/.github/workflows/pipeline-review-gate.yml
@@ -22,7 +22,15 @@ permissions:
 
 jobs:
   review-gate:
-    if: github.event_name != 'issue_comment' || github.event.issue.pull_request
+    if: |
+      github.event_name != 'issue_comment' ||
+      (
+        github.event.issue.pull_request &&
+        (
+          contains(github.event.comment.body, '/review-gate') ||
+          contains(github.event.comment.body, '/pipeline review-gate')
+        )
+      )
     runs-on: ubuntu-latest
 
     steps:

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -162,6 +162,10 @@ for the pipeline.
    - `.github/workflows/pipeline-review-gate.yml` runs
      `node scripts/pipeline-review-gate.mjs --pr <number>` against live
      GitHub state for public content, site, and pipeline PRs.
+   - The workflow runs automatically for PR lifecycle and review events.
+     Issue comments only trigger it when the comment explicitly contains
+     `/review-gate` or `/pipeline review-gate`, so routine `/gemini review`
+     prompts and worker status comments do not create premature red checks.
    - For content-collection PRs, the gate requires a successful current-head
      `validate` check. Green checks from an older head SHA do not count.
    - For public content/site/pipeline PRs, the gate requires an AI second
@@ -236,7 +240,7 @@ same queue/validation path as discovery-generated tasks.
 | Discovery publishes via | `pipeline/discovery` branch + auto-PR | labeled `pipeline/discovery`, no direct push to `main` | Workflow |
 | Dispatcher publishes via | `pipeline/dispatcher` branch + auto-PR | labeled `pipeline/dispatcher`, no direct push to `main`; skips duplicate `pipeline/ready` Issues when one is already open | Workflow |
 | PR batch review | Human merge (not auto-merge) | Nothing lands on `main` without review | Workflow + branch protection |
-| Review readiness gate | `pipeline-review-gate.yml` + `pipeline-review-gate.mjs` | Current-head validation for content PRs, current-head AI second review from Gemini Code Assist or `dangermouse-bot`, zero unresolved AI review threads | Live GitHub state |
+| Review readiness gate | `pipeline-review-gate.yml` + `pipeline-review-gate.mjs` | Current-head validation for content PRs, current-head AI second review from Gemini Code Assist or `dangermouse-bot`, zero unresolved AI review threads; issue-comment runs require `/review-gate` or `/pipeline review-gate` | Live GitHub state |
 | Editorial queue backpressure (hysteresis) | `pipeline-dispatcher.yml` (via `scripts/pipeline-config.mjs`); state tracked via labeled GitHub Issue (`pipeline/backpressure`) | Pause at 50 pending · stay paused until queue < 40 (auto-resume + Issue auto-close) | `config.yml` (`queues.editorial.max_pending` / `backpressure_resume`) |
 | Stale-lock timeout | `pipeline-dispatcher.yml` (via `scripts/pipeline-config.mjs`) | 30 minutes | `config.yml` (`scheduling.stale_lock_minutes`) |
 | Circuit breaker | `pipeline-dispatcher.yml` (via `scripts/pipeline-config.mjs`) | 3 failures in 120min → Issue + halt; 60min cooldown | `config.yml` (`circuit_breaker.*`) |

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -165,7 +165,7 @@ for the pipeline.
    - The workflow runs automatically for PR lifecycle and review events.
      Issue comments only trigger it when the comment explicitly contains
      `/review-gate` or `/pipeline review-gate`, so routine `/gemini review`
-     prompts and worker status comments do not create premature red checks.
+     prompts and worker status comments do not create unnecessary workflow failures.
    - For content-collection PRs, the gate requires a successful current-head
      `validate` check. Green checks from an older head SHA do not count.
    - For public content/site/pipeline PRs, the gate requires an AI second


### PR DESCRIPTION
## Summary

- Keeps `Pipeline: Review Gate` as a hard gate for PR lifecycle and PR review events.
- Makes `issue_comment` runs opt-in only when the comment explicitly contains `/review-gate` or `/pipeline review-gate`.
- Updates pipeline docs so workers know routine `/gemini review` prompts and status comments should not trigger premature red review-gate checks.

## Why

Recent review-gate failures were completing in seconds with policy exit code 1, usually because an `issue_comment` event fired before Gemini or DM had submitted a current-head AI review. The gate finding was valid at that instant, but the trigger was noisy and produced false-red workflow churn. This preserves the current-head AI-review requirement while removing routine comment noise.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pipeline-review-gate.yml")'`
- `node --check scripts/pipeline-review-gate.mjs`
- `git diff --check`
