### PR TITLE
feat(frameworks): pin ATT&CK v19 and ATLAS data

### DIFF
--- a/.github/pipeline/data/frameworks/mitre-atlas-v5.6.0-techniques.json
+++ b/.github/pipeline/data/frameworks/mitre-atlas-v5.6.0-techniques.json
@@ -1,0 +1,2096 @@
+{
+  "framework": "MITRE ATLAS",
+  "version": "v5.6.0",
+  "source": {
+    "url": "https://raw.githubusercontent.com/mitre-atlas/atlas-data/v5.6.0/data/techniques.yaml",
+    "githubBlobSha": "6e7b68650a46176ee4d72b139134d94e4061ab57",
+    "sha256": "fe8d7b9e7793673d87ee839330320cdedc25357a128734c3fda625f28362be2d",
+    "bytes": 154547
+  },
+  "techniqueCount": 170,
+  "activeTechniqueCount": 170,
+  "techniques": [
+    {
+      "id": "AML.T0000",
+      "name": "Search Open Technical Databases",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{reconnaissance.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0000.000",
+      "name": "Journals and Conference Proceedings",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{victim_research.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0000.001",
+      "name": "Pre-Print Repositories",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{victim_research.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2021-05-13T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0000.002",
+      "name": "Technical Blogs",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{victim_research.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-10-13T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0001",
+      "name": "Search Open AI Vulnerability Analysis",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{reconnaissance.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-17T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0002",
+      "name": "Acquire Public AI Artifacts",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{resource_development.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0002.000",
+      "name": "Datasets",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{acquire_ml_artifacts.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2021-05-13T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0002.001",
+      "name": "Models",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{acquire_ml_artifacts.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2023-02-28T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0002.002",
+      "name": "AI Agent Configuration",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{acquire_ml_artifacts.id}}",
+      "tactics": [],
+      "createdDate": "2026-04-22T00:00:00.000Z",
+      "modifiedDate": "2026-04-22T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0003",
+      "name": "Search Victim-Owned Websites",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{reconnaissance.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0004",
+      "name": "Search Application Repositories",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{reconnaissance.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-10-13T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0005",
+      "name": "Create Proxy AI Model",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{ml_attack_staging.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0005.000",
+      "name": "Train Proxy via Gathered AI Artifacts",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{train_proxy_model.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0005.001",
+      "name": "Train Proxy via Replication",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{train_proxy_model.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2021-05-13T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0005.002",
+      "name": "Use Pre-Trained Model",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{train_proxy_model.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2021-05-13T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0006",
+      "name": "Active Scanning",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{reconnaissance.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-11-04T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0007",
+      "name": "Discover AI Artifacts",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{discovery.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0008",
+      "name": "Acquire Infrastructure",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{resource_development.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-03-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0008.000",
+      "name": "AI Development Workspaces",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{acquire_infra.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0008.001",
+      "name": "Consumer Hardware",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{acquire_infra.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2021-05-13T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0008.002",
+      "name": "Domains",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{acquire_infra.id}}",
+      "tactics": [],
+      "createdDate": "2025-03-12T00:00:00.000Z",
+      "modifiedDate": "2025-03-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0008.003",
+      "name": "Physical Countermeasures",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{acquire_infra.id}}",
+      "tactics": [],
+      "createdDate": "2025-03-12T00:00:00.000Z",
+      "modifiedDate": "2025-03-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0008.004",
+      "name": "Serverless",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{acquire_infra.id}}",
+      "tactics": [],
+      "createdDate": "2025-04-15T00:00:00.000Z",
+      "modifiedDate": "2025-04-15T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0008.005",
+      "name": "AI Service Proxies",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{acquire_infra.id}}",
+      "tactics": [],
+      "createdDate": "2026-03-30T00:00:00.000Z",
+      "modifiedDate": "2026-03-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0010",
+      "name": "AI Supply Chain Compromise",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{initial_access.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0010.000",
+      "name": "Hardware",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{supply_chain.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-03-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0010.001",
+      "name": "AI Software",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{supply_chain.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2026-03-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0010.002",
+      "name": "Data",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{supply_chain.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0010.003",
+      "name": "Model",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{supply_chain.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0010.004",
+      "name": "Container Registry",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{supply_chain.id}}",
+      "tactics": [],
+      "createdDate": "2024-04-11T00:00:00.000Z",
+      "modifiedDate": "2024-04-11T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0010.005",
+      "name": "AI Agent Tool",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{supply_chain.id}}",
+      "tactics": [],
+      "createdDate": "2026-03-30T00:00:00.000Z",
+      "modifiedDate": "2026-03-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0011",
+      "name": "User Execution",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{execution.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2023-01-18T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0011.000",
+      "name": "Unsafe AI Artifacts",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{user_execution.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0011.001",
+      "name": "Malicious Package",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{user_execution.id}}",
+      "tactics": [],
+      "createdDate": "2025-03-12T00:00:00.000Z",
+      "modifiedDate": "2025-03-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0011.002",
+      "name": "Poisoned AI Agent Tool",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{user_execution.id}}",
+      "tactics": [],
+      "createdDate": "2026-01-30T00:00:00.000Z",
+      "modifiedDate": "2026-02-05T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0011.003",
+      "name": "Malicious Link",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{user_execution.id}}",
+      "tactics": [],
+      "createdDate": "2026-01-30T00:00:00.000Z",
+      "modifiedDate": "2026-02-05T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0012",
+      "name": "Valid Accounts",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{initial_access.id}}",
+        "{{privilege_escalation.id}}"
+      ],
+      "createdDate": "2022-01-24T00:00:00.000Z",
+      "modifiedDate": "2025-12-24T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0013",
+      "name": "Discover AI Model Ontology",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{discovery.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0014",
+      "name": "Discover AI Model Family",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{discovery.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0015",
+      "name": "Evade AI Model",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{defense_evasion.id}}",
+        "{{impact.id}}",
+        "{{initial_access.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-11-04T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0016",
+      "name": "Obtain Capabilities",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{resource_development.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0016.000",
+      "name": "Adversarial AI Attack Implementations",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{obtain_cap.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0016.001",
+      "name": "Software Tools",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{obtain_cap.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0016.002",
+      "name": "Generative AI",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{obtain_cap.id}}",
+      "tactics": [],
+      "createdDate": "2025-03-12T00:00:00.000Z",
+      "modifiedDate": "2025-12-23T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0017",
+      "name": "Develop Capabilities",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{resource_development.id}}"
+      ],
+      "createdDate": "2023-10-25T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0017.000",
+      "name": "Adversarial AI Attacks",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{develop_capabilities.id}}",
+      "tactics": [],
+      "createdDate": "2023-10-25T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0018",
+      "name": "Manipulate AI Model",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{ml_attack_staging.id}}",
+        "{{persistence.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-14T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0018.000",
+      "name": "Poison AI Model",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{backdoor_model.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-12-23T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0018.001",
+      "name": "Modify AI Model Architecture",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{backdoor_model.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2024-04-11T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0018.002",
+      "name": "Embed Malware",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{backdoor_model.id}}",
+      "tactics": [],
+      "createdDate": "2025-04-09T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0019",
+      "name": "Publish Poisoned Datasets",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{resource_development.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2021-05-13T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0020",
+      "name": "Poison Training Data",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{persistence.id}}",
+        "{{resource_development.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0021",
+      "name": "Establish Accounts",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{resource_development.id}}"
+      ],
+      "createdDate": "2022-01-24T00:00:00.000Z",
+      "modifiedDate": "2023-01-18T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0024",
+      "name": "Exfiltration via AI Inference API",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{exfiltration.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0024.000",
+      "name": "Infer Training Data Membership",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{exfiltrate_via_api.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-11-06T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0024.001",
+      "name": "Invert AI Model",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{exfiltrate_via_api.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0024.002",
+      "name": "Extract AI Model",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{exfiltrate_via_api.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-12-23T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0025",
+      "name": "Exfiltration via Cyber Means",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{exfiltration.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0029",
+      "name": "Denial of AI Service",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{impact.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0031",
+      "name": "Erode AI Model Integrity",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{impact.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0034",
+      "name": "Cost Harvesting",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{impact.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2026-03-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0034.000",
+      "name": "Excessive Queries",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{cost_harvesting.id}}",
+      "tactics": [],
+      "createdDate": "2026-03-30T00:00:00.000Z",
+      "modifiedDate": "2026-03-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0034.001",
+      "name": "Resource-Intensive Queries",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{cost_harvesting.id}}",
+      "tactics": [],
+      "createdDate": "2026-03-30T00:00:00.000Z",
+      "modifiedDate": "2026-03-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0034.002",
+      "name": "Agentic Resource Consumption",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{cost_harvesting.id}}",
+      "tactics": [],
+      "createdDate": "2026-03-30T00:00:00.000Z",
+      "modifiedDate": "2026-03-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0035",
+      "name": "AI Artifact Collection",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{collection.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0036",
+      "name": "Data from Information Repositories",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{collection.id}}"
+      ],
+      "createdDate": "2022-01-24T00:00:00.000Z",
+      "modifiedDate": "2023-01-18T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0037",
+      "name": "Data from Local System",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{collection.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2023-01-18T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0040",
+      "name": "AI Model Inference API Access",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{ml_model_access.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-03-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0041",
+      "name": "Physical Environment Access",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{ml_model_access.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2021-05-13T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0042",
+      "name": "Verify Attack",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{ml_attack_staging.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2021-05-13T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0043",
+      "name": "Craft Adversarial Data",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{ml_attack_staging.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0043.000",
+      "name": "White-Box Optimization",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{craft_adv.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2024-01-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0043.001",
+      "name": "Black-Box Optimization",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{craft_adv.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2021-05-13T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0043.002",
+      "name": "Black-Box Transfer",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{craft_adv.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2024-01-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0043.003",
+      "name": "Manual Modification",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{craft_adv.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2021-05-13T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0043.004",
+      "name": "Insert Backdoor Trigger",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{craft_adv.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2021-05-13T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0044",
+      "name": "Full AI Model Access",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{ml_model_access.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0046",
+      "name": "Spamming AI System with Chaff Data",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{impact.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-12-18T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0047",
+      "name": "AI-Enabled Product or Service",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{ml_model_access.id}}"
+      ],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0048",
+      "name": "External Harms",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{impact.id}}"
+      ],
+      "createdDate": "2022-10-27T00:00:00.000Z",
+      "modifiedDate": "2023-10-25T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0048.000",
+      "name": "Financial Harm",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{external_harms.id}}",
+      "tactics": [],
+      "createdDate": "2023-10-25T00:00:00.000Z",
+      "modifiedDate": "2023-10-25T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0048.001",
+      "name": "Reputational Harm",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{external_harms.id}}",
+      "tactics": [],
+      "createdDate": "2023-10-25T00:00:00.000Z",
+      "modifiedDate": "2023-10-25T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0048.002",
+      "name": "Societal Harm",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{external_harms.id}}",
+      "tactics": [],
+      "createdDate": "2023-10-25T00:00:00.000Z",
+      "modifiedDate": "2023-10-25T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0048.003",
+      "name": "User Harm",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{external_harms.id}}",
+      "tactics": [],
+      "createdDate": "2023-10-25T00:00:00.000Z",
+      "modifiedDate": "2023-10-25T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0048.004",
+      "name": "AI Intellectual Property Theft",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{external_harms.id}}",
+      "tactics": [],
+      "createdDate": "2021-05-13T00:00:00.000Z",
+      "modifiedDate": "2025-04-09T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0049",
+      "name": "Exploit Public-Facing Application",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{initial_access.id}}"
+      ],
+      "createdDate": "2023-02-28T00:00:00.000Z",
+      "modifiedDate": "2023-02-28T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0050",
+      "name": "Command and Scripting Interpreter",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{execution.id}}"
+      ],
+      "createdDate": "2023-02-28T00:00:00.000Z",
+      "modifiedDate": "2023-10-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0051",
+      "name": "LLM Prompt Injection",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{execution.id}}"
+      ],
+      "createdDate": "2023-10-25T00:00:00.000Z",
+      "modifiedDate": "2025-11-05T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0051.000",
+      "name": "Direct",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{llm_prompt_injection.id}}",
+      "tactics": [],
+      "createdDate": "2023-10-25T00:00:00.000Z",
+      "modifiedDate": "2023-10-25T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0051.001",
+      "name": "Indirect",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{llm_prompt_injection.id}}",
+      "tactics": [],
+      "createdDate": "2023-10-25T00:00:00.000Z",
+      "modifiedDate": "2023-10-25T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0051.002",
+      "name": "Triggered",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{llm_prompt_injection.id}}",
+      "tactics": [],
+      "createdDate": "2025-11-04T00:00:00.000Z",
+      "modifiedDate": "2025-11-05T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0052",
+      "name": "Phishing",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{initial_access.id}}",
+        "{{lateral_movement.id}}"
+      ],
+      "createdDate": "2023-10-25T00:00:00.000Z",
+      "modifiedDate": "2026-04-22T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0052.000",
+      "name": "Spearphishing via Social Engineering LLM",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{phishing.id}}",
+      "tactics": [],
+      "createdDate": "2023-10-25T00:00:00.000Z",
+      "modifiedDate": "2023-10-25T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0052.001",
+      "name": "Deepfake-Assisted Phishing",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{phishing.id}}",
+      "tactics": [],
+      "createdDate": "2026-04-22T00:00:00.000Z",
+      "modifiedDate": "2026-04-22T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0053",
+      "name": "AI Agent Tool Invocation",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{execution.id}}",
+        "{{privilege_escalation.id}}"
+      ],
+      "createdDate": "2023-10-25T00:00:00.000Z",
+      "modifiedDate": "2025-11-04T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0054",
+      "name": "LLM Jailbreak",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{defense_evasion.id}}",
+        "{{privilege_escalation.id}}"
+      ],
+      "createdDate": "2023-10-25T00:00:00.000Z",
+      "modifiedDate": "2026-04-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0055",
+      "name": "Unsecured Credentials",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{credential_access.id}}"
+      ],
+      "createdDate": "2023-10-25T00:00:00.000Z",
+      "modifiedDate": "2024-04-29T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0056",
+      "name": "Extract LLM System Prompt",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{exfiltration.id}}"
+      ],
+      "createdDate": "2023-10-25T00:00:00.000Z",
+      "modifiedDate": "2025-03-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0057",
+      "name": "LLM Data Leakage",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{exfiltration.id}}"
+      ],
+      "createdDate": "2023-10-25T00:00:00.000Z",
+      "modifiedDate": "2023-10-25T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0058",
+      "name": "Publish Poisoned Models",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{resource_development.id}}"
+      ],
+      "createdDate": "2025-03-12T00:00:00.000Z",
+      "modifiedDate": "2025-03-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0059",
+      "name": "Erode Dataset Integrity",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{impact.id}}"
+      ],
+      "createdDate": "2025-03-12T00:00:00.000Z",
+      "modifiedDate": "2025-03-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0060",
+      "name": "Publish Hallucinated Entities",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{resource_development.id}}"
+      ],
+      "createdDate": "2025-03-12T00:00:00.000Z",
+      "modifiedDate": "2025-10-31T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0061",
+      "name": "LLM Prompt Self-Replication",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{persistence.id}}"
+      ],
+      "createdDate": "2025-03-12T00:00:00.000Z",
+      "modifiedDate": "2025-03-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0062",
+      "name": "Discover LLM Hallucinations",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{discovery.id}}"
+      ],
+      "createdDate": "2025-03-12T00:00:00.000Z",
+      "modifiedDate": "2025-10-31T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0063",
+      "name": "Discover AI Model Outputs",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{discovery.id}}"
+      ],
+      "createdDate": "2025-03-12T00:00:00.000Z",
+      "modifiedDate": "2025-03-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0064",
+      "name": "Gather RAG-Indexed Targets",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{reconnaissance.id}}"
+      ],
+      "createdDate": "2025-03-12T00:00:00.000Z",
+      "modifiedDate": "2025-03-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0065",
+      "name": "LLM Prompt Crafting",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{resource_development.id}}"
+      ],
+      "createdDate": "2025-03-12T00:00:00.000Z",
+      "modifiedDate": "2025-03-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0066",
+      "name": "Retrieval Content Crafting",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{resource_development.id}}"
+      ],
+      "createdDate": "2025-03-12T00:00:00.000Z",
+      "modifiedDate": "2025-03-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0067",
+      "name": "LLM Trusted Output Components Manipulation",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{defense_evasion.id}}"
+      ],
+      "createdDate": "2025-03-12T00:00:00.000Z",
+      "modifiedDate": "2025-03-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0067.000",
+      "name": "Citations",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{llm_output_manip.id}}",
+      "tactics": [],
+      "createdDate": "2025-03-12T00:00:00.000Z",
+      "modifiedDate": "2025-03-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0068",
+      "name": "LLM Prompt Obfuscation",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{defense_evasion.id}}"
+      ],
+      "createdDate": "2025-03-12T00:00:00.000Z",
+      "modifiedDate": "2026-01-28T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0069",
+      "name": "Discover LLM System Information",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{discovery.id}}"
+      ],
+      "createdDate": "2025-03-12T00:00:00.000Z",
+      "modifiedDate": "2025-03-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0069.000",
+      "name": "Special Character Sets",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{llm_sys_info.id}}",
+      "tactics": [],
+      "createdDate": "2025-03-12T00:00:00.000Z",
+      "modifiedDate": "2025-03-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0069.001",
+      "name": "System Instruction Keywords",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{llm_sys_info.id}}",
+      "tactics": [],
+      "createdDate": "2025-03-12T00:00:00.000Z",
+      "modifiedDate": "2025-03-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0069.002",
+      "name": "System Prompt",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{llm_sys_info.id}}",
+      "tactics": [],
+      "createdDate": "2025-03-12T00:00:00.000Z",
+      "modifiedDate": "2025-03-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0070",
+      "name": "RAG Poisoning",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{persistence.id}}"
+      ],
+      "createdDate": "2025-03-12T00:00:00.000Z",
+      "modifiedDate": "2025-03-12T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0071",
+      "name": "False RAG Entry Injection",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{defense_evasion.id}}"
+      ],
+      "createdDate": "2025-03-12T00:00:00.000Z",
+      "modifiedDate": "2025-12-24T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0072",
+      "name": "Reverse Shell",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{command_and_control.id}}"
+      ],
+      "createdDate": "2024-04-11T00:00:00.000Z",
+      "modifiedDate": "2025-04-14T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0073",
+      "name": "Impersonation",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{defense_evasion.id}}"
+      ],
+      "createdDate": "2025-04-14T00:00:00.000Z",
+      "modifiedDate": "2025-04-14T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0074",
+      "name": "Masquerading",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{defense_evasion.id}}"
+      ],
+      "createdDate": "2025-04-14T00:00:00.000Z",
+      "modifiedDate": "2025-04-14T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0075",
+      "name": "Cloud Service Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{discovery.id}}"
+      ],
+      "createdDate": "2025-04-14T00:00:00.000Z",
+      "modifiedDate": "2025-12-24T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0076",
+      "name": "Corrupt AI Model",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{defense_evasion.id}}"
+      ],
+      "createdDate": "2025-04-14T00:00:00.000Z",
+      "modifiedDate": "2025-04-14T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0077",
+      "name": "LLM Response Rendering",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{exfiltration.id}}"
+      ],
+      "createdDate": "2025-04-15T00:00:00.000Z",
+      "modifiedDate": "2025-04-15T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0078",
+      "name": "Drive-by Compromise",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{initial_access.id}}"
+      ],
+      "createdDate": "2025-04-16T00:00:00.000Z",
+      "modifiedDate": "2025-04-17T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0079",
+      "name": "Stage Capabilities",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{resource_development.id}}"
+      ],
+      "createdDate": "2025-04-16T00:00:00.000Z",
+      "modifiedDate": "2025-04-17T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0080",
+      "name": "AI Agent Context Poisoning",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{persistence.id}}"
+      ],
+      "createdDate": "2025-09-30T00:00:00.000Z",
+      "modifiedDate": "2025-10-13T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0080.000",
+      "name": "Memory",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{llm_context.id}}",
+      "tactics": [],
+      "createdDate": "2025-09-30T00:00:00.000Z",
+      "modifiedDate": "2025-09-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0080.001",
+      "name": "Thread",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{llm_context.id}}",
+      "tactics": [],
+      "createdDate": "2025-09-30T00:00:00.000Z",
+      "modifiedDate": "2025-09-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0081",
+      "name": "Modify AI Agent Configuration",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{defense_evasion.id}}",
+        "{{persistence.id}}"
+      ],
+      "createdDate": "2025-09-30T00:00:00.000Z",
+      "modifiedDate": "2026-02-05T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0082",
+      "name": "RAG Credential Harvesting",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{credential_access.id}}"
+      ],
+      "createdDate": "2025-09-30T00:00:00.000Z",
+      "modifiedDate": "2025-09-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0083",
+      "name": "Credentials from AI Agent Configuration",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{credential_access.id}}"
+      ],
+      "createdDate": "2025-09-30T00:00:00.000Z",
+      "modifiedDate": "2025-10-13T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0084",
+      "name": "Discover AI Agent Configuration",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{discovery.id}}"
+      ],
+      "createdDate": "2025-09-30T00:00:00.000Z",
+      "modifiedDate": "2025-09-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0084.000",
+      "name": "Embedded Knowledge",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{discover_agent_config.id}}",
+      "tactics": [],
+      "createdDate": "2025-09-30T00:00:00.000Z",
+      "modifiedDate": "2025-09-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0084.001",
+      "name": "Tool Definitions",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{discover_agent_config.id}}",
+      "tactics": [],
+      "createdDate": "2025-09-30T00:00:00.000Z",
+      "modifiedDate": "2025-09-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0084.002",
+      "name": "Activation Triggers",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{discover_agent_config.id}}",
+      "tactics": [],
+      "createdDate": "2025-09-30T00:00:00.000Z",
+      "modifiedDate": "2025-09-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0084.003",
+      "name": "Call Chains",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{discover_agent_config.id}}",
+      "tactics": [],
+      "createdDate": "2026-03-30T00:00:00.000Z",
+      "modifiedDate": "2026-03-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0085",
+      "name": "Data from AI Services",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{collection.id}}"
+      ],
+      "createdDate": "2025-09-30T00:00:00.000Z",
+      "modifiedDate": "2025-11-04T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0085.000",
+      "name": "RAG Databases",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{data_from_ai.id}}",
+      "tactics": [],
+      "createdDate": "2025-09-30T00:00:00.000Z",
+      "modifiedDate": "2025-09-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0085.001",
+      "name": "AI Agent Tools",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{data_from_ai.id}}",
+      "tactics": [],
+      "createdDate": "2025-09-30T00:00:00.000Z",
+      "modifiedDate": "2025-09-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0086",
+      "name": "Exfiltration via AI Agent Tool Invocation",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{exfiltration.id}}"
+      ],
+      "createdDate": "2025-09-30T00:00:00.000Z",
+      "modifiedDate": "2026-03-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0087",
+      "name": "Gather Victim Identity Information",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{reconnaissance.id}}"
+      ],
+      "createdDate": "2025-10-31T00:00:00.000Z",
+      "modifiedDate": "2025-10-27T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0088",
+      "name": "Generate Deepfakes",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{ml_attack_staging.id}}"
+      ],
+      "createdDate": "2025-10-31T00:00:00.000Z",
+      "modifiedDate": "2025-11-04T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0089",
+      "name": "Process Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{discovery.id}}"
+      ],
+      "createdDate": "2025-10-27T00:00:00.000Z",
+      "modifiedDate": "2025-11-04T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0090",
+      "name": "OS Credential Dumping",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{credential_access.id}}"
+      ],
+      "createdDate": "2025-10-27T00:00:00.000Z",
+      "modifiedDate": "2025-11-04T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0091",
+      "name": "Use Alternate Authentication Material",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{lateral_movement.id}}"
+      ],
+      "createdDate": "2025-10-27T00:00:00.000Z",
+      "modifiedDate": "2025-11-04T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0091.000",
+      "name": "Application Access Token",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{alt_auth.id}}",
+      "tactics": [],
+      "createdDate": "2025-10-28T00:00:00.000Z",
+      "modifiedDate": "2025-12-23T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0092",
+      "name": "Manipulate User LLM Chat History",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{defense_evasion.id}}"
+      ],
+      "createdDate": "2025-10-27T00:00:00.000Z",
+      "modifiedDate": "2025-11-04T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0093",
+      "name": "Prompt Infiltration via Public-Facing Application",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{initial_access.id}}",
+        "{{persistence.id}}"
+      ],
+      "createdDate": "2025-10-29T00:00:00.000Z",
+      "modifiedDate": "2025-12-18T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0094",
+      "name": "Delay Execution of LLM Instructions",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{defense_evasion.id}}"
+      ],
+      "createdDate": "2025-11-04T00:00:00.000Z",
+      "modifiedDate": "2025-11-05T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0095",
+      "name": "Search Open Websites/Domains",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{reconnaissance.id}}"
+      ],
+      "createdDate": "2025-11-05T00:00:00.000Z",
+      "modifiedDate": "2025-11-06T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0095.000",
+      "name": "Code Repositories",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{search_open_sites.id}}",
+      "tactics": [],
+      "createdDate": "2026-04-22T00:00:00.000Z",
+      "modifiedDate": "2026-04-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0096",
+      "name": "AI Service API",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{command_and_control.id}}"
+      ],
+      "createdDate": "2025-12-24T00:00:00.000Z",
+      "modifiedDate": "2025-12-23T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0097",
+      "name": "Virtualization/Sandbox Evasion",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{defense_evasion.id}}"
+      ],
+      "createdDate": "2025-11-25T00:00:00.000Z",
+      "modifiedDate": "2025-12-23T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0098",
+      "name": "AI Agent Tool Credential Harvesting",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{credential_access.id}}"
+      ],
+      "createdDate": "2025-11-25T00:00:00.000Z",
+      "modifiedDate": "2025-12-19T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0099",
+      "name": "AI Agent Tool Data Poisoning",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{persistence.id}}"
+      ],
+      "createdDate": "2025-11-25T00:00:00.000Z",
+      "modifiedDate": "2025-11-25T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0100",
+      "name": "AI Agent Clickbait",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{execution.id}}"
+      ],
+      "createdDate": "2025-11-25T00:00:00.000Z",
+      "modifiedDate": "2025-11-25T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0101",
+      "name": "Data Destruction via AI Agent Tool Invocation",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{impact.id}}"
+      ],
+      "createdDate": "2025-11-25T00:00:00.000Z",
+      "modifiedDate": "2025-11-25T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0102",
+      "name": "Generate Malicious Commands",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{ml_attack_staging.id}}"
+      ],
+      "createdDate": "2025-11-25T00:00:00.000Z",
+      "modifiedDate": "2025-12-23T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0103",
+      "name": "Deploy AI Agent",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{execution.id}}"
+      ],
+      "createdDate": "2026-01-28T00:00:00.000Z",
+      "modifiedDate": "2026-01-28T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0104",
+      "name": "Publish Poisoned AI Agent Tool",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{resource_development.id}}"
+      ],
+      "createdDate": "2026-01-30T00:00:00.000Z",
+      "modifiedDate": "2026-03-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0105",
+      "name": "Escape to Host",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{privilege_escalation.id}}"
+      ],
+      "createdDate": "2026-01-30T00:00:00.000Z",
+      "modifiedDate": "2026-01-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0106",
+      "name": "Exploitation for Credential Access",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{credential_access.id}}"
+      ],
+      "createdDate": "2026-01-30T00:00:00.000Z",
+      "modifiedDate": "2026-02-05T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0107",
+      "name": "Exploitation for Defense Evasion",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{defense_evasion.id}}"
+      ],
+      "createdDate": "2026-01-30T00:00:00.000Z",
+      "modifiedDate": "2026-02-05T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0108",
+      "name": "AI Agent",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{command_and_control.id}}"
+      ],
+      "createdDate": "2026-01-30T00:00:00.000Z",
+      "modifiedDate": "2026-02-05T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0109",
+      "name": "AI Supply Chain Rug Pull",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{defense_evasion.id}}"
+      ],
+      "createdDate": "2026-03-30T00:00:00.000Z",
+      "modifiedDate": "2026-03-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0110",
+      "name": "AI Agent Tool Poisoning",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{persistence.id}}"
+      ],
+      "createdDate": "2026-03-30T00:00:00.000Z",
+      "modifiedDate": "2026-03-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0111",
+      "name": "AI Supply Chain Reputation Inflation",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{defense_evasion.id}}"
+      ],
+      "createdDate": "2026-03-30T00:00:00.000Z",
+      "modifiedDate": "2026-03-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0112",
+      "name": "Machine Compromise",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": null,
+      "tactics": [
+        "{{impact.id}}"
+      ],
+      "createdDate": "2026-03-30T00:00:00.000Z",
+      "modifiedDate": "2026-03-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0112.000",
+      "name": "Local AI Agent",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{maschine_compromise.id}}",
+      "tactics": [],
+      "createdDate": "2026-03-30T00:00:00.000Z",
+      "modifiedDate": "2026-03-30T00:00:00.000Z"
+    },
+    {
+      "id": "AML.T0112.001",
+      "name": "AI Artifacts",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "subtechniqueOf": "{{maschine_compromise.id}}",
+      "tactics": [],
+      "createdDate": "2026-03-30T00:00:00.000Z",
+      "modifiedDate": "2026-03-30T00:00:00.000Z"
+    }
+  ]
+}

--- a/.github/pipeline/data/frameworks/mitre-atlas-v5.6.0-techniques.json
+++ b/.github/pipeline/data/frameworks/mitre-atlas-v5.6.0-techniques.json
@@ -7,6 +7,14 @@
     "sha256": "fe8d7b9e7793673d87ee839330320cdedc25357a128734c3fda625f28362be2d",
     "bytes": 154547
   },
+  "upstreamNormalizations": [
+    {
+      "field": "subtechnique-of",
+      "from": "{{maschine_compromise.id}}",
+      "to": "{{machine_compromise.id}}",
+      "reason": "MITRE ATLAS v5.6.0 upstream YAML uses a misspelled Machine Compromise anchor."
+    }
+  ],
   "techniqueCount": 170,
   "activeTechniqueCount": 170,
   "techniques": [
@@ -2076,7 +2084,7 @@
       "kind": "subtechnique",
       "revoked": false,
       "deprecated": false,
-      "subtechniqueOf": "{{maschine_compromise.id}}",
+      "subtechniqueOf": "{{machine_compromise.id}}",
       "tactics": [],
       "createdDate": "2026-03-30T00:00:00.000Z",
       "modifiedDate": "2026-03-30T00:00:00.000Z"
@@ -2087,7 +2095,7 @@
       "kind": "subtechnique",
       "revoked": false,
       "deprecated": false,
-      "subtechniqueOf": "{{maschine_compromise.id}}",
+      "subtechniqueOf": "{{machine_compromise.id}}",
       "tactics": [],
       "createdDate": "2026-03-30T00:00:00.000Z",
       "modifiedDate": "2026-03-30T00:00:00.000Z"

--- a/.github/pipeline/data/frameworks/mitre-attack-enterprise-v19.0-techniques.json
+++ b/.github/pipeline/data/frameworks/mitre-attack-enterprise-v19.0-techniques.json
@@ -1,0 +1,8827 @@
+{
+  "framework": "MITRE ATT&CK",
+  "domain": "enterprise-attack",
+  "version": "v19.0",
+  "source": {
+    "url": "https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack-19.0.json",
+    "githubBlobSha": "04a73232da6f55c3df32daf1479888265a3032a7",
+    "sha256": "df520ea0775a57db7bff760145b02fed89290802913e056b7ed5970b02f3626a",
+    "bytes": 52680865
+  },
+  "techniqueCount": 858,
+  "activeTechniqueCount": 697,
+  "techniques": [
+    {
+      "id": "T1001",
+      "name": "Data Obfuscation",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1001.001",
+      "name": "Junk Data",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1001.002",
+      "name": "Steganography",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1001.003",
+      "name": "Protocol or Service Impersonation",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1002",
+      "name": "Data Compressed",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "exfiltration"
+      ]
+    },
+    {
+      "id": "T1003",
+      "name": "OS Credential Dumping",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1003.001",
+      "name": "LSASS Memory",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1003.002",
+      "name": "Security Account Manager",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1003.003",
+      "name": "NTDS",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1003.004",
+      "name": "LSA Secrets",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1003.005",
+      "name": "Cached Domain Credentials",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1003.006",
+      "name": "DCSync",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1003.007",
+      "name": "Proc Filesystem",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1003.008",
+      "name": "/etc/passwd and /etc/shadow",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1004",
+      "name": "Winlogon Helper DLL",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1005",
+      "name": "Data from Local System",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1006",
+      "name": "Direct Volume Access",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1007",
+      "name": "System Service Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1008",
+      "name": "Fallback Channels",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1009",
+      "name": "Binary Padding",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1010",
+      "name": "Application Window Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1011",
+      "name": "Exfiltration Over Other Network Medium",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "exfiltration"
+      ]
+    },
+    {
+      "id": "T1011.001",
+      "name": "Exfiltration Over Bluetooth",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "exfiltration"
+      ]
+    },
+    {
+      "id": "T1012",
+      "name": "Query Registry",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1013",
+      "name": "Port Monitors",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1014",
+      "name": "Rootkit",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1015",
+      "name": "Accessibility Features",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1016",
+      "name": "System Network Configuration Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1016.001",
+      "name": "Internet Connection Discovery",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1016.002",
+      "name": "Wi-Fi Discovery",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1017",
+      "name": "Application Deployment Software",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1018",
+      "name": "Remote System Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1019",
+      "name": "System Firmware",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1020",
+      "name": "Automated Exfiltration",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "exfiltration"
+      ]
+    },
+    {
+      "id": "T1020.001",
+      "name": "Traffic Duplication",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "exfiltration"
+      ]
+    },
+    {
+      "id": "T1021",
+      "name": "Remote Services",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1021.001",
+      "name": "Remote Desktop Protocol",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1021.002",
+      "name": "SMB/Windows Admin Shares",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1021.003",
+      "name": "Distributed Component Object Model",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1021.004",
+      "name": "SSH",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1021.005",
+      "name": "VNC",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1021.006",
+      "name": "Windows Remote Management",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1021.007",
+      "name": "Cloud Services",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1021.008",
+      "name": "Direct Cloud VM Connections",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1022",
+      "name": "Data Encrypted",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "exfiltration"
+      ]
+    },
+    {
+      "id": "T1023",
+      "name": "Shortcut Modification",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1024",
+      "name": "Custom Cryptographic Protocol",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1025",
+      "name": "Data from Removable Media",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1026",
+      "name": "Multiband Communication",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": true,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1027",
+      "name": "Obfuscated Files or Information",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1027.001",
+      "name": "Binary Padding",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1027.002",
+      "name": "Software Packing",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1027.003",
+      "name": "Steganography",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1027.004",
+      "name": "Compile After Delivery",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1027.005",
+      "name": "Indicator Removal from Tools",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1027.006",
+      "name": "HTML Smuggling",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1027.007",
+      "name": "Dynamic API Resolution",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1027.008",
+      "name": "Stripped Payloads",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1027.009",
+      "name": "Embedded Payloads",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1027.010",
+      "name": "Command Obfuscation",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1027.011",
+      "name": "Fileless Storage",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1027.012",
+      "name": "LNK Icon Smuggling",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1027.013",
+      "name": "Encrypted/Encoded File",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1027.014",
+      "name": "Polymorphic Code",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1027.015",
+      "name": "Compression",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1027.016",
+      "name": "Junk Code Insertion",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1027.017",
+      "name": "SVG Smuggling",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1027.018",
+      "name": "Invisible Unicode",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1028",
+      "name": "Windows Remote Management",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1029",
+      "name": "Scheduled Transfer",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "exfiltration"
+      ]
+    },
+    {
+      "id": "T1030",
+      "name": "Data Transfer Size Limits",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "exfiltration"
+      ]
+    },
+    {
+      "id": "T1031",
+      "name": "Modify Existing Service",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1032",
+      "name": "Standard Cryptographic Protocol",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1033",
+      "name": "System Owner/User Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1034",
+      "name": "Path Interception",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": true,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1035",
+      "name": "Service Execution",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1036",
+      "name": "Masquerading",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1036.001",
+      "name": "Invalid Code Signature",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1036.002",
+      "name": "Right-to-Left Override",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1036.003",
+      "name": "Rename Legitimate Utilities",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1036.004",
+      "name": "Masquerade Task or Service",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1036.005",
+      "name": "Match Legitimate Resource Name or Location",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1036.006",
+      "name": "Space after Filename",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1036.007",
+      "name": "Double File Extension",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1036.008",
+      "name": "Masquerade File Type",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1036.009",
+      "name": "Break Process Trees",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1036.010",
+      "name": "Masquerade Account Name",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1036.011",
+      "name": "Overwrite Process Arguments",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1036.012",
+      "name": "Browser Fingerprint",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1037",
+      "name": "Boot or Logon Initialization Scripts",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1037.001",
+      "name": "Logon Script (Windows)",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1037.002",
+      "name": "Login Hook",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1037.003",
+      "name": "Network Logon Script",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1037.004",
+      "name": "RC Scripts",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1037.005",
+      "name": "Startup Items",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1038",
+      "name": "DLL Search Order Hijacking",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1039",
+      "name": "Data from Network Shared Drive",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1040",
+      "name": "Network Sniffing",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access",
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1041",
+      "name": "Exfiltration Over C2 Channel",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "exfiltration"
+      ]
+    },
+    {
+      "id": "T1042",
+      "name": "Change Default File Association",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1043",
+      "name": "Commonly Used Port",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": true,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1044",
+      "name": "File System Permissions Weakness",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1045",
+      "name": "Software Packing",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1046",
+      "name": "Network Service Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1047",
+      "name": "Windows Management Instrumentation",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1048",
+      "name": "Exfiltration Over Alternative Protocol",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "exfiltration"
+      ]
+    },
+    {
+      "id": "T1048.001",
+      "name": "Exfiltration Over Symmetric Encrypted Non-C2 Protocol",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "exfiltration"
+      ]
+    },
+    {
+      "id": "T1048.002",
+      "name": "Exfiltration Over Asymmetric Encrypted Non-C2 Protocol",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "exfiltration"
+      ]
+    },
+    {
+      "id": "T1048.003",
+      "name": "Exfiltration Over Unencrypted Non-C2 Protocol",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "exfiltration"
+      ]
+    },
+    {
+      "id": "T1049",
+      "name": "System Network Connections Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1050",
+      "name": "New Service",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1051",
+      "name": "Shared Webroot",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": true,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1052",
+      "name": "Exfiltration Over Physical Medium",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "exfiltration"
+      ]
+    },
+    {
+      "id": "T1052.001",
+      "name": "Exfiltration over USB",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "exfiltration"
+      ]
+    },
+    {
+      "id": "T1053",
+      "name": "Scheduled Task/Job",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1053.001",
+      "name": "At (Linux)",
+      "kind": "subtechnique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1053.002",
+      "name": "At",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1053.003",
+      "name": "Cron",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1053.004",
+      "name": "Launchd",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": true,
+      "tactics": [
+        "execution",
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1053.005",
+      "name": "Scheduled Task",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1053.006",
+      "name": "Systemd Timers",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1053.007",
+      "name": "Container Orchestration Job",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1054",
+      "name": "Indicator Blocking",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1055",
+      "name": "Process Injection",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1055.001",
+      "name": "Dynamic-link Library Injection",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1055.002",
+      "name": "Portable Executable Injection",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1055.003",
+      "name": "Thread Execution Hijacking",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1055.004",
+      "name": "Asynchronous Procedure Call",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1055.005",
+      "name": "Thread Local Storage",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1055.008",
+      "name": "Ptrace System Calls",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1055.009",
+      "name": "Proc Memory",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1055.011",
+      "name": "Extra Window Memory Injection",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1055.012",
+      "name": "Process Hollowing",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1055.013",
+      "name": "Process Doppelgänging",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1055.014",
+      "name": "VDSO Hijacking",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1055.015",
+      "name": "ListPlanting",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1056",
+      "name": "Input Capture",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection",
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1056.001",
+      "name": "Keylogging",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection",
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1056.002",
+      "name": "GUI Input Capture",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection",
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1056.003",
+      "name": "Web Portal Capture",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection",
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1056.004",
+      "name": "Credential API Hooking",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection",
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1057",
+      "name": "Process Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1058",
+      "name": "Service Registry Permissions Weakness",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1059",
+      "name": "Command and Scripting Interpreter",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1059.001",
+      "name": "PowerShell",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1059.002",
+      "name": "AppleScript",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1059.003",
+      "name": "Windows Command Shell",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1059.004",
+      "name": "Unix Shell",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1059.005",
+      "name": "Visual Basic",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1059.006",
+      "name": "Python",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1059.007",
+      "name": "JavaScript",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1059.008",
+      "name": "Network Device CLI",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1059.009",
+      "name": "Cloud API",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1059.010",
+      "name": "AutoHotKey & AutoIT",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1059.011",
+      "name": "Lua",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1059.012",
+      "name": "Hypervisor CLI",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1059.013",
+      "name": "Container CLI/API",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1060",
+      "name": "Registry Run Keys / Startup Folder",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1061",
+      "name": "Graphical User Interface",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": true,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1062",
+      "name": "Hypervisor",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": true,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1063",
+      "name": "Security Software Discovery",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1064",
+      "name": "Scripting",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": true,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1065",
+      "name": "Uncommonly Used Port",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1066",
+      "name": "Indicator Removal from Tools",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1067",
+      "name": "Bootkit",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1068",
+      "name": "Exploitation for Privilege Escalation",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1069",
+      "name": "Permission Groups Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1069.001",
+      "name": "Local Groups",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1069.002",
+      "name": "Domain Groups",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1069.003",
+      "name": "Cloud Groups",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1070",
+      "name": "Indicator Removal",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1070.001",
+      "name": "Clear Windows Event Logs",
+      "kind": "subtechnique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1070.002",
+      "name": "Clear Linux or Mac System Logs",
+      "kind": "subtechnique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1070.003",
+      "name": "Clear Command History",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1070.004",
+      "name": "File Deletion",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1070.005",
+      "name": "Network Share Connection Removal",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1070.006",
+      "name": "Timestomp",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1070.007",
+      "name": "Clear Network Connection History and Configurations",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1070.008",
+      "name": "Clear Mailbox Data",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1070.009",
+      "name": "Clear Persistence",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1070.010",
+      "name": "Relocate Malware",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1071",
+      "name": "Application Layer Protocol",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1071.001",
+      "name": "Web Protocols",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1071.002",
+      "name": "File Transfer Protocols",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1071.003",
+      "name": "Mail Protocols",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1071.004",
+      "name": "DNS",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1071.005",
+      "name": "Publish/Subscribe Protocols",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1072",
+      "name": "Software Deployment Tools",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1073",
+      "name": "DLL Side-Loading",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1074",
+      "name": "Data Staged",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1074.001",
+      "name": "Local Data Staging",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1074.002",
+      "name": "Remote Data Staging",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1075",
+      "name": "Pass the Hash",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1076",
+      "name": "Remote Desktop Protocol",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1077",
+      "name": "Windows Admin Shares",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1078",
+      "name": "Valid Accounts",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "initial-access",
+        "persistence",
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1078.001",
+      "name": "Default Accounts",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "initial-access",
+        "persistence",
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1078.002",
+      "name": "Domain Accounts",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "initial-access",
+        "persistence",
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1078.003",
+      "name": "Local Accounts",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "initial-access",
+        "persistence",
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1078.004",
+      "name": "Cloud Accounts",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "initial-access",
+        "persistence",
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1079",
+      "name": "Multilayer Encryption",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1080",
+      "name": "Taint Shared Content",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1081",
+      "name": "Credentials in Files",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1082",
+      "name": "System Information Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1083",
+      "name": "File and Directory Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1084",
+      "name": "Windows Management Instrumentation Event Subscription",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1085",
+      "name": "Rundll32",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1086",
+      "name": "PowerShell",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1087",
+      "name": "Account Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1087.001",
+      "name": "Local Account",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1087.002",
+      "name": "Domain Account",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1087.003",
+      "name": "Email Account",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1087.004",
+      "name": "Cloud Account",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1088",
+      "name": "Bypass User Account Control",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1089",
+      "name": "Disabling Security Tools",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1090",
+      "name": "Proxy",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1090.001",
+      "name": "Internal Proxy",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1090.002",
+      "name": "External Proxy",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1090.003",
+      "name": "Multi-hop Proxy",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1090.004",
+      "name": "Domain Fronting",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1091",
+      "name": "Replication Through Removable Media",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "initial-access",
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1092",
+      "name": "Communication Through Removable Media",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1093",
+      "name": "Process Hollowing",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1094",
+      "name": "Custom Command and Control Protocol",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1095",
+      "name": "Non-Application Layer Protocol",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1096",
+      "name": "NTFS File Attributes",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1097",
+      "name": "Pass the Ticket",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1098",
+      "name": "Account Manipulation",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1098.001",
+      "name": "Additional Cloud Credentials",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1098.002",
+      "name": "Additional Email Delegate Permissions",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1098.003",
+      "name": "Additional Cloud Roles",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1098.004",
+      "name": "SSH Authorized Keys",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1098.005",
+      "name": "Device Registration",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1098.006",
+      "name": "Additional Container Cluster Roles",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1098.007",
+      "name": "Additional Local or Domain Groups",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1099",
+      "name": "Timestomp",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1100",
+      "name": "Web Shell",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1101",
+      "name": "Security Support Provider",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1102",
+      "name": "Web Service",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1102.001",
+      "name": "Dead Drop Resolver",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1102.002",
+      "name": "Bidirectional Communication",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1102.003",
+      "name": "One-Way Communication",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1103",
+      "name": "AppInit DLLs",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1104",
+      "name": "Multi-Stage Channels",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1105",
+      "name": "Ingress Tool Transfer",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1106",
+      "name": "Native API",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1107",
+      "name": "File Deletion",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1108",
+      "name": "Redundant Access",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": true,
+      "tactics": [
+        "persistence",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1109",
+      "name": "Component Firmware",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1110",
+      "name": "Brute Force",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1110.001",
+      "name": "Password Guessing",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1110.002",
+      "name": "Password Cracking",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1110.003",
+      "name": "Password Spraying",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1110.004",
+      "name": "Credential Stuffing",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1111",
+      "name": "Multi-Factor Authentication Interception",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1112",
+      "name": "Modify Registry",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment",
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1113",
+      "name": "Screen Capture",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1114",
+      "name": "Email Collection",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1114.001",
+      "name": "Local Email Collection",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1114.002",
+      "name": "Remote Email Collection",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1114.003",
+      "name": "Email Forwarding Rule",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1115",
+      "name": "Clipboard Data",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1116",
+      "name": "Code Signing",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1117",
+      "name": "Regsvr32",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1118",
+      "name": "InstallUtil",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1119",
+      "name": "Automated Collection",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1120",
+      "name": "Peripheral Device Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1121",
+      "name": "Regsvcs/Regasm",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1122",
+      "name": "Component Object Model Hijacking",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1123",
+      "name": "Audio Capture",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1124",
+      "name": "System Time Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1125",
+      "name": "Video Capture",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1126",
+      "name": "Network Share Connection Removal",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1127",
+      "name": "Trusted Developer Utilities Proxy Execution",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1127.001",
+      "name": "MSBuild",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1127.002",
+      "name": "ClickOnce",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1127.003",
+      "name": "JamPlus",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1128",
+      "name": "Netsh Helper DLL",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1129",
+      "name": "Shared Modules",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1130",
+      "name": "Install Root Certificate",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1131",
+      "name": "Authentication Package",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1132",
+      "name": "Data Encoding",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1132.001",
+      "name": "Standard Encoding",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1132.002",
+      "name": "Non-Standard Encoding",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1133",
+      "name": "External Remote Services",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "initial-access",
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1134",
+      "name": "Access Token Manipulation",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1134.001",
+      "name": "Token Impersonation/Theft",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1134.002",
+      "name": "Create Process with Token",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1134.003",
+      "name": "Make and Impersonate Token",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1134.004",
+      "name": "Parent PID Spoofing",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1134.005",
+      "name": "SID-History Injection",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1135",
+      "name": "Network Share Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1136",
+      "name": "Create Account",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1136.001",
+      "name": "Local Account",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1136.002",
+      "name": "Domain Account",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1136.003",
+      "name": "Cloud Account",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1137",
+      "name": "Office Application Startup",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1137.001",
+      "name": "Office Template Macros",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1137.002",
+      "name": "Office Test",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1137.003",
+      "name": "Outlook Forms",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1137.004",
+      "name": "Outlook Home Page",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1137.005",
+      "name": "Outlook Rules",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1137.006",
+      "name": "Add-ins",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1138",
+      "name": "Application Shimming",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1139",
+      "name": "Bash History",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1140",
+      "name": "Deobfuscate/Decode Files or Information",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1141",
+      "name": "Input Prompt",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1142",
+      "name": "Keychain",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1143",
+      "name": "Hidden Window",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1144",
+      "name": "Gatekeeper Bypass",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1145",
+      "name": "Private Keys",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1146",
+      "name": "Clear Command History",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1147",
+      "name": "Hidden Users",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1148",
+      "name": "HISTCONTROL",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1149",
+      "name": "LC_MAIN Hijacking",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": true,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1150",
+      "name": "Plist Modification",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1151",
+      "name": "Space after Filename",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1152",
+      "name": "Launchctl",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "persistence",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1153",
+      "name": "Source",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": true,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1154",
+      "name": "Trap",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1155",
+      "name": "AppleScript",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1156",
+      "name": "Malicious Shell Modification",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1157",
+      "name": "Dylib Hijacking",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1158",
+      "name": "Hidden Files and Directories",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1159",
+      "name": "Launch Agent",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1160",
+      "name": "Launch Daemon",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1161",
+      "name": "LC_LOAD_DYLIB Addition",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1162",
+      "name": "Login Item",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1163",
+      "name": "Rc.common",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1164",
+      "name": "Re-opened Applications",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1165",
+      "name": "Startup Items",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1166",
+      "name": "Setuid and Setgid",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1167",
+      "name": "Securityd Memory",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1168",
+      "name": "Local Job Scheduling",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1169",
+      "name": "Sudo",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1170",
+      "name": "Mshta",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1171",
+      "name": "LLMNR/NBT-NS Poisoning and Relay",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1172",
+      "name": "Domain Fronting",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1173",
+      "name": "Dynamic Data Exchange",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1174",
+      "name": "Password Filter DLL",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1175",
+      "name": "Component Object Model and Distributed COM",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": true,
+      "tactics": [
+        "execution",
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1176",
+      "name": "Software Extensions",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1176.001",
+      "name": "Browser Extensions",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1176.002",
+      "name": "IDE Extensions",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1177",
+      "name": "LSASS Driver",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1178",
+      "name": "SID-History Injection",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1179",
+      "name": "Hooking",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "credential-access",
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1180",
+      "name": "Screensaver",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1181",
+      "name": "Extra Window Memory Injection",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1182",
+      "name": "AppCert DLLs",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1183",
+      "name": "Image File Execution Options Injection",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1184",
+      "name": "SSH Hijacking",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1185",
+      "name": "Browser Session Hijacking",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1186",
+      "name": "Process Doppelgänging",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1187",
+      "name": "Forced Authentication",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1188",
+      "name": "Multi-hop Proxy",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1189",
+      "name": "Drive-by Compromise",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "initial-access"
+      ]
+    },
+    {
+      "id": "T1190",
+      "name": "Exploit Public-Facing Application",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "initial-access"
+      ]
+    },
+    {
+      "id": "T1191",
+      "name": "CMSTP",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1192",
+      "name": "Spearphishing Link",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "initial-access"
+      ]
+    },
+    {
+      "id": "T1193",
+      "name": "Spearphishing Attachment",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "initial-access"
+      ]
+    },
+    {
+      "id": "T1194",
+      "name": "Spearphishing via Service",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "initial-access"
+      ]
+    },
+    {
+      "id": "T1195",
+      "name": "Supply Chain Compromise",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "initial-access"
+      ]
+    },
+    {
+      "id": "T1195.001",
+      "name": "Compromise Software Dependencies and Development Tools",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "initial-access"
+      ]
+    },
+    {
+      "id": "T1195.002",
+      "name": "Compromise Software Supply Chain",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "initial-access"
+      ]
+    },
+    {
+      "id": "T1195.003",
+      "name": "Compromise Hardware Supply Chain",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "initial-access"
+      ]
+    },
+    {
+      "id": "T1196",
+      "name": "Control Panel Items",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1197",
+      "name": "BITS Jobs",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "persistence",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1198",
+      "name": "SIP and Trust Provider Hijacking",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1199",
+      "name": "Trusted Relationship",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "initial-access"
+      ]
+    },
+    {
+      "id": "T1200",
+      "name": "Hardware Additions",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "initial-access"
+      ]
+    },
+    {
+      "id": "T1201",
+      "name": "Password Policy Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1202",
+      "name": "Indirect Command Execution",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1203",
+      "name": "Exploitation for Client Execution",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1204",
+      "name": "User Execution",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1204.001",
+      "name": "Malicious Link",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1204.002",
+      "name": "Malicious File",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1204.003",
+      "name": "Malicious Image",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1204.004",
+      "name": "Malicious Copy and Paste",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1204.005",
+      "name": "Malicious Library",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1205",
+      "name": "Traffic Signaling",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control",
+        "persistence",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1205.001",
+      "name": "Port Knocking",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control",
+        "persistence",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1205.002",
+      "name": "Socket Filters",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control",
+        "persistence",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1206",
+      "name": "Sudo Caching",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1207",
+      "name": "Rogue Domain Controller",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1208",
+      "name": "Kerberoasting",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1209",
+      "name": "Time Providers",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1210",
+      "name": "Exploitation of Remote Services",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1211",
+      "name": "Exploitation for Stealth",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1212",
+      "name": "Exploitation for Credential Access",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1213",
+      "name": "Data from Information Repositories",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1213.001",
+      "name": "Confluence",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1213.002",
+      "name": "Sharepoint",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1213.003",
+      "name": "Code Repositories",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1213.004",
+      "name": "Customer Relationship Management Software",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1213.005",
+      "name": "Messaging Applications",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1213.006",
+      "name": "Databases",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1214",
+      "name": "Credentials in Registry",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1215",
+      "name": "Kernel Modules and Extensions",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1216",
+      "name": "System Script Proxy Execution",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1216.001",
+      "name": "PubPrn",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1216.002",
+      "name": "SyncAppvPublishingServer",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1217",
+      "name": "Browser Information Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1218",
+      "name": "System Binary Proxy Execution",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1218.001",
+      "name": "Compiled HTML File",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1218.002",
+      "name": "Control Panel",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1218.003",
+      "name": "CMSTP",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1218.004",
+      "name": "InstallUtil",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1218.005",
+      "name": "Mshta",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1218.007",
+      "name": "Msiexec",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1218.008",
+      "name": "Odbcconf",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1218.009",
+      "name": "Regsvcs/Regasm",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1218.010",
+      "name": "Regsvr32",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1218.011",
+      "name": "Rundll32",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1218.012",
+      "name": "Verclsid",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1218.013",
+      "name": "Mavinject",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1218.014",
+      "name": "MMC",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1218.015",
+      "name": "Electron Applications",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1219",
+      "name": "Remote Access Tools",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1219.001",
+      "name": "IDE Tunneling",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1219.002",
+      "name": "Remote Desktop Software",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1219.003",
+      "name": "Remote Access Hardware",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1220",
+      "name": "XSL Script Processing",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1221",
+      "name": "Template Injection",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1222",
+      "name": "File and Directory Permissions Modification",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1222.001",
+      "name": "Windows Permissions",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1222.002",
+      "name": "Linux and Mac Permissions",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1223",
+      "name": "Compiled HTML File",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1480",
+      "name": "Execution Guardrails",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1480.001",
+      "name": "Environmental Keying",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1480.002",
+      "name": "Mutual Exclusion",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1482",
+      "name": "Domain Trust Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1483",
+      "name": "Domain Generation Algorithms",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1484",
+      "name": "Domain or Tenant Policy Modification",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1484.001",
+      "name": "Group Policy Modification",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1484.002",
+      "name": "Trust Modification",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1485",
+      "name": "Data Destruction",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1485.001",
+      "name": "Lifecycle-Triggered Deletion",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1486",
+      "name": "Data Encrypted for Impact",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1487",
+      "name": "Disk Structure Wipe",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1488",
+      "name": "Disk Content Wipe",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1489",
+      "name": "Service Stop",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1490",
+      "name": "Inhibit System Recovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1491",
+      "name": "Defacement",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1491.001",
+      "name": "Internal Defacement",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1491.002",
+      "name": "External Defacement",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1492",
+      "name": "Stored Data Manipulation",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1493",
+      "name": "Transmitted Data Manipulation",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1494",
+      "name": "Runtime Data Manipulation",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1495",
+      "name": "Firmware Corruption",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1496",
+      "name": "Resource Hijacking",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1496.001",
+      "name": "Compute Hijacking",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1496.002",
+      "name": "Bandwidth Hijacking",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1496.003",
+      "name": "SMS Pumping",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1496.004",
+      "name": "Cloud Service Hijacking",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1497",
+      "name": "Virtualization/Sandbox Evasion",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1497.001",
+      "name": "System Checks",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1497.002",
+      "name": "User Activity Based Checks",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1497.003",
+      "name": "Time Based Checks",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1498",
+      "name": "Network Denial of Service",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1498.001",
+      "name": "Direct Network Flood",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1498.002",
+      "name": "Reflection Amplification",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1499",
+      "name": "Endpoint Denial of Service",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1499.001",
+      "name": "OS Exhaustion Flood",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1499.002",
+      "name": "Service Exhaustion Flood",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1499.003",
+      "name": "Application Exhaustion Flood",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1499.004",
+      "name": "Application or System Exploitation",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1500",
+      "name": "Compile After Delivery",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1501",
+      "name": "Systemd Service",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1502",
+      "name": "Parent PID Spoofing",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1503",
+      "name": "Credentials from Web Browsers",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1504",
+      "name": "PowerShell Profile",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1505",
+      "name": "Server Software Component",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1505.001",
+      "name": "SQL Stored Procedures",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1505.002",
+      "name": "Transport Agent",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1505.003",
+      "name": "Web Shell",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1505.004",
+      "name": "IIS Components",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1505.005",
+      "name": "Terminal Services DLL",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1505.006",
+      "name": "vSphere Installation Bundles",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1506",
+      "name": "Web Session Cookie",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1514",
+      "name": "Elevated Execution with Prompt",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1518",
+      "name": "Software Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1518.001",
+      "name": "Security Software Discovery",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1518.002",
+      "name": "Backup Software Discovery",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1519",
+      "name": "Emond",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1522",
+      "name": "Cloud Instance Metadata API",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1525",
+      "name": "Implant Internal Image",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1526",
+      "name": "Cloud Service Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1527",
+      "name": "Application Access Token",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1528",
+      "name": "Steal Application Access Token",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1529",
+      "name": "System Shutdown/Reboot",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1530",
+      "name": "Data from Cloud Storage",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1531",
+      "name": "Account Access Removal",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1534",
+      "name": "Internal Spearphishing",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1535",
+      "name": "Unused/Unsupported Cloud Regions",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1536",
+      "name": "Revert Cloud Instance",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1537",
+      "name": "Transfer Data to Cloud Account",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "exfiltration"
+      ]
+    },
+    {
+      "id": "T1538",
+      "name": "Cloud Service Dashboard",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1539",
+      "name": "Steal Web Session Cookie",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1542",
+      "name": "Pre-OS Boot",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1542.001",
+      "name": "System Firmware",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1542.002",
+      "name": "Component Firmware",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1542.003",
+      "name": "Bootkit",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1542.004",
+      "name": "ROMMONkit",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1542.005",
+      "name": "TFTP Boot",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1543",
+      "name": "Create or Modify System Process",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1543.001",
+      "name": "Launch Agent",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1543.002",
+      "name": "Systemd Service",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1543.003",
+      "name": "Windows Service",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1543.004",
+      "name": "Launch Daemon",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1543.005",
+      "name": "Container Service",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1546",
+      "name": "Event Triggered Execution",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1546.001",
+      "name": "Change Default File Association",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1546.002",
+      "name": "Screensaver",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1546.003",
+      "name": "Windows Management Instrumentation Event Subscription",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1546.004",
+      "name": "Unix Shell Configuration Modification",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1546.005",
+      "name": "Trap",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1546.006",
+      "name": "LC_LOAD_DYLIB Addition",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1546.007",
+      "name": "Netsh Helper DLL",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1546.008",
+      "name": "Accessibility Features",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1546.009",
+      "name": "AppCert DLLs",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1546.010",
+      "name": "AppInit DLLs",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1546.011",
+      "name": "Application Shimming",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1546.012",
+      "name": "Image File Execution Options Injection",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1546.013",
+      "name": "PowerShell Profile",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1546.014",
+      "name": "Emond",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1546.015",
+      "name": "Component Object Model Hijacking",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1546.016",
+      "name": "Installer Packages",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1546.017",
+      "name": "Udev Rules",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1546.018",
+      "name": "Python Startup Hooks",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1547",
+      "name": "Boot or Logon Autostart Execution",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1547.001",
+      "name": "Registry Run Keys / Startup Folder",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1547.002",
+      "name": "Authentication Package",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1547.003",
+      "name": "Time Providers",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1547.004",
+      "name": "Winlogon Helper DLL",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1547.005",
+      "name": "Security Support Provider",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1547.006",
+      "name": "Kernel Modules and Extensions",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1547.007",
+      "name": "Re-opened Applications",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1547.008",
+      "name": "LSASS Driver",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1547.009",
+      "name": "Shortcut Modification",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1547.010",
+      "name": "Port Monitors",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1547.011",
+      "name": "Plist Modification",
+      "kind": "subtechnique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1547.012",
+      "name": "Print Processors",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1547.013",
+      "name": "XDG Autostart Entries",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1547.014",
+      "name": "Active Setup",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1547.015",
+      "name": "Login Items",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1548",
+      "name": "Abuse Elevation Control Mechanism",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1548.001",
+      "name": "Setuid and Setgid",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1548.002",
+      "name": "Bypass User Account Control",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1548.003",
+      "name": "Sudo and Sudo Caching",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1548.004",
+      "name": "Elevated Execution with Prompt",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1548.005",
+      "name": "Temporary Elevated Cloud Access",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1548.006",
+      "name": "TCC Manipulation",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1550",
+      "name": "Use Alternate Authentication Material",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1550.001",
+      "name": "Application Access Token",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1550.002",
+      "name": "Pass the Hash",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1550.003",
+      "name": "Pass the Ticket",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1550.004",
+      "name": "Web Session Cookie",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1552",
+      "name": "Unsecured Credentials",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1552.001",
+      "name": "Credentials In Files",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1552.002",
+      "name": "Credentials in Registry",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1552.003",
+      "name": "Shell History",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1552.004",
+      "name": "Private Keys",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1552.005",
+      "name": "Cloud Instance Metadata API",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1552.006",
+      "name": "Group Policy Preferences",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1552.007",
+      "name": "Container API",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1552.008",
+      "name": "Chat Messages",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1553",
+      "name": "Subvert Trust Controls",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1553.001",
+      "name": "Gatekeeper Bypass",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1553.002",
+      "name": "Code Signing",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1553.003",
+      "name": "SIP and Trust Provider Hijacking",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1553.004",
+      "name": "Install Root Certificate",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1553.005",
+      "name": "Mark-of-the-Web Bypass",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1553.006",
+      "name": "Code Signing Policy Modification",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1554",
+      "name": "Compromise Host Software Binary",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1555",
+      "name": "Credentials from Password Stores",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1555.001",
+      "name": "Keychain",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1555.002",
+      "name": "Securityd Memory",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1555.003",
+      "name": "Credentials from Web Browsers",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1555.004",
+      "name": "Windows Credential Manager",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1555.005",
+      "name": "Password Managers",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1555.006",
+      "name": "Cloud Secrets Management Stores",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1556",
+      "name": "Modify Authentication Process",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access",
+        "defense-impairment",
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1556.001",
+      "name": "Domain Controller Authentication",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access",
+        "defense-impairment",
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1556.002",
+      "name": "Password Filter DLL",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access",
+        "defense-impairment",
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1556.003",
+      "name": "Pluggable Authentication Modules",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access",
+        "defense-impairment",
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1556.004",
+      "name": "Network Device Authentication",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access",
+        "defense-impairment",
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1556.005",
+      "name": "Reversible Encryption",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access",
+        "defense-impairment",
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1556.006",
+      "name": "Multi-Factor Authentication",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access",
+        "defense-impairment",
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1556.007",
+      "name": "Hybrid Identity",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access",
+        "defense-impairment",
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1556.008",
+      "name": "Network Provider DLL",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access",
+        "defense-impairment",
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1556.009",
+      "name": "Conditional Access Policies",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access",
+        "defense-impairment",
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1557",
+      "name": "Adversary-in-the-Middle",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection",
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1557.001",
+      "name": "Name Resolution Poisoning and SMB Relay",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection",
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1557.002",
+      "name": "ARP Cache Poisoning",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection",
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1557.003",
+      "name": "DHCP Spoofing",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection",
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1557.004",
+      "name": "Evil Twin",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection",
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1558",
+      "name": "Steal or Forge Kerberos Tickets",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1558.001",
+      "name": "Golden Ticket",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1558.002",
+      "name": "Silver Ticket",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1558.003",
+      "name": "Kerberoasting",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1558.004",
+      "name": "AS-REP Roasting",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1558.005",
+      "name": "Ccache Files",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1559",
+      "name": "Inter-Process Communication",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1559.001",
+      "name": "Component Object Model",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1559.002",
+      "name": "Dynamic Data Exchange",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1559.003",
+      "name": "XPC Services",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1560",
+      "name": "Archive Collected Data",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1560.001",
+      "name": "Archive via Utility",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1560.002",
+      "name": "Archive via Library",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1560.003",
+      "name": "Archive via Custom Method",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1561",
+      "name": "Disk Wipe",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1561.001",
+      "name": "Disk Content Wipe",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1561.002",
+      "name": "Disk Structure Wipe",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1562",
+      "name": "Impair Defenses",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1562.001",
+      "name": "Disable or Modify Tools",
+      "kind": "subtechnique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1562.002",
+      "name": "Disable Windows Event Logging",
+      "kind": "subtechnique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1562.003",
+      "name": "Impair Command History Logging",
+      "kind": "subtechnique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1562.004",
+      "name": "Disable or Modify System Firewall",
+      "kind": "subtechnique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1562.006",
+      "name": "Indicator Blocking",
+      "kind": "subtechnique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1562.007",
+      "name": "Disable or Modify Cloud Firewall",
+      "kind": "subtechnique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1562.008",
+      "name": "Disable or Modify Cloud Logs",
+      "kind": "subtechnique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1562.009",
+      "name": "Safe Mode Boot",
+      "kind": "subtechnique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1562.010",
+      "name": "Downgrade Attack",
+      "kind": "subtechnique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1562.011",
+      "name": "Spoof Security Alerting",
+      "kind": "subtechnique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1562.012",
+      "name": "Disable or Modify Linux Audit System",
+      "kind": "subtechnique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1562.013",
+      "name": "Disable or Modify Network Device Firewall",
+      "kind": "subtechnique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1563",
+      "name": "Remote Service Session Hijacking",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1563.001",
+      "name": "SSH Hijacking",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1563.002",
+      "name": "RDP Hijacking",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1564",
+      "name": "Hide Artifacts",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1564.001",
+      "name": "Hidden Files and Directories",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1564.002",
+      "name": "Hidden Users",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1564.003",
+      "name": "Hidden Window",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1564.004",
+      "name": "NTFS File Attributes",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1564.005",
+      "name": "Hidden File System",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1564.006",
+      "name": "Run Virtual Instance",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1564.007",
+      "name": "VBA Stomping",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1564.008",
+      "name": "Email Hiding Rules",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1564.009",
+      "name": "Resource Forking",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1564.010",
+      "name": "Process Argument Spoofing",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1564.011",
+      "name": "Ignore Process Interrupts",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1564.012",
+      "name": "File/Path Exclusions",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1564.013",
+      "name": "Bind Mounts",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1564.014",
+      "name": "Extended Attributes",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1565",
+      "name": "Data Manipulation",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1565.001",
+      "name": "Stored Data Manipulation",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1565.002",
+      "name": "Transmitted Data Manipulation",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1565.003",
+      "name": "Runtime Data Manipulation",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1566",
+      "name": "Phishing",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "initial-access"
+      ]
+    },
+    {
+      "id": "T1566.001",
+      "name": "Spearphishing Attachment",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "initial-access"
+      ]
+    },
+    {
+      "id": "T1566.002",
+      "name": "Spearphishing Link",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "initial-access"
+      ]
+    },
+    {
+      "id": "T1566.003",
+      "name": "Spearphishing via Service",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "initial-access"
+      ]
+    },
+    {
+      "id": "T1566.004",
+      "name": "Spearphishing Voice",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "initial-access"
+      ]
+    },
+    {
+      "id": "T1567",
+      "name": "Exfiltration Over Web Service",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "exfiltration"
+      ]
+    },
+    {
+      "id": "T1567.001",
+      "name": "Exfiltration to Code Repository",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "exfiltration"
+      ]
+    },
+    {
+      "id": "T1567.002",
+      "name": "Exfiltration to Cloud Storage",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "exfiltration"
+      ]
+    },
+    {
+      "id": "T1567.003",
+      "name": "Exfiltration to Text Storage Sites",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "exfiltration"
+      ]
+    },
+    {
+      "id": "T1567.004",
+      "name": "Exfiltration Over Webhook",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "exfiltration"
+      ]
+    },
+    {
+      "id": "T1568",
+      "name": "Dynamic Resolution",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1568.001",
+      "name": "Fast Flux DNS",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1568.002",
+      "name": "Domain Generation Algorithms",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1568.003",
+      "name": "DNS Calculation",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1569",
+      "name": "System Services",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1569.001",
+      "name": "Launchctl",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1569.002",
+      "name": "Service Execution",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1569.003",
+      "name": "Systemctl",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1570",
+      "name": "Lateral Tool Transfer",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "lateral-movement"
+      ]
+    },
+    {
+      "id": "T1571",
+      "name": "Non-Standard Port",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1572",
+      "name": "Protocol Tunneling",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1573",
+      "name": "Encrypted Channel",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1573.001",
+      "name": "Symmetric Cryptography",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1573.002",
+      "name": "Asymmetric Cryptography",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1574",
+      "name": "Hijack Execution Flow",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1574.001",
+      "name": "DLL",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1574.002",
+      "name": "DLL Side-Loading",
+      "kind": "subtechnique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1574.004",
+      "name": "Dylib Hijacking",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1574.005",
+      "name": "Executable Installer File Permissions Weakness",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1574.006",
+      "name": "Dynamic Linker Hijacking",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1574.007",
+      "name": "Path Interception by PATH Environment Variable",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1574.008",
+      "name": "Path Interception by Search Order Hijacking",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1574.009",
+      "name": "Path Interception by Unquoted Path",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1574.010",
+      "name": "Services File Permissions Weakness",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1574.011",
+      "name": "Services Registry Permissions Weakness",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1574.012",
+      "name": "COR_PROFILER",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1574.013",
+      "name": "KernelCallbackTable",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1574.014",
+      "name": "AppDomainManager",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1578",
+      "name": "Modify Cloud Compute Infrastructure",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1578.001",
+      "name": "Create Snapshot",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1578.002",
+      "name": "Create Cloud Instance",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1578.003",
+      "name": "Delete Cloud Instance",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1578.004",
+      "name": "Revert Cloud Instance",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1578.005",
+      "name": "Modify Cloud Compute Configurations",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1580",
+      "name": "Cloud Infrastructure Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1583",
+      "name": "Acquire Infrastructure",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1583.001",
+      "name": "Domains",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1583.002",
+      "name": "DNS Server",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1583.003",
+      "name": "Virtual Private Server",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1583.004",
+      "name": "Server",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1583.005",
+      "name": "Botnet",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1583.006",
+      "name": "Web Services",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1583.007",
+      "name": "Serverless",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1583.008",
+      "name": "Malvertising",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1584",
+      "name": "Compromise Infrastructure",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1584.001",
+      "name": "Domains",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1584.002",
+      "name": "DNS Server",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1584.003",
+      "name": "Virtual Private Server",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1584.004",
+      "name": "Server",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1584.005",
+      "name": "Botnet",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1584.006",
+      "name": "Web Services",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1584.007",
+      "name": "Serverless",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1584.008",
+      "name": "Network Devices",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1585",
+      "name": "Establish Accounts",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1585.001",
+      "name": "Social Media Accounts",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1585.002",
+      "name": "Email Accounts",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1585.003",
+      "name": "Cloud Accounts",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1586",
+      "name": "Compromise Accounts",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1586.001",
+      "name": "Social Media Accounts",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1586.002",
+      "name": "Email Accounts",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1586.003",
+      "name": "Cloud Accounts",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1587",
+      "name": "Develop Capabilities",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1587.001",
+      "name": "Malware",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1587.002",
+      "name": "Code Signing Certificates",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1587.003",
+      "name": "Digital Certificates",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1587.004",
+      "name": "Exploits",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1588",
+      "name": "Obtain Capabilities",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1588.001",
+      "name": "Malware",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1588.002",
+      "name": "Tool",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1588.003",
+      "name": "Code Signing Certificates",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1588.004",
+      "name": "Digital Certificates",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1588.005",
+      "name": "Exploits",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1588.006",
+      "name": "Vulnerabilities",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1588.007",
+      "name": "Artificial Intelligence",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1589",
+      "name": "Gather Victim Identity Information",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1589.001",
+      "name": "Credentials",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1589.002",
+      "name": "Email Addresses",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1589.003",
+      "name": "Employee Names",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1590",
+      "name": "Gather Victim Network Information",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1590.001",
+      "name": "Domain Properties",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1590.002",
+      "name": "DNS",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1590.003",
+      "name": "Network Trust Dependencies",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1590.004",
+      "name": "Network Topology",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1590.005",
+      "name": "IP Addresses",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1590.006",
+      "name": "Network Security Appliances",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1591",
+      "name": "Gather Victim Org Information",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1591.001",
+      "name": "Determine Physical Locations",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1591.002",
+      "name": "Business Relationships",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1591.003",
+      "name": "Identify Business Tempo",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1591.004",
+      "name": "Identify Roles",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1592",
+      "name": "Gather Victim Host Information",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1592.001",
+      "name": "Hardware",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1592.002",
+      "name": "Software",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1592.003",
+      "name": "Firmware",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1592.004",
+      "name": "Client Configurations",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1593",
+      "name": "Search Open Websites/Domains",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1593.001",
+      "name": "Social Media",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1593.002",
+      "name": "Search Engines",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1593.003",
+      "name": "Code Repositories",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1594",
+      "name": "Search Victim-Owned Websites",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1595",
+      "name": "Active Scanning",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1595.001",
+      "name": "Scanning IP Blocks",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1595.002",
+      "name": "Vulnerability Scanning",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1595.003",
+      "name": "Wordlist Scanning",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1596",
+      "name": "Search Open Technical Databases",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1596.001",
+      "name": "DNS/Passive DNS",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1596.002",
+      "name": "WHOIS",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1596.003",
+      "name": "Digital Certificates",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1596.004",
+      "name": "CDNs",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1596.005",
+      "name": "Scan Databases",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1597",
+      "name": "Search Closed Sources",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1597.001",
+      "name": "Threat Intel Vendors",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1597.002",
+      "name": "Purchase Technical Data",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1598",
+      "name": "Phishing for Information",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1598.001",
+      "name": "Spearphishing Service",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1598.002",
+      "name": "Spearphishing Attachment",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1598.003",
+      "name": "Spearphishing Link",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1598.004",
+      "name": "Spearphishing Voice",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1599",
+      "name": "Network Boundary Bridging",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1599.001",
+      "name": "Network Address Translation Traversal",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1600",
+      "name": "Weaken Encryption",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1600.001",
+      "name": "Reduce Key Space",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1600.002",
+      "name": "Disable Crypto Hardware",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1601",
+      "name": "Modify System Image",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1601.001",
+      "name": "Patch System Image",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1601.002",
+      "name": "Downgrade System Image",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1602",
+      "name": "Data from Configuration Repository",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1602.001",
+      "name": "SNMP (MIB Dump)",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1602.002",
+      "name": "Network Device Configuration Dump",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "collection"
+      ]
+    },
+    {
+      "id": "T1606",
+      "name": "Forge Web Credentials",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1606.001",
+      "name": "Web Cookies",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1606.002",
+      "name": "SAML Tokens",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1608",
+      "name": "Stage Capabilities",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1608.001",
+      "name": "Upload Malware",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1608.002",
+      "name": "Upload Tool",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1608.003",
+      "name": "Install Digital Certificate",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1608.004",
+      "name": "Drive-by Target",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1608.005",
+      "name": "Link Target",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1608.006",
+      "name": "SEO Poisoning",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1609",
+      "name": "Container Administration Command",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1610",
+      "name": "Deploy Container",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1611",
+      "name": "Escape to Host",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1612",
+      "name": "Build Image on Host",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1613",
+      "name": "Container and Resource Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1614",
+      "name": "System Location Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1614.001",
+      "name": "System Language Discovery",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1615",
+      "name": "Group Policy Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1619",
+      "name": "Cloud Storage Object Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1620",
+      "name": "Reflective Code Loading",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1621",
+      "name": "Multi-Factor Authentication Request Generation",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1622",
+      "name": "Debugger Evasion",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery",
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1647",
+      "name": "Plist File Modification",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1648",
+      "name": "Serverless Execution",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1649",
+      "name": "Steal or Forge Authentication Certificates",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1650",
+      "name": "Acquire Access",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1651",
+      "name": "Cloud Administration Command",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1652",
+      "name": "Device Driver Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1653",
+      "name": "Power Settings",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1654",
+      "name": "Log Enumeration",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1656",
+      "name": "Impersonation",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1657",
+      "name": "Financial Theft",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1659",
+      "name": "Content Injection",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control",
+        "initial-access"
+      ]
+    },
+    {
+      "id": "T1665",
+      "name": "Hide Infrastructure",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1666",
+      "name": "Modify Cloud Resource Hierarchy",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1667",
+      "name": "Email Bombing",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "impact"
+      ]
+    },
+    {
+      "id": "T1668",
+      "name": "Exclusive Control",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1669",
+      "name": "Wi-Fi Networks",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "initial-access"
+      ]
+    },
+    {
+      "id": "T1671",
+      "name": "Cloud Application Integration",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "persistence"
+      ]
+    },
+    {
+      "id": "T1672",
+      "name": "Email Spoofing",
+      "kind": "technique",
+      "revoked": true,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1673",
+      "name": "Virtual Machine Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1674",
+      "name": "Input Injection",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1675",
+      "name": "ESXi Administration Command",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1677",
+      "name": "Poisoned Pipeline Execution",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1678",
+      "name": "Delay Execution",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1679",
+      "name": "Selective Exclusion",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1680",
+      "name": "Local Storage Discovery",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1681",
+      "name": "Search Threat Vendor Data",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1682",
+      "name": "Query Public AI Services",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "reconnaissance"
+      ]
+    },
+    {
+      "id": "T1683",
+      "name": "Generate Content",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1683.001",
+      "name": "Written Content",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1683.002",
+      "name": "Audio-Visual Content",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "resource-development"
+      ]
+    },
+    {
+      "id": "T1684",
+      "name": "Social Engineering",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1684.001",
+      "name": "Impersonation",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1684.002",
+      "name": "Email Spoofing",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "stealth"
+      ]
+    },
+    {
+      "id": "T1685",
+      "name": "Disable or Modify Tools",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1685.001",
+      "name": "Disable or Modify Windows Event Log",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1685.002",
+      "name": "Disable or Modify Cloud Log",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1685.003",
+      "name": "Modify or Spoof Tool UI",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1685.004",
+      "name": "Disable or Modify Linux Audit System Log",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1685.005",
+      "name": "Clear Windows Event Logs",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1685.006",
+      "name": "Clear Linux or Mac System Logs",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1686",
+      "name": "Disable or Modify System Firewall",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1686.001",
+      "name": "Cloud Firewall",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1686.002",
+      "name": "Network Device Firewall",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1686.003",
+      "name": "Windows Host Firewall",
+      "kind": "subtechnique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1687",
+      "name": "Exploitation for Defense Impairment",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1688",
+      "name": "Safe Mode Boot",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1689",
+      "name": "Downgrade Attack",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    },
+    {
+      "id": "T1690",
+      "name": "Prevent Command History Logging",
+      "kind": "technique",
+      "revoked": false,
+      "deprecated": false,
+      "tactics": [
+        "defense-impairment"
+      ]
+    }
+  ]
+}

--- a/scripts/framework-data.mjs
+++ b/scripts/framework-data.mjs
@@ -1,0 +1,69 @@
+import { existsSync, readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const FRAMEWORK_DATA_DIR = resolve(ROOT, '.github/pipeline/data/frameworks');
+
+const ATTACK_DATA_FILE = resolve(FRAMEWORK_DATA_DIR, 'mitre-attack-enterprise-v19.0-techniques.json');
+const ATLAS_DATA_FILE = resolve(FRAMEWORK_DATA_DIR, 'mitre-atlas-v5.6.0-techniques.json');
+
+let attackData = null;
+let atlasData = null;
+
+function loadJson(filePath) {
+  if (!existsSync(filePath)) {
+    throw new Error(`Pinned framework data file not found: ${filePath}`);
+  }
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+function buildTechniqueMap(data) {
+  const techniques = Array.isArray(data?.techniques) ? data.techniques : [];
+  return new Map(techniques.map((technique) => [technique.id, technique]));
+}
+
+export function getAttackEnterpriseData() {
+  if (!attackData) {
+    const data = loadJson(ATTACK_DATA_FILE);
+    attackData = {
+      ...data,
+      techniqueById: buildTechniqueMap(data),
+    };
+  }
+  return attackData;
+}
+
+export function getAtlasData() {
+  if (!atlasData) {
+    const data = loadJson(ATLAS_DATA_FILE);
+    atlasData = {
+      ...data,
+      techniqueById: buildTechniqueMap(data),
+    };
+  }
+  return atlasData;
+}
+
+export function getAttackEnterpriseTechnique(techniqueId) {
+  return getAttackEnterpriseData().techniqueById.get(techniqueId) || null;
+}
+
+export function getAtlasTechnique(techniqueId) {
+  return getAtlasData().techniqueById.get(techniqueId) || null;
+}
+
+export function normalizeFrameworkName(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+export function isPinnedAttackVersion(value) {
+  const version = normalizeFrameworkName(value);
+  return version === '' || version === 'v19' || version === 'v19.0';
+}
+
+export function isPinnedAtlasVersion(value) {
+  const version = normalizeFrameworkName(value);
+  return version === '' || version === '5.6.0' || version === 'v5.6.0';
+}

--- a/scripts/framework-mapping-validation.mjs
+++ b/scripts/framework-mapping-validation.mjs
@@ -5,6 +5,15 @@ import {
   SCHEMA_MAPPING_CONFIDENCE_VALUES,
   SCHEMA_MITRE_TECHNIQUE_ID_PATTERN,
 } from './pipeline-schema.mjs';
+import {
+  getAtlasData,
+  getAtlasTechnique,
+  getAttackEnterpriseData,
+  getAttackEnterpriseTechnique,
+  isPinnedAtlasVersion,
+  isPinnedAttackVersion,
+  normalizeFrameworkName,
+} from './framework-data.mjs';
 
 const ATTACK_VERSION_RE = new RegExp(SCHEMA_ATTACK_VERSION_PATTERN);
 const ATLAS_TECHNIQUE_ID_RE = new RegExp(SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN);
@@ -22,6 +31,7 @@ function trimOptionalString(value) {
 export function getMitreMappingValidationIssues(mappings, options = {}) {
   const labelPrefix = options.labelPrefix || 'MITRE mapping';
   const issues = [];
+  const attackData = getAttackEnterpriseData();
 
   for (let i = 0; i < mappings.length; i += 1) {
     const label = mappingLabel(labelPrefix, i);
@@ -32,6 +42,21 @@ export function getMitreMappingValidationIssues(mappings, options = {}) {
       issues.push(`${label}: techniqueId "${techniqueId}" should use canonical "." separator (${techniqueId.replace('-', '.')})`);
     } else if (!MITRE_TECHNIQUE_ID_RE.test(techniqueId)) {
       issues.push(`${label}: invalid techniqueId "${techniqueId}" — expected format T####[.###]`);
+    } else {
+      const attackVersion = mapping.attackVersion ?? mapping.attack_version;
+      const shouldUsePinnedAttackData = isPinnedAttackVersion(attackVersion);
+      const technique = shouldUsePinnedAttackData ? getAttackEnterpriseTechnique(techniqueId) : null;
+      if (shouldUsePinnedAttackData && !technique) {
+        issues.push(`${label}: techniqueId "${techniqueId}" is not present in ATT&CK Enterprise ${attackData.version}`);
+      } else if (technique?.revoked || technique?.deprecated) {
+        issues.push(`${label}: techniqueId "${techniqueId}" is ${technique.revoked ? 'revoked' : 'deprecated'} in ATT&CK Enterprise ${attackData.version}`);
+      } else if (technique) {
+        const providedName = normalizeFrameworkName(mapping.techniqueName);
+        const officialName = normalizeFrameworkName(technique.name);
+        if (providedName && providedName !== officialName) {
+          issues.push(`${label}: techniqueName "${providedName}" should match ATT&CK Enterprise ${attackData.version} name "${officialName}"`);
+        }
+      }
     }
 
     if (!mapping.techniqueName || String(mapping.techniqueName).trim() === '') {
@@ -64,6 +89,7 @@ export function getMitreMappingValidationIssues(mappings, options = {}) {
 export function getAtlasMappingValidationIssues(atlasMappings, options = {}) {
   const labelPrefix = options.labelPrefix || 'ATLAS mapping';
   const issues = [];
+  const atlasData = getAtlasData();
 
   if (atlasMappings !== undefined && !Array.isArray(atlasMappings)) {
     issues.push('atlasMappings must be an array when present');
@@ -77,6 +103,21 @@ export function getAtlasMappingValidationIssues(atlasMappings, options = {}) {
 
       if (!ATLAS_TECHNIQUE_ID_RE.test(techniqueId)) {
         issues.push(`${label}: invalid techniqueId "${techniqueId}" — expected format AML.T####[.###]`);
+      } else {
+        const atlasVersion = mapping.atlasVersion;
+        const shouldUsePinnedAtlasData = isPinnedAtlasVersion(atlasVersion);
+        const technique = shouldUsePinnedAtlasData ? getAtlasTechnique(techniqueId) : null;
+        if (shouldUsePinnedAtlasData && !technique) {
+          issues.push(`${label}: techniqueId "${techniqueId}" is not present in MITRE ATLAS ${atlasData.version}`);
+        } else if (technique?.revoked || technique?.deprecated) {
+          issues.push(`${label}: techniqueId "${techniqueId}" is ${technique.revoked ? 'revoked' : 'deprecated'} in MITRE ATLAS ${atlasData.version}`);
+        } else if (technique) {
+          const providedName = normalizeFrameworkName(mapping.techniqueName);
+          const officialName = normalizeFrameworkName(technique.name);
+          if (providedName && providedName !== officialName) {
+            issues.push(`${label}: techniqueName "${providedName}" should match MITRE ATLAS ${atlasData.version} name "${officialName}"`);
+          }
+        }
       }
 
       if (!mapping.techniqueName || String(mapping.techniqueName).trim() === '') {

--- a/scripts/framework-mapping-validation.mjs
+++ b/scripts/framework-mapping-validation.mjs
@@ -100,11 +100,11 @@ export function getAtlasMappingValidationIssues(atlasMappings, options = {}) {
       const label = mappingLabel(labelPrefix, i);
       const mapping = atlasMappings[i] || {};
       const techniqueId = trimOptionalString(mapping.techniqueId);
+      const atlasVersion = mapping.atlasVersion ?? mapping.atlas_version;
 
       if (!ATLAS_TECHNIQUE_ID_RE.test(techniqueId)) {
         issues.push(`${label}: invalid techniqueId "${techniqueId}" — expected format AML.T####[.###]`);
       } else {
-        const atlasVersion = mapping.atlasVersion;
         const shouldUsePinnedAtlasData = isPinnedAtlasVersion(atlasVersion);
         const technique = shouldUsePinnedAtlasData ? getAtlasTechnique(techniqueId) : null;
         if (shouldUsePinnedAtlasData && !technique) {
@@ -131,9 +131,9 @@ export function getAtlasMappingValidationIssues(atlasMappings, options = {}) {
         issues.push(`${label}: confidence must be ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')}`);
       }
 
-      if (mapping.atlasVersion !== undefined) {
-        const atlasVersion = typeof mapping.atlasVersion === 'string' ? mapping.atlasVersion.trim() : '';
-        if (!ATLAS_VERSION_RE.test(atlasVersion)) {
+      if (atlasVersion !== undefined) {
+        const version = typeof atlasVersion === 'string' ? atlasVersion.trim() : '';
+        if (!ATLAS_VERSION_RE.test(version)) {
           issues.push(`${label}: atlasVersion must match N.N.N`);
         }
       }

--- a/scripts/framework-mapping-validation.mjs
+++ b/scripts/framework-mapping-validation.mjs
@@ -131,7 +131,7 @@ export function getAtlasMappingValidationIssues(atlasMappings, options = {}) {
         issues.push(`${label}: confidence must be ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')}`);
       }
 
-      if (atlasVersion !== undefined) {
+      if (atlasVersion != null && atlasVersion !== '') {
         const version = typeof atlasVersion === 'string' ? atlasVersion.trim() : '';
         if (!ATLAS_VERSION_RE.test(version)) {
           issues.push(`${label}: atlasVersion must match N.N.N`);

--- a/scripts/framework-mapping-validation.mjs
+++ b/scripts/framework-mapping-validation.mjs
@@ -37,13 +37,13 @@ export function getMitreMappingValidationIssues(mappings, options = {}) {
     const label = mappingLabel(labelPrefix, i);
     const mapping = mappings[i] || {};
     const techniqueId = trimOptionalString(mapping.techniqueId);
+    const attackVersion = mapping.attackVersion ?? mapping.attack_version;
 
     if (/^T\d{4}-\d{3}$/.test(techniqueId)) {
       issues.push(`${label}: techniqueId "${techniqueId}" should use canonical "." separator (${techniqueId.replace('-', '.')})`);
     } else if (!MITRE_TECHNIQUE_ID_RE.test(techniqueId)) {
       issues.push(`${label}: invalid techniqueId "${techniqueId}" — expected format T####[.###]`);
     } else {
-      const attackVersion = mapping.attackVersion ?? mapping.attack_version;
       const shouldUsePinnedAttackData = isPinnedAttackVersion(attackVersion);
       const technique = shouldUsePinnedAttackData ? getAttackEnterpriseTechnique(techniqueId) : null;
       if (shouldUsePinnedAttackData && !technique) {
@@ -63,7 +63,6 @@ export function getMitreMappingValidationIssues(mappings, options = {}) {
       issues.push(`${label}: missing techniqueName`);
     }
 
-    const attackVersion = mapping.attackVersion ?? mapping.attack_version;
     if (attackVersion !== undefined) {
       const version = typeof attackVersion === 'string' ? attackVersion.trim() : '';
       if (!ATTACK_VERSION_RE.test(version)) {

--- a/scripts/pipeline-build-framework-indexes.mjs
+++ b/scripts/pipeline-build-framework-indexes.mjs
@@ -2,14 +2,16 @@
 
 import { createHash } from 'crypto';
 import { mkdirSync, readFileSync, writeFileSync } from 'fs';
-import { resolve } from 'path';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
 import yaml from 'js-yaml';
 import {
   SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN,
   SCHEMA_MITRE_TECHNIQUE_ID_PATTERN,
 } from './pipeline-schema.mjs';
 
-const ROOT = resolve(new URL('..', import.meta.url).pathname);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
 const OUT_DIR = resolve(ROOT, '.github/pipeline/data/frameworks');
 const ATLAS_TECHNIQUE_ID_RE = new RegExp(SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN);
 const MITRE_TECHNIQUE_ID_RE = new RegExp(SCHEMA_MITRE_TECHNIQUE_ID_PATTERN);

--- a/scripts/pipeline-build-framework-indexes.mjs
+++ b/scripts/pipeline-build-framework-indexes.mjs
@@ -4,9 +4,18 @@ import { createHash } from 'crypto';
 import { mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
 import yaml from 'js-yaml';
+import {
+  SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN,
+  SCHEMA_MITRE_TECHNIQUE_ID_PATTERN,
+} from './pipeline-schema.mjs';
 
 const ROOT = resolve(new URL('..', import.meta.url).pathname);
 const OUT_DIR = resolve(ROOT, '.github/pipeline/data/frameworks');
+const ATLAS_TECHNIQUE_ID_RE = new RegExp(SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN);
+const MITRE_TECHNIQUE_ID_RE = new RegExp(SCHEMA_MITRE_TECHNIQUE_ID_PATTERN);
+const ATLAS_REFERENCE_NORMALIZATIONS = Object.freeze({
+  '{{maschine_compromise.id}}': '{{machine_compromise.id}}',
+});
 
 function usage() {
   console.log(`Usage:
@@ -74,9 +83,14 @@ function findAttackTechniqueId(object) {
   const ref = object.external_references?.find((entry) => (
     entry?.source_name === 'mitre-attack' &&
     typeof entry.external_id === 'string' &&
-    /^T\d{4}(?:\.\d{3})?$/.test(entry.external_id)
+    MITRE_TECHNIQUE_ID_RE.test(entry.external_id)
   ));
   return ref?.external_id || null;
+}
+
+function normalizeAtlasReference(value) {
+  if (!value) return null;
+  return ATLAS_REFERENCE_NORMALIZATIONS[value] || value;
 }
 
 function buildAttackIndex(args) {
@@ -126,18 +140,26 @@ function buildAtlasIndex(args) {
       kind: String(object.id).includes('.', 'AML.T0000'.length) ? 'subtechnique' : 'technique',
       revoked: false,
       deprecated: false,
-      subtechniqueOf: object['subtechnique-of'] || null,
+      subtechniqueOf: normalizeAtlasReference(object['subtechnique-of']),
       tactics: Array.isArray(object.tactics) ? [...object.tactics].sort() : [],
       createdDate: object.created_date || null,
       modifiedDate: object.modified_date || null,
     }))
-    .filter((object) => /^AML\.T\d{4}(?:\.\d{3})?$/.test(object.id))
+    .filter((object) => ATLAS_TECHNIQUE_ID_RE.test(object.id))
     .sort((a, b) => compareTechniqueIds(a.id, b.id));
 
   return {
     framework: 'MITRE ATLAS',
     version: 'v5.6.0',
     source: sourceMetadata(args['atlas-source'], args['atlas-url'], args['atlas-github-sha']),
+    upstreamNormalizations: [
+      {
+        field: 'subtechnique-of',
+        from: '{{maschine_compromise.id}}',
+        to: '{{machine_compromise.id}}',
+        reason: 'MITRE ATLAS v5.6.0 upstream YAML uses a misspelled Machine Compromise anchor.',
+      },
+    ],
     techniqueCount: techniques.length,
     activeTechniqueCount: techniques.filter((technique) => !technique.revoked && !technique.deprecated).length,
     techniques,

--- a/scripts/pipeline-build-framework-indexes.mjs
+++ b/scripts/pipeline-build-framework-indexes.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+
+import { createHash } from 'crypto';
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { resolve } from 'path';
+import yaml from 'js-yaml';
+
+const ROOT = resolve(new URL('..', import.meta.url).pathname);
+const OUT_DIR = resolve(ROOT, '.github/pipeline/data/frameworks');
+
+function usage() {
+  console.log(`Usage:
+  node scripts/pipeline-build-framework-indexes.mjs \\
+    --attack-source /path/to/enterprise-attack-19.0.json \\
+    --attack-url https://raw.githubusercontent.com/.../enterprise-attack-19.0.json \\
+    --attack-github-sha <github-blob-sha> \\
+    --atlas-source /path/to/techniques.yaml \\
+    --atlas-url https://raw.githubusercontent.com/.../techniques.yaml \\
+    --atlas-github-sha <github-blob-sha>
+`);
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      usage();
+      process.exit(0);
+    }
+    if (!arg.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+    const key = arg.slice(2);
+    args[key] = argv[++i] || '';
+  }
+
+  for (const key of [
+    'attack-source',
+    'attack-url',
+    'attack-github-sha',
+    'atlas-source',
+    'atlas-url',
+    'atlas-github-sha',
+  ]) {
+    if (!args[key]) {
+      throw new Error(`Missing required --${key}`);
+    }
+  }
+  return args;
+}
+
+function sourceMetadata(filePath, url, githubBlobSha) {
+  const bytes = readFileSync(filePath);
+  return {
+    url,
+    githubBlobSha,
+    sha256: createHash('sha256').update(bytes).digest('hex'),
+    bytes: bytes.length,
+  };
+}
+
+function compareTechniqueIds(a, b) {
+  const aParts = String(a).match(/\d+/g)?.map(Number) || [];
+  const bParts = String(b).match(/\d+/g)?.map(Number) || [];
+  for (let i = 0; i < Math.max(aParts.length, bParts.length); i += 1) {
+    const delta = (aParts[i] || 0) - (bParts[i] || 0);
+    if (delta !== 0) return delta;
+  }
+  return String(a).localeCompare(String(b));
+}
+
+function findAttackTechniqueId(object) {
+  const ref = object.external_references?.find((entry) => (
+    entry?.source_name === 'mitre-attack' &&
+    typeof entry.external_id === 'string' &&
+    /^T\d{4}(?:\.\d{3})?$/.test(entry.external_id)
+  ));
+  return ref?.external_id || null;
+}
+
+function buildAttackIndex(args) {
+  const raw = JSON.parse(readFileSync(args['attack-source'], 'utf8'));
+  const techniques = raw.objects
+    .filter((object) => object?.type === 'attack-pattern')
+    .map((object) => {
+      const id = findAttackTechniqueId(object);
+      if (!id) return null;
+      return {
+        id,
+        name: object.name,
+        kind: id.includes('.') ? 'subtechnique' : 'technique',
+        revoked: Boolean(object.revoked),
+        deprecated: Boolean(object.x_mitre_deprecated),
+        tactics: (object.kill_chain_phases || [])
+          .filter((phase) => phase?.kill_chain_name === 'mitre-attack')
+          .map((phase) => phase.phase_name)
+          .sort(),
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => compareTechniqueIds(a.id, b.id));
+
+  return {
+    framework: 'MITRE ATT&CK',
+    domain: 'enterprise-attack',
+    version: 'v19.0',
+    source: sourceMetadata(args['attack-source'], args['attack-url'], args['attack-github-sha']),
+    techniqueCount: techniques.length,
+    activeTechniqueCount: techniques.filter((technique) => !technique.revoked && !technique.deprecated).length,
+    techniques,
+  };
+}
+
+function buildAtlasIndex(args) {
+  const raw = yaml.load(readFileSync(args['atlas-source'], 'utf8'));
+  if (!Array.isArray(raw)) {
+    throw new Error('ATLAS techniques YAML must be an array');
+  }
+
+  const techniques = raw
+    .filter((object) => object?.['object-type'] === 'technique')
+    .map((object) => ({
+      id: object.id,
+      name: object.name,
+      kind: String(object.id).includes('.', 'AML.T0000'.length) ? 'subtechnique' : 'technique',
+      revoked: false,
+      deprecated: false,
+      subtechniqueOf: object['subtechnique-of'] || null,
+      tactics: Array.isArray(object.tactics) ? [...object.tactics].sort() : [],
+      createdDate: object.created_date || null,
+      modifiedDate: object.modified_date || null,
+    }))
+    .filter((object) => /^AML\.T\d{4}(?:\.\d{3})?$/.test(object.id))
+    .sort((a, b) => compareTechniqueIds(a.id, b.id));
+
+  return {
+    framework: 'MITRE ATLAS',
+    version: 'v5.6.0',
+    source: sourceMetadata(args['atlas-source'], args['atlas-url'], args['atlas-github-sha']),
+    techniqueCount: techniques.length,
+    activeTechniqueCount: techniques.filter((technique) => !technique.revoked && !technique.deprecated).length,
+    techniques,
+  };
+}
+
+function writeJson(fileName, payload) {
+  mkdirSync(OUT_DIR, { recursive: true });
+  writeFileSync(resolve(OUT_DIR, fileName), `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  writeJson('mitre-attack-enterprise-v19.0-techniques.json', buildAttackIndex(args));
+  writeJson('mitre-atlas-v5.6.0-techniques.json', buildAtlasIndex(args));
+}
+
+main();

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -89,6 +89,7 @@ const atlasMapping = z.object({
   techniqueName: z.string(),
   tactic: z.string().optional(),
   atlasVersion: z.string().regex(/^\d+\.\d+\.\d+$/).optional(),
+  atlas_version: z.string().regex(/^\d+\.\d+\.\d+$/).optional(),
   confidence: mappingConfidence.optional(),
   evidence: z.string().min(1).optional(),
   notes: z.string().optional(),


### PR DESCRIPTION
## Summary

- pins normalized MITRE ATT&CK Enterprise v19.0 and MITRE ATLAS v5.6.0 technique indexes under `.github/pipeline/data/frameworks/`
- adds a reproducible local index builder for the official source snapshots
- wires framework mapping validation to check pinned technique IDs, active/deprecated state, and official technique names when mappings target the pinned versions

## Official Sources

- ATT&CK Enterprise v19.0: `mitre-attack/attack-stix-data`, `enterprise-attack/enterprise-attack-19.0.json`, GitHub blob `04a73232da6f55c3df32daf1479888265a3032a7`, SHA-256 `df520ea0775a57db7bff760145b02fed89290802913e056b7ed5970b02f3626a`
- MITRE ATLAS v5.6.0: `mitre-atlas/atlas-data`, `data/techniques.yaml`, GitHub blob `6e7b68650a46176ee4d72b139134d94e4061ab57`, SHA-256 `fe8d7b9e7793673d87ee839330320cdedc25357a128734c3fda625f28362be2d`

## Validation

- `npm --prefix scripts ci --no-audit --no-fund`
- `node --check scripts/framework-data.mjs`
- `node --check scripts/framework-mapping-validation.mjs`
- `node --check scripts/pipeline-build-framework-indexes.mjs`
- `node --check scripts/pipeline-run-task.mjs`
- `node --check scripts/validate-content-corpus.mjs`
- `node scripts/pipeline-schema.mjs`
- `node scripts/validate-content-corpus.mjs --files-file /tmp/threatpedia-framework-data-validator-files.txt`
- `npm --prefix site ci`
- `npm --prefix site run build`

## Notes

This PR intentionally stores compact normalized indexes instead of the full 52 MB ATT&CK STIX bundle. The source metadata records official URLs, GitHub blob SHAs, byte counts, and SHA-256 hashes so the index can be regenerated and audited without bloating the repo.
