### PR TITLE
feat(frameworks): add ATT&CK v19 and ATLAS schema foundation

### DIFF
--- a/scripts/framework-mapping-validation.mjs
+++ b/scripts/framework-mapping-validation.mjs
@@ -1,0 +1,107 @@
+import {
+  SCHEMA_ATTACK_VERSION_PATTERN,
+  SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN,
+  SCHEMA_ATLAS_VERSION_PATTERN,
+  SCHEMA_MAPPING_CONFIDENCE_VALUES,
+  SCHEMA_MITRE_TECHNIQUE_ID_PATTERN,
+} from './pipeline-schema.mjs';
+
+const ATTACK_VERSION_RE = new RegExp(SCHEMA_ATTACK_VERSION_PATTERN);
+const ATLAS_TECHNIQUE_ID_RE = new RegExp(SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN);
+const ATLAS_VERSION_RE = new RegExp(SCHEMA_ATLAS_VERSION_PATTERN);
+const MITRE_TECHNIQUE_ID_RE = new RegExp(SCHEMA_MITRE_TECHNIQUE_ID_PATTERN);
+
+function mappingLabel(prefix, index) {
+  return `${prefix} ${index + 1}`;
+}
+
+function trimOptionalString(value) {
+  return value ? String(value).trim() : '';
+}
+
+export function getMitreMappingValidationIssues(mappings, options = {}) {
+  const labelPrefix = options.labelPrefix || 'MITRE mapping';
+  const issues = [];
+
+  for (let i = 0; i < mappings.length; i += 1) {
+    const label = mappingLabel(labelPrefix, i);
+    const mapping = mappings[i] || {};
+    const techniqueId = trimOptionalString(mapping.techniqueId);
+
+    if (/^T\d{4}-\d{3}$/.test(techniqueId)) {
+      issues.push(`${label}: techniqueId "${techniqueId}" should use canonical "." separator (${techniqueId.replace('-', '.')})`);
+    } else if (!MITRE_TECHNIQUE_ID_RE.test(techniqueId)) {
+      issues.push(`${label}: invalid techniqueId "${techniqueId}" — expected format T####[.###]`);
+    }
+
+    if (!mapping.techniqueName || String(mapping.techniqueName).trim() === '') {
+      issues.push(`${label}: missing techniqueName`);
+    }
+
+    const attackVersion = mapping.attackVersion ?? mapping.attack_version;
+    if (attackVersion !== undefined) {
+      const version = typeof attackVersion === 'string' ? attackVersion.trim() : '';
+      if (!ATTACK_VERSION_RE.test(version)) {
+        issues.push(`${label}: attackVersion must match vNN[.N]`);
+      }
+    }
+
+    if (
+      mapping.confidence !== undefined &&
+      !SCHEMA_MAPPING_CONFIDENCE_VALUES.includes(String(mapping.confidence).trim())
+    ) {
+      issues.push(`${label}: confidence must be ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')}`);
+    }
+
+    if (mapping.evidence !== undefined && (typeof mapping.evidence !== 'string' || mapping.evidence.trim() === '')) {
+      issues.push(`${label}: evidence must be a non-empty string`);
+    }
+  }
+
+  return issues;
+}
+
+export function getAtlasMappingValidationIssues(atlasMappings, options = {}) {
+  const labelPrefix = options.labelPrefix || 'ATLAS mapping';
+  const issues = [];
+
+  if (atlasMappings !== undefined && !Array.isArray(atlasMappings)) {
+    issues.push('atlasMappings must be an array when present');
+  }
+
+  if (Array.isArray(atlasMappings)) {
+    for (let i = 0; i < atlasMappings.length; i += 1) {
+      const label = mappingLabel(labelPrefix, i);
+      const mapping = atlasMappings[i] || {};
+      const techniqueId = trimOptionalString(mapping.techniqueId);
+
+      if (!ATLAS_TECHNIQUE_ID_RE.test(techniqueId)) {
+        issues.push(`${label}: invalid techniqueId "${techniqueId}" — expected format AML.T####[.###]`);
+      }
+
+      if (!mapping.techniqueName || String(mapping.techniqueName).trim() === '') {
+        issues.push(`${label}: missing techniqueName`);
+      }
+
+      if (
+        mapping.confidence !== undefined &&
+        !SCHEMA_MAPPING_CONFIDENCE_VALUES.includes(String(mapping.confidence).trim())
+      ) {
+        issues.push(`${label}: confidence must be ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')}`);
+      }
+
+      if (mapping.atlasVersion !== undefined) {
+        const atlasVersion = typeof mapping.atlasVersion === 'string' ? mapping.atlasVersion.trim() : '';
+        if (!ATLAS_VERSION_RE.test(atlasVersion)) {
+          issues.push(`${label}: atlasVersion must match N.N.N`);
+        }
+      }
+
+      if (mapping.evidence !== undefined && (typeof mapping.evidence !== 'string' || mapping.evidence.trim() === '')) {
+        issues.push(`${label}: evidence must be a non-empty string`);
+      }
+    }
+  }
+
+  return issues;
+}

--- a/scripts/pipeline-run-task.mjs
+++ b/scripts/pipeline-run-task.mjs
@@ -30,8 +30,12 @@ import yaml from 'js-yaml';
 // The validator workflow loads the same enum via its CLI. Both track the
 // authoritative definitions in site/src/content.config.ts manually.
 import {
+  SCHEMA_ATTACK_VERSION_PATTERN,
+  SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN,
+  SCHEMA_ATLAS_VERSION_PATTERN,
   SCHEMA_CANONICAL_PUBLISHER_ALIASES,
   SCHEMA_GENERATED_BY_VALUES,
+  SCHEMA_MAPPING_CONFIDENCE_VALUES,
   SCHEMA_MITRE_TACTICS,
   SCHEMA_REQUIRED_H2_BY_TYPE,
   SCHEMA_REVIEW_STATUSES,
@@ -52,6 +56,9 @@ const EDITORIAL_WORDS = [
 ];
 const EDITORIAL_RE = new RegExp(`\\b(${EDITORIAL_WORDS.join('|')})\\b`, 'gi');
 const SOURCE_BODY_LINE_RE = /^\s*-\s+\[(.+?):\s+(.+)\]\((https?:\/\/[^\s)]+)\)\s+([—–-])\s+(.+?),\s+(\d{4}-\d{2}-\d{2})\s*$/;
+const ATTACK_VERSION_RE = new RegExp(SCHEMA_ATTACK_VERSION_PATTERN);
+const ATLAS_TECHNIQUE_ID_RE = new RegExp(SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN);
+const ATLAS_VERSION_RE = new RegExp(SCHEMA_ATLAS_VERSION_PATTERN);
 
 // ── Stage-aware reviewStatus rule matching ─────────────────────────────────
 // A task's acceptance.review_status is a declarative contract the validator
