### PR TITLE
fix(pipeline): let auto-rebase ignore skipped checks

### DIFF
--- a/.github/workflows/auto-rebase-prs.yml
+++ b/.github/workflows/auto-rebase-prs.yml
@@ -54,12 +54,14 @@ jobs:
             # toward merge readiness.
             pr_status=$(gh pr view "${pr_number}" --json statusCheckRollup)
             failing_or_pending_checks=$(echo "$pr_status" | jq '
+              def allowed_conclusion: . == "SUCCESS" or . == "SKIPPED" or . == "NEUTRAL";
+              def allowed_state: . == "SUCCESS" or . == "SKIPPED" or . == "NEUTRAL";
               [
                 .statusCheckRollup[]?
                 | select(
                     (has("status") and .status != "COMPLETED")
-                    or (has("conclusion") and ((.conclusion // "PENDING") != "SUCCESS"))
-                    or (has("state") and .state != "SUCCESS")
+                    or (has("conclusion") and ((.conclusion // "PENDING") | allowed_conclusion | not))
+                    or (has("state") and (.state | allowed_state | not))
                   )
               ] | length
             ')


### PR DESCRIPTION
## Summary

- Treat `SKIPPED` and `NEUTRAL` status-check conclusions/states as non-blocking in the auto-rebase health filter.
- Keep pending, failed, cancelled, timed-out, and incomplete checks blocking auto-rebase.

## Failure class

- Area: `deploy`
- Failure class: `workflow-failure`
- Decision: `patch`
- Reason: the auto-rebase workflow skipped approved PRs with green required checks because non-applicable `SKIPPED` review-gate runs were counted as unhealthy.

## Validation

- PASS: jq expression fixture returns `0` blockers for `SUCCESS`/`SKIPPED` states and conclusions.
- PASS: jq expression fixture returns `3` blockers for failure/in-progress states.
- NOT RUN: full site build, because this changes only workflow status-rollup filtering and no site or script runtime code.

## Out of scope

- Does not change merge policy or force-rebase behavior.
- Does not modify review-gate itself.