### PR TITLE
chore(pipeline): seed incident smoke-test tasks

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0218.json
+++ b/.github/pipeline/tasks/TASK-2026-0218.json
@@ -20,7 +20,7 @@
     "candidate_data": {
       "severity": "critical"
     },
-    "notes": "Smoke-test incident pipeline seed for a high-impact healthcare ransomware incident; draft conservatively from UnitedHealth/HHS sources and avoid unsupported attribution beyond public evidence."
+    "notes": "Smoke-test incident pipeline seed for a healthcare ransomware incident; draft conservatively from UnitedHealth/HHS sources and avoid unsupported attribution beyond public evidence."
   },
   "specs": [
     "DATA-STANDARDS-v1.0.md",
@@ -30,7 +30,7 @@
   "acceptance_criteria": {
     "frontmatter_valid": true,
     "min_sources": 3,
-    "min_h2_sections": 5,
+    "min_h2_sections": 8,
     "min_mitre_mappings": 1,
     "review_status": "draft_ai",
     "schema_validation": "pass",

--- a/.github/pipeline/tasks/TASK-2026-0218.json
+++ b/.github/pipeline/tasks/TASK-2026-0218.json
@@ -1,0 +1,58 @@
+{
+  "task_id": "TASK-2026-0218",
+  "stage": "draft",
+  "type": "incident",
+  "priority": "P0",
+  "status": "pending",
+  "created": "2026-05-01T16:50:00.588Z",
+  "updated": "2026-05-01T16:50:00.588Z",
+  "source": "manual_submission",
+  "submitted_by": "Kernel K",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "Change Healthcare ransomware attack",
+    "sources": [
+      "https://www.unitedhealthgroup.com/newsroom/2024/2024-04-22-uhg-updates-on-change-healthcare-cyberattack.html",
+      "https://www.unitedhealthgroup.com/newsroom/2024/2024-03-07-uhg-update-change-healthcare-cyberattack.html",
+      "https://www.sec.gov/Archives/edgar/data/731766/000073176624000045/unh-20240221.htm"
+    ],
+    "candidate_data": {
+      "severity": "critical"
+    },
+    "notes": "Smoke-test incident pipeline seed for a high-impact healthcare ransomware incident; draft conservatively from UnitedHealth/HHS sources and avoid unsupported attribution beyond public evidence."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "INGESTION-SPEC.md §2"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 5,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/incidents/{slug}.md",
+    "branch": "pipeline/TASK-2026-0218",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-05-01T16:50:00.588Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "Kernel K",
+      "note": "Manual link submission via scripts/pipeline-submit-link.mjs"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0219.json
+++ b/.github/pipeline/tasks/TASK-2026-0219.json
@@ -1,0 +1,58 @@
+{
+  "task_id": "TASK-2026-0219",
+  "stage": "draft",
+  "type": "incident",
+  "priority": "P0",
+  "status": "pending",
+  "created": "2026-05-01T16:50:06.083Z",
+  "updated": "2026-05-01T16:50:06.083Z",
+  "source": "manual_submission",
+  "submitted_by": "Kernel K",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "XZ Utils backdoor supply-chain compromise",
+    "sources": [
+      "https://www.openwall.com/lists/oss-security/2024/03/29/4",
+      "https://www.cisa.gov/news-events/alerts/2024/03/29/reported-supply-chain-compromise-affecting-xz-utils-data-compression-library-cve-2024-3094",
+      "https://www.redhat.com/en/blog/urgent-security-alert-fedora-40-and-rawhide-users"
+    ],
+    "candidate_data": {
+      "severity": "critical"
+    },
+    "notes": "Smoke-test incident pipeline seed for the 2024 XZ Utils/liblzma backdoor; treat as a supply-chain compromise attempt and avoid unsupported attribution."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "INGESTION-SPEC.md §2"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 5,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/incidents/{slug}.md",
+    "branch": "pipeline/TASK-2026-0219",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-05-01T16:50:06.083Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "Kernel K",
+      "note": "Manual link submission via scripts/pipeline-submit-link.mjs"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0219.json
+++ b/.github/pipeline/tasks/TASK-2026-0219.json
@@ -30,7 +30,7 @@
   "acceptance_criteria": {
     "frontmatter_valid": true,
     "min_sources": 3,
-    "min_h2_sections": 5,
+    "min_h2_sections": 8,
     "min_mitre_mappings": 1,
     "review_status": "draft_ai",
     "schema_validation": "pass",


### PR DESCRIPTION
## Summary\n\nSeeds two pending incident tasks so the incident CoWork worker can smoke-test queue pickup and article PR creation:\n\n- TASK-2026-0218 — Change Healthcare ransomware attack\n- TASK-2026-0219 — XZ Utils backdoor supply-chain compromise\n\nBoth tasks were created through scripts/pipeline-submit-link.mjs and are task JSON only. No article files are changed in this PR.\n\n## Validation\n\n- npm --prefix scripts ci --no-audit --no-fund\n- node scripts/pipeline-submit-link.mjs dry-run for both candidates: no duplicate URLs found\n- node scripts/pipeline-run-task.mjs --list --all: both tasks appear as pending incident tasks\n- node -e task-shape check: both tasks are incident/pending/draft with draft_ai acceptance criteria and 3 sources\n- Source URL preflight: all six task source URLs returned HTTP 200 with a normal user agent\n\n## Notes\n\nThis is a smoke-test seed PR. After merge, the dispatcher should have exactly two incident tasks available for the incident worker. The thread incident heartbeat should remain active until we confirm queue pickup works, then it can be removed so this thread can focus on campaigns.