### PR TITLE
ci: dedupe review gate runs

### DIFF
--- a/.github/workflows/pipeline-review-gate.yml
+++ b/.github/workflows/pipeline-review-gate.yml
@@ -18,6 +18,10 @@ permissions:
   issues: read
   pull-requests: read
 
+concurrency:
+  group: review-gate-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+  cancel-in-progress: true
+
 jobs:
   review-gate:
     if: |


### PR DESCRIPTION
## Summary

Adds workflow-level concurrency to Pipeline: Review Gate so repeated review/comment events for the same PR cancel in-progress duplicate gate runs instead of stacking redundant checks.

## Failure class

- Area: review-gate
- Failure class: cost-efficiency
- Decision: patch
- Reason: PR #438 generated many review-gate runs on the same head after repeated bot review events; concurrency is a general workflow-level dedupe rather than a bot-specific special case.

## Validation

- npm --prefix scripts ci --no-audit --no-fund
- node scripts/pipeline-schema.mjs
- git diff --check

## Out of scope

- Does not change review-gate pass/fail logic.
- Does not suppress any reviewer events outright.
- Does not change article validation or merge policy.