### PR TITLE
ci: keep noop comments out of review gate concurrency

### DIFF
--- a/.github/workflows/pipeline-review-gate.yml
+++ b/.github/workflows/pipeline-review-gate.yml
@@ -19,7 +19,10 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: review-gate-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+  # Non-gate issue comments still instantiate the workflow before the job-level
+  # guard skips them. Keep those no-op runs out of the shared PR gate group so
+  # commands such as /gemini review cannot cancel an active review-gate run.
+  group: review-gate-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}-${{ github.event_name != 'issue_comment' && 'gate' || startsWith(github.event.comment.body, '/review-gate') && 'gate' || startsWith(github.event.comment.body, '/pipeline review-gate') && 'gate' || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

This patch prevents no-op `issue_comment` workflow runs from joining the same concurrency group as real review-gate evaluations.

## Failure class

- Area: `review-gate`
- Failure class: `flaky-check`
- Decision: `patch`
- Reason: A skipped `/gemini review` comment workflow can cancel an active review-gate run before the job-level guard skips it, so changing concurrency grouping fixes the existing gate instead of adding another gate.

## Evidence

- PR #447 had a current-head review-gate run cancelled immediately after non-gate issue-comment workflow activity.
- Rerunning the cancelled PR #447 review-gate run passed on current head `5aac72181bf89f51723334c3e95667fd85853f94`.
- PR #449 also showed review-gate failures for the legitimate blocker `No AI second review exists on the current head SHA`, so this patch does not weaken the gate requirement.

## Validation

- `git diff --check` PASS
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/pipeline-review-gate.yml')"` PASS
- Live rerun: `Pipeline: Review Gate` for PR #447 PASS after rerun

## Out of scope

- Does not bypass current-head AI review requirements.
- Does not change `pipeline-review-gate.mjs` gate logic.
- Does not alter PR #449, which still needs a current-head AI second review.