@@ -103,6 +110,25 @@ const SOURCE_SCHEMA = `  Each source object requires:
     archived: boolean (default false)
     archiveUrl: string (optional, valid URL)`;
 
+const MITRE_MAPPING_SCHEMA = `    Each MITRE ATT&CK mapping requires:
+      techniqueId: string (e.g., "T1566.001")
+      techniqueName: string (e.g., "Phishing: Spearphishing Attachment")
+      tactic: string (optional, canonical ATT&CK tactic casing)
+      attackVersion: string (optional, e.g., "v19"; attack_version is tolerated for legacy DATA-STANDARDS text)
+      confidence: enum (optional) — ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')}
+      evidence: string (optional, source-supported rationale)
+      notes: string (optional, context for this article)`;
+
+const ATLAS_MAPPING_SCHEMA = `  atlasMappings: array of MITRE ATLAS mapping objects (optional; only for article-supported adversarial AI/ML behavior)
+    Each ATLAS mapping requires:
+      techniqueId: string (e.g., "AML.T0042")
+      techniqueName: string
+      tactic: string (optional)
+      atlasVersion: string (optional, e.g., "5.6.0")
+      confidence: enum (optional) — ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')}
+      evidence: string (optional, source-supported rationale)
+      notes: string (optional)`;
+
 // ── Schemas per content type ────────────────────────────────────────────────
 const SCHEMAS = {
   incident: {
@@ -127,11 +153,8 @@ const SCHEMAS = {
   sources: array of structured source objects — MINIMUM 3, at least 1 government source
 ${SOURCE_SCHEMA}
   mitreMappings: array of MITRE ATT&CK mapping objects — MINIMUM 1
-    Each mapping requires:
-      techniqueId: string (e.g., "T1566.001")
-      techniqueName: string (e.g., "Phishing: Spearphishing Attachment")
-      tactic: string (optional, e.g., "Initial Access")
-      notes: string (optional, context for this article)`,
+${MITRE_MAPPING_SCHEMA}
+${ATLAS_MAPPING_SCHEMA}`,
     bodySpec: `Required H2 sections (minimum 5):
   ## Summary — 2-3 paragraphs: what happened, who was affected, scope
   ## Technical Analysis — attack mechanism, tools used, vulnerability details
@@ -168,7 +191,9 @@ ${SOURCE_SCHEMA}
   tags: array of strings
   sources: array of structured source objects — MINIMUM 3, at least 1 government source
 ${SOURCE_SCHEMA}
-  mitreMappings: array of MITRE ATT&CK mapping objects — MINIMUM 1`,
+  mitreMappings: array of MITRE ATT&CK mapping objects — MINIMUM 1
+${MITRE_MAPPING_SCHEMA}
+${ATLAS_MAPPING_SCHEMA}`,
     bodySpec: `Required H2 sections (minimum 6):
   ## Executive Summary — campaign overview, objectives, scope, current status
   ## Technical Analysis — tools, techniques, infrastructure, operator workflow
@@ -196,11 +221,8 @@ ${SOURCE_SCHEMA}
   targetGeographies: array of strings
   tools: array of strings — known malware and tools
   mitreMappings: array of MITRE ATT&CK mapping objects — MINIMUM 3
-    Each mapping requires:
-      techniqueId: string
-      techniqueName: string
-      tactic: string (optional)
-      notes: string (optional)
+${MITRE_MAPPING_SCHEMA}
+${ATLAS_MAPPING_SCHEMA}
   attributionConfidence: enum (optional) — A1 through A6
   attributionRationale: string (optional, max 500 chars)
   reviewStatus: constrained by task acceptance (see ACCEPTANCE CRITERIA below)
@@ -247,11 +269,8 @@ ${SOURCE_SCHEMA}`,
   sources: array of structured source objects — MINIMUM 3, at least 1 government source
 ${SOURCE_SCHEMA}
   mitreMappings: array of MITRE ATT&CK mapping objects — MINIMUM 1
-    Each mapping requires:
-      techniqueId: string
-      techniqueName: string
-      tactic: string (optional)
-      notes: string (optional)`,
+${MITRE_MAPPING_SCHEMA}
+${ATLAS_MAPPING_SCHEMA}`,
     bodySpec: `Required H2 sections (minimum 5):
   ## Severity Assessment — Exploitability, Impact, Weaponization Risk, Patch Urgency, Detection Coverage (scored X/10)
   ## Summary — what the vulnerability is, scope of affected systems, significance
@@ -294,9 +313,10 @@ function buildRules(task) {
      — Every frontmatter source URL must appear in the body exactly once
      — No orphan sources: every body source entry must have a matching frontmatter source object
      — No plain-text sources: every body entry must be a markdown hyperlink
-  11. MITRE tactic casing must use the canonical ATT&CK vocabulary
-  12. Canonical publisher aliases must be normalized in frontmatter and body
-  13. The Astro build must pass: cd site && npm run build`;
+  11. MITRE tactic casing must use the canonical ATT&CK vocabulary; optional metadata must use attackVersion vNN[.N], confidence ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')}, and non-empty evidence when present
+  12. atlasMappings are optional and only allowed for source-supported adversarial AI/ML behavior; techniqueId must match AML.T####[.###]
+  13. Canonical publisher aliases must be normalized in frontmatter and body
+  14. The Astro build must pass: cd site && npm run build`;
 }
 
 // ── CLI Parsing ─────────────────────────────────────────────────────────────
@@ -1028,6 +1048,7 @@ ${buildRules(task)}
      → Follow the frontmatter schema and body structure above
      → Include structured source objects in frontmatter (not just body text)
      → Include MITRE ATT&CK mappings in frontmatter mitreMappings array
+     → Include ATLAS mappings only when article-supported adversarial AI/ML behavior exists
      → Ensure all acceptance criteria are met
   4. Validate:         node scripts/pipeline-run-task.mjs --task ${task.task_id} --validate
   5. Fix any issues and re-validate until ALL CHECKS PASSED
@@ -1217,6 +1238,62 @@ function validateOutput(task, explicitFile) {
           issues.push(`MITRE mapping ${i + 1}: tactic "${tactic}" is not in the canonical ATT&CK tactic list`);
         } else if (canonicalTactic !== tactic) {
           issues.push(`MITRE mapping ${i + 1}: tactic "${tactic}" should use canonical casing "${canonicalTactic}"`);
+        }
+      }
+
+      const attackVersion = mapping.attackVersion ?? mapping.attack_version;
+      if (attackVersion !== undefined) {
+        const version = typeof attackVersion === 'string' ? attackVersion.trim() : '';
+        if (!ATTACK_VERSION_RE.test(version)) {
+          issues.push(`MITRE mapping ${i + 1}: attackVersion must match vNN[.N]`);
+        }
+      }
+
+      if (
+        mapping.confidence !== undefined &&
+        !SCHEMA_MAPPING_CONFIDENCE_VALUES.includes(String(mapping.confidence).trim())
+      ) {
+        issues.push(`MITRE mapping ${i + 1}: confidence must be ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')}`);
+      }
+
+      if (mapping.evidence !== undefined && (typeof mapping.evidence !== 'string' || mapping.evidence.trim() === '')) {
+        issues.push(`MITRE mapping ${i + 1}: evidence must be a non-empty string`);
+      }
+    }
+
+    const atlasMappings = frontmatter.atlasMappings;
+    if (atlasMappings !== undefined && !Array.isArray(atlasMappings)) {
+      issues.push('atlasMappings must be an array when present');
+    }
+
+    if (Array.isArray(atlasMappings)) {
+      for (let i = 0; i < atlasMappings.length; i++) {
+        const mapping = atlasMappings[i] || {};
+        const techniqueId = mapping.techniqueId ? String(mapping.techniqueId).trim() : '';
+        if (!ATLAS_TECHNIQUE_ID_RE.test(techniqueId)) {
+          issues.push(`ATLAS mapping ${i + 1}: invalid techniqueId "${techniqueId}" — expected format AML.T####[.###]`);
+        }
+
+        if (!mapping.techniqueName || String(mapping.techniqueName).trim() === '') {
+          issues.push(`ATLAS mapping ${i + 1}: missing techniqueName`);
+        }
+
+        if (
+          mapping.confidence !== undefined &&
+          !SCHEMA_MAPPING_CONFIDENCE_VALUES.includes(String(mapping.confidence).trim())
+        ) {
+          issues.push(`ATLAS mapping ${i + 1}: confidence must be ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')}`);
+        }
+
+        if (mapping.atlasVersion !== undefined) {
+          const atlasVersion = typeof mapping.atlasVersion === 'string' ? mapping.atlasVersion.trim() : '';
+          if (!ATLAS_VERSION_RE.test(atlasVersion)) {
+            issues.push(`ATLAS mapping ${i + 1}: atlasVersion must match N.N.N`);
+          }
+        }
+
+        if (mapping.evidence !== undefined && (typeof mapping.evidence !== 'string' || mapping.evidence.trim() === '')) {
+          issues.push(`ATLAS mapping ${i + 1}: evidence must be a non-empty string`);
         }
       }
     }

--- a/scripts/pipeline-run-task.mjs
+++ b/scripts/pipeline-run-task.mjs
@@ -1227,8 +1227,14 @@ function validateOutput(task, explicitFile) {
     for (let i = 0; i < mitreMappings.length; i++) {
       const mapping = mitreMappings[i] || {};
       const techniqueId = mapping.techniqueId ? String(mapping.techniqueId).trim() : '';
-      if (!/^T\d{4}(\.\d{3})?$/.test(techniqueId)) {
+      if (/^T\d{4}-\d{3}$/.test(techniqueId)) {
+        issues.push(`MITRE mapping ${i + 1}: techniqueId "${techniqueId}" should use canonical "." separator (${techniqueId.replace('-', '.')})`);
+      } else if (!/^T\d{4}(\.\d{3})?$/.test(techniqueId)) {
         issues.push(`MITRE mapping ${i + 1}: invalid techniqueId "${techniqueId}" — expected format T####[.###]`);
+      }
+
+      if (!mapping.techniqueName || String(mapping.techniqueName).trim() === '') {
+        issues.push(`MITRE mapping ${i + 1}: missing techniqueName`);
       }
 
       if (mapping.tactic) {

--- a/scripts/pipeline-run-task.mjs
+++ b/scripts/pipeline-run-task.mjs
@@ -30,17 +30,17 @@ import yaml from 'js-yaml';
 // The validator workflow loads the same enum via its CLI. Both track the
 // authoritative definitions in site/src/content.config.ts manually.
 import {
-  SCHEMA_ATTACK_VERSION_PATTERN,
-  SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN,
-  SCHEMA_ATLAS_VERSION_PATTERN,
   SCHEMA_CANONICAL_PUBLISHER_ALIASES,
   SCHEMA_GENERATED_BY_VALUES,
   SCHEMA_MAPPING_CONFIDENCE_VALUES,
-  SCHEMA_MITRE_TECHNIQUE_ID_PATTERN,
   SCHEMA_MITRE_TACTICS,
   SCHEMA_REQUIRED_H2_BY_TYPE,
   SCHEMA_REVIEW_STATUSES,
 } from './pipeline-schema.mjs';
+import {
+  getAtlasMappingValidationIssues,
+  getMitreMappingValidationIssues,
+} from './framework-mapping-validation.mjs';
 import { getPublicProseGuardrailIssues } from './public-prose-guardrails.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -57,10 +57,6 @@ const EDITORIAL_WORDS = [
 ];
 const EDITORIAL_RE = new RegExp(`\\b(${EDITORIAL_WORDS.join('|')})\\b`, 'gi');
 const SOURCE_BODY_LINE_RE = /^\s*-\s+\[(.+?):\s+(.+)\]\((https?:\/\/[^\s)]+)\)\s+([—–-])\s+(.+?),\s+(\d{4}-\d{2}-\d{2})\s*$/;
-const ATTACK_VERSION_RE = new RegExp(SCHEMA_ATTACK_VERSION_PATTERN);
-const ATLAS_TECHNIQUE_ID_RE = new RegExp(SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN);
-const ATLAS_VERSION_RE = new RegExp(SCHEMA_ATLAS_VERSION_PATTERN);
-const MITRE_TECHNIQUE_ID_RE = new RegExp(SCHEMA_MITRE_TECHNIQUE_ID_PATTERN);
 
 // ── Stage-aware reviewStatus rule matching ─────────────────────────────────
 // A task's acceptance.review_status is a declarative contract the validator
@@ -1226,19 +1222,10 @@ function validateOutput(task, explicitFile) {
       issues.push(`Only ${mitreMappings.length} MITRE mapping(s) in frontmatter (need ${minMitre}+). Add mitreMappings array with techniqueId, techniqueName fields.`);
     }
 
+    issues.push(...getMitreMappingValidationIssues(mitreMappings));
+
     for (let i = 0; i < mitreMappings.length; i++) {
       const mapping = mitreMappings[i] || {};
-      const techniqueId = mapping.techniqueId ? String(mapping.techniqueId).trim() : '';
-      if (/^T\d{4}-\d{3}$/.test(techniqueId)) {
-        issues.push(`MITRE mapping ${i + 1}: techniqueId "${techniqueId}" should use canonical "." separator (${techniqueId.replace('-', '.')})`);
-      } else if (!MITRE_TECHNIQUE_ID_RE.test(techniqueId)) {
-        issues.push(`MITRE mapping ${i + 1}: invalid techniqueId "${techniqueId}" — expected format T####[.###]`);
-      }
-
-      if (!mapping.techniqueName || String(mapping.techniqueName).trim() === '') {
-        issues.push(`MITRE mapping ${i + 1}: missing techniqueName`);
-      }
-
       if (mapping.tactic) {
         const tactic = String(mapping.tactic).trim();
         const canonicalTactic = findCanonicalCaseMatch(tactic, SCHEMA_MITRE_TACTICS);
@@ -1248,63 +1235,10 @@ function validateOutput(task, explicitFile) {
           issues.push(`MITRE mapping ${i + 1}: tactic "${tactic}" should use canonical casing "${canonicalTactic}"`);
         }
       }
-
-      const attackVersion = mapping.attackVersion ?? mapping.attack_version;
-      if (attackVersion !== undefined) {
-        const version = typeof attackVersion === 'string' ? attackVersion.trim() : '';
-        if (!ATTACK_VERSION_RE.test(version)) {
-          issues.push(`MITRE mapping ${i + 1}: attackVersion must match vNN[.N]`);
-        }
-      }
-
-      if (
-        mapping.confidence !== undefined &&
-        !SCHEMA_MAPPING_CONFIDENCE_VALUES.includes(String(mapping.confidence).trim())
-      ) {
-        issues.push(`MITRE mapping ${i + 1}: confidence must be ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')}`);
-      }
-
-      if (mapping.evidence !== undefined && (typeof mapping.evidence !== 'string' || mapping.evidence.trim() === '')) {
-        issues.push(`MITRE mapping ${i + 1}: evidence must be a non-empty string`);
-      }
     }
 
     const atlasMappings = frontmatter.atlasMappings;
-    if (atlasMappings !== undefined && !Array.isArray(atlasMappings)) {
-      issues.push('atlasMappings must be an array when present');
-    }
-
-    if (Array.isArray(atlasMappings)) {
-      for (let i = 0; i < atlasMappings.length; i++) {
-        const mapping = atlasMappings[i] || {};
-        const techniqueId = mapping.techniqueId ? String(mapping.techniqueId).trim() : '';
-        if (!ATLAS_TECHNIQUE_ID_RE.test(techniqueId)) {
-          issues.push(`ATLAS mapping ${i + 1}: invalid techniqueId "${techniqueId}" — expected format AML.T####[.###]`);
-        }
-
-        if (!mapping.techniqueName || String(mapping.techniqueName).trim() === '') {
-          issues.push(`ATLAS mapping ${i + 1}: missing techniqueName`);
-        }
-
-        if (
-          mapping.confidence !== undefined &&
-          !SCHEMA_MAPPING_CONFIDENCE_VALUES.includes(String(mapping.confidence).trim())
-        ) {
-          issues.push(`ATLAS mapping ${i + 1}: confidence must be ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')}`);
-        }
-
-        if (mapping.atlasVersion !== undefined) {
-          const atlasVersion = typeof mapping.atlasVersion === 'string' ? mapping.atlasVersion.trim() : '';
-          if (!ATLAS_VERSION_RE.test(atlasVersion)) {
-            issues.push(`ATLAS mapping ${i + 1}: atlasVersion must match N.N.N`);
-          }
-        }
-
-        if (mapping.evidence !== undefined && (typeof mapping.evidence !== 'string' || mapping.evidence.trim() === '')) {
-          issues.push(`ATLAS mapping ${i + 1}: evidence must be a non-empty string`);
-        }
-      }
-    }
+    issues.push(...getAtlasMappingValidationIssues(atlasMappings));
 
     // ── 8. Exact H2 section headings ───────────────────────────────────────
     const requiredH2 = SCHEMA_REQUIRED_H2_BY_TYPE[task.type] || [];

--- a/scripts/pipeline-run-task.mjs
+++ b/scripts/pipeline-run-task.mjs
@@ -36,6 +36,7 @@ import {
   SCHEMA_CANONICAL_PUBLISHER_ALIASES,
   SCHEMA_GENERATED_BY_VALUES,
   SCHEMA_MAPPING_CONFIDENCE_VALUES,
+  SCHEMA_MITRE_TECHNIQUE_ID_PATTERN,
   SCHEMA_MITRE_TACTICS,
   SCHEMA_REQUIRED_H2_BY_TYPE,
   SCHEMA_REVIEW_STATUSES,
@@ -59,6 +60,7 @@ const SOURCE_BODY_LINE_RE = /^\s*-\s+\[(.+?):\s+(.+)\]\((https?:\/\/[^\s)]+)\)\s
 const ATTACK_VERSION_RE = new RegExp(SCHEMA_ATTACK_VERSION_PATTERN);
 const ATLAS_TECHNIQUE_ID_RE = new RegExp(SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN);
 const ATLAS_VERSION_RE = new RegExp(SCHEMA_ATLAS_VERSION_PATTERN);
+const MITRE_TECHNIQUE_ID_RE = new RegExp(SCHEMA_MITRE_TECHNIQUE_ID_PATTERN);
 
 // ── Stage-aware reviewStatus rule matching ─────────────────────────────────
 // A task's acceptance.review_status is a declarative contract the validator
@@ -1229,7 +1231,7 @@ function validateOutput(task, explicitFile) {
       const techniqueId = mapping.techniqueId ? String(mapping.techniqueId).trim() : '';
       if (/^T\d{4}-\d{3}$/.test(techniqueId)) {
         issues.push(`MITRE mapping ${i + 1}: techniqueId "${techniqueId}" should use canonical "." separator (${techniqueId.replace('-', '.')})`);
-      } else if (!/^T\d{4}(\.\d{3})?$/.test(techniqueId)) {
+      } else if (!MITRE_TECHNIQUE_ID_RE.test(techniqueId)) {
         issues.push(`MITRE mapping ${i + 1}: invalid techniqueId "${techniqueId}" — expected format T####[.###]`);
       }
 

--- a/scripts/pipeline-schema.mjs
+++ b/scripts/pipeline-schema.mjs
@@ -46,6 +46,8 @@ export const SCHEMA_MITRE_TACTICS = Object.freeze([
   'Execution',
   'Persistence',
   'Privilege Escalation',
+  'Stealth',
+  'Defense Impairment',
   'Defense Evasion',
   'Credential Access',
   'Discovery',
@@ -56,6 +58,19 @@ export const SCHEMA_MITRE_TACTICS = Object.freeze([
   'Impact',
   'Impair Process Control',
 ]);
+
+/**
+ * Optional mapping metadata shared by ATT&CK and ATLAS mappings.
+ */
+export const SCHEMA_MAPPING_CONFIDENCE_VALUES = Object.freeze([
+  'confirmed',
+  'probable',
+  'possible',
+]);
+
+export const SCHEMA_ATTACK_VERSION_PATTERN = '^v\\d+(?:\\.\\d+)?$';
+export const SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN = '^AML\\.T\\d{4}(?:\\.\\d{3})?$';
+export const SCHEMA_ATLAS_VERSION_PATTERN = '^\\d+\\.\\d+\\.\\d+$';
 
 /**
  * Canonical generatedBy identities currently recognized in the corpus.
@@ -138,6 +153,10 @@ export const SCHEMA_CANONICAL_PUBLISHER_ALIASES = Object.freeze({
 export const SCHEMA = Object.freeze({
   reviewStatuses: SCHEMA_REVIEW_STATUSES,
   mitreTactics: SCHEMA_MITRE_TACTICS,
+  mappingConfidenceValues: SCHEMA_MAPPING_CONFIDENCE_VALUES,
+  attackVersionPattern: SCHEMA_ATTACK_VERSION_PATTERN,
+  atlasTechniqueIdPattern: SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN,
+  atlasVersionPattern: SCHEMA_ATLAS_VERSION_PATTERN,
   generatedByValues: SCHEMA_GENERATED_BY_VALUES,
   requiredH2ByType: SCHEMA_REQUIRED_H2_BY_TYPE,
   canonicalPublisherAliases: SCHEMA_CANONICAL_PUBLISHER_ALIASES,
@@ -161,6 +180,18 @@ function selfTest() {
     if (typeof v !== 'string' || v.trim() === '') {
       throw new Error(`SCHEMA_MITRE_TACTICS element invalid: ${JSON.stringify(v)}`);
     }
+  }
+
+  if (!Array.isArray(SCHEMA_MAPPING_CONFIDENCE_VALUES) || SCHEMA_MAPPING_CONFIDENCE_VALUES.length !== 3) {
+    throw new Error(`SCHEMA_MAPPING_CONFIDENCE_VALUES expected 3 entries, got ${JSON.stringify(SCHEMA_MAPPING_CONFIDENCE_VALUES)}`);
+  }
+  for (const v of SCHEMA_MAPPING_CONFIDENCE_VALUES) {
+    if (typeof v !== 'string' || !/^[a-z]+$/.test(v)) {
+      throw new Error(`SCHEMA_MAPPING_CONFIDENCE_VALUES element invalid: ${JSON.stringify(v)}`);
+    }
+  }
+  for (const pattern of [SCHEMA_ATTACK_VERSION_PATTERN, SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN, SCHEMA_ATLAS_VERSION_PATTERN]) {
+    new RegExp(pattern);
   }
 
   if (!Array.isArray(SCHEMA_GENERATED_BY_VALUES) || SCHEMA_GENERATED_BY_VALUES.length < 1) {

--- a/scripts/pipeline-schema.mjs
+++ b/scripts/pipeline-schema.mjs
@@ -71,6 +71,7 @@ export const SCHEMA_MAPPING_CONFIDENCE_VALUES = Object.freeze([
 export const SCHEMA_ATTACK_VERSION_PATTERN = '^v\\d+(?:\\.\\d+)?$';
 export const SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN = '^AML\\.T\\d{4}(?:\\.\\d{3})?$';
 export const SCHEMA_ATLAS_VERSION_PATTERN = '^\\d+\\.\\d+\\.\\d+$';
+export const SCHEMA_MITRE_TECHNIQUE_ID_PATTERN = '^T\\d{4}(?:\\.\\d{3})?$';
 
 /**
  * Canonical generatedBy identities currently recognized in the corpus.
@@ -157,6 +158,7 @@ export const SCHEMA = Object.freeze({
   attackVersionPattern: SCHEMA_ATTACK_VERSION_PATTERN,
   atlasTechniqueIdPattern: SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN,
   atlasVersionPattern: SCHEMA_ATLAS_VERSION_PATTERN,
+  mitreTechniqueIdPattern: SCHEMA_MITRE_TECHNIQUE_ID_PATTERN,
   generatedByValues: SCHEMA_GENERATED_BY_VALUES,
   requiredH2ByType: SCHEMA_REQUIRED_H2_BY_TYPE,
   canonicalPublisherAliases: SCHEMA_CANONICAL_PUBLISHER_ALIASES,
@@ -190,7 +192,7 @@ function selfTest() {
       throw new Error(`SCHEMA_MAPPING_CONFIDENCE_VALUES element invalid: ${JSON.stringify(v)}`);
     }
   }
-  for (const pattern of [SCHEMA_ATTACK_VERSION_PATTERN, SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN, SCHEMA_ATLAS_VERSION_PATTERN]) {
+  for (const pattern of [SCHEMA_ATTACK_VERSION_PATTERN, SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN, SCHEMA_ATLAS_VERSION_PATTERN, SCHEMA_MITRE_TECHNIQUE_ID_PATTERN]) {
     new RegExp(pattern);
   }
 

--- a/scripts/validate-content-corpus.mjs
+++ b/scripts/validate-content-corpus.mjs
@@ -12,6 +12,7 @@ import {
   SCHEMA_CANONICAL_PUBLISHER_ALIASES,
   SCHEMA_GENERATED_BY_VALUES,
   SCHEMA_MAPPING_CONFIDENCE_VALUES,
+  SCHEMA_MITRE_TECHNIQUE_ID_PATTERN,
   SCHEMA_MITRE_TACTICS,
   SCHEMA_REQUIRED_H2_BY_TYPE,
   SCHEMA_REVIEW_STATUSES,
@@ -28,6 +29,7 @@ const SOURCE_BODY_LINE_RE = /^\s*-\s+\[(.+?):\s+(.+)\]\((https?:\/\/[^\s)]+)\)\s
 const ATTACK_VERSION_RE = new RegExp(SCHEMA_ATTACK_VERSION_PATTERN);
 const ATLAS_TECHNIQUE_ID_RE = new RegExp(SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN);
 const ATLAS_VERSION_RE = new RegExp(SCHEMA_ATLAS_VERSION_PATTERN);
+const MITRE_TECHNIQUE_ID_RE = new RegExp(SCHEMA_MITRE_TECHNIQUE_ID_PATTERN);
 const ZERO_DAY_SEVERITY_METRICS = [
   'Exploitability',
   'Impact',
@@ -422,8 +424,8 @@ function validateFile(file, newFiles) {
     const techniqueId = mapping.techniqueId ? String(mapping.techniqueId).trim() : '';
     if (/^T\d{4}-\d{3}$/.test(techniqueId)) {
       mitreMetadataIssues.push(`mapping ${i + 1}: techniqueId "${techniqueId}" should use canonical "." separator (${techniqueId.replace('-', '.')})`);
-    } else if (!/^T\d{4}(\.\d{3})?$/.test(techniqueId)) {
-      mitreMetadataIssues.push(`mapping ${i + 1}: invalid techniqueId "${techniqueId}"`);
+    } else if (!MITRE_TECHNIQUE_ID_RE.test(techniqueId)) {
+      mitreMetadataIssues.push(`mapping ${i + 1}: invalid techniqueId "${techniqueId}" — expected format T####[.###]`);
     }
     if (!mapping.techniqueName || String(mapping.techniqueName).trim() === '') {
       mitreMetadataIssues.push(`mapping ${i + 1}: missing techniqueName`);
@@ -464,7 +466,7 @@ function validateFile(file, newFiles) {
       const mapping = atlasMappings[i] || {};
       const techniqueId = mapping.techniqueId ? String(mapping.techniqueId).trim() : '';
       if (!ATLAS_TECHNIQUE_ID_RE.test(techniqueId)) {
-        atlasIssues.push(`mapping ${i + 1}: invalid techniqueId "${techniqueId}"`);
+        atlasIssues.push(`mapping ${i + 1}: invalid techniqueId "${techniqueId}" — expected format AML.T####[.###]`);
       }
       if (!mapping.techniqueName || String(mapping.techniqueName).trim() === '') {
         atlasIssues.push(`mapping ${i + 1}: missing techniqueName`);

--- a/scripts/validate-content-corpus.mjs
+++ b/scripts/validate-content-corpus.mjs
@@ -419,6 +419,15 @@ function validateFile(file, newFiles) {
   const mitreMetadataIssues = [];
   for (let i = 0; i < mitreMappings.length; i += 1) {
     const mapping = mitreMappings[i] || {};
+    const techniqueId = mapping.techniqueId ? String(mapping.techniqueId).trim() : '';
+    if (/^T\d{4}-\d{3}$/.test(techniqueId)) {
+      mitreMetadataIssues.push(`mapping ${i + 1}: techniqueId "${techniqueId}" should use canonical "." separator (${techniqueId.replace('-', '.')})`);
+    } else if (!/^T\d{4}(\.\d{3})?$/.test(techniqueId)) {
+      mitreMetadataIssues.push(`mapping ${i + 1}: invalid techniqueId "${techniqueId}"`);
+    }
+    if (!mapping.techniqueName || String(mapping.techniqueName).trim() === '') {
+      mitreMetadataIssues.push(`mapping ${i + 1}: missing techniqueName`);
+    }
     const attackVersion = mapping.attackVersion ?? mapping.attack_version;
     if (attackVersion !== undefined) {
       const version = typeof attackVersion === 'string' ? attackVersion.trim() : '';
@@ -437,10 +446,10 @@ function validateFile(file, newFiles) {
     }
   }
   checks.push({
-    name: 'MITRE mapping metadata',
+    name: 'MITRE mapping fields and metadata',
     pass: mitreMetadataIssues.length === 0,
     detail: mitreMetadataIssues.length === 0
-      ? 'Optional mapping metadata is valid'
+      ? 'Required fields and optional metadata are valid'
       : mitreMetadataIssues.join(' | '),
   });
   if (mitreMetadataIssues.length > 0) pass = false;

--- a/scripts/validate-content-corpus.mjs
+++ b/scripts/validate-content-corpus.mjs
@@ -6,17 +6,16 @@ import { fileURLToPath } from 'url';
 import yaml from 'js-yaml';
 
 import {
-  SCHEMA_ATTACK_VERSION_PATTERN,
-  SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN,
-  SCHEMA_ATLAS_VERSION_PATTERN,
   SCHEMA_CANONICAL_PUBLISHER_ALIASES,
   SCHEMA_GENERATED_BY_VALUES,
-  SCHEMA_MAPPING_CONFIDENCE_VALUES,
-  SCHEMA_MITRE_TECHNIQUE_ID_PATTERN,
   SCHEMA_MITRE_TACTICS,
   SCHEMA_REQUIRED_H2_BY_TYPE,
   SCHEMA_REVIEW_STATUSES,
 } from './pipeline-schema.mjs';
+import {
+  getAtlasMappingValidationIssues,
+  getMitreMappingValidationIssues,
+} from './framework-mapping-validation.mjs';
 import {
   getPublicProseGuardrailIssues,
   maskTextPreservingNewlines,
@@ -26,10 +25,6 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
 
 const SOURCE_BODY_LINE_RE = /^\s*-\s+\[(.+?):\s+(.+)\]\((https?:\/\/[^\s)]+)\)\s+([—–-])\s+(.+?),\s+(\d{4}-\d{2}-\d{2})\s*$/;
-const ATTACK_VERSION_RE = new RegExp(SCHEMA_ATTACK_VERSION_PATTERN);
-const ATLAS_TECHNIQUE_ID_RE = new RegExp(SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN);
-const ATLAS_VERSION_RE = new RegExp(SCHEMA_ATLAS_VERSION_PATTERN);
-const MITRE_TECHNIQUE_ID_RE = new RegExp(SCHEMA_MITRE_TECHNIQUE_ID_PATTERN);
 const ZERO_DAY_SEVERITY_METRICS = [
   'Exploitability',
   'Impact',
@@ -418,35 +413,9 @@ function validateFile(file, newFiles) {
   });
   if (invalidTactics.length > 0) pass = false;
 
-  const mitreMetadataIssues = [];
-  for (let i = 0; i < mitreMappings.length; i += 1) {
-    const mapping = mitreMappings[i] || {};
-    const techniqueId = mapping.techniqueId ? String(mapping.techniqueId).trim() : '';
-    if (/^T\d{4}-\d{3}$/.test(techniqueId)) {
-      mitreMetadataIssues.push(`mapping ${i + 1}: techniqueId "${techniqueId}" should use canonical "." separator (${techniqueId.replace('-', '.')})`);
-    } else if (!MITRE_TECHNIQUE_ID_RE.test(techniqueId)) {
-      mitreMetadataIssues.push(`mapping ${i + 1}: invalid techniqueId "${techniqueId}" — expected format T####[.###]`);
-    }
-    if (!mapping.techniqueName || String(mapping.techniqueName).trim() === '') {
-      mitreMetadataIssues.push(`mapping ${i + 1}: missing techniqueName`);
-    }
-    const attackVersion = mapping.attackVersion ?? mapping.attack_version;
-    if (attackVersion !== undefined) {
-      const version = typeof attackVersion === 'string' ? attackVersion.trim() : '';
-      if (!ATTACK_VERSION_RE.test(version)) {
-        mitreMetadataIssues.push(`mapping ${i + 1}: attackVersion must match vNN[.N]`);
-      }
-    }
-    if (
-      mapping.confidence !== undefined &&
-      !SCHEMA_MAPPING_CONFIDENCE_VALUES.includes(String(mapping.confidence).trim())
-    ) {
-      mitreMetadataIssues.push(`mapping ${i + 1}: confidence must be ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')}`);
-    }
-    if (mapping.evidence !== undefined && (typeof mapping.evidence !== 'string' || mapping.evidence.trim() === '')) {
-      mitreMetadataIssues.push(`mapping ${i + 1}: evidence must be a non-empty string`);
-    }
-  }
+  const mitreMetadataIssues = getMitreMappingValidationIssues(mitreMappings, {
+    labelPrefix: 'mapping',
+  });
   checks.push({
     name: 'MITRE mapping fields and metadata',
     pass: mitreMetadataIssues.length === 0,
@@ -457,37 +426,9 @@ function validateFile(file, newFiles) {
   if (mitreMetadataIssues.length > 0) pass = false;
 
   const atlasMappings = fm.atlasMappings;
-  const atlasIssues = [];
-  if (atlasMappings !== undefined && !Array.isArray(atlasMappings)) {
-    atlasIssues.push('atlasMappings must be an array when present');
-  }
-  if (Array.isArray(atlasMappings)) {
-    for (let i = 0; i < atlasMappings.length; i += 1) {
-      const mapping = atlasMappings[i] || {};
-      const techniqueId = mapping.techniqueId ? String(mapping.techniqueId).trim() : '';
-      if (!ATLAS_TECHNIQUE_ID_RE.test(techniqueId)) {
-        atlasIssues.push(`mapping ${i + 1}: invalid techniqueId "${techniqueId}" — expected format AML.T####[.###]`);
-      }
-      if (!mapping.techniqueName || String(mapping.techniqueName).trim() === '') {
-        atlasIssues.push(`mapping ${i + 1}: missing techniqueName`);
-      }
-      if (
-        mapping.confidence !== undefined &&
-        !SCHEMA_MAPPING_CONFIDENCE_VALUES.includes(String(mapping.confidence).trim())
-      ) {
-        atlasIssues.push(`mapping ${i + 1}: confidence must be ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')}`);
-      }
-      if (mapping.atlasVersion !== undefined) {
-        const atlasVersion = typeof mapping.atlasVersion === 'string' ? mapping.atlasVersion.trim() : '';
-        if (!ATLAS_VERSION_RE.test(atlasVersion)) {
-          atlasIssues.push(`mapping ${i + 1}: atlasVersion must match N.N.N`);
-        }
-      }
-      if (mapping.evidence !== undefined && (typeof mapping.evidence !== 'string' || mapping.evidence.trim() === '')) {
-        atlasIssues.push(`mapping ${i + 1}: evidence must be a non-empty string`);
-      }
-    }
-  }
+  const atlasIssues = getAtlasMappingValidationIssues(atlasMappings, {
+    labelPrefix: 'mapping',
+  });
   checks.push({
     name: 'ATLAS mappings',
     pass: atlasIssues.length === 0,

--- a/scripts/validate-content-corpus.mjs
+++ b/scripts/validate-content-corpus.mjs
@@ -6,8 +6,12 @@ import { fileURLToPath } from 'url';
 import yaml from 'js-yaml';
 
 import {
+  SCHEMA_ATTACK_VERSION_PATTERN,
+  SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN,
+  SCHEMA_ATLAS_VERSION_PATTERN,
   SCHEMA_CANONICAL_PUBLISHER_ALIASES,
   SCHEMA_GENERATED_BY_VALUES,
+  SCHEMA_MAPPING_CONFIDENCE_VALUES,
   SCHEMA_MITRE_TACTICS,
   SCHEMA_REQUIRED_H2_BY_TYPE,
   SCHEMA_REVIEW_STATUSES,
@@ -21,6 +25,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
 
 const SOURCE_BODY_LINE_RE = /^\s*-\s+\[(.+?):\s+(.+)\]\((https?:\/\/[^\s)]+)\)\s+([—–-])\s+(.+?),\s+(\d{4}-\d{2}-\d{2})\s*$/;
+const ATTACK_VERSION_RE = new RegExp(SCHEMA_ATTACK_VERSION_PATTERN);
+const ATLAS_TECHNIQUE_ID_RE = new RegExp(SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN);
+const ATLAS_VERSION_RE = new RegExp(SCHEMA_ATLAS_VERSION_PATTERN);
 const ZERO_DAY_SEVERITY_METRICS = [
   'Exploitability',
   'Impact',
@@ -408,6 +415,76 @@ function validateFile(file, newFiles) {
     detail: invalidTactics.length === 0 ? 'Canonical ATT&CK tactic casing' : invalidTactics.join(', '),
   });
   if (invalidTactics.length > 0) pass = false;
+
+  const mitreMetadataIssues = [];
+  for (let i = 0; i < mitreMappings.length; i += 1) {
+    const mapping = mitreMappings[i] || {};
+    const attackVersion = mapping.attackVersion ?? mapping.attack_version;
+    if (attackVersion !== undefined) {
+      const version = typeof attackVersion === 'string' ? attackVersion.trim() : '';
+      if (!ATTACK_VERSION_RE.test(version)) {
+        mitreMetadataIssues.push(`mapping ${i + 1}: attackVersion must match vNN[.N]`);
+      }
+    }
+    if (
+      mapping.confidence !== undefined &&
+      !SCHEMA_MAPPING_CONFIDENCE_VALUES.includes(String(mapping.confidence).trim())
+    ) {
+      mitreMetadataIssues.push(`mapping ${i + 1}: confidence must be ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')}`);
+    }
+    if (mapping.evidence !== undefined && (typeof mapping.evidence !== 'string' || mapping.evidence.trim() === '')) {
+      mitreMetadataIssues.push(`mapping ${i + 1}: evidence must be a non-empty string`);
+    }
+  }
+  checks.push({
+    name: 'MITRE mapping metadata',
+    pass: mitreMetadataIssues.length === 0,
+    detail: mitreMetadataIssues.length === 0
+      ? 'Optional mapping metadata is valid'
+      : mitreMetadataIssues.join(' | '),
+  });
+  if (mitreMetadataIssues.length > 0) pass = false;
+
+  const atlasMappings = fm.atlasMappings;
+  const atlasIssues = [];
+  if (atlasMappings !== undefined && !Array.isArray(atlasMappings)) {
+    atlasIssues.push('atlasMappings must be an array when present');
+  }
+  if (Array.isArray(atlasMappings)) {
+    for (let i = 0; i < atlasMappings.length; i += 1) {
+      const mapping = atlasMappings[i] || {};
+      const techniqueId = mapping.techniqueId ? String(mapping.techniqueId).trim() : '';
+      if (!ATLAS_TECHNIQUE_ID_RE.test(techniqueId)) {
+        atlasIssues.push(`mapping ${i + 1}: invalid techniqueId "${techniqueId}"`);
+      }
+      if (!mapping.techniqueName || String(mapping.techniqueName).trim() === '') {
+        atlasIssues.push(`mapping ${i + 1}: missing techniqueName`);
+      }
+      if (
+        mapping.confidence !== undefined &&
+        !SCHEMA_MAPPING_CONFIDENCE_VALUES.includes(String(mapping.confidence).trim())
+      ) {
+        atlasIssues.push(`mapping ${i + 1}: confidence must be ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')}`);
+      }
+      if (mapping.atlasVersion !== undefined) {
+        const atlasVersion = typeof mapping.atlasVersion === 'string' ? mapping.atlasVersion.trim() : '';
+        if (!ATLAS_VERSION_RE.test(atlasVersion)) {
+          atlasIssues.push(`mapping ${i + 1}: atlasVersion must match N.N.N`);
+        }
+      }
+      if (mapping.evidence !== undefined && (typeof mapping.evidence !== 'string' || mapping.evidence.trim() === '')) {
+        atlasIssues.push(`mapping ${i + 1}: evidence must be a non-empty string`);
+      }
+    }
+  }
+  checks.push({
+    name: 'ATLAS mappings',
+    pass: atlasIssues.length === 0,
+    detail: atlasIssues.length === 0
+      ? `${Array.isArray(atlasMappings) ? atlasMappings.length : 0} optional mapping(s)`
+      : atlasIssues.join(' | '),
+  });
+  if (atlasIssues.length > 0) pass = false;
 
   const sources = Array.isArray(fm.sources) ? fm.sources : [];
   const publisherAliasViolations = [];

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -73,7 +73,7 @@ const sourceSchema = z.object({
 
 /** MITRE ATT&CK mapping schema */
 const mitreMapping = z.object({
-  techniqueId: z.string(),
+  techniqueId: z.string().regex(/^T\d{4}(?:\.\d{3})?$/),
   techniqueName: z.string(),
   tactic: mitreTactic.optional(),
   attackVersion: z.string().regex(/^v\d+(?:\.\d+)?$/).optional(),

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -44,6 +44,8 @@ const mitreTactic = z.enum([
   'Execution',
   'Persistence',
   'Privilege Escalation',
+  'Stealth',
+  'Defense Impairment',
   'Defense Evasion',
   'Credential Access',
   'Discovery',
@@ -54,6 +56,8 @@ const mitreTactic = z.enum([
   'Impact',
   'Impair Process Control',
 ]);
+
+const mappingConfidence = z.enum(['confirmed', 'probable', 'possible']);
 
 /** Source citation schema per SOURCE-SPEC v1.0 */
 const sourceSchema = z.object({
@@ -72,6 +76,21 @@ const mitreMapping = z.object({
   techniqueId: z.string(),
   techniqueName: z.string(),
   tactic: mitreTactic.optional(),
+  attackVersion: z.string().regex(/^v\d+(?:\.\d+)?$/).optional(),
+  attack_version: z.string().regex(/^v\d+(?:\.\d+)?$/).optional(),
+  confidence: mappingConfidence.optional(),
+  evidence: z.string().min(1).optional(),
+  notes: z.string().optional(),
+});
+
+/** MITRE ATLAS mapping schema */
+const atlasMapping = z.object({
+  techniqueId: z.string().regex(/^AML\.T\d{4}(?:\.\d{3})?$/),
+  techniqueName: z.string(),
+  tactic: z.string().optional(),
+  atlasVersion: z.string().regex(/^\d+\.\d+\.\d+$/).optional(),
+  confidence: mappingConfidence.optional(),
+  evidence: z.string().min(1).optional(),
   notes: z.string().optional(),
 });
 
@@ -113,6 +132,7 @@ const incidents = defineCollection({
 
     // MITRE
     mitreMappings: z.array(mitreMapping).default([]),
+    atlasMappings: z.array(atlasMapping).default([]),
   }),
 });
 
@@ -156,6 +176,7 @@ const campaigns = defineCollection({
 
     // MITRE
     mitreMappings: z.array(mitreMapping).min(1),
+    atlasMappings: z.array(atlasMapping).default([]),
   }).superRefine((data, ctx) => {
     if (data.ongoing && data.endDate) {
       ctx.addIssue({
@@ -213,6 +234,7 @@ const threatActors = defineCollection({
     targetGeographies: z.array(z.string()).default([]),
     tools: z.array(z.string()).default([]),
     mitreMappings: z.array(mitreMapping).default([]),
+    atlasMappings: z.array(atlasMapping).default([]),
 
     // Quality
     attributionConfidence: attributionConfidence.optional(),
@@ -265,6 +287,7 @@ const zeroDays = defineCollection({
 
     // MITRE
     mitreMappings: z.array(mitreMapping).default([]),
+    atlasMappings: z.array(atlasMapping).default([]),
   }),
 });
 


### PR DESCRIPTION
## Summary

- add ATT&CK v19 tactic vocabulary support while keeping legacy `Defense Evasion` accepted for existing mappings
- add optional mapping metadata for ATT&CK mappings: version, confidence, and evidence
- add optional `atlasMappings` frontmatter support across all article collections with AML technique ID validation
- update the pipeline schema mirror, corpus validator, and task runner instructions/validation together

## Source References

- MITRE ATT&CK v19 release: https://attack.mitre.org/resources/updates/updates-april-2026/
- MITRE ATLAS data source: https://github.com/mitre-atlas/atlas-data
- MITRE ATLAS current data YAML reference: https://raw.githubusercontent.com/mitre-atlas/atlas-data/main/dist/ATLAS.yaml

## Validation

- `npm --prefix scripts ci --no-audit --no-fund`
- `npm --prefix site ci`
- `node scripts/pipeline-schema.mjs --key mitreTactics`
- `node scripts/pipeline-schema.mjs --key atlasTechniqueIdPattern`
- `node scripts/pipeline-schema.mjs`
- `node scripts/validate-content-corpus.mjs --files-file /tmp/threatpedia-framework-validator-files.txt`
- `npm --prefix site run build`

## Notes

This is intentionally schema/validator-only. It does not remap the corpus yet and does not require existing articles to add ATLAS mappings or ATT&CK version metadata.
