### PR TITLE
fix(pipeline): skip non-AI review gate events

### DIFF
--- a/.github/workflows/pipeline-review-gate.yml
+++ b/.github/workflows/pipeline-review-gate.yml
@@ -21,8 +21,16 @@ permissions:
 jobs:
   review-gate:
     if: |
-      github.event_name != 'issue_comment' ||
+      github.event_name == 'workflow_dispatch' ||
       (
+        github.event_name == 'pull_request_review' &&
+        contains(
+          fromJSON('["gemini-code-assist", "gemini-code-assist[bot]", "dangermouse-bot"]'),
+          github.event.review.user.login
+        )
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         (
           startsWith(github.event.comment.body, '/review-gate') ||

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -162,8 +162,11 @@ for the pipeline.
    - `.github/workflows/pipeline-review-gate.yml` runs
      `node scripts/pipeline-review-gate.mjs --pr <number>` against live
      GitHub state for public content, site, and pipeline PRs.
-   - The workflow runs automatically for PR review events, including AI review
-     submission and dismissal. It does not run on every PR push because
+   - The workflow runs automatically for configured AI reviewer PR review
+     events, including Gemini Code Assist or `dangermouse-bot` review
+     submission and dismissal. It skips worker/human review submissions because
+     those often record disposition or remediation notes before current-head AI
+     review is available. It does not run on every PR push because
      push-time runs race current-head validation and current-head AI review
      creation, producing status check failures until the current-head
      validation and AI review requirements for that PR have completed.
@@ -245,7 +248,7 @@ same queue/validation path as discovery-generated tasks.
 | Discovery publishes via | `pipeline/discovery` branch + auto-PR | labeled `pipeline/discovery`, no direct push to `main` | Workflow |
 | Dispatcher publishes via | `pipeline/dispatcher` branch + auto-PR | labeled `pipeline/dispatcher`, no direct push to `main`; skips duplicate `pipeline/ready` Issues when one is already open | Workflow |
 | PR batch review | Human merge (not auto-merge) | Nothing lands on `main` without review | Workflow + branch protection |
-| Review readiness gate | `pipeline-review-gate.yml` + `pipeline-review-gate.mjs` | Current-head validation for content PRs, current-head AI second review from Gemini Code Assist or `dangermouse-bot`, zero unresolved AI review threads; issue-comment runs require `/review-gate` or `/pipeline review-gate` | Live GitHub state |
+| Review readiness gate | `pipeline-review-gate.yml` + `pipeline-review-gate.mjs` | Current-head validation for content PRs, current-head AI second review from Gemini Code Assist or `dangermouse-bot`, zero unresolved AI review threads; automatic PR-review runs are limited to configured AI reviewer logins; issue-comment runs require `/review-gate` or `/pipeline review-gate` | Live GitHub state |
 | Editorial queue backpressure (hysteresis) | `pipeline-dispatcher.yml` (via `scripts/pipeline-config.mjs`); state tracked via labeled GitHub Issue (`pipeline/backpressure`) | Pause at 50 pending · stay paused until queue < 40 (auto-resume + Issue auto-close) | `config.yml` (`queues.editorial.max_pending` / `backpressure_resume`) |
 | Stale-lock timeout | `pipeline-dispatcher.yml` (via `scripts/pipeline-config.mjs`) | 30 minutes | `config.yml` (`scheduling.stale_lock_minutes`) |
 | Circuit breaker | `pipeline-dispatcher.yml` (via `scripts/pipeline-config.mjs`) | 3 failures in 120min → Issue + halt; 60min cooldown | `config.yml` (`circuit_breaker.*`) |


### PR DESCRIPTION
## Summary

This narrows the review-gate workflow trigger after the latest live failure pattern on PR #416.

## Failure class

- `flaky-check`: worker/human review disposition events can run the review gate before current-head validation and AI second review are both available.

## Decision

- `patch`: keep automatic review-gate runs for configured AI reviewer PR review events, manual workflow dispatch, and explicit gate command comments.
- Skip non-AI PR review events so worker/human disposition reviews do not create predictable red checks.

## Validation

- `git diff --check` passed.
- Ruby YAML parse for `.github/workflows/pipeline-review-gate.yml` passed.
- `node scripts/pipeline-review-gate.mjs --help` passed.

## Out of scope

- No changes to the review-gate script semantics.
- No changes to article validation or merge policy.