### PR TITLE
feat(pipeline): TASK-2026-0225 — MuddyWater Iranian state-sponsored threat actor profile

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0225.json
+++ b/.github/pipeline/tasks/TASK-2026-0225.json
@@ -3,13 +3,13 @@
   "stage": "draft",
   "type": "threat-actor",
   "priority": "P1",
-  "status": "pending",
+  "status": "locked",
   "created": "2026-05-06T00:45:00.000Z",
-  "updated": "2026-05-06T01:51:00.149Z",
+  "updated": "2026-05-06T01:54:41.791Z",
   "source": "manual_submission",
   "submitted_by": "Kernel K",
-  "locked_by": null,
-  "locked_at": null,
+  "locked_by": "Kernel K",
+  "locked_at": "2026-05-06T01:54:41.790Z",
   "input": {
     "topic": "MuddyWater Iranian state-sponsored threat actor profile",
     "sources": [
@@ -71,6 +71,13 @@
       "to": "pending",
       "agent": "dispatcher",
       "note": "Dispatched as Issue #489"
+    },
+    {
+      "timestamp": "2026-05-06T01:54:41.791Z",
+      "from": "pending",
+      "to": "locked",
+      "agent": "Kernel K",
+      "note": "Locked for execution"
     }
   ]
 }

--- a/.github/pipeline/tasks/TASK-2026-0225.json
+++ b/.github/pipeline/tasks/TASK-2026-0225.json
@@ -3,13 +3,13 @@
   "stage": "draft",
   "type": "threat-actor",
   "priority": "P1",
-  "status": "locked",
+  "status": "pr_open",
   "created": "2026-05-06T00:45:00.000Z",
-  "updated": "2026-05-06T01:54:41.791Z",
+  "updated": "2026-05-06T01:58:15.379Z",
   "source": "manual_submission",
   "submitted_by": "Kernel K",
-  "locked_by": "Kernel K",
-  "locked_at": "2026-05-06T01:54:41.790Z",
+  "locked_by": null,
+  "locked_at": null,
   "input": {
     "topic": "MuddyWater Iranian state-sponsored threat actor profile",
     "sources": [
@@ -78,6 +78,16 @@
       "to": "locked",
       "agent": "Kernel K",
       "note": "Locked for execution"
+    },
+    {
+      "timestamp": "2026-05-06T01:58:15.379Z",
+      "from": "locked",
+      "to": "pr_open",
+      "agent": "Kernel K",
+      "action": "pr_opened",
+      "note": "Article generated, validated, and recorded against PR #491"
     }
-  ]
+  ],
+  "pr_number": 491,
+  "pr_url": "https://github.com/MahdiHedhli/threatpedia/pull/491"
 }

--- a/site/src/content/threat-actors/muddywater.md
+++ b/site/src/content/threat-actors/muddywater.md
@@ -104,7 +104,7 @@ sources:
     accessDate: "2026-05-06"
     archived: false
   - url: "https://cloud.google.com/blog/topics/threat-intelligence/telegram-malware-iranian-espionage/"
-    publisher: "Google Cloud"
+    publisher: "Mandiant"
     publisherType: vendor
     reliability: R1
     publicationDate: "2022-02-24"
@@ -114,7 +114,7 @@ sources:
 
 ## Executive Summary
 
-MuddyWater is an Iranian state-sponsored cyber-espionage group publicly identified by U.S. Cyber Command and a joint advisory from the FBI, CISA, CNMF, and UK NCSC as a subordinate element within Iran's Ministry of Intelligence and Security. The group is tracked by MITRE ATT&CK as G0069 and is also reported under aliases including Static Kitten, Seedworm, TEMP.Zagros, MERCURY, Mango Sandstorm, and Earth Vetala.
+MuddyWater is an Iranian state-sponsored cyber-espionage group publicly identified by U.S. Cyber Command and a joint advisory from the FBI, CISA, U.S. Cyber Command Cyber National Mission Force (CNMF), and UK NCSC as a subordinate element within Iran's Ministry of Intelligence and Security (MOIS). The group is tracked by MITRE ATT&CK as G0069 and is also reported under aliases including Static Kitten, Seedworm, TEMP.Zagros, MERCURY, Mango Sandstorm, and Earth Vetala.
 
 Public government and research reporting describes MuddyWater as active since at least 2017. Its operations have targeted government and private-sector organizations across telecommunications, defense, local government, finance, and oil and natural gas sectors in the Middle East, Asia, Africa, Europe, and North America. MuddyWater maintains an espionage-focused profile, with technical activity built around phishing, exploitation of known vulnerabilities, remote access tooling, credential collection, and post-compromise staging.
 
