### PR TITLE
fix(pipeline): run review gate after review events

### DIFF
--- a/.github/workflows/pipeline-review-gate.yml
+++ b/.github/workflows/pipeline-review-gate.yml
@@ -25,8 +25,8 @@ jobs:
       (
         github.event.issue.pull_request &&
         (
-          contains(github.event.comment.body, '/review-gate') ||
-          contains(github.event.comment.body, '/pipeline review-gate')
+          startsWith(github.event.comment.body, '/review-gate') ||
+          startsWith(github.event.comment.body, '/pipeline review-gate')
         )
       )
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline-review-gate.yml
+++ b/.github/workflows/pipeline-review-gate.yml
@@ -1,8 +1,6 @@
 name: "Pipeline: Review Gate"
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
   pull_request_review:
     types: [submitted, dismissed]
   issue_comment:
@@ -50,7 +48,7 @@ jobs:
             workflow_dispatch)
               number="${{ inputs.pr_number }}"
               ;;
-            pull_request|pull_request_review)
+            pull_request_review)
               number="${{ github.event.pull_request.number }}"
               ;;
             issue_comment)

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -165,8 +165,8 @@ for the pipeline.
    - The workflow runs automatically for PR review events, including AI review
      submission and dismissal. It does not run on every PR push because
      push-time runs race current-head validation and current-head AI review
-     creation, producing status check failures that are expected to pass only
-     after a later review.
+     creation, producing status check failures until the current-head
+     validation and AI review requirements for that PR have completed.
      Issue comments only trigger it when the comment starts with `/review-gate`
      or `/pipeline review-gate`, so routine `/gemini review` prompts and worker
      status comments that merely mention the command do not create unnecessary

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -163,9 +163,10 @@ for the pipeline.
      `node scripts/pipeline-review-gate.mjs --pr <number>` against live
      GitHub state for public content, site, and pipeline PRs.
    - The workflow runs automatically for PR review events, including AI review
-     submission and dismissal. It deliberately does not run on every PR push,
-     because push-time runs race current-head validation and AI review creation,
-     producing red checks that are expected to pass only after a later review.
+     submission and dismissal. It does not run on every PR push because
+     push-time runs race current-head validation and current-head AI review
+     creation, producing status check failures that are expected to pass only
+     after a later review.
      Issue comments only trigger it when the comment starts with `/review-gate`
      or `/pipeline review-gate`, so routine `/gemini review` prompts and worker
      status comments that merely mention the command do not create unnecessary

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -166,9 +166,10 @@ for the pipeline.
      submission and dismissal. It deliberately does not run on every PR push,
      because push-time runs race current-head validation and AI review creation,
      producing red checks that are expected to pass only after a later review.
-     Issue comments only trigger it when the comment explicitly contains
-     `/review-gate` or `/pipeline review-gate`, so routine `/gemini review`
-     prompts and worker status comments do not create unnecessary workflow failures.
+     Issue comments only trigger it when the comment starts with `/review-gate`
+     or `/pipeline review-gate`, so routine `/gemini review` prompts and worker
+     status comments that merely mention the command do not create unnecessary
+     workflow failures.
    - For content-collection PRs, the gate requires a successful current-head
      `validate` check. Green checks from an older head SHA do not count.
    - For public content/site/pipeline PRs, the gate requires an AI second

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -162,7 +162,10 @@ for the pipeline.
    - `.github/workflows/pipeline-review-gate.yml` runs
      `node scripts/pipeline-review-gate.mjs --pr <number>` against live
      GitHub state for public content, site, and pipeline PRs.
-   - The workflow runs automatically for PR lifecycle and review events.
+   - The workflow runs automatically for PR review events, including AI review
+     submission and dismissal. It deliberately does not run on every PR push,
+     because push-time runs race current-head validation and AI review creation,
+     producing red checks that are expected to pass only after a later review.
      Issue comments only trigger it when the comment explicitly contains
      `/review-gate` or `/pipeline review-gate`, so routine `/gemini review`
      prompts and worker status comments do not create unnecessary workflow failures.


### PR DESCRIPTION
## Summary

- Stops `Pipeline: Review Gate` from running on every `pull_request` push.
- Keeps automatic review-gate evaluation on `pull_request_review` submission/dismissal, explicit `/review-gate` issue comments, and manual dispatch.
- Documents why push-time gate runs create predictable red checks: they race current-head validation and current-head AI review creation.

## Failure Class

`flaky-check` / `workflow-failure`: review-gate checks were failing on PR push before validate and AI review state could exist, then later passing after rerun or review events.

## Validation

- `git diff --check`
- YAML parsed with Ruby `YAML.load_file`
- `node scripts/pipeline-review-gate.mjs --help`

## Out of Scope

- Does not change review-gate enforcement semantics.
- Does not auto-merge content PRs.
- Does not relax the requirement for current-head validation, AI second review, and zero unresolved AI threads.