### PR TITLE
fix(pipeline): run review gate on current PR heads

### DIFF
--- a/.github/workflows/pipeline-review-gate.yml
+++ b/.github/workflows/pipeline-review-gate.yml
@@ -1,6 +1,16 @@
 name: "Pipeline: Review Gate"
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "site/src/**"
+      - "site/package*.json"
+      - "site/astro.config.*"
+      - "scripts/**"
+      - ".github/workflows/**"
+      - ".github/pipeline/config.yml"
+      - "docs/PIPELINE.md"
   pull_request_review:
     types: [submitted, dismissed]
   issue_comment:
@@ -28,6 +38,7 @@ concurrency:
 jobs:
   review-gate:
     if: |
+      github.event_name == 'pull_request' ||
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request_review' &&
@@ -63,6 +74,9 @@ jobs:
             workflow_dispatch)
               number="${{ inputs.pr_number }}"
               ;;
+            pull_request)
+              number="${{ github.event.pull_request.number }}"
+              ;;
             pull_request_review)
               number="${{ github.event.pull_request.number }}"
               ;;
@@ -81,4 +95,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
+          VALIDATE_CHECK_WAIT_SECONDS: "120"
         run: node scripts/pipeline-review-gate.mjs --pr "$PR_NUMBER"

--- a/scripts/pipeline-review-gate.mjs
+++ b/scripts/pipeline-review-gate.mjs
@@ -22,6 +22,7 @@ function parseArgs(argv) {
     pr: process.env.PR_NUMBER ? Number.parseInt(process.env.PR_NUMBER, 10) : null,
     repo: process.env.GITHUB_REPOSITORY || null,
     json: false,
+    validateWaitSeconds: parseNonNegativeInteger(process.env.VALIDATE_CHECK_WAIT_SECONDS, 0),
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -29,6 +30,9 @@ function parseArgs(argv) {
     if (arg === '--pr' && argv[i + 1]) parsed.pr = Number.parseInt(argv[++i], 10);
     else if (arg === '--repo' && argv[i + 1]) parsed.repo = argv[++i];
     else if (arg === '--json') parsed.json = true;
+    else if (arg === '--validate-wait-seconds' && argv[i + 1]) {
+      parsed.validateWaitSeconds = parseNonNegativeInteger(argv[++i], 0);
+    }
     else if (arg === '--help' || arg === '-h') {
       printHelp();
       process.exit(0);
@@ -50,12 +54,19 @@ function parseArgs(argv) {
   return parsed;
 }
 
+function parseNonNegativeInteger(value, fallback) {
+  if (value === undefined || value === null || value === '') return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
 function printHelp() {
-  console.log(`Usage: node scripts/pipeline-review-gate.mjs --pr <number> [--repo owner/name] [--json]
+  console.log(`Usage: node scripts/pipeline-review-gate.mjs --pr <number> [--repo owner/name] [--json] [--validate-wait-seconds seconds]
 
 Environment:
   GITHUB_TOKEN or GITHUB_PAT must be present.
   AI_REVIEW_LOGINS may override the comma-separated AI reviewer login list.
+  VALIDATE_CHECK_WAIT_SECONDS may wait for current-head validation before evaluating.
 `);
 }
 
@@ -154,6 +165,33 @@ async function listCheckRuns(owner, repo, ref, token) {
     (payload) => payload.check_runs || [],
   );
   return { check_runs: results };
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function getValidateChecks(checkRunsPayload) {
+  return (checkRunsPayload.check_runs || []).filter((check) => check.name === 'validate');
+}
+
+async function listCheckRunsAfterValidateSettles(owner, repo, ref, token, waitSeconds) {
+  const deadline = Date.now() + (waitSeconds * 1000);
+  let latest = await listCheckRuns(owner, repo, ref, token);
+
+  while (waitSeconds > 0 && Date.now() < deadline) {
+    const validateChecks = getValidateChecks(latest);
+    const completedValidate = validateChecks.find((check) => check.status === 'completed');
+    if (completedValidate) break;
+
+    const remainingMs = deadline - Date.now();
+    await sleep(Math.min(5000, Math.max(1000, remainingMs)));
+    latest = await listCheckRuns(owner, repo, ref, token);
+  }
+
+  return latest;
 }
 
 async function getReviewThreadComments(threadId, token, after = null) {
@@ -255,7 +293,7 @@ function latestDate(items, getter) {
   return new Date(latest).toISOString();
 }
 
-async function evaluate({ repo: repoSlug, pr: prNumber }) {
+async function evaluate({ repo: repoSlug, pr: prNumber, validateWaitSeconds = 0 }) {
   const token = getToken();
   if (!token) {
     throw new Error('GITHUB_TOKEN or GITHUB_PAT is required. Do not read local secret files for this gate.');
@@ -292,11 +330,11 @@ async function evaluate({ repo: repoSlug, pr: prNumber }) {
   const [reviews, issueComments, checkRunsPayload, threads] = await Promise.all([
     listPaginated(`/repos/${owner}/${repo}/pulls/${prNumber}/reviews`, token),
     listPaginated(`/repos/${owner}/${repo}/issues/${prNumber}/comments`, token),
-    listCheckRuns(owner, repo, pr.head.sha, token),
+    listCheckRunsAfterValidateSettles(owner, repo, pr.head.sha, token, validateWaitSeconds),
     getReviewThreads(owner, repo, prNumber, token),
   ]);
 
-  const validateChecks = (checkRunsPayload.check_runs || []).filter((check) => check.name === 'validate');
+  const validateChecks = getValidateChecks(checkRunsPayload);
   const passingValidate = validateChecks.find((check) => check.status === 'completed' && check.conclusion === 'success');
   if (requiresValidation && !passingValidate) {
     failures.push('No successful Pipeline: Validate Article PR "validate" check exists on the current head SHA.');

--- a/scripts/pipeline-review-gate.mjs
+++ b/scripts/pipeline-review-gate.mjs
@@ -177,14 +177,35 @@ function getValidateChecks(checkRunsPayload) {
   return (checkRunsPayload.check_runs || []).filter((check) => check.name === 'validate');
 }
 
+function checkRunTimestamp(check) {
+  const candidates = [
+    check.completed_at,
+    check.started_at,
+    check.created_at,
+  ];
+
+  for (const candidate of candidates) {
+    const timestamp = new Date(candidate).getTime();
+    if (Number.isFinite(timestamp)) return timestamp;
+  }
+
+  return 0;
+}
+
+function getLatestValidateCheck(checkRunsPayload) {
+  const [latest] = getValidateChecks(checkRunsPayload)
+    .slice()
+    .sort((left, right) => checkRunTimestamp(right) - checkRunTimestamp(left));
+  return latest || null;
+}
+
 async function listCheckRunsAfterValidateSettles(owner, repo, ref, token, waitSeconds) {
   const deadline = Date.now() + (waitSeconds * 1000);
   let latest = await listCheckRuns(owner, repo, ref, token);
 
   while (waitSeconds > 0 && Date.now() < deadline) {
-    const validateChecks = getValidateChecks(latest);
-    const completedValidate = validateChecks.find((check) => check.status === 'completed');
-    if (completedValidate) break;
+    const latestValidate = getLatestValidateCheck(latest);
+    if (latestValidate?.status === 'completed') break;
 
     const remainingMs = deadline - Date.now();
     await sleep(Math.min(5000, Math.max(1000, remainingMs)));
@@ -335,9 +356,10 @@ async function evaluate({ repo: repoSlug, pr: prNumber, validateWaitSeconds = 0 
   ]);
 
   const validateChecks = getValidateChecks(checkRunsPayload);
-  const passingValidate = validateChecks.find((check) => check.status === 'completed' && check.conclusion === 'success');
+  const latestValidate = getLatestValidateCheck(checkRunsPayload);
+  const passingValidate = latestValidate?.status === 'completed' && latestValidate.conclusion === 'success';
   if (requiresValidation && !passingValidate) {
-    failures.push('No successful Pipeline: Validate Article PR "validate" check exists on the current head SHA.');
+    failures.push('No latest successful Pipeline: Validate Article PR "validate" check exists on the current head SHA.');
   }
 
   const currentHeadAiReviews = reviews.filter((review) =>
@@ -415,6 +437,12 @@ async function evaluate({ repo: repoSlug, pr: prNumber, validateWaitSeconds = 0 
         startedAt: check.started_at,
         completedAt: check.completed_at,
       })),
+      latestValidateCheck: latestValidate ? {
+        status: latestValidate.status,
+        conclusion: latestValidate.conclusion,
+        startedAt: latestValidate.started_at,
+        completedAt: latestValidate.completed_at,
+      } : null,
       aiReviewsOnHead: currentHeadAiReviews.map((review) => ({
         author: review.user?.login || 'unknown',
         state: review.state,

--- a/scripts/pipeline-review-gate.mjs
+++ b/scripts/pipeline-review-gate.mjs
@@ -330,7 +330,7 @@ async function evaluate({ repo: repoSlug, pr: prNumber, validateWaitSeconds = 0 
   const [reviews, issueComments, checkRunsPayload, threads] = await Promise.all([
     listPaginated(`/repos/${owner}/${repo}/pulls/${prNumber}/reviews`, token),
     listPaginated(`/repos/${owner}/${repo}/issues/${prNumber}/comments`, token),
-    listCheckRunsAfterValidateSettles(owner, repo, pr.head.sha, token, validateWaitSeconds),
+    listCheckRunsAfterValidateSettles(owner, repo, pr.head.sha, token, requiresValidation ? validateWaitSeconds : 0),
     getReviewThreads(owner, repo, prNumber, token),
   ]);
 

--- a/scripts/pipeline-review-gate.mjs
+++ b/scripts/pipeline-review-gate.mjs
@@ -185,6 +185,7 @@ function checkRunTimestamp(check) {
   ];
 
   for (const candidate of candidates) {
+    if (!candidate) continue;
     const timestamp = new Date(candidate).getTime();
     if (Number.isFinite(timestamp)) return timestamp;
   }

--- a/scripts/pipeline-review-gate.mjs
+++ b/scripts/pipeline-review-gate.mjs
@@ -178,19 +178,8 @@ function getValidateChecks(checkRunsPayload) {
 }
 
 function checkRunTimestamp(check) {
-  const candidates = [
-    check.completed_at,
-    check.started_at,
-    check.created_at,
-  ];
-
-  for (const candidate of candidates) {
-    if (!candidate) continue;
-    const timestamp = new Date(candidate).getTime();
-    if (Number.isFinite(timestamp)) return timestamp;
-  }
-
-  return 0;
+  const timestamp = new Date(check.created_at).getTime();
+  return Number.isFinite(timestamp) ? timestamp : 0;
 }
 
 function getLatestValidateCheck(checkRunsPayload) {


### PR DESCRIPTION
## Summary

- Run `Pipeline: Review Gate` on relevant PR head changes, not only review/comment/manual events.
- Reuse `scripts/pipeline-review-gate.mjs` as the deterministic gate; no new state store or duplicate validator is added.
- Add an optional validate-check wait so the new PR-triggered gate does not race `Pipeline: Validate Article PR` on fresh pushes.

## Failure Classification

- Area: `review-gate`
- Failure class: `queue-drift`
- Decision: `patch`
- Reason: The existing review gate already catches stale current-head reviews when invoked; the durable fix is to invoke it on PR head changes.

## Validation

- `node --check scripts/pipeline-review-gate.mjs`
- `git diff --check`
- `cd scripts && npm ci --no-audit --no-fund`
- `cd scripts && node pipeline-schema.mjs`
- `cd scripts && node validate-content-corpus.mjs --files-file /private/tmp/threatpedia-review-gate-drift.8e8CZd/changed-files.txt`

## Notes

- Live drift observed on PR #472: a post-review bookkeeping commit advanced the head after AI review, leaving `validate` green on the current head while review-gate runs existed only for the previous head.
- Full site build was not run because this PR touches only workflow/script gate behavior and no site runtime or content files.