@@ -163,4 +163,4 @@ The alias boundary remains important. MITRE lists Earth Vetala, MERCURY, Static 
 - [CISA: Iranian Government-Sponsored Actors Conduct Cyber Operations Against Global Government and Commercial Networks](https://www.cisa.gov/news-events/cybersecurity-advisories/aa22-055a) — CISA, 2022-02-24
 - [U.S. Cyber Command: Iranian intel cyber suite of malware uses open source tools](https://www.cybercom.mil/Media/News/Article/2897570/iranian-intel-cyber-suite-of-malware-uses-open-source-tools/) — U.S. Cyber Command, 2022-01-12
 - [MITRE ATT&CK: MuddyWater](https://attack.mitre.org/groups/G0069/) — MITRE ATT&CK, 2026-04-23
-- [Google Cloud: Left On Read: Telegram Malware Spotted in Latest Iranian Cyber Espionage Activity](https://cloud.google.com/blog/topics/threat-intelligence/telegram-malware-iranian-espionage/) — Google Cloud, 2022-02-24
+- [Mandiant: Left On Read: Telegram Malware Spotted in Latest Iranian Cyber Espionage Activity](https://cloud.google.com/blog/topics/threat-intelligence/telegram-malware-iranian-espionage/) — Mandiant, 2022-02-24

--- a/site/src/content/threat-actors/muddywater.md
+++ b/site/src/content/threat-actors/muddywater.md
@@ -111,7 +111,7 @@ Public government and research reporting describes MuddyWater as active since at
 
 ## Notable Campaigns
 
-### 2017-present -- Government and Commercial Network Targeting
+### 2017-present — Government and Commercial Network Targeting
 
 The 2022 joint cybersecurity advisory describes MuddyWater activity against government and commercial networks across multiple regions. The advisory identifies telecommunications, defense, local government, and oil and natural gas organizations as part of the observed target set and provides intrusion patterns including spearphishing, exploitation of known vulnerabilities, and the use of open-source tools.
 
@@ -125,7 +125,7 @@ U.S. Cyber Command's Cyber National Mission Force publicly disclosed malware sam
 
 ## Technical Capabilities
 
-MuddyWater operations rely heavily on social engineering and known-vulnerability exploitation rather than only custom malware. Public reporting describes spearphishing emails, malicious documents, archive files, and links used to initiate access. The group has also exploited publicly known vulnerabilities and used legitimate remote access or remote management tools to maintain access in victim environments.
+MuddyWater operations rely on social engineering and known-vulnerability exploitation rather than only custom malware. Public reporting describes spearphishing emails, malicious documents, archive files, and links used to initiate access. The group has also exploited publicly known vulnerabilities and used legitimate remote access or remote management tools to maintain access in victim environments.
 
 The group's tooling has included POWERSTATS, POWGOOP, MORIAGENT, Small Sieve, Canopy, STARWHALE, and GRAMDOOR. CISA and MITRE reporting also document PowerShell, JavaScript, Visual Basic, command shell activity, DLL side-loading, credential-dumping utilities, and staged tool transfer during post-compromise operations.
 
@@ -133,7 +133,7 @@ MuddyWater's tradecraft includes obfuscating scripts, using legitimate administr
 
 ## Attribution
 
-Attribution to Iran's Ministry of Intelligence and Security is strong in the public record. U.S. Cyber Command stated in January 2022 that MuddyWater is a subordinate element within MOIS, and the February 2022 joint advisory from FBI, CISA, CNMF, and UK NCSC repeated that assessment while describing global government and commercial targeting.
+Attribution to Iran's Ministry of Intelligence and Security is documented in the public record. U.S. Cyber Command stated in January 2022 that MuddyWater is a subordinate element within MOIS, and the February 2022 joint advisory from FBI, CISA, CNMF, and UK NCSC repeated that assessment while describing global government and commercial targeting.
 
 The alias boundary remains important. MITRE lists Earth Vetala, MERCURY, Static Kitten, Seedworm, TEMP.Zagros, Mango Sandstorm, TA450, and MuddyKrill as associated group names for MuddyWater. This profile treats those names as public tracking aliases or overlapping reporting labels and does not assume that every Iran-nexus intrusion using similar tools is MuddyWater unless a cited source makes that link.
 

--- a/site/src/content/threat-actors/muddywater.md
+++ b/site/src/content/threat-actors/muddywater.md
@@ -115,11 +115,11 @@ Public government and research reporting describes MuddyWater as active since at
 
 The 2022 joint cybersecurity advisory describes MuddyWater activity against government and commercial networks across multiple regions. The advisory identifies telecommunications, defense, local government, and oil and natural gas organizations as part of the observed target set and provides intrusion patterns including spearphishing, exploitation of known vulnerabilities, and the use of open-source tools.
 
-### 2021 -- Middle East Government Intrusion Tracked by Mandiant
+### 2021 — Middle East Government Intrusion Tracked by Mandiant
 
 Mandiant reported a 2021 intrusion at a Middle East government customer under the UNC3313 cluster. Mandiant assessed with moderate confidence that UNC3313 was associated with TEMP.Zagros, which open sources report as MuddyWater. The intrusion involved targeted phishing, public remote-access software, and malware families including GRAMDOOR and STARWHALE.
 
-### 2022 -- Public Disclosure of MOIS-Linked Malware Activity
+### 2022 — Public Disclosure of MOIS-Linked Malware Activity
 
 U.S. Cyber Command's Cyber National Mission Force publicly disclosed malware samples and tools associated with Iranian intelligence actors tracked as MuddyWater. The disclosure described the group's use of open-source tools, side-loading DLLs, obfuscated PowerShell, and JavaScript components used to connect to malicious infrastructure.
 

--- a/site/src/content/threat-actors/muddywater.md
+++ b/site/src/content/threat-actors/muddywater.md
@@ -144,7 +144,7 @@ MuddyWater's tradecraft includes obfuscating scripts, using legitimate administr
 
 Attribution to Iran's Ministry of Intelligence and Security is documented in the public record. U.S. Cyber Command stated in January 2022 that MuddyWater is a subordinate element within MOIS, and the February 2022 joint advisory from FBI, CISA, CNMF, and UK NCSC repeated that assessment while describing global government and commercial targeting.
 
-The alias boundary remains important. MITRE lists Earth Vetala, MERCURY, Static Kitten, Seedworm, TEMP.Zagros, Mango Sandstorm, TA450, and MuddyKrill as associated group names for MuddyWater. These names are considered public tracking aliases or overlapping reporting labels; attribution of Iran-nexus activity to MuddyWater requires direct evidence or cited source linkage.
+MITRE lists Earth Vetala, MERCURY, Static Kitten, Seedworm, TEMP.Zagros, Mango Sandstorm, TA450, and MuddyKrill as associated group names for MuddyWater. These names are considered public tracking aliases or overlapping reporting labels; attribution of Iran-nexus activity to MuddyWater requires direct evidence or cited source linkage.
 
 ## MITRE ATT&CK Profile
 

--- a/site/src/content/threat-actors/muddywater.md
+++ b/site/src/content/threat-actors/muddywater.md
@@ -38,6 +38,7 @@ tools:
   - "GRAMDOOR"
   - "ScreenConnect"
   - "LaZagne"
+  - "Mimikatz"
 mitreMappings:
   - techniqueId: "T1566.001"
     techniqueName: "Phishing: Spearphishing Attachment"
@@ -59,6 +60,14 @@ mitreMappings:
     techniqueName: "Ingress Tool Transfer"
     tactic: "Command and Control"
     notes: "The group has staged and transferred additional malware, remote access tools, and scripts during post-compromise operations."
+  - techniqueId: "T1074"
+    techniqueName: "Data Staged"
+    tactic: "Collection"
+    notes: "MITRE reporting documents local data staging during MuddyWater-linked activity."
+  - techniqueId: "T1041"
+    techniqueName: "Exfiltration Over C2 Channel"
+    tactic: "Exfiltration"
+    notes: "MITRE reporting documents exfiltration over command-and-control or cloud storage services in MuddyWater-linked activity."
 attributionConfidence: A1
 attributionRationale: "U.S. Cyber Command and a joint FBI/CISA/CNMF/NCSC-UK advisory publicly identify MuddyWater as a subordinate element within Iran's Ministry of Intelligence and Security."
 reviewStatus: "draft_ai"

--- a/site/src/content/threat-actors/muddywater.md
+++ b/site/src/content/threat-actors/muddywater.md
@@ -114,9 +114,9 @@ sources:
 
 ## Executive Summary
 
-MuddyWater is an Iranian state-sponsored cyber-espionage group publicly identified by U.S. Cyber Command and a joint FBI, CISA, U.S. Cyber Command Cyber National Mission Force, and UK NCSC advisory as a subordinate element within Iran's Ministry of Intelligence and Security. The group is tracked by MITRE ATT&CK as G0069 and is also reported under aliases including Static Kitten, Seedworm, TEMP.Zagros, MERCURY, Mango Sandstorm, and Earth Vetala.
+MuddyWater is an Iranian state-sponsored cyber-espionage group publicly identified by U.S. Cyber Command and a joint advisory from the FBI, CISA, CNMF, and UK NCSC as a subordinate element within Iran's Ministry of Intelligence and Security. The group is tracked by MITRE ATT&CK as G0069 and is also reported under aliases including Static Kitten, Seedworm, TEMP.Zagros, MERCURY, Mango Sandstorm, and Earth Vetala.
 
-Public government and research reporting describes MuddyWater as active since at least 2017. Its operations have targeted government and private-sector organizations across telecommunications, defense, local government, finance, and oil and natural gas sectors in the Middle East, Asia, Africa, Europe, and North America. The public evidence supports an espionage-focused profile, with technical activity built around phishing, exploitation of known vulnerabilities, remote access tooling, credential collection, and post-compromise staging.
+Public government and research reporting describes MuddyWater as active since at least 2017. Its operations have targeted government and private-sector organizations across telecommunications, defense, local government, finance, and oil and natural gas sectors in the Middle East, Asia, Africa, Europe, and North America. MuddyWater maintains an espionage-focused profile, with technical activity built around phishing, exploitation of known vulnerabilities, remote access tooling, credential collection, and post-compromise staging.
 
 ## Notable Campaigns
 
@@ -126,11 +126,11 @@ The 2022 joint cybersecurity advisory describes MuddyWater activity against gove
 
 ### 2021 — Middle East Government Intrusion Tracked by Mandiant
 
-Mandiant reported a 2021 intrusion at a Middle East government customer under the UNC3313 cluster. Mandiant assessed with moderate confidence that UNC3313 was associated with TEMP.Zagros, which open sources report as MuddyWater. The intrusion involved targeted phishing, public remote-access software, and malware families including GRAMDOOR and STARWHALE.
+Mandiant reported a 2021 intrusion at a Middle East government customer under the UNC3313 cluster. Mandiant assessed with moderate confidence that UNC3313 was associated with TEMP.Zagros, which public reporting associates with MuddyWater. The intrusion involved targeted phishing, public remote-access software, and malware families including GRAMDOOR and STARWHALE.
 
 ### 2022 — Public Disclosure of MOIS-Linked Malware Activity
 
-U.S. Cyber Command's Cyber National Mission Force publicly disclosed malware samples and tools associated with Iranian intelligence actors tracked as MuddyWater. The disclosure described the group's use of open-source tools, side-loading DLLs, obfuscated PowerShell, and JavaScript components used to connect to malicious infrastructure.
+U.S. Cyber Command's Cyber National Mission Force publicly disclosed malware samples and tools associated with Iranian intelligence actors tracked as MuddyWater. The disclosure described the group's use of open-source tools, side-loading DLLs, obfuscated PowerShell, and JavaScript components used to connect to attacker-controlled infrastructure.
 
 ## Technical Capabilities
 
@@ -138,13 +138,13 @@ MuddyWater operations rely on social engineering and known-vulnerability exploit
 
 The group's tooling has included POWERSTATS, POWGOOP, MORIAGENT, Small Sieve, Canopy, STARWHALE, and GRAMDOOR. CISA and MITRE reporting also document PowerShell, JavaScript, Visual Basic, command shell activity, DLL side-loading, credential-dumping utilities, and staged tool transfer during post-compromise operations.
 
-MuddyWater's tradecraft includes obfuscating scripts, using legitimate administrative tools, collecting credentials, and transferring additional payloads after initial access. The available public reporting supports a profile of a persistent intelligence-collection group that blends custom tooling with publicly available offensive security tools and remote access software.
+MuddyWater's tradecraft includes obfuscating scripts, using legitimate administrative tools, collecting credentials, and transferring additional payloads after initial access. MuddyWater is a persistent intelligence-collection group that blends custom tooling with publicly available offensive security tools and remote access software.
 
 ## Attribution
 
 Attribution to Iran's Ministry of Intelligence and Security is documented in the public record. U.S. Cyber Command stated in January 2022 that MuddyWater is a subordinate element within MOIS, and the February 2022 joint advisory from FBI, CISA, CNMF, and UK NCSC repeated that assessment while describing global government and commercial targeting.
 
-The alias boundary remains important. MITRE lists Earth Vetala, MERCURY, Static Kitten, Seedworm, TEMP.Zagros, Mango Sandstorm, TA450, and MuddyKrill as associated group names for MuddyWater. This profile treats those names as public tracking aliases or overlapping reporting labels and does not assume that every Iran-nexus intrusion using similar tools is MuddyWater unless a cited source makes that link.
+The alias boundary remains important. MITRE lists Earth Vetala, MERCURY, Static Kitten, Seedworm, TEMP.Zagros, Mango Sandstorm, TA450, and MuddyKrill as associated group names for MuddyWater. These names are considered public tracking aliases or overlapping reporting labels; attribution of Iran-nexus activity to MuddyWater requires direct evidence or cited source linkage.
 
 ## MITRE ATT&CK Profile
 

--- a/site/src/content/threat-actors/muddywater.md
+++ b/site/src/content/threat-actors/muddywater.md
@@ -1,0 +1,157 @@
+---
+name: "MuddyWater"
+aliases:
+  - "Earth Vetala"
+  - "MERCURY"
+  - "Static Kitten"
+  - "Seedworm"
+  - "TEMP.Zagros"
+  - "Mango Sandstorm"
+  - "TA450"
+  - "MuddyKrill"
+affiliation: "Iranian Ministry of Intelligence and Security"
+motivation: "Espionage"
+status: active
+country: "Iran"
+firstSeen: "2017"
+lastSeen: "2026"
+targetSectors:
+  - "Government"
+  - "Telecommunications"
+  - "Defense"
+  - "Finance"
+  - "Oil and Natural Gas"
+  - "Local Government"
+targetGeographies:
+  - "Middle East"
+  - "Asia"
+  - "Africa"
+  - "Europe"
+  - "North America"
+tools:
+  - "POWERSTATS"
+  - "POWGOOP"
+  - "MORIAGENT"
+  - "Small Sieve"
+  - "Canopy"
+  - "STARWHALE"
+  - "GRAMDOOR"
+  - "ScreenConnect"
+  - "LaZagne"
+mitreMappings:
+  - techniqueId: "T1566.001"
+    techniqueName: "Phishing: Spearphishing Attachment"
+    tactic: "Initial Access"
+    notes: "MuddyWater has used targeted spearphishing emails with malicious attachments and links to begin intrusions."
+  - techniqueId: "T1190"
+    techniqueName: "Exploit Public-Facing Application"
+    tactic: "Initial Access"
+    notes: "Public reporting and CISA advisory material describe exploitation of known vulnerabilities, including Microsoft Exchange and Netlogon issues."
+  - techniqueId: "T1059.001"
+    techniqueName: "Command and Scripting Interpreter: PowerShell"
+    tactic: "Execution"
+    notes: "The group has repeatedly used obfuscated PowerShell for payload execution and command-and-control functions."
+  - techniqueId: "T1003.001"
+    techniqueName: "OS Credential Dumping: LSASS Memory"
+    tactic: "Credential Access"
+    notes: "MuddyWater tooling and procedures include credential-dumping activity using tools such as Mimikatz and related utilities."
+  - techniqueId: "T1105"
+    techniqueName: "Ingress Tool Transfer"
+    tactic: "Command and Control"
+    notes: "The group has staged and transferred additional malware, remote access tools, and scripts during post-compromise operations."
+attributionConfidence: A1
+attributionRationale: "U.S. Cyber Command and a joint FBI/CISA/CNMF/NCSC-UK advisory publicly identify MuddyWater as a subordinate element within Iran's Ministry of Intelligence and Security."
+reviewStatus: "draft_ai"
+generatedBy: "kernel-k"
+generatedDate: 2026-05-06
+tags:
+  - "nation-state"
+  - "iran"
+  - "mois"
+  - "espionage"
+  - "muddywater"
+  - "seedworm"
+  - "temp-zagros"
+sources:
+  - url: "https://www.cisa.gov/news-events/cybersecurity-advisories/aa22-055a"
+    publisher: "CISA"
+    publisherType: government
+    reliability: R1
+    publicationDate: "2022-02-24"
+    accessDate: "2026-05-06"
+    archived: false
+  - url: "https://www.cybercom.mil/Media/News/Article/2897570/iranian-intel-cyber-suite-of-malware-uses-open-source-tools/"
+    publisher: "U.S. Cyber Command"
+    publisherType: government
+    reliability: R1
+    publicationDate: "2022-01-12"
+    accessDate: "2026-05-06"
+    archived: false
+  - url: "https://attack.mitre.org/groups/G0069/"
+    publisher: "MITRE ATT&CK"
+    publisherType: research
+    reliability: R1
+    publicationDate: "2026-04-23"
+    accessDate: "2026-05-06"
+    archived: false
+  - url: "https://cloud.google.com/blog/topics/threat-intelligence/telegram-malware-iranian-espionage/"
+    publisher: "Google Cloud"
+    publisherType: vendor
+    reliability: R1
+    publicationDate: "2022-02-24"
+    accessDate: "2026-05-06"
+    archived: false
+---
+
+## Executive Summary
+
+MuddyWater is an Iranian state-sponsored cyber-espionage group publicly identified by U.S. Cyber Command and a joint FBI, CISA, U.S. Cyber Command Cyber National Mission Force, and UK NCSC advisory as a subordinate element within Iran's Ministry of Intelligence and Security. The group is tracked by MITRE ATT&CK as G0069 and is also reported under aliases including Static Kitten, Seedworm, TEMP.Zagros, MERCURY, Mango Sandstorm, and Earth Vetala.
+
+Public government and research reporting describes MuddyWater as active since at least 2017. Its operations have targeted government and private-sector organizations across telecommunications, defense, local government, finance, and oil and natural gas sectors in the Middle East, Asia, Africa, Europe, and North America. The public evidence supports an espionage-focused profile, with technical activity built around phishing, exploitation of known vulnerabilities, remote access tooling, credential collection, and post-compromise staging.
+
+## Notable Campaigns
+
+### 2017-present -- Government and Commercial Network Targeting
+
+The 2022 joint cybersecurity advisory describes MuddyWater activity against government and commercial networks across multiple regions. The advisory identifies telecommunications, defense, local government, and oil and natural gas organizations as part of the observed target set and provides intrusion patterns including spearphishing, exploitation of known vulnerabilities, and the use of open-source tools.
+
+### 2021 -- Middle East Government Intrusion Tracked by Mandiant
+
+Mandiant reported a 2021 intrusion at a Middle East government customer under the UNC3313 cluster. Mandiant assessed with moderate confidence that UNC3313 was associated with TEMP.Zagros, which open sources report as MuddyWater. The intrusion involved targeted phishing, public remote-access software, and malware families including GRAMDOOR and STARWHALE.
+
+### 2022 -- Public Disclosure of MOIS-Linked Malware Activity
+
+U.S. Cyber Command's Cyber National Mission Force publicly disclosed malware samples and tools associated with Iranian intelligence actors tracked as MuddyWater. The disclosure described the group's use of open-source tools, side-loading DLLs, obfuscated PowerShell, and JavaScript components used to connect to malicious infrastructure.
+
+## Technical Capabilities
+
+MuddyWater operations rely heavily on social engineering and known-vulnerability exploitation rather than only custom malware. Public reporting describes spearphishing emails, malicious documents, archive files, and links used to initiate access. The group has also exploited publicly known vulnerabilities and used legitimate remote access or remote management tools to maintain access in victim environments.
+
+The group's tooling has included POWERSTATS, POWGOOP, MORIAGENT, Small Sieve, Canopy, STARWHALE, and GRAMDOOR. CISA and MITRE reporting also document PowerShell, JavaScript, Visual Basic, command shell activity, DLL side-loading, credential-dumping utilities, and staged tool transfer during post-compromise operations.
+
+MuddyWater's tradecraft includes obfuscating scripts, using legitimate administrative tools, collecting credentials, and transferring additional payloads after initial access. The available public reporting supports a profile of a persistent intelligence-collection group that blends custom tooling with publicly available offensive security tools and remote access software.
+
+## Attribution
+
+Attribution to Iran's Ministry of Intelligence and Security is strong in the public record. U.S. Cyber Command stated in January 2022 that MuddyWater is a subordinate element within MOIS, and the February 2022 joint advisory from FBI, CISA, CNMF, and UK NCSC repeated that assessment while describing global government and commercial targeting.
+
+The alias boundary remains important. MITRE lists Earth Vetala, MERCURY, Static Kitten, Seedworm, TEMP.Zagros, Mango Sandstorm, TA450, and MuddyKrill as associated group names for MuddyWater. This profile treats those names as public tracking aliases or overlapping reporting labels and does not assume that every Iran-nexus intrusion using similar tools is MuddyWater unless a cited source makes that link.
+
+## MITRE ATT&CK Profile
+
+**Initial Access**: MuddyWater uses spearphishing attachments and links (T1566.001) and has exploited public-facing applications or known vulnerabilities (T1190) to gain initial access.
+
+**Execution**: The group uses PowerShell (T1059.001), Windows command shell, JavaScript, and Visual Basic execution paths to run payloads and post-compromise scripts.
+
+**Credential Access**: Public reporting describes credential-dumping activity, including LSASS memory access (T1003.001) and use of credential theft utilities such as LaZagne.
+
+**Command and Control**: MuddyWater has transferred tools into victim environments (T1105), used HTTP-based communications, and relied on public or legitimate infrastructure and remote access software during operations.
+
+**Collection and Exfiltration**: MITRE reporting documents local data staging, archive creation, and exfiltration over command-and-control or cloud storage services in MuddyWater-linked activity.
+
+## Sources & References
+
+- [CISA: Iranian Government-Sponsored Actors Conduct Cyber Operations Against Global Government and Commercial Networks](https://www.cisa.gov/news-events/cybersecurity-advisories/aa22-055a) — CISA, 2022-02-24
+- [U.S. Cyber Command: Iranian intel cyber suite of malware uses open source tools](https://www.cybercom.mil/Media/News/Article/2897570/iranian-intel-cyber-suite-of-malware-uses-open-source-tools/) — U.S. Cyber Command, 2022-01-12
+- [MITRE ATT&CK: MuddyWater](https://attack.mitre.org/groups/G0069/) — MITRE ATT&CK, 2026-04-23
+- [Google Cloud: Left On Read: Telegram Malware Spotted in Latest Iranian Cyber Espionage Activity](https://cloud.google.com/blog/topics/threat-intelligence/telegram-malware-iranian-espionage/) — Google Cloud, 2022-02-24


### PR DESCRIPTION
## Pipeline Task

- Task: `TASK-2026-0225`
- Type: `threat-actor`
- Topic: MuddyWater Iranian state-sponsored threat actor profile
- Output file: `site/src/content/threat-actors/muddywater.md`

## Validation

- Local validator: `node scripts/pipeline-run-task.mjs --task TASK-2026-0225 --validate`
- Minimum sources: `3`
- Minimum H2 sections: `6`
- Minimum MITRE mappings: `3`

Opened via the one-step pipeline wrapper so PR creation and task-state recording stay in sync.
