### PR TITLE
feat(frameworks): add ATT&CK v19 corpus audit report

### DIFF
--- a/.github/pipeline/reports/framework-mapping-audit-2026-05-07.json
+++ b/.github/pipeline/reports/framework-mapping-audit-2026-05-07.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-07T01:31:25.686Z",
+  "generatedAt": "2026-05-07T13:11:08.564Z",
   "attackVersion": "v19.0",
   "source": {
     "url": "https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack-19.0.json",

--- a/.github/pipeline/reports/framework-mapping-audit-2026-05-07.json
+++ b/.github/pipeline/reports/framework-mapping-audit-2026-05-07.json
@@ -1,0 +1,14109 @@
+{
+  "generatedAt": "2026-05-07T01:31:25.686Z",
+  "attackVersion": "v19.0",
+  "source": {
+    "url": "https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack-19.0.json",
+    "githubBlobSha": "04a73232da6f55c3df32daf1479888265a3032a7",
+    "sha256": "df520ea0775a57db7bff760145b02fed89290802913e056b7ed5970b02f3626a",
+    "bytes": 52680865
+  },
+  "summary": {
+    "files": 161,
+    "mappedFiles": 161,
+    "mappings": 484,
+    "findings": 1646
+  },
+  "collectionCounts": {
+    "campaigns": {
+      "files": 14,
+      "mappedFiles": 14,
+      "mappings": 59
+    },
+    "incidents": {
+      "files": 67,
+      "mappedFiles": 67,
+      "mappings": 192
+    },
+    "threat-actors": {
+      "files": 40,
+      "mappedFiles": 40,
+      "mappings": 140
+    },
+    "zero-days": {
+      "files": 40,
+      "mappedFiles": 40,
+      "mappings": 93
+    }
+  },
+  "findingCounts": {
+    "missing-attack-version": 477,
+    "missing-confidence": 477,
+    "missing-evidence": 477,
+    "revoked-technique": 9,
+    "tactic-mismatch": 2,
+    "technique-name-mismatch": 170,
+    "unknown-technique-id": 7,
+    "v19-defense-evasion-split-candidate": 27
+  },
+  "severityCounts": {
+    "error": 16,
+    "fixable": 170,
+    "metadata-gap": 1431,
+    "review-required": 27,
+    "warning": 2
+  },
+  "findings": [
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1566.002",
+      "current": "Phishing: Spearphishing Link",
+      "recommended": "Spearphishing Link",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Link."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1566.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1566.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1566.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1204.002",
+      "current": "User Execution: Malicious File",
+      "recommended": "Malicious File",
+      "message": "Technique name should match ATT&CK v19.0: Malicious File."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1204.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1204.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1204.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1543.004",
+      "current": "Create or Modify System Process: Launch Daemon",
+      "recommended": "Launch Daemon",
+      "message": "Technique name should match ATT&CK v19.0: Launch Daemon."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1543.004",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1543.004",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1543.004",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1071.001",
+      "current": "Application Layer Protocol: Web Protocols",
+      "recommended": "Web Protocols",
+      "message": "Technique name should match ATT&CK v19.0: Web Protocols."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1071.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1071.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1071.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[4]",
+      "collection": "campaigns",
+      "techniqueId": "T1041",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[4]",
+      "collection": "campaigns",
+      "techniqueId": "T1041",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[4]",
+      "collection": "campaigns",
+      "techniqueId": "T1041",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1566.001",
+      "current": "Phishing: Spearphishing Attachment",
+      "recommended": "Spearphishing Attachment",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Attachment."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1566.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1547.001",
+      "current": "Boot or Logon Autostart Execution: Registry Run Keys / Startup Folder",
+      "recommended": "Registry Run Keys / Startup Folder",
+      "message": "Technique name should match ATT&CK v19.0: Registry Run Keys / Startup Folder."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1547.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1547.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1547.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1056.001",
+      "current": "Input Capture: Keylogging",
+      "recommended": "Keylogging",
+      "message": "Technique name should match ATT&CK v19.0: Keylogging."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1056.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1056.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1056.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1219",
+      "current": "Remote Access Software",
+      "recommended": "Remote Access Tools",
+      "message": "Technique name should match ATT&CK v19.0: Remote Access Tools."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1219",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1219",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1219",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1567.002",
+      "current": "Exfiltration Over Web Service: Exfiltration to Cloud Storage",
+      "recommended": "Exfiltration to Cloud Storage",
+      "message": "Technique name should match ATT&CK v19.0: Exfiltration to Cloud Storage."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1567.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1567.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1567.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1490",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1490",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1490",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1557",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1557",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1557",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1528",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1528",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1528",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1539",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1539",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1539",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1505.003",
+      "current": "Server Software Component: Web Shell",
+      "recommended": "Web Shell",
+      "message": "Technique name should match ATT&CK v19.0: Web Shell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1505.003",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1505.003",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1505.003",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1059.001",
+      "current": "Command and Scripting Interpreter: PowerShell",
+      "recommended": "PowerShell",
+      "message": "Technique name should match ATT&CK v19.0: PowerShell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1059.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1059.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1059.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1005",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1566.002",
+      "current": "Phishing: Spearphishing Link",
+      "recommended": "Spearphishing Link",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Link."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1566.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1566.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1566.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1528",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1528",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1528",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1550.001",
+      "current": "Use Alternate Authentication Material: Application Access Token",
+      "recommended": "Application Access Token",
+      "message": "Technique name should match ATT&CK v19.0: Application Access Token."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1550.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1550.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1550.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1550.001",
+      "current": "Defense Evasion",
+      "recommended": "Lateral Movement",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Lateral Movement."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1195.002",
+      "current": "Supply Chain Compromise: Compromise Software Supply Chain",
+      "recommended": "Compromise Software Supply Chain",
+      "message": "Technique name should match ATT&CK v19.0: Compromise Software Supply Chain."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1195.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1003.001",
+      "current": "OS Credential Dumping: LSASS Memory",
+      "recommended": "LSASS Memory",
+      "message": "Technique name should match ATT&CK v19.0: LSASS Memory."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1003.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1003.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1003.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1210",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1210",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1210",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1047",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1047",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1047",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "warning",
+      "category": "tactic-mismatch",
+      "label": "site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1047",
+      "current": "Lateral Movement",
+      "recommended": "Execution",
+      "message": "Mapped tactic \"Lateral Movement\" is not among ATT&CK v19.0 tactics: Execution."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[4]",
+      "collection": "campaigns",
+      "techniqueId": "T1021.002",
+      "current": "Remote Services: SMB/Windows Admin Shares",
+      "recommended": "SMB/Windows Admin Shares",
+      "message": "Technique name should match ATT&CK v19.0: SMB/Windows Admin Shares."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[4]",
+      "collection": "campaigns",
+      "techniqueId": "T1021.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[4]",
+      "collection": "campaigns",
+      "techniqueId": "T1021.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[4]",
+      "collection": "campaigns",
+      "techniqueId": "T1021.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[5]",
+      "collection": "campaigns",
+      "techniqueId": "T1485",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[5]",
+      "collection": "campaigns",
+      "techniqueId": "T1485",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[5]",
+      "collection": "campaigns",
+      "techniqueId": "T1485",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1566.002",
+      "current": "Phishing: Spearphishing Link",
+      "recommended": "Spearphishing Link",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Link."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1566.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1566.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1566.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1189",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1189",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1189",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1203",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1203",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1203",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1005",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/operation-cloud-hopper-msp-espionage-campaign.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1199",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/operation-cloud-hopper-msp-espionage-campaign.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1199",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/operation-cloud-hopper-msp-espionage-campaign.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1199",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/operation-cloud-hopper-msp-espionage-campaign.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1566.001",
+      "current": "Phishing: Spearphishing Attachment",
+      "recommended": "Spearphishing Attachment",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Attachment."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/operation-cloud-hopper-msp-espionage-campaign.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1566.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/operation-cloud-hopper-msp-espionage-campaign.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/operation-cloud-hopper-msp-espionage-campaign.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/operation-cloud-hopper-msp-espionage-campaign.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/operation-cloud-hopper-msp-espionage-campaign.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/operation-cloud-hopper-msp-espionage-campaign.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/campaigns/operation-cloud-hopper-msp-espionage-campaign.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1078",
+      "current": "Defense Evasion",
+      "recommended": "Initial Access, Persistence, Privilege Escalation, Stealth",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Initial Access, Persistence, Privilege Escalation, Stealth."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/operation-cloud-hopper-msp-espionage-campaign.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1071.001",
+      "current": "Application Layer Protocol: Web Protocols",
+      "recommended": "Web Protocols",
+      "message": "Technique name should match ATT&CK v19.0: Web Protocols."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/operation-cloud-hopper-msp-espionage-campaign.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1071.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/operation-cloud-hopper-msp-espionage-campaign.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1071.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/operation-cloud-hopper-msp-espionage-campaign.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1071.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/operation-truechaos.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1195.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/operation-truechaos.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/operation-truechaos.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "error",
+      "category": "revoked-technique",
+      "label": "site/src/content/campaigns/operation-truechaos.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1574.002",
+      "officialName": "DLL Side-Loading",
+      "message": "T1574.002 is revoked in pinned ATT&CK Enterprise v19.0."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/operation-truechaos.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1574.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/operation-truechaos.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1574.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/operation-truechaos.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1574.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/campaigns/operation-truechaos.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1574.002",
+      "current": "Defense Evasion",
+      "recommended": "Execution, Stealth",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Execution, Stealth."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/operation-truechaos.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1021.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/operation-truechaos.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1021.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/operation-truechaos.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1021.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/operation-truechaos.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1071.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/operation-truechaos.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1071.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/operation-truechaos.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1071.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "error",
+      "category": "unknown-technique-id",
+      "label": "site/src/content/campaigns/sandworm-ukraine-power-grid-campaign-2015.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T0822",
+      "message": "Technique ID is not present in pinned ATT&CK Enterprise v19.0."
+    },
+    {
+      "severity": "error",
+      "category": "unknown-technique-id",
+      "label": "site/src/content/campaigns/sandworm-ukraine-power-grid-campaign-2015.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T0823",
+      "message": "Technique ID is not present in pinned ATT&CK Enterprise v19.0."
+    },
+    {
+      "severity": "error",
+      "category": "unknown-technique-id",
+      "label": "site/src/content/campaigns/sandworm-ukraine-power-grid-campaign-2015.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T0831",
+      "message": "Technique ID is not present in pinned ATT&CK Enterprise v19.0."
+    },
+    {
+      "severity": "error",
+      "category": "unknown-technique-id",
+      "label": "site/src/content/campaigns/sandworm-ukraine-power-grid-campaign-2015.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T0814",
+      "message": "Technique ID is not present in pinned ATT&CK Enterprise v19.0."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1195.002",
+      "current": "Supply Chain Compromise: Compromise Software Supply Chain",
+      "recommended": "Compromise Software Supply Chain",
+      "message": "Technique name should match ATT&CK v19.0: Compromise Software Supply Chain."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1195.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1071.001",
+      "current": "Application Layer Protocol: Web Protocols",
+      "recommended": "Web Protocols",
+      "message": "Technique name should match ATT&CK v19.0: Web Protocols."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1071.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1071.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1071.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1098.001",
+      "current": "Account Manipulation: Additional Cloud Credentials",
+      "recommended": "Additional Cloud Credentials",
+      "message": "Technique name should match ATT&CK v19.0: Additional Cloud Credentials."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1098.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1098.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1098.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1484.002",
+      "current": "Domain or Tenant Policy Modification: Trust Modification",
+      "recommended": "Trust Modification",
+      "message": "Technique name should match ATT&CK v19.0: Trust Modification."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1484.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1484.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1484.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1484.002",
+      "current": "Defense Evasion",
+      "recommended": "Defense Impairment, Privilege Escalation",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Defense Impairment, Privilege Escalation."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[4]",
+      "collection": "campaigns",
+      "techniqueId": "T1114.002",
+      "current": "Email Collection: Remote Email Collection",
+      "recommended": "Remote Email Collection",
+      "message": "Technique name should match ATT&CK v19.0: Remote Email Collection."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[4]",
+      "collection": "campaigns",
+      "techniqueId": "T1114.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[4]",
+      "collection": "campaigns",
+      "techniqueId": "T1114.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[4]",
+      "collection": "campaigns",
+      "techniqueId": "T1114.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/teampcp-supply-chain-campaign-2026.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1195.002",
+      "current": "Supply Chain Compromise: Compromise Software Supply Chain",
+      "recommended": "Compromise Software Supply Chain",
+      "message": "Technique name should match ATT&CK v19.0: Compromise Software Supply Chain."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/teampcp-supply-chain-campaign-2026.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1195.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/teampcp-supply-chain-campaign-2026.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/teampcp-supply-chain-campaign-2026.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/teampcp-supply-chain-campaign-2026.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1552.001",
+      "current": "Unsecured Credentials: Credentials In Files",
+      "recommended": "Credentials In Files",
+      "message": "Technique name should match ATT&CK v19.0: Credentials In Files."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/teampcp-supply-chain-campaign-2026.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1552.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/teampcp-supply-chain-campaign-2026.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1552.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/teampcp-supply-chain-campaign-2026.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1552.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/teampcp-supply-chain-campaign-2026.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1199",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/teampcp-supply-chain-campaign-2026.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1199",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/teampcp-supply-chain-campaign-2026.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1199",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/teampcp-supply-chain-campaign-2026.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1027",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/teampcp-supply-chain-campaign-2026.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1027",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/teampcp-supply-chain-campaign-2026.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1027",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/campaigns/teampcp-supply-chain-campaign-2026.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1027",
+      "current": "Defense Evasion",
+      "recommended": "Stealth",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Stealth."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/wannacry-ransomware-campaign-2017.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/wannacry-ransomware-campaign-2017.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/wannacry-ransomware-campaign-2017.md#mitreMappings[0]",
+      "collection": "campaigns",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/wannacry-ransomware-campaign-2017.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1210",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/wannacry-ransomware-campaign-2017.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1210",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/wannacry-ransomware-campaign-2017.md#mitreMappings[1]",
+      "collection": "campaigns",
+      "techniqueId": "T1210",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/wannacry-ransomware-campaign-2017.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/wannacry-ransomware-campaign-2017.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/wannacry-ransomware-campaign-2017.md#mitreMappings[2]",
+      "collection": "campaigns",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/campaigns/wannacry-ransomware-campaign-2017.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1059.003",
+      "current": "Command and Scripting Interpreter: Windows Command Shell",
+      "recommended": "Windows Command Shell",
+      "message": "Technique name should match ATT&CK v19.0: Windows Command Shell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/campaigns/wannacry-ransomware-campaign-2017.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1059.003",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/campaigns/wannacry-ransomware-campaign-2017.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1059.003",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/campaigns/wannacry-ransomware-campaign-2017.md#mitreMappings[3]",
+      "collection": "campaigns",
+      "techniqueId": "T1059.003",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "current": "Phishing: Spearphishing Attachment",
+      "recommended": "Spearphishing Attachment",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Attachment."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1204.002",
+      "current": "User Execution: Malicious File",
+      "recommended": "Malicious File",
+      "message": "Technique name should match ATT&CK v19.0: Malicious File."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1204.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1204.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1204.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1078.004",
+      "current": "Valid Accounts: Cloud Accounts",
+      "recommended": "Cloud Accounts",
+      "message": "Technique name should match ATT&CK v19.0: Cloud Accounts."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1078.004",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1078.004",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1078.004",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1530",
+      "current": "Data from Cloud Storage Object",
+      "recommended": "Data from Cloud Storage",
+      "message": "Technique name should match ATT&CK v19.0: Data from Cloud Storage."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1530",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1530",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1530",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[4]",
+      "collection": "incidents",
+      "techniqueId": "T1567",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[4]",
+      "collection": "incidents",
+      "techniqueId": "T1567",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[4]",
+      "collection": "incidents",
+      "techniqueId": "T1567",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/anthem-health-data-breach-2015.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.002",
+      "current": "Phishing: Spearphishing Link",
+      "recommended": "Spearphishing Link",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Link."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/anthem-health-data-breach-2015.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/anthem-health-data-breach-2015.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/anthem-health-data-breach-2015.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/anthem-health-data-breach-2015.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1071",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/anthem-health-data-breach-2015.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1071",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/anthem-health-data-breach-2015.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1071",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/anthem-health-data-breach-2015.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1041",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/anthem-health-data-breach-2015.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1041",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/anthem-health-data-breach-2015.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1041",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/axios-unc1069-compromise.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/axios-unc1069-compromise.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/axios-unc1069-compromise.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/axios-unc1069-compromise.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "current": "Supply Chain Compromise: Compromise Software Supply Chain",
+      "recommended": "Compromise Software Supply Chain",
+      "message": "Technique name should match ATT&CK v19.0: Compromise Software Supply Chain."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/axios-unc1069-compromise.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/axios-unc1069-compromise.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/axios-unc1069-compromise.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/bluehammer-windows-defender-zero-day-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1068",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/bluehammer-windows-defender-zero-day-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1068",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/bluehammer-windows-defender-zero-day-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1068",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/carecloud-healthcare-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/carecloud-healthcare-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/carecloud-healthcare-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/carecloud-healthcare-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/carecloud-healthcare-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/carecloud-healthcare-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/carecloud-healthcare-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1567",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/carecloud-healthcare-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1567",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/carecloud-healthcare-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1567",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/cegedim-sante-health-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/cegedim-sante-health-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/cegedim-sante-health-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/cegedim-sante-health-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1530",
+      "current": "Data from Cloud Storage Object",
+      "recommended": "Data from Cloud Storage",
+      "message": "Technique name should match ATT&CK v19.0: Data from Cloud Storage."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/cegedim-sante-health-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1530",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/cegedim-sante-health-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1530",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/cegedim-sante-health-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1530",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/cegedim-sante-health-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1567",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/cegedim-sante-health-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1567",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/cegedim-sante-health-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1567",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/cegedim-sante-health-breach-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/cegedim-sante-health-breach-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/cegedim-sante-health-breach-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/change-healthcare-ransomware-2024.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/change-healthcare-ransomware-2024.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/change-healthcare-ransomware-2024.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/change-healthcare-ransomware-2024.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/change-healthcare-ransomware-2024.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/change-healthcare-ransomware-2024.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/change-healthcare-ransomware-2024.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1041",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/change-healthcare-ransomware-2024.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1041",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/change-healthcare-ransomware-2024.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1041",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/chipsoft-ransomware-dutch-healthcare-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/chipsoft-ransomware-dutch-healthcare-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/chipsoft-ransomware-dutch-healthcare-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/chipsoft-ransomware-dutch-healthcare-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1567",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/chipsoft-ransomware-dutch-healthcare-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1567",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/chipsoft-ransomware-dutch-healthcare-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1567",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/chipsoft-ransomware-dutch-healthcare-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/chipsoft-ransomware-dutch-healthcare-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/chipsoft-ransomware-dutch-healthcare-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/chrome-cve-2026-2441-css-zero-day.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1189",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/chrome-cve-2026-2441-css-zero-day.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1189",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/chrome-cve-2026-2441-css-zero-day.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1189",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/chrome-cve-2026-2441-css-zero-day.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1203",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/chrome-cve-2026-2441-css-zero-day.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1203",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/chrome-cve-2026-2441-css-zero-day.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1203",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/chrome-cve-2026-5281-zero-day.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1203",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/chrome-cve-2026-5281-zero-day.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1203",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/chrome-cve-2026-5281-zero-day.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1203",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/cisco-trivy-supply-chain-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "current": "Supply Chain Compromise: Compromise Software Supply Chain",
+      "recommended": "Compromise Software Supply Chain",
+      "message": "Technique name should match ATT&CK v19.0: Compromise Software Supply Chain."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/cisco-trivy-supply-chain-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/cisco-trivy-supply-chain-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/cisco-trivy-supply-chain-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/cisco-trivy-supply-chain-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1552.001",
+      "current": "Unsecured Credentials: Credentials In Files",
+      "recommended": "Credentials In Files",
+      "message": "Technique name should match ATT&CK v19.0: Credentials In Files."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/cisco-trivy-supply-chain-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1552.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/cisco-trivy-supply-chain-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1552.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/cisco-trivy-supply-chain-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1552.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/cisco-trivy-supply-chain-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1213",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/cisco-trivy-supply-chain-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1213",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/cisco-trivy-supply-chain-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1213",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/code-red-nimda-worm-outbreaks-2001.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/code-red-nimda-worm-outbreaks-2001.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/code-red-nimda-worm-outbreaks-2001.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/code-red-nimda-worm-outbreaks-2001.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "current": "Phishing: Spearphishing Attachment",
+      "recommended": "Spearphishing Attachment",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Attachment."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/code-red-nimda-worm-outbreaks-2001.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/code-red-nimda-worm-outbreaks-2001.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/code-red-nimda-worm-outbreaks-2001.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/code-red-nimda-worm-outbreaks-2001.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1498",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/code-red-nimda-worm-outbreaks-2001.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1498",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/code-red-nimda-worm-outbreaks-2001.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1498",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/colonial-pipeline-darkside-ransomware-2021.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1133",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/colonial-pipeline-darkside-ransomware-2021.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1133",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/colonial-pipeline-darkside-ransomware-2021.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1133",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/colonial-pipeline-darkside-ransomware-2021.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/colonial-pipeline-darkside-ransomware-2021.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/colonial-pipeline-darkside-ransomware-2021.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/colonial-pipeline-darkside-ransomware-2021.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/colonial-pipeline-darkside-ransomware-2021.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/colonial-pipeline-darkside-ransomware-2021.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/colonial-pipeline-darkside-ransomware-2021.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1490",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/colonial-pipeline-darkside-ransomware-2021.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1490",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/colonial-pipeline-darkside-ransomware-2021.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1490",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/conduent-data-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/conduent-data-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/conduent-data-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/conduent-data-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/conduent-data-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/conduent-data-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/conduent-data-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1048",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/conduent-data-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1048",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/conduent-data-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1048",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/conduent-data-breach-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/conduent-data-breach-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/conduent-data-breach-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/conficker-worm-2008.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1210",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/conficker-worm-2008.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1210",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/conficker-worm-2008.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1210",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/conficker-worm-2008.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1110",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/conficker-worm-2008.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1110",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/conficker-worm-2008.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1110",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/conficker-worm-2008.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1091",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/conficker-worm-2008.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1091",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/conficker-worm-2008.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1091",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/conficker-worm-2008.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1105",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/conficker-worm-2008.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1105",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/conficker-worm-2008.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1105",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/crowdstrike-falcon-global-bsod-outage-2024.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "current": "Supply Chain Compromise — Compromise Software Supply Chain",
+      "recommended": "Compromise Software Supply Chain",
+      "message": "Technique name should match ATT&CK v19.0: Compromise Software Supply Chain."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/crowdstrike-falcon-global-bsod-outage-2024.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/crowdstrike-falcon-global-bsod-outage-2024.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/crowdstrike-falcon-global-bsod-outage-2024.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/crowdstrike-falcon-global-bsod-outage-2024.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1499.004",
+      "current": "Endpoint Denial of Service — Application or System Exploitation",
+      "recommended": "Application or System Exploitation",
+      "message": "Technique name should match ATT&CK v19.0: Application or System Exploitation."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/crowdstrike-falcon-global-bsod-outage-2024.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1499.004",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/crowdstrike-falcon-global-bsod-outage-2024.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1499.004",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/crowdstrike-falcon-global-bsod-outage-2024.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1499.004",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/crowdstrike-falcon-global-bsod-outage-2024.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1561.002",
+      "current": "Disk Wipe — Disk Structure Wipe",
+      "recommended": "Disk Structure Wipe",
+      "message": "Technique name should match ATT&CK v19.0: Disk Structure Wipe."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/crowdstrike-falcon-global-bsod-outage-2024.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1561.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/crowdstrike-falcon-global-bsod-outage-2024.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1561.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/crowdstrike-falcon-global-bsod-outage-2024.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1561.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/die-linke-qilin-ransomware-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/die-linke-qilin-ransomware-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/die-linke-qilin-ransomware-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/die-linke-qilin-ransomware-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1048",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/die-linke-qilin-ransomware-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1048",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/die-linke-qilin-ransomware-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1048",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/die-linke-qilin-ransomware-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/die-linke-qilin-ransomware-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/die-linke-qilin-ransomware-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/die-linke-qilin-ransomware-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/die-linke-qilin-ransomware-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/die-linke-qilin-ransomware-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/diginotar-certificate-authority-compromise-2011.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1557",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/diginotar-certificate-authority-compromise-2011.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1557",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/diginotar-certificate-authority-compromise-2011.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1557",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/diginotar-certificate-authority-compromise-2011.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1588.004",
+      "current": "Obtain Capabilities: Digital Certificates",
+      "recommended": "Digital Certificates",
+      "message": "Technique name should match ATT&CK v19.0: Digital Certificates."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/diginotar-certificate-authority-compromise-2011.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1588.004",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/diginotar-certificate-authority-compromise-2011.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1588.004",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/diginotar-certificate-authority-compromise-2011.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1588.004",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/docketwise-immigration-data-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/docketwise-immigration-data-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/docketwise-immigration-data-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/docketwise-immigration-data-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1213",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/docketwise-immigration-data-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1213",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/docketwise-immigration-data-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1213",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/docketwise-immigration-data-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1530",
+      "current": "Data from Cloud Storage Object",
+      "recommended": "Data from Cloud Storage",
+      "message": "Technique name should match ATT&CK v19.0: Data from Cloud Storage."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/docketwise-immigration-data-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1530",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/docketwise-immigration-data-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1530",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/docketwise-immigration-data-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1530",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/drift-protocol-dprk-exploit-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1565",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/drift-protocol-dprk-exploit-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1565",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/drift-protocol-dprk-exploit-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1565",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/equifax-data-breach-2017.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/equifax-data-breach-2017.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/equifax-data-breach-2017.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/equifax-data-breach-2017.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1083",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/equifax-data-breach-2017.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1083",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/equifax-data-breach-2017.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1083",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/equifax-data-breach-2017.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1041",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/equifax-data-breach-2017.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1041",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/equifax-data-breach-2017.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1041",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/estonia-ddos-attacks-2007.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1498",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/estonia-ddos-attacks-2007.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1498",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/estonia-ddos-attacks-2007.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1498",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/european-commission-trivy-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "current": "Supply Chain Compromise: Compromise Software Supply Chain",
+      "recommended": "Compromise Software Supply Chain",
+      "message": "Technique name should match ATT&CK v19.0: Compromise Software Supply Chain."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/european-commission-trivy-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/european-commission-trivy-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/european-commission-trivy-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/european-commission-trivy-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/european-commission-trivy-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/european-commission-trivy-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/european-commission-trivy-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1530",
+      "current": "Data from Cloud Storage Object",
+      "recommended": "Data from Cloud Storage",
+      "message": "Technique name should match ATT&CK v19.0: Data from Cloud Storage."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/european-commission-trivy-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1530",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/european-commission-trivy-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1530",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/european-commission-trivy-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1530",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/european-commission-trivy-breach-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1567",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/european-commission-trivy-breach-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1567",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/european-commission-trivy-breach-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1567",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/fbi-dcsnet-surveillance-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1199",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/fbi-dcsnet-surveillance-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1199",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/fbi-dcsnet-surveillance-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1199",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/fbi-dcsnet-surveillance-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/fbi-dcsnet-surveillance-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/fbi-dcsnet-surveillance-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/fbi-dcsnet-surveillance-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/fbi-dcsnet-surveillance-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/fbi-dcsnet-surveillance-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/fireeye-red-team-tools-breach-2020.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "current": "Supply Chain Compromise: Compromise Software Supply Chain",
+      "recommended": "Compromise Software Supply Chain",
+      "message": "Technique name should match ATT&CK v19.0: Compromise Software Supply Chain."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/fireeye-red-team-tools-breach-2020.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/fireeye-red-team-tools-breach-2020.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/fireeye-red-team-tools-breach-2020.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/forticlient-ems-cve-2026-35616.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/forticlient-ems-cve-2026-35616.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/forticlient-ems-cve-2026-35616.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/foster-city-ransomware-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/foster-city-ransomware-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/foster-city-ransomware-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/hims-hers-shinyhunters-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/hims-hers-shinyhunters-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/hims-hers-shinyhunters-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/iloveyou-worm-outbreak-2000.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "current": "Phishing: Spearphishing Attachment",
+      "recommended": "Spearphishing Attachment",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Attachment."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/iloveyou-worm-outbreak-2000.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/iloveyou-worm-outbreak-2000.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/iloveyou-worm-outbreak-2000.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/iloveyou-worm-outbreak-2000.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1204.002",
+      "current": "User Execution: Malicious File",
+      "recommended": "Malicious File",
+      "message": "Technique name should match ATT&CK v19.0: Malicious File."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/iloveyou-worm-outbreak-2000.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1204.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/iloveyou-worm-outbreak-2000.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1204.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/iloveyou-worm-outbreak-2000.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1204.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/iloveyou-worm-outbreak-2000.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1059.005",
+      "current": "Command and Scripting Interpreter: Visual Basic",
+      "recommended": "Visual Basic",
+      "message": "Technique name should match ATT&CK v19.0: Visual Basic."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/iloveyou-worm-outbreak-2000.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1059.005",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/iloveyou-worm-outbreak-2000.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1059.005",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/iloveyou-worm-outbreak-2000.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1059.005",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/jbs-foods-ransomware-2021.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/jbs-foods-ransomware-2021.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/jbs-foods-ransomware-2021.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/jbs-foods-ransomware-2021.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1490",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/jbs-foods-ransomware-2021.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1490",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/jbs-foods-ransomware-2021.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1490",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/jbs-foods-ransomware-2021.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/jbs-foods-ransomware-2021.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/jbs-foods-ransomware-2021.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/kaseya-vsa-supply-chain-attack-2021.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "current": "Supply Chain Compromise: Compromise Software Supply Chain",
+      "recommended": "Compromise Software Supply Chain",
+      "message": "Technique name should match ATT&CK v19.0: Compromise Software Supply Chain."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/kaseya-vsa-supply-chain-attack-2021.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/kaseya-vsa-supply-chain-attack-2021.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/kaseya-vsa-supply-chain-attack-2021.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/kaseya-vsa-supply-chain-attack-2021.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/kaseya-vsa-supply-chain-attack-2021.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/kaseya-vsa-supply-chain-attack-2021.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/kaseya-vsa-supply-chain-attack-2021.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1059.001",
+      "current": "Command and Scripting Interpreter: PowerShell",
+      "recommended": "PowerShell",
+      "message": "Technique name should match ATT&CK v19.0: PowerShell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/kaseya-vsa-supply-chain-attack-2021.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1059.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/kaseya-vsa-supply-chain-attack-2021.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1059.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/kaseya-vsa-supply-chain-attack-2021.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1059.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/langflow-cve-2026-33017-rce-exploitation.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/langflow-cve-2026-33017-rce-exploitation.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/langflow-cve-2026-33017-rce-exploitation.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/langflow-cve-2026-33017-rce-exploitation.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1059.006",
+      "current": "Command and Scripting Interpreter: Python",
+      "recommended": "Python",
+      "message": "Technique name should match ATT&CK v19.0: Python."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/langflow-cve-2026-33017-rce-exploitation.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1059.006",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/langflow-cve-2026-33017-rce-exploitation.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1059.006",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/langflow-cve-2026-33017-rce-exploitation.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1059.006",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/langflow-cve-2026-33017-rce-exploitation.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1552.001",
+      "current": "Unsecured Credentials: Credentials in Files",
+      "recommended": "Credentials In Files",
+      "message": "Technique name should match ATT&CK v19.0: Credentials In Files."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/langflow-cve-2026-33017-rce-exploitation.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1552.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/langflow-cve-2026-33017-rce-exploitation.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1552.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/langflow-cve-2026-33017-rce-exploitation.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1552.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/lexisnexis-react2shell-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/lexisnexis-react2shell-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/lexisnexis-react2shell-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/lexisnexis-react2shell-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1552.005",
+      "current": "Unsecured Credentials: Cloud Instance Metadata API",
+      "recommended": "Cloud Instance Metadata API",
+      "message": "Technique name should match ATT&CK v19.0: Cloud Instance Metadata API."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/lexisnexis-react2shell-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1552.005",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/lexisnexis-react2shell-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1552.005",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/lexisnexis-react2shell-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1552.005",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/lexisnexis-react2shell-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1078.004",
+      "current": "Valid Accounts: Cloud Accounts",
+      "recommended": "Cloud Accounts",
+      "message": "Technique name should match ATT&CK v19.0: Cloud Accounts."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/lexisnexis-react2shell-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1078.004",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/lexisnexis-react2shell-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1078.004",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/lexisnexis-react2shell-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1078.004",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/incidents/lexisnexis-react2shell-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1078.004",
+      "current": "Defense Evasion",
+      "recommended": "Initial Access, Persistence, Privilege Escalation, Stealth",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Initial Access, Persistence, Privilege Escalation, Stealth."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/lexisnexis-react2shell-breach-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1530",
+      "current": "Data from Cloud Storage Object",
+      "recommended": "Data from Cloud Storage",
+      "message": "Technique name should match ATT&CK v19.0: Data from Cloud Storage."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/lexisnexis-react2shell-breach-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1530",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/lexisnexis-react2shell-breach-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1530",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/lexisnexis-react2shell-breach-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1530",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/log4shell-mass-exploitation-2021.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/log4shell-mass-exploitation-2021.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/log4shell-mass-exploitation-2021.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/log4shell-mass-exploitation-2021.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1059",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/log4shell-mass-exploitation-2021.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1059",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/log4shell-mass-exploitation-2021.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1059",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/log4shell-mass-exploitation-2021.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1588.006",
+      "current": "Obtain Capabilities: Vulnerabilities",
+      "recommended": "Vulnerabilities",
+      "message": "Technique name should match ATT&CK v19.0: Vulnerabilities."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/log4shell-mass-exploitation-2021.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1588.006",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/log4shell-mass-exploitation-2021.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1588.006",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/log4shell-mass-exploitation-2021.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1588.006",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/m365-oauth-device-code-phishing-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.002",
+      "current": "Phishing: Spearphishing Link",
+      "recommended": "Spearphishing Link",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Link."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/m365-oauth-device-code-phishing-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/m365-oauth-device-code-phishing-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/m365-oauth-device-code-phishing-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/m365-oauth-device-code-phishing-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1528",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/m365-oauth-device-code-phishing-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1528",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/m365-oauth-device-code-phishing-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1528",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/m365-oauth-device-code-phishing-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1550.001",
+      "current": "Use Alternate Authentication Material: Application Access Token",
+      "recommended": "Application Access Token",
+      "message": "Technique name should match ATT&CK v19.0: Application Access Token."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/m365-oauth-device-code-phishing-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1550.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/m365-oauth-device-code-phishing-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1550.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/m365-oauth-device-code-phishing-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1550.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/incidents/m365-oauth-device-code-phishing-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1550.001",
+      "current": "Defense Evasion",
+      "recommended": "Lateral Movement",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Lateral Movement."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/marks-spencer-scattered-spider-2025.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.004",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/marks-spencer-scattered-spider-2025.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.004",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/marks-spencer-scattered-spider-2025.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.004",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/marks-spencer-scattered-spider-2025.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/marks-spencer-scattered-spider-2025.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/marks-spencer-scattered-spider-2025.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/marks-spencer-scattered-spider-2025.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1021.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/marks-spencer-scattered-spider-2025.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1021.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/marks-spencer-scattered-spider-2025.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1021.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/marks-spencer-scattered-spider-2025.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/marks-spencer-scattered-spider-2025.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/marks-spencer-scattered-spider-2025.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/marks-spencer-scattered-spider-2025.md#mitreMappings[4]",
+      "collection": "incidents",
+      "techniqueId": "T1490",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/marks-spencer-scattered-spider-2025.md#mitreMappings[4]",
+      "collection": "incidents",
+      "techniqueId": "T1490",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/marks-spencer-scattered-spider-2025.md#mitreMappings[4]",
+      "collection": "incidents",
+      "techniqueId": "T1490",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/marks-spencer-scattered-spider-2025.md#mitreMappings[5]",
+      "collection": "incidents",
+      "techniqueId": "T1071.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/marks-spencer-scattered-spider-2025.md#mitreMappings[5]",
+      "collection": "incidents",
+      "techniqueId": "T1071.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/marks-spencer-scattered-spider-2025.md#mitreMappings[5]",
+      "collection": "incidents",
+      "techniqueId": "T1071.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/marriott-starwood-data-breach-2018.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/marriott-starwood-data-breach-2018.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/marriott-starwood-data-breach-2018.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/marriott-starwood-data-breach-2018.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/marriott-starwood-data-breach-2018.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/marriott-starwood-data-breach-2018.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/marriott-starwood-data-breach-2018.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1560",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/marriott-starwood-data-breach-2018.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1560",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/marriott-starwood-data-breach-2018.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1560",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/marriott-starwood-data-breach-2018.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1071",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/marriott-starwood-data-breach-2018.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1071",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/marriott-starwood-data-breach-2018.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1071",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/mcp-ecosystem-vulnerability-disclosure-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1059",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/mcp-ecosystem-vulnerability-disclosure-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1059",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/mcp-ecosystem-vulnerability-disclosure-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1059",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/mcp-ecosystem-vulnerability-disclosure-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/mcp-ecosystem-vulnerability-disclosure-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/mcp-ecosystem-vulnerability-disclosure-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/melissa-macro-virus-outbreak-1999.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "current": "Phishing: Spearphishing Attachment",
+      "recommended": "Spearphishing Attachment",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Attachment."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/melissa-macro-virus-outbreak-1999.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/melissa-macro-virus-outbreak-1999.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/melissa-macro-virus-outbreak-1999.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/melissa-macro-virus-outbreak-1999.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1204.002",
+      "current": "User Execution: Malicious File",
+      "recommended": "Malicious File",
+      "message": "Technique name should match ATT&CK v19.0: Malicious File."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/melissa-macro-virus-outbreak-1999.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1204.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/melissa-macro-virus-outbreak-1999.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1204.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/melissa-macro-virus-outbreak-1999.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1204.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/melissa-macro-virus-outbreak-1999.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1499",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/melissa-macro-virus-outbreak-1999.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1499",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/melissa-macro-virus-outbreak-1999.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1499",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/mercor-litellm-supply-chain-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.001",
+      "current": "Supply Chain Compromise: Compromise Software Dependencies and Development Tools",
+      "recommended": "Compromise Software Dependencies and Development Tools",
+      "message": "Technique name should match ATT&CK v19.0: Compromise Software Dependencies and Development Tools."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/mercor-litellm-supply-chain-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/mercor-litellm-supply-chain-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/mercor-litellm-supply-chain-breach-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/mercor-litellm-supply-chain-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1199",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/mercor-litellm-supply-chain-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1199",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/mercor-litellm-supply-chain-breach-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1199",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/mercor-litellm-supply-chain-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1552.001",
+      "current": "Unsecured Credentials: Credentials In Files",
+      "recommended": "Credentials In Files",
+      "message": "Technique name should match ATT&CK v19.0: Credentials In Files."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/mercor-litellm-supply-chain-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1552.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/mercor-litellm-supply-chain-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1552.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/mercor-litellm-supply-chain-breach-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1552.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/mercor-litellm-supply-chain-breach-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1567",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/mercor-litellm-supply-chain-breach-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1567",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/mercor-litellm-supply-chain-breach-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1567",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/mercor-litellm-supply-chain-breach-2026.md#mitreMappings[4]",
+      "collection": "incidents",
+      "techniqueId": "T1657",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/mercor-litellm-supply-chain-breach-2026.md#mitreMappings[4]",
+      "collection": "incidents",
+      "techniqueId": "T1657",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/mercor-litellm-supply-chain-breach-2026.md#mitreMappings[4]",
+      "collection": "incidents",
+      "techniqueId": "T1657",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/morris-worm-1988.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1210",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/morris-worm-1988.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1210",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/morris-worm-1988.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1210",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/morris-worm-1988.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1499",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/morris-worm-1988.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1499",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/morris-worm-1988.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1499",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/moveit-transfer-clop-mass-exploitation-2023.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/moveit-transfer-clop-mass-exploitation-2023.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/moveit-transfer-clop-mass-exploitation-2023.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/moveit-transfer-clop-mass-exploitation-2023.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1059.003",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/moveit-transfer-clop-mass-exploitation-2023.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1059.003",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/moveit-transfer-clop-mass-exploitation-2023.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1059.003",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/moveit-transfer-clop-mass-exploitation-2023.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/moveit-transfer-clop-mass-exploitation-2023.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/moveit-transfer-clop-mass-exploitation-2023.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/moveit-transfer-clop-mass-exploitation-2023.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1567.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/moveit-transfer-clop-mass-exploitation-2023.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1567.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/moveit-transfer-clop-mass-exploitation-2023.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1567.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/moveit-transfer-clop-mass-exploitation-2023.md#mitreMappings[4]",
+      "collection": "incidents",
+      "techniqueId": "T1588.006",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/moveit-transfer-clop-mass-exploitation-2023.md#mitreMappings[4]",
+      "collection": "incidents",
+      "techniqueId": "T1588.006",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/moveit-transfer-clop-mass-exploitation-2023.md#mitreMappings[4]",
+      "collection": "incidents",
+      "techniqueId": "T1588.006",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/notpetya-wiper-attack-2017.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "current": "Supply Chain Compromise: Compromise Software Supply Chain",
+      "recommended": "Compromise Software Supply Chain",
+      "message": "Technique name should match ATT&CK v19.0: Compromise Software Supply Chain."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/notpetya-wiper-attack-2017.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/notpetya-wiper-attack-2017.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/notpetya-wiper-attack-2017.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/notpetya-wiper-attack-2017.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1210",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/notpetya-wiper-attack-2017.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1210",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/notpetya-wiper-attack-2017.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1210",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/notpetya-wiper-attack-2017.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1561.002",
+      "current": "Disk Wipe: Disk Structure Wipe",
+      "recommended": "Disk Structure Wipe",
+      "message": "Technique name should match ATT&CK v19.0: Disk Structure Wipe."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/notpetya-wiper-attack-2017.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1561.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/notpetya-wiper-attack-2017.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1561.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/notpetya-wiper-attack-2017.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1561.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/notpetya-wiper-attack-2017.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1003.001",
+      "current": "OS Credential Dumping: LSASS Memory",
+      "recommended": "LSASS Memory",
+      "message": "Technique name should match ATT&CK v19.0: LSASS Memory."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/notpetya-wiper-attack-2017.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1003.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/notpetya-wiper-attack-2017.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1003.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/notpetya-wiper-attack-2017.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1003.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/operation-aurora-espionage-2009.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.002",
+      "current": "Phishing: Spearphishing Link",
+      "recommended": "Spearphishing Link",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Link."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/operation-aurora-espionage-2009.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/operation-aurora-espionage-2009.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/operation-aurora-espionage-2009.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/operation-aurora-espionage-2009.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1189",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/operation-aurora-espionage-2009.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1189",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/operation-aurora-espionage-2009.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1189",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/operation-aurora-espionage-2009.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1203",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/operation-aurora-espionage-2009.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1203",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/operation-aurora-espionage-2009.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1203",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/operation-aurora-espionage-2009.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/operation-aurora-espionage-2009.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/operation-aurora-espionage-2009.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/operation-truechaos-trueconf-zero-day-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "current": "Supply Chain Compromise: Compromise Software Supply Chain",
+      "recommended": "Compromise Software Supply Chain",
+      "message": "Technique name should match ATT&CK v19.0: Compromise Software Supply Chain."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/operation-truechaos-trueconf-zero-day-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/operation-truechaos-trueconf-zero-day-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/operation-truechaos-trueconf-zero-day-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "error",
+      "category": "revoked-technique",
+      "label": "site/src/content/incidents/operation-truechaos-trueconf-zero-day-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1574.002",
+      "officialName": "DLL Side-Loading",
+      "message": "T1574.002 is revoked in pinned ATT&CK Enterprise v19.0."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/operation-truechaos-trueconf-zero-day-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1574.002",
+      "current": "Hijack Execution Flow: DLL Side-Loading",
+      "recommended": "DLL Side-Loading",
+      "message": "Technique name should match ATT&CK v19.0: DLL Side-Loading."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/operation-truechaos-trueconf-zero-day-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1574.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/operation-truechaos-trueconf-zero-day-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1574.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/operation-truechaos-trueconf-zero-day-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1574.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/incidents/operation-truechaos-trueconf-zero-day-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1574.002",
+      "current": "Defense Evasion",
+      "recommended": "Execution, Stealth",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Execution, Stealth."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/passaic-county-medusa-ransomware-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/passaic-county-medusa-ransomware-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/passaic-county-medusa-ransomware-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/patriot-regional-emergency-comms-attack-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/patriot-regional-emergency-comms-attack-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/patriot-regional-emergency-comms-attack-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/patriot-regional-emergency-comms-attack-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1489",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/patriot-regional-emergency-comms-attack-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1489",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/patriot-regional-emergency-comms-attack-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1489",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/shamoon-saudi-aramco-wiper-attack-2012.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1485",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/shamoon-saudi-aramco-wiper-attack-2012.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1485",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/shamoon-saudi-aramco-wiper-attack-2012.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1485",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/shamoon-saudi-aramco-wiper-attack-2012.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1561.002",
+      "current": "Disk Wipe: Disk Structure Wipe",
+      "recommended": "Disk Structure Wipe",
+      "message": "Technique name should match ATT&CK v19.0: Disk Structure Wipe."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/shamoon-saudi-aramco-wiper-attack-2012.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1561.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/shamoon-saudi-aramco-wiper-attack-2012.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1561.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/shamoon-saudi-aramco-wiper-attack-2012.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1561.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "current": "Supply Chain Compromise — Compromise Software Supply Chain",
+      "recommended": "Compromise Software Supply Chain",
+      "message": "Technique name should match ATT&CK v19.0: Compromise Software Supply Chain."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1071.001",
+      "current": "Application Layer Protocol — Web Protocols",
+      "recommended": "Web Protocols",
+      "message": "Technique name should match ATT&CK v19.0: Web Protocols."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1071.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1071.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1071.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1027",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1027",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1027",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1027",
+      "current": "Defense Evasion",
+      "recommended": "Stealth",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Stealth."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1036",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1036",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1036",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1036",
+      "current": "Defense Evasion",
+      "recommended": "Stealth",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Stealth."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[4]",
+      "collection": "incidents",
+      "techniqueId": "T1083",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[4]",
+      "collection": "incidents",
+      "techniqueId": "T1083",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[4]",
+      "collection": "incidents",
+      "techniqueId": "T1083",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[5]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[5]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[5]",
+      "collection": "incidents",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/sony-pictures-destructive-attack-2014.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1485",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/sony-pictures-destructive-attack-2014.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1485",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/sony-pictures-destructive-attack-2014.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1485",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/sony-pictures-destructive-attack-2014.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/sony-pictures-destructive-attack-2014.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/sony-pictures-destructive-attack-2014.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/sql-slammer-worm-2003.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1210",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/sql-slammer-worm-2003.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1210",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/sql-slammer-worm-2003.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1210",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/sql-slammer-worm-2003.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1046",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/sql-slammer-worm-2003.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1046",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/sql-slammer-worm-2003.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1046",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/sql-slammer-worm-2003.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1498",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/sql-slammer-worm-2003.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1498",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/sql-slammer-worm-2003.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1498",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/stryker-handala-wiper-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/stryker-handala-wiper-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/stryker-handala-wiper-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/stryker-handala-wiper-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1072",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/stryker-handala-wiper-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1072",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/stryker-handala-wiper-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1072",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/stryker-handala-wiper-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1485",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/stryker-handala-wiper-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1485",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/stryker-handala-wiper-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1485",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/stuxnet-iran-nuclear-sabotage-2010.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1091",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/stuxnet-iran-nuclear-sabotage-2010.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1091",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/stuxnet-iran-nuclear-sabotage-2010.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1091",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/stuxnet-iran-nuclear-sabotage-2010.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1203",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/stuxnet-iran-nuclear-sabotage-2010.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1203",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/stuxnet-iran-nuclear-sabotage-2010.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1203",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "error",
+      "category": "unknown-technique-id",
+      "label": "site/src/content/incidents/stuxnet-iran-nuclear-sabotage-2010.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T0831",
+      "message": "Technique ID is not present in pinned ATT&CK Enterprise v19.0."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/target-pos-data-breach-2013.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/target-pos-data-breach-2013.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/target-pos-data-breach-2013.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/target-pos-data-breach-2013.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1041",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/target-pos-data-breach-2013.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1041",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/target-pos-data-breach-2013.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1041",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/trivy-cve-2026-33634.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/trivy-cve-2026-33634.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/trivy-cve-2026-33634.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/trivy-cve-2026-33634.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/trivy-cve-2026-33634.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/trivy-cve-2026-33634.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/trivy-cve-2026-33634.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1552.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/trivy-cve-2026-33634.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1552.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/trivy-cve-2026-33634.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1552.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/twitter-social-engineering-attack-2020.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.004",
+      "current": "Phishing: Spearphishing Voice",
+      "recommended": "Spearphishing Voice",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Voice."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/twitter-social-engineering-attack-2020.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.004",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/twitter-social-engineering-attack-2020.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.004",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/twitter-social-engineering-attack-2020.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.004",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/twitter-social-engineering-attack-2020.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/twitter-social-engineering-attack-2020.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/twitter-social-engineering-attack-2020.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/twitter-social-engineering-attack-2020.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1098",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/twitter-social-engineering-attack-2020.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1098",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/twitter-social-engineering-attack-2020.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1098",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/ukraine-power-grid-attack-2015.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "current": "Phishing: Spearphishing Attachment",
+      "recommended": "Spearphishing Attachment",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Attachment."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/ukraine-power-grid-attack-2015.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/ukraine-power-grid-attack-2015.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/ukraine-power-grid-attack-2015.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/ukraine-power-grid-attack-2015.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1059.001",
+      "current": "Command and Scripting Interpreter: PowerShell",
+      "recommended": "PowerShell",
+      "message": "Technique name should match ATT&CK v19.0: PowerShell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/ukraine-power-grid-attack-2015.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1059.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/ukraine-power-grid-attack-2015.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1059.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/ukraine-power-grid-attack-2015.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1059.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/ukraine-power-grid-attack-2015.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1021.001",
+      "current": "Remote Services: Remote Desktop Protocol",
+      "recommended": "Remote Desktop Protocol",
+      "message": "Technique name should match ATT&CK v19.0: Remote Desktop Protocol."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/ukraine-power-grid-attack-2015.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1021.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/ukraine-power-grid-attack-2015.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1021.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/ukraine-power-grid-attack-2015.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1021.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/ukraine-power-grid-attack-2015.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1489",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/ukraine-power-grid-attack-2015.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1489",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/ukraine-power-grid-attack-2015.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1489",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "error",
+      "category": "unknown-technique-id",
+      "label": "site/src/content/incidents/ukraine-power-grid-industroyer-2016.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T0831",
+      "message": "Technique ID is not present in pinned ATT&CK Enterprise v19.0."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/ummc-medusa-ransomware-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/ummc-medusa-ransomware-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/ummc-medusa-ransomware-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/us-office-personnel-management-breach-2015.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1213",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/us-office-personnel-management-breach-2015.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1213",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/us-office-personnel-management-breach-2015.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1213",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/vivaticket-ransomhouse-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/vivaticket-ransomhouse-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/vivaticket-ransomhouse-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/vivaticket-ransomhouse-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/vivaticket-ransomhouse-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/vivaticket-ransomhouse-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/vivaticket-ransomhouse-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1087",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/vivaticket-ransomhouse-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1087",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/vivaticket-ransomhouse-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1087",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/vivaticket-ransomhouse-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1021",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/vivaticket-ransomhouse-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1021",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/vivaticket-ransomhouse-2026.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1021",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/vivaticket-ransomhouse-2026.md#mitreMappings[4]",
+      "collection": "incidents",
+      "techniqueId": "T1567",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/vivaticket-ransomhouse-2026.md#mitreMappings[4]",
+      "collection": "incidents",
+      "techniqueId": "T1567",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/vivaticket-ransomhouse-2026.md#mitreMappings[4]",
+      "collection": "incidents",
+      "techniqueId": "T1567",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/vivaticket-ransomhouse-2026.md#mitreMappings[5]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/vivaticket-ransomhouse-2026.md#mitreMappings[5]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/vivaticket-ransomhouse-2026.md#mitreMappings[5]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/vivaticket-ransomhouse-2026.md#mitreMappings[6]",
+      "collection": "incidents",
+      "techniqueId": "T1531",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/vivaticket-ransomhouse-2026.md#mitreMappings[6]",
+      "collection": "incidents",
+      "techniqueId": "T1531",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/vivaticket-ransomhouse-2026.md#mitreMappings[6]",
+      "collection": "incidents",
+      "techniqueId": "T1531",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/volt-typhoon-critical-infrastructure-2023.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/volt-typhoon-critical-infrastructure-2023.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/volt-typhoon-critical-infrastructure-2023.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/volt-typhoon-critical-infrastructure-2023.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1003.003",
+      "current": "OS Credential Dumping: NTDS",
+      "recommended": "NTDS",
+      "message": "Technique name should match ATT&CK v19.0: NTDS."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/volt-typhoon-critical-infrastructure-2023.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1003.003",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/volt-typhoon-critical-infrastructure-2023.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1003.003",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/volt-typhoon-critical-infrastructure-2023.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1003.003",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/volt-typhoon-critical-infrastructure-2023.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1090.002",
+      "current": "Proxy: External Proxy",
+      "recommended": "External Proxy",
+      "message": "Technique name should match ATT&CK v19.0: External Proxy."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/volt-typhoon-critical-infrastructure-2023.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1090.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/volt-typhoon-critical-infrastructure-2023.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1090.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/volt-typhoon-critical-infrastructure-2023.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1090.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/volt-typhoon-critical-infrastructure-2023.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/volt-typhoon-critical-infrastructure-2023.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/volt-typhoon-critical-infrastructure-2023.md#mitreMappings[3]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/wannacry-ransomware-2017.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1210",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/wannacry-ransomware-2017.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1210",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/wannacry-ransomware-2017.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1210",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/wannacry-ransomware-2017.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/wannacry-ransomware-2017.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/wannacry-ransomware-2017.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/wannacry-ransomware-2017.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1570",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/wannacry-ransomware-2017.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1570",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/wannacry-ransomware-2017.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1570",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/winona-county-ransomware-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/winona-county-ransomware-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/winona-county-ransomware-2026.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/winona-county-ransomware-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/winona-county-ransomware-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/winona-county-ransomware-2026.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/winona-county-ransomware-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1490",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/winona-county-ransomware-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1490",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/winona-county-ransomware-2026.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1490",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/xz-utils-backdoor-2024.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.001",
+      "current": "Supply Chain Compromise: Compromise Software Dependencies and Development Tools",
+      "recommended": "Compromise Software Dependencies and Development Tools",
+      "message": "Technique name should match ATT&CK v19.0: Compromise Software Dependencies and Development Tools."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/xz-utils-backdoor-2024.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/xz-utils-backdoor-2024.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/xz-utils-backdoor-2024.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1195.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/xz-utils-backdoor-2024.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1554",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/xz-utils-backdoor-2024.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1554",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/xz-utils-backdoor-2024.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1554",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/yahoo-data-breach-2013.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/yahoo-data-breach-2013.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/yahoo-data-breach-2013.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/incidents/yahoo-data-breach-2014.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "current": "Phishing: Spearphishing Attachment",
+      "recommended": "Spearphishing Attachment",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Attachment."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/yahoo-data-breach-2014.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/yahoo-data-breach-2014.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/yahoo-data-breach-2014.md#mitreMappings[0]",
+      "collection": "incidents",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/yahoo-data-breach-2014.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1539",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/yahoo-data-breach-2014.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1539",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/yahoo-data-breach-2014.md#mitreMappings[1]",
+      "collection": "incidents",
+      "techniqueId": "T1539",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/incidents/yahoo-data-breach-2014.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1114",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/incidents/yahoo-data-breach-2014.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1114",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/incidents/yahoo-data-breach-2014.md#mitreMappings[2]",
+      "collection": "incidents",
+      "techniqueId": "T1114",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1133",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1133",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1133",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "current": "Command and Scripting Interpreter: PowerShell",
+      "recommended": "PowerShell",
+      "message": "Technique name should match ATT&CK v19.0: PowerShell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1560.001",
+      "current": "Archive Collected Data: Archive via Utility",
+      "recommended": "Archive via Utility",
+      "message": "Technique name should match ATT&CK v19.0: Archive via Utility."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1560.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1560.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1560.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[4]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567.002",
+      "current": "Exfiltration Over Web Service: Exfiltration to Cloud Storage",
+      "recommended": "Exfiltration to Cloud Storage",
+      "message": "Technique name should match ATT&CK v19.0: Exfiltration to Cloud Storage."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[4]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[4]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[4]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[5]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[5]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[5]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[6]",
+      "collection": "threat-actors",
+      "techniqueId": "T1490",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[6]",
+      "collection": "threat-actors",
+      "techniqueId": "T1490",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/akira-ransomware.md#mitreMappings[6]",
+      "collection": "threat-actors",
+      "techniqueId": "T1490",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/apt1.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.002",
+      "current": "Phishing: Spearphishing Link",
+      "recommended": "Spearphishing Link",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Link."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt1.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt1.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt1.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/apt1.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "current": "Command and Scripting Interpreter: PowerShell",
+      "recommended": "PowerShell",
+      "message": "Technique name should match ATT&CK v19.0: PowerShell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt1.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt1.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt1.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt1.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1003",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt1.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1003",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt1.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1003",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt10.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1199",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt10.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1199",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt10.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1199",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/apt10.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1560.001",
+      "current": "Archive Collected Data: Archive via Utility",
+      "recommended": "Archive via Utility",
+      "message": "Technique name should match ATT&CK v19.0: Archive via Utility."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt10.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1560.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt10.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1560.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt10.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1560.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/apt10.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1071.001",
+      "current": "Application Layer Protocol: Web Protocols",
+      "recommended": "Web Protocols",
+      "message": "Technique name should match ATT&CK v19.0: Web Protocols."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt10.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1071.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt10.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1071.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt10.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1071.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt27.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt27.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt27.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/apt27.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1505.003",
+      "current": "Server Software Component: Web Shell",
+      "recommended": "Web Shell",
+      "message": "Technique name should match ATT&CK v19.0: Web Shell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt27.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1505.003",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt27.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1505.003",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt27.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1505.003",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "error",
+      "category": "revoked-technique",
+      "label": "site/src/content/threat-actors/apt27.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1574.002",
+      "officialName": "DLL Side-Loading",
+      "message": "T1574.002 is revoked in pinned ATT&CK Enterprise v19.0."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/apt27.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1574.002",
+      "current": "Hijack Execution Flow: DLL Side-Loading",
+      "recommended": "DLL Side-Loading",
+      "message": "Technique name should match ATT&CK v19.0: DLL Side-Loading."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt27.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1574.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt27.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1574.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt27.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1574.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/threat-actors/apt27.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1574.002",
+      "current": "Defense Evasion",
+      "recommended": "Execution, Stealth",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Execution, Stealth."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/apt28.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "current": "Phishing: Spearphishing Attachment",
+      "recommended": "Spearphishing Attachment",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Attachment."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt28.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt28.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt28.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/apt28.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1071.001",
+      "current": "Application Layer Protocol: Web Protocols",
+      "recommended": "Web Protocols",
+      "message": "Technique name should match ATT&CK v19.0: Web Protocols."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt28.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1071.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt28.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1071.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt28.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1071.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/apt28.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1588.006",
+      "current": "Obtain Capabilities: Vulnerabilities",
+      "recommended": "Vulnerabilities",
+      "message": "Technique name should match ATT&CK v19.0: Vulnerabilities."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt28.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1588.006",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt28.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1588.006",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt28.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1588.006",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt28.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt28.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt28.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/apt29.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1195.002",
+      "current": "Supply Chain Compromise: Compromise Software Supply Chain",
+      "recommended": "Compromise Software Supply Chain",
+      "message": "Technique name should match ATT&CK v19.0: Compromise Software Supply Chain."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt29.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1195.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt29.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt29.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/apt29.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1484.002",
+      "current": "Domain Policy Modification: Domain Trust Modification",
+      "recommended": "Trust Modification",
+      "message": "Technique name should match ATT&CK v19.0: Trust Modification."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt29.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1484.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt29.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1484.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt29.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1484.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/threat-actors/apt29.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1484.002",
+      "current": "Defense Evasion",
+      "recommended": "Defense Impairment, Privilege Escalation",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Defense Impairment, Privilege Escalation."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/apt29.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078.004",
+      "current": "Valid Accounts: Cloud Accounts",
+      "recommended": "Cloud Accounts",
+      "message": "Technique name should match ATT&CK v19.0: Cloud Accounts."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt29.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078.004",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt29.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078.004",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt29.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078.004",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/apt29.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1550.001",
+      "current": "Use Alternate Authentication Material: Application Access Token",
+      "recommended": "Application Access Token",
+      "message": "Technique name should match ATT&CK v19.0: Application Access Token."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt29.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1550.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt29.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1550.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt29.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1550.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt31.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt31.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt31.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/apt31.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.002",
+      "current": "Phishing: Spearphishing Link",
+      "recommended": "Spearphishing Link",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Link."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt31.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt31.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt31.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/apt31.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1071.001",
+      "current": "Application Layer Protocol: Web Protocols",
+      "recommended": "Web Protocols",
+      "message": "Technique name should match ATT&CK v19.0: Web Protocols."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt31.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1071.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt31.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1071.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt31.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1071.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt38.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1657",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt38.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1657",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt38.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1657",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/apt38.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "current": "Command and Scripting Interpreter: PowerShell",
+      "recommended": "PowerShell",
+      "message": "Technique name should match ATT&CK v19.0: PowerShell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt38.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt38.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt38.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt38.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1485",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt38.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1485",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt38.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1485",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt40.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt40.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt40.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/apt40.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1505.003",
+      "current": "Server Software Component: Web Shell",
+      "recommended": "Web Shell",
+      "message": "Technique name should match ATT&CK v19.0: Web Shell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt40.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1505.003",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt40.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1505.003",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt40.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1505.003",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt40.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1003",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt40.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1003",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt40.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1003",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/apt41.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1195.002",
+      "current": "Supply Chain Compromise: Compromise Software Supply Chain",
+      "recommended": "Compromise Software Supply Chain",
+      "message": "Technique name should match ATT&CK v19.0: Compromise Software Supply Chain."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt41.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1195.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt41.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt41.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/apt41.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "current": "Command and Scripting Interpreter: PowerShell",
+      "recommended": "PowerShell",
+      "message": "Technique name should match ATT&CK v19.0: PowerShell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt41.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt41.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt41.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "error",
+      "category": "revoked-technique",
+      "label": "site/src/content/threat-actors/apt41.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1574.002",
+      "officialName": "DLL Side-Loading",
+      "message": "T1574.002 is revoked in pinned ATT&CK Enterprise v19.0."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/apt41.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1574.002",
+      "current": "Hijack Execution Flow: DLL Side-Loading",
+      "recommended": "DLL Side-Loading",
+      "message": "Technique name should match ATT&CK v19.0: DLL Side-Loading."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/apt41.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1574.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/apt41.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1574.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/apt41.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1574.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/threat-actors/apt41.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1574.002",
+      "current": "Defense Evasion",
+      "recommended": "Execution, Stealth",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Execution, Stealth."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/blackbasta.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/blackbasta.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/blackbasta.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/blackbasta.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/blackbasta.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/blackbasta.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/blackbasta.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1490",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/blackbasta.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1490",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/blackbasta.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1490",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/blackcat-alphv.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/blackcat-alphv.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/blackcat-alphv.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/blackcat-alphv.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567.002",
+      "current": "Exfiltration Over Web Service: Exfiltration to Cloud Storage",
+      "recommended": "Exfiltration to Cloud Storage",
+      "message": "Technique name should match ATT&CK v19.0: Exfiltration to Cloud Storage."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/blackcat-alphv.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/blackcat-alphv.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/blackcat-alphv.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/blackcat-alphv.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1489",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/blackcat-alphv.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1489",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/blackcat-alphv.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1489",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/cl0p-group.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/cl0p-group.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/cl0p-group.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/cl0p-group.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/cl0p-group.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/cl0p-group.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/cl0p-group.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567.002",
+      "current": "Exfiltration Over Web Service: Exfiltration to Cloud Storage",
+      "recommended": "Exfiltration to Cloud Storage",
+      "message": "Technique name should match ATT&CK v19.0: Exfiltration to Cloud Storage."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/cl0p-group.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/cl0p-group.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/cl0p-group.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/dragonforce.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/dragonforce.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/dragonforce.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/dragonforce.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/dragonforce.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/dragonforce.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/dragonforce.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1021.001",
+      "current": "Remote Services: Remote Desktop Protocol",
+      "recommended": "Remote Desktop Protocol",
+      "message": "Technique name should match ATT&CK v19.0: Remote Desktop Protocol."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/dragonforce.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1021.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/dragonforce.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1021.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/dragonforce.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1021.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/evil-corp.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/evil-corp.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/evil-corp.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/evil-corp.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "current": "Phishing: Spearphishing Attachment",
+      "recommended": "Spearphishing Attachment",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Attachment."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/evil-corp.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/evil-corp.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/evil-corp.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/evil-corp.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1055",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/evil-corp.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1055",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/evil-corp.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1055",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/threat-actors/evil-corp.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1055",
+      "current": "Defense Evasion",
+      "recommended": "Privilege Escalation, Stealth",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Privilege Escalation, Stealth."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/eviltokens.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.002",
+      "current": "Phishing: Spearphishing Link",
+      "recommended": "Spearphishing Link",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Link."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/eviltokens.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/eviltokens.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/eviltokens.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/eviltokens.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1528",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/eviltokens.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1528",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/eviltokens.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1528",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/eviltokens.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1550.001",
+      "current": "Use Alternate Authentication Material: Application Access Token",
+      "recommended": "Application Access Token",
+      "message": "Technique name should match ATT&CK v19.0: Application Access Token."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/eviltokens.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1550.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/eviltokens.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1550.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/eviltokens.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1550.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/threat-actors/eviltokens.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1550.001",
+      "current": "Defense Evasion",
+      "recommended": "Lateral Movement",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Lateral Movement."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/fin11.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/fin11.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/fin11.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/fin11.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/fin11.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/fin11.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/fin11.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "current": "Phishing: Spearphishing Attachment",
+      "recommended": "Spearphishing Attachment",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Attachment."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/fin11.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/fin11.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/fin11.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/fin12.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/fin12.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/fin12.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/fin12.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "current": "Command and Scripting Interpreter: PowerShell",
+      "recommended": "PowerShell",
+      "message": "Technique name should match ATT&CK v19.0: PowerShell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/fin12.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/fin12.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/fin12.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/fin12.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/fin12.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/fin12.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/fin7.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "current": "Phishing: Spearphishing Attachment",
+      "recommended": "Spearphishing Attachment",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Attachment."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/fin7.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/fin7.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/fin7.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/fin7.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.005",
+      "current": "Command and Scripting Interpreter: Visual Basic",
+      "recommended": "Visual Basic",
+      "message": "Technique name should match ATT&CK v19.0: Visual Basic."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/fin7.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.005",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/fin7.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.005",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/fin7.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.005",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/fin7.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1657",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/fin7.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1657",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/fin7.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1657",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/fulcrumsec.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/fulcrumsec.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/fulcrumsec.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/fulcrumsec.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1611",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/fulcrumsec.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1611",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/fulcrumsec.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1611",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/fulcrumsec.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1530",
+      "current": "Data from Cloud Storage Object",
+      "recommended": "Data from Cloud Storage",
+      "message": "Technique name should match ATT&CK v19.0: Data from Cloud Storage."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/fulcrumsec.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1530",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/fulcrumsec.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1530",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/fulcrumsec.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1530",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/fulcrumsec.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567.003",
+      "current": "Exfiltration Over Web Service: Exfiltration to Public Sites",
+      "recommended": "Exfiltration to Text Storage Sites",
+      "message": "Technique name should match ATT&CK v19.0: Exfiltration to Text Storage Sites."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/fulcrumsec.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567.003",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/fulcrumsec.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567.003",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/fulcrumsec.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567.003",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/handala.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1485",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/handala.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1485",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/handala.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1485",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/handala.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.002",
+      "current": "Phishing: Spearphishing Link",
+      "recommended": "Spearphishing Link",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Link."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/handala.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/handala.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/handala.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/handala.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1491.002",
+      "current": "Defacement: External Defacement",
+      "recommended": "External Defacement",
+      "message": "Technique name should match ATT&CK v19.0: External Defacement."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/handala.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1491.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/handala.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1491.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/handala.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1491.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/lazarus-group.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "current": "Phishing: Spearphishing Attachment",
+      "recommended": "Spearphishing Attachment",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Attachment."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/lazarus-group.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/lazarus-group.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/lazarus-group.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/lazarus-group.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1195.002",
+      "current": "Supply Chain Compromise: Compromise Software Supply Chain",
+      "recommended": "Compromise Software Supply Chain",
+      "message": "Technique name should match ATT&CK v19.0: Compromise Software Supply Chain."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/lazarus-group.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1195.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/lazarus-group.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/lazarus-group.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/lazarus-group.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1657",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/lazarus-group.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1657",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/lazarus-group.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1657",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/lazarus-group.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1485",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/lazarus-group.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1485",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/lazarus-group.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1485",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/lockbit.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/lockbit.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/lockbit.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/lockbit.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1490",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/lockbit.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1490",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/lockbit.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1490",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/lockbit.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/lockbit.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/lockbit.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/medusa.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/medusa.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/medusa.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/medusa.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/medusa.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/medusa.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/medusa.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1490",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/medusa.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1490",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/medusa.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1490",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/mr-raccoon.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1657",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/mr-raccoon.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1657",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/mr-raccoon.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1657",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/mr-raccoon.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1213",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/mr-raccoon.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1213",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/mr-raccoon.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1213",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/mr-raccoon.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1589",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/mr-raccoon.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1589",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/mr-raccoon.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1589",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "current": "Phishing: Spearphishing Attachment",
+      "recommended": "Spearphishing Attachment",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Attachment."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "current": "Command and Scripting Interpreter: PowerShell",
+      "recommended": "PowerShell",
+      "message": "Technique name should match ATT&CK v19.0: PowerShell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1003.001",
+      "current": "OS Credential Dumping: LSASS Memory",
+      "recommended": "LSASS Memory",
+      "message": "Technique name should match ATT&CK v19.0: LSASS Memory."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1003.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1003.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1003.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[4]",
+      "collection": "threat-actors",
+      "techniqueId": "T1105",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[4]",
+      "collection": "threat-actors",
+      "techniqueId": "T1105",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[4]",
+      "collection": "threat-actors",
+      "techniqueId": "T1105",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[5]",
+      "collection": "threat-actors",
+      "techniqueId": "T1074",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[5]",
+      "collection": "threat-actors",
+      "techniqueId": "T1074",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[5]",
+      "collection": "threat-actors",
+      "techniqueId": "T1074",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[6]",
+      "collection": "threat-actors",
+      "techniqueId": "T1041",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[6]",
+      "collection": "threat-actors",
+      "techniqueId": "T1041",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/muddywater.md#mitreMappings[6]",
+      "collection": "threat-actors",
+      "techniqueId": "T1041",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/play-ransomware.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/play-ransomware.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/play-ransomware.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/play-ransomware.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/play-ransomware.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/play-ransomware.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/play-ransomware.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/play-ransomware.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/play-ransomware.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/qilin.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/qilin.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/qilin.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/qilin.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567.002",
+      "current": "Exfiltration Over Web Service: Exfiltration to Cloud Storage",
+      "recommended": "Exfiltration to Cloud Storage",
+      "message": "Technique name should match ATT&CK v19.0: Exfiltration to Cloud Storage."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/qilin.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/qilin.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/qilin.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/qilin.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/qilin.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/qilin.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/qilin.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1490",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/qilin.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1490",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/qilin.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1490",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/ransomhouse.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/ransomhouse.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/ransomhouse.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/ransomhouse.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1021.004",
+      "current": "Remote Services: SSH",
+      "recommended": "SSH",
+      "message": "Technique name should match ATT&CK v19.0: SSH."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/ransomhouse.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1021.004",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/ransomhouse.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1021.004",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/ransomhouse.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1021.004",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "error",
+      "category": "revoked-technique",
+      "label": "site/src/content/threat-actors/ransomhouse.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1562.004",
+      "officialName": "Disable or Modify System Firewall",
+      "message": "T1562.004 is revoked in pinned ATT&CK Enterprise v19.0."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/ransomhouse.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1562.004",
+      "current": "Impair Defenses: Disable or Modify System Firewall",
+      "recommended": "Disable or Modify System Firewall",
+      "message": "Technique name should match ATT&CK v19.0: Disable or Modify System Firewall."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/ransomhouse.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1562.004",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/ransomhouse.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1562.004",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/ransomhouse.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1562.004",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/threat-actors/ransomhouse.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1562.004",
+      "current": "Defense Evasion",
+      "recommended": "Stealth",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Stealth."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/ransomhouse.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/ransomhouse.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/ransomhouse.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/ransomhouse.md#mitreMappings[4]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/ransomhouse.md#mitreMappings[4]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/ransomhouse.md#mitreMappings[4]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/salt-typhoon.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/salt-typhoon.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/salt-typhoon.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/salt-typhoon.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1557",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/salt-typhoon.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1557",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/salt-typhoon.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1557",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/salt-typhoon.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1014",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/salt-typhoon.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1014",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/salt-typhoon.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1014",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/threat-actors/salt-typhoon.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1014",
+      "current": "Defense Evasion",
+      "recommended": "Stealth",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Stealth."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/sandworm.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1485",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/sandworm.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1485",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/sandworm.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1485",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/sandworm.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "current": "Command and Scripting Interpreter: PowerShell",
+      "recommended": "PowerShell",
+      "message": "Technique name should match ATT&CK v19.0: PowerShell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/sandworm.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/sandworm.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/sandworm.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/sandworm.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1195.002",
+      "current": "Supply Chain Compromise: Compromise Software Supply Chain",
+      "recommended": "Compromise Software Supply Chain",
+      "message": "Technique name should match ATT&CK v19.0: Compromise Software Supply Chain."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/sandworm.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1195.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/sandworm.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/sandworm.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "error",
+      "category": "revoked-technique",
+      "label": "site/src/content/threat-actors/sandworm.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1562.001",
+      "officialName": "Disable or Modify Tools",
+      "message": "T1562.001 is revoked in pinned ATT&CK Enterprise v19.0."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/sandworm.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1562.001",
+      "current": "Impair Defenses: Disable or Modify Tools",
+      "recommended": "Disable or Modify Tools",
+      "message": "Technique name should match ATT&CK v19.0: Disable or Modify Tools."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/sandworm.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1562.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/sandworm.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1562.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/sandworm.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1562.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/threat-actors/sandworm.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1562.001",
+      "current": "Defense Evasion",
+      "recommended": "Stealth",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Stealth."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/scattered-spider.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.002",
+      "current": "Phishing: Spearphishing Link",
+      "recommended": "Spearphishing Link",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Link."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/scattered-spider.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/scattered-spider.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/scattered-spider.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/scattered-spider.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1621",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/scattered-spider.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1621",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/scattered-spider.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1621",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "error",
+      "category": "revoked-technique",
+      "label": "site/src/content/threat-actors/scattered-spider.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1656",
+      "officialName": "Impersonation",
+      "message": "T1656 is revoked in pinned ATT&CK Enterprise v19.0."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/scattered-spider.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1656",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/scattered-spider.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1656",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/scattered-spider.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1656",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/threat-actors/scattered-spider.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1656",
+      "current": "Defense Evasion",
+      "recommended": "Stealth",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Stealth."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/shinyhunters.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078.004",
+      "current": "Valid Accounts: Cloud Accounts",
+      "recommended": "Cloud Accounts",
+      "message": "Technique name should match ATT&CK v19.0: Cloud Accounts."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/shinyhunters.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078.004",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/shinyhunters.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078.004",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/shinyhunters.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078.004",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/shinyhunters.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1213",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/shinyhunters.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1213",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/shinyhunters.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1213",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/shinyhunters.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1530",
+      "current": "Data from Cloud Storage Object",
+      "recommended": "Data from Cloud Storage",
+      "message": "Technique name should match ATT&CK v19.0: Data from Cloud Storage."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/shinyhunters.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1530",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/shinyhunters.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1530",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/shinyhunters.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1530",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/shinyhunters.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/shinyhunters.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/shinyhunters.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1567",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/shinyhunters.md#mitreMappings[4]",
+      "collection": "threat-actors",
+      "techniqueId": "T1657",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/shinyhunters.md#mitreMappings[4]",
+      "collection": "threat-actors",
+      "techniqueId": "T1657",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/shinyhunters.md#mitreMappings[4]",
+      "collection": "threat-actors",
+      "techniqueId": "T1657",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/storm-2372.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.003",
+      "current": "Phishing: Spearphishing via Service",
+      "recommended": "Spearphishing via Service",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing via Service."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/storm-2372.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.003",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/storm-2372.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.003",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/storm-2372.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.003",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/storm-2372.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1528",
+      "current": "Steal or Forge Authentication Tokens",
+      "recommended": "Steal Application Access Token",
+      "message": "Technique name should match ATT&CK v19.0: Steal Application Access Token."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/storm-2372.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1528",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/storm-2372.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1528",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/storm-2372.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1528",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/storm-2372.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1098.005",
+      "current": "Account Manipulation: Device Registration",
+      "recommended": "Device Registration",
+      "message": "Technique name should match ATT&CK v19.0: Device Registration."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/storm-2372.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1098.005",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/storm-2372.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1098.005",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/storm-2372.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1098.005",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/storm-2372.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1071.001",
+      "current": "Application Layer Protocol: Web Protocols",
+      "recommended": "Web Protocols",
+      "message": "Technique name should match ATT&CK v19.0: Web Protocols."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/storm-2372.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1071.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/storm-2372.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1071.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/storm-2372.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1071.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/ta505.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "current": "Phishing: Spearphishing Attachment",
+      "recommended": "Spearphishing Attachment",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Attachment."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/ta505.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/ta505.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/ta505.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/ta505.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.005",
+      "current": "Command and Scripting Interpreter: Visual Basic",
+      "recommended": "Visual Basic",
+      "message": "Technique name should match ATT&CK v19.0: Visual Basic."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/ta505.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.005",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/ta505.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.005",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/ta505.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.005",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/ta505.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/ta505.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/ta505.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/teampcp.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1195.002",
+      "current": "Supply Chain Compromise: Compromise Software Supply Chain",
+      "recommended": "Compromise Software Supply Chain",
+      "message": "Technique name should match ATT&CK v19.0: Compromise Software Supply Chain."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/teampcp.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1195.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/teampcp.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/teampcp.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/teampcp.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1552.001",
+      "current": "Unsecured Credentials: Credentials In Files",
+      "recommended": "Credentials In Files",
+      "message": "Technique name should match ATT&CK v19.0: Credentials In Files."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/teampcp.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1552.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/teampcp.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1552.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/teampcp.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1552.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/teampcp.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1199",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/teampcp.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1199",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/teampcp.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1199",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/turla.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1071.004",
+      "current": "Application Layer Protocol: DNS",
+      "recommended": "DNS",
+      "message": "Technique name should match ATT&CK v19.0: DNS."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/turla.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1071.004",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/turla.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1071.004",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/turla.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1071.004",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/turla.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1027",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/turla.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1027",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/turla.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1027",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/threat-actors/turla.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1027",
+      "current": "Defense Evasion",
+      "recommended": "Stealth",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Stealth."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/turla.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1505.003",
+      "current": "Server Software Component: Web Shell",
+      "recommended": "Web Shell",
+      "message": "Technique name should match ATT&CK v19.0: Web Shell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/turla.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1505.003",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/turla.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1505.003",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/turla.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1505.003",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/unc6783.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.004",
+      "current": "Phishing: Spearphishing Voice",
+      "recommended": "Spearphishing Voice",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Voice."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/unc6783.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.004",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/unc6783.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.004",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/unc6783.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1566.004",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/unc6783.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1556.006",
+      "current": "Modify Authentication Process: Multi-Factor Authentication",
+      "recommended": "Multi-Factor Authentication",
+      "message": "Technique name should match ATT&CK v19.0: Multi-Factor Authentication."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/unc6783.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1556.006",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/unc6783.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1556.006",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/unc6783.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1556.006",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/unc6783.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1213",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/unc6783.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1213",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/unc6783.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1213",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/unc6783.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1657",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/unc6783.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1657",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/unc6783.md#mitreMappings[3]",
+      "collection": "threat-actors",
+      "techniqueId": "T1657",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/volt-typhoon.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1218",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/volt-typhoon.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1218",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/volt-typhoon.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1218",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/threat-actors/volt-typhoon.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1218",
+      "current": "Defense Evasion",
+      "recommended": "Stealth",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Stealth."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/volt-typhoon.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1090.002",
+      "current": "Proxy: External Proxy",
+      "recommended": "External Proxy",
+      "message": "Technique name should match ATT&CK v19.0: External Proxy."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/volt-typhoon.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1090.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/volt-typhoon.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1090.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/volt-typhoon.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1090.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/volt-typhoon.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/volt-typhoon.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/volt-typhoon.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/wizard-spider.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/wizard-spider.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/wizard-spider.md#mitreMappings[0]",
+      "collection": "threat-actors",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/threat-actors/wizard-spider.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "current": "Command and Scripting Interpreter: PowerShell",
+      "recommended": "PowerShell",
+      "message": "Technique name should match ATT&CK v19.0: PowerShell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/wizard-spider.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/wizard-spider.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/wizard-spider.md#mitreMappings[1]",
+      "collection": "threat-actors",
+      "techniqueId": "T1059.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/threat-actors/wizard-spider.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1055",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/threat-actors/wizard-spider.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1055",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/threat-actors/wizard-spider.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1055",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/threat-actors/wizard-spider.md#mitreMappings[2]",
+      "collection": "threat-actors",
+      "techniqueId": "T1055",
+      "current": "Defense Evasion",
+      "recommended": "Privilege Escalation, Stealth",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Privilege Escalation, Stealth."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/adobe-acrobat-and-reader-cve-2026-34621.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1203",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/adobe-acrobat-and-reader-cve-2026-34621.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1203",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/adobe-acrobat-and-reader-cve-2026-34621.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1203",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/adobe-acrobat-and-reader-cve-2026-34621.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1566.001",
+      "current": "Phishing: Spearphishing Attachment",
+      "recommended": "Spearphishing Attachment",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Attachment."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/adobe-acrobat-and-reader-cve-2026-34621.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1566.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/adobe-acrobat-and-reader-cve-2026-34621.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/adobe-acrobat-and-reader-cve-2026-34621.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/adobe-acrobat-cve-2020-9715.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1189",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/adobe-acrobat-cve-2020-9715.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1189",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/adobe-acrobat-cve-2020-9715.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1189",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/adobe-acrobat-cve-2020-9715.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/adobe-acrobat-cve-2020-9715.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/adobe-acrobat-cve-2020-9715.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/apache-activemq-cve-2026-34197.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/apache-activemq-cve-2026-34197.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/apache-activemq-cve-2026-34197.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/apache-activemq-cve-2026-34197.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/apache-activemq-cve-2026-34197.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/apache-activemq-cve-2026-34197.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/apache-struts-rce-cve-2017-5638.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/apache-struts-rce-cve-2017-5638.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/apache-struts-rce-cve-2017-5638.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/bluehammer-windows-defender-lpe-2026.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1068",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/bluehammer-windows-defender-lpe-2026.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1068",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/bluehammer-windows-defender-lpe-2026.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1068",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/chrome-dawn-cve-2026-5281.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1189",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/chrome-dawn-cve-2026-5281.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1189",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/chrome-dawn-cve-2026-5281.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1189",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/chrome-dawn-cve-2026-5281.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1068",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/chrome-dawn-cve-2026-5281.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1068",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/chrome-dawn-cve-2026-5281.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1068",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20122.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20122.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20122.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20122.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1565.001",
+      "current": "Data Manipulation: Stored Data Manipulation",
+      "recommended": "Stored Data Manipulation",
+      "message": "Technique name should match ATT&CK v19.0: Stored Data Manipulation."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20122.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1565.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20122.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1565.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20122.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1565.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20122.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1548",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20122.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1548",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20122.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1548",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20128.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1552.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20128.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1552.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20128.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1552.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20128.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20128.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20128.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20128.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1078",
+      "current": "Defense Evasion",
+      "recommended": "Initial Access, Persistence, Privilege Escalation, Stealth",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Initial Access, Persistence, Privilege Escalation, Stealth."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20133.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1083",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20133.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1083",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20133.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1083",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20133.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1005",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20133.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20133.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/cisco-fmc-cve-2026-20131.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/cisco-fmc-cve-2026-20131.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/cisco-fmc-cve-2026-20131.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/cisco-fmc-cve-2026-20131.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/cisco-fmc-cve-2026-20131.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/cisco-fmc-cve-2026-20131.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/cisco-fmc-cve-2026-20131.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1133",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/cisco-fmc-cve-2026-20131.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1133",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/cisco-fmc-cve-2026-20131.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1133",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/cisco-fmc-cve-2026-20131.md#mitreMappings[3]",
+      "collection": "zero-days",
+      "techniqueId": "T1649",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/cisco-fmc-cve-2026-20131.md#mitreMappings[3]",
+      "collection": "zero-days",
+      "techniqueId": "T1649",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/cisco-fmc-cve-2026-20131.md#mitreMappings[3]",
+      "collection": "zero-days",
+      "techniqueId": "T1649",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/connectwise-screenconnect-cve-2024-1708.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/connectwise-screenconnect-cve-2024-1708.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/connectwise-screenconnect-cve-2024-1708.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/connectwise-screenconnect-cve-2024-1708.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1083",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/connectwise-screenconnect-cve-2024-1708.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1083",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/connectwise-screenconnect-cve-2024-1708.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1083",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/connectwise-screenconnect-cve-2024-1708.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1505.003",
+      "current": "Server Software Component: Web Shell",
+      "recommended": "Web Shell",
+      "message": "Technique name should match ATT&CK v19.0: Web Shell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/connectwise-screenconnect-cve-2024-1708.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1505.003",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/connectwise-screenconnect-cve-2024-1708.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1505.003",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/connectwise-screenconnect-cve-2024-1708.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1505.003",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/connectwise-screenconnect-cve-2024-1708.md#mitreMappings[3]",
+      "collection": "zero-days",
+      "techniqueId": "T1210",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/connectwise-screenconnect-cve-2024-1708.md#mitreMappings[3]",
+      "collection": "zero-days",
+      "techniqueId": "T1210",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/connectwise-screenconnect-cve-2024-1708.md#mitreMappings[3]",
+      "collection": "zero-days",
+      "techniqueId": "T1210",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/connectwise-screenconnect-cve-2024-1708.md#mitreMappings[4]",
+      "collection": "zero-days",
+      "techniqueId": "T1486",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/connectwise-screenconnect-cve-2024-1708.md#mitreMappings[4]",
+      "collection": "zero-days",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/connectwise-screenconnect-cve-2024-1708.md#mitreMappings[4]",
+      "collection": "zero-days",
+      "techniqueId": "T1486",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/d-link-dir-823x-cve-2025-29635.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/d-link-dir-823x-cve-2025-29635.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/d-link-dir-823x-cve-2025-29635.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/d-link-dir-823x-cve-2025-29635.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.004",
+      "current": "Command and Scripting Interpreter: Unix Shell",
+      "recommended": "Unix Shell",
+      "message": "Technique name should match ATT&CK v19.0: Unix Shell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/d-link-dir-823x-cve-2025-29635.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.004",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/d-link-dir-823x-cve-2025-29635.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.004",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/d-link-dir-823x-cve-2025-29635.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.004",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/d-link-dir-823x-cve-2025-29635.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1498.001",
+      "current": "Network Denial of Service: Direct Network Flood",
+      "recommended": "Direct Network Flood",
+      "message": "Technique name should match ATT&CK v19.0: Direct Network Flood."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/d-link-dir-823x-cve-2025-29635.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1498.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/d-link-dir-823x-cve-2025-29635.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1498.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/d-link-dir-823x-cve-2025-29635.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1498.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/eternalblue-ms17-010-cve-2017-0144.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1210",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/eternalblue-ms17-010-cve-2017-0144.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1210",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/eternalblue-ms17-010-cve-2017-0144.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1210",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/forticlient-ems-cve-2026-35616.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/forticlient-ems-cve-2026-35616.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/forticlient-ems-cve-2026-35616.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/forticlient-ems-cve-2026-35616.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/forticlient-ems-cve-2026-35616.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/forticlient-ems-cve-2026-35616.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/forticlient-ems-cve-2026-35616.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1072",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/forticlient-ems-cve-2026-35616.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1072",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/forticlient-ems-cve-2026-35616.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1072",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/fortinet-forticlient-ems-cve-2026-21643.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/fortinet-forticlient-ems-cve-2026-21643.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/fortinet-forticlient-ems-cve-2026-21643.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/fortinet-forticlient-ems-cve-2026-21643.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.004",
+      "current": "Command and Scripting Interpreter: Unix Shell",
+      "recommended": "Unix Shell",
+      "message": "Technique name should match ATT&CK v19.0: Unix Shell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/fortinet-forticlient-ems-cve-2026-21643.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.004",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/fortinet-forticlient-ems-cve-2026-21643.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.004",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/fortinet-forticlient-ems-cve-2026-21643.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.004",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/github-enterprise-server-cve-2026-3854.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/github-enterprise-server-cve-2026-3854.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/github-enterprise-server-cve-2026-3854.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/github-enterprise-server-cve-2026-3854.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/github-enterprise-server-cve-2026-3854.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/github-enterprise-server-cve-2026-3854.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/github-enterprise-server-cve-2026-3854.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1083",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/github-enterprise-server-cve-2026-3854.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1083",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/github-enterprise-server-cve-2026-3854.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1083",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/github-enterprise-server-cve-2026-3854.md#mitreMappings[3]",
+      "collection": "zero-days",
+      "techniqueId": "T1552",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/github-enterprise-server-cve-2026-3854.md#mitreMappings[3]",
+      "collection": "zero-days",
+      "techniqueId": "T1552",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/github-enterprise-server-cve-2026-3854.md#mitreMappings[3]",
+      "collection": "zero-days",
+      "techniqueId": "T1552",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/heartbleed-openssl-cve-2014-0160.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1005",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/heartbleed-openssl-cve-2014-0160.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/heartbleed-openssl-cve-2014-0160.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1005",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/heartbleed-openssl-cve-2014-0160.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1552.004",
+      "current": "Unsecured Credentials: Private Keys",
+      "recommended": "Private Keys",
+      "message": "Technique name should match ATT&CK v19.0: Private Keys."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/heartbleed-openssl-cve-2014-0160.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1552.004",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/heartbleed-openssl-cve-2014-0160.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1552.004",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/heartbleed-openssl-cve-2014-0160.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1552.004",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/ivanti-epmm-cve-2026-1340.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/ivanti-epmm-cve-2026-1340.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/ivanti-epmm-cve-2026-1340.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/ivanti-epmm-cve-2026-1340.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.004",
+      "current": "Command and Scripting Interpreter: Unix Shell",
+      "recommended": "Unix Shell",
+      "message": "Technique name should match ATT&CK v19.0: Unix Shell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/ivanti-epmm-cve-2026-1340.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.004",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/ivanti-epmm-cve-2026-1340.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.004",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/ivanti-epmm-cve-2026-1340.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.004",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/ivanti-epmm-cve-2026-1340.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1505.003",
+      "current": "Server Software Component: Web Shell",
+      "recommended": "Web Shell",
+      "message": "Technique name should match ATT&CK v19.0: Web Shell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/ivanti-epmm-cve-2026-1340.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1505.003",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/ivanti-epmm-cve-2026-1340.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1505.003",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/ivanti-epmm-cve-2026-1340.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1505.003",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/ivanti-epmm-cve-2026-1340.md#mitreMappings[3]",
+      "collection": "zero-days",
+      "techniqueId": "T1496",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/ivanti-epmm-cve-2026-1340.md#mitreMappings[3]",
+      "collection": "zero-days",
+      "techniqueId": "T1496",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/ivanti-epmm-cve-2026-1340.md#mitreMappings[3]",
+      "collection": "zero-days",
+      "techniqueId": "T1496",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/jetbrains-teamcity-cve-2024-27199.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/jetbrains-teamcity-cve-2024-27199.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/jetbrains-teamcity-cve-2024-27199.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/jetbrains-teamcity-cve-2024-27199.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1136.001",
+      "current": "Create Account: Local Account",
+      "recommended": "Local Account",
+      "message": "Technique name should match ATT&CK v19.0: Local Account."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/jetbrains-teamcity-cve-2024-27199.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1136.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/jetbrains-teamcity-cve-2024-27199.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1136.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/jetbrains-teamcity-cve-2024-27199.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1136.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/kentico-kentico-xperience-cve-2025-2749.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1505.003",
+      "current": "Server Software Component: Web Shell",
+      "recommended": "Web Shell",
+      "message": "Technique name should match ATT&CK v19.0: Web Shell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/kentico-kentico-xperience-cve-2025-2749.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1505.003",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/kentico-kentico-xperience-cve-2025-2749.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1505.003",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/kentico-kentico-xperience-cve-2025-2749.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1505.003",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/kentico-kentico-xperience-cve-2025-2749.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/kentico-kentico-xperience-cve-2025-2749.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/kentico-kentico-xperience-cve-2025-2749.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/linux-kernel-cve-2026-31431.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1068",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/linux-kernel-cve-2026-31431.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1068",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/linux-kernel-cve-2026-31431.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1068",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/linux-kernel-cve-2026-31431.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.004",
+      "current": "Command and Script Interpreter: Unix Shell",
+      "recommended": "Unix Shell",
+      "message": "Technique name should match ATT&CK v19.0: Unix Shell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/linux-kernel-cve-2026-31431.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.004",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/linux-kernel-cve-2026-31431.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.004",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/linux-kernel-cve-2026-31431.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.004",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/linux-kernel-cve-2026-31431.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1548.001",
+      "current": "Abuse Elevation Control Mechanism: Setuid and Setgid",
+      "recommended": "Setuid and Setgid",
+      "message": "Technique name should match ATT&CK v19.0: Setuid and Setgid."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/linux-kernel-cve-2026-31431.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1548.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/linux-kernel-cve-2026-31431.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1548.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/linux-kernel-cve-2026-31431.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1548.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/log4shell-apache-log4j-cve-2021-44228.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/log4shell-apache-log4j-cve-2021-44228.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/log4shell-apache-log4j-cve-2021-44228.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/log4shell-apache-log4j-cve-2021-44228.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1105",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/log4shell-apache-log4j-cve-2021-44228.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1105",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/log4shell-apache-log4j-cve-2021-44228.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1105",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/marimo-marimo-cve-2026-39987.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/marimo-marimo-cve-2026-39987.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/marimo-marimo-cve-2026-39987.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/marimo-marimo-cve-2026-39987.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/marimo-marimo-cve-2026-39987.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/marimo-marimo-cve-2026-39987.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/marimo-marimo-cve-2026-39987.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1552.001",
+      "current": "Unsecured Credentials: Credentials in Files",
+      "recommended": "Credentials In Files",
+      "message": "Technique name should match ATT&CK v19.0: Credentials In Files."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/marimo-marimo-cve-2026-39987.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1552.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/marimo-marimo-cve-2026-39987.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1552.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/marimo-marimo-cve-2026-39987.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1552.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/microsoft-exchange-server-cve-2023-21529.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/microsoft-exchange-server-cve-2023-21529.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/microsoft-exchange-server-cve-2023-21529.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/microsoft-exchange-server-cve-2023-21529.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/microsoft-exchange-server-cve-2023-21529.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/microsoft-exchange-server-cve-2023-21529.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/microsoft-office-cve-2009-0238.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1203",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/microsoft-office-cve-2009-0238.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1203",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/microsoft-office-cve-2009-0238.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1203",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/microsoft-office-cve-2009-0238.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1566.001",
+      "current": "Phishing: Spearphishing Attachment",
+      "recommended": "Spearphishing Attachment",
+      "message": "Technique name should match ATT&CK v19.0: Spearphishing Attachment."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/microsoft-office-cve-2009-0238.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1566.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/microsoft-office-cve-2009-0238.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/microsoft-office-cve-2009-0238.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1566.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/microsoft-sharepoint-server-cve-2026-32201.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/microsoft-sharepoint-server-cve-2026-32201.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/microsoft-sharepoint-server-cve-2026-32201.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/microsoft-sharepoint-server-cve-2026-32201.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/microsoft-sharepoint-server-cve-2026-32201.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/microsoft-sharepoint-server-cve-2026-32201.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/microsoft-visual-basic-for-applications-vba--cve-2012-1854.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1574.001",
+      "current": "Hijack Execution Flow: DLL Search Order Hijacking",
+      "recommended": "DLL",
+      "message": "Technique name should match ATT&CK v19.0: DLL."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/microsoft-visual-basic-for-applications-vba--cve-2012-1854.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1574.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/microsoft-visual-basic-for-applications-vba--cve-2012-1854.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1574.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/microsoft-visual-basic-for-applications-vba--cve-2012-1854.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1574.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "warning",
+      "category": "tactic-mismatch",
+      "label": "site/src/content/zero-days/microsoft-visual-basic-for-applications-vba--cve-2012-1854.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1574.001",
+      "current": "Persistence",
+      "recommended": "Execution, Stealth",
+      "message": "Mapped tactic \"Persistence\" is not among ATT&CK v19.0 tactics: Execution, Stealth."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/microsoft-visual-basic-for-applications-vba--cve-2012-1854.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1204.002",
+      "current": "User Execution: Malicious File",
+      "recommended": "Malicious File",
+      "message": "Technique name should match ATT&CK v19.0: Malicious File."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/microsoft-visual-basic-for-applications-vba--cve-2012-1854.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1204.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/microsoft-visual-basic-for-applications-vba--cve-2012-1854.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1204.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/microsoft-visual-basic-for-applications-vba--cve-2012-1854.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1204.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/microsoft-windows-cve-2023-36424.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1068",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/microsoft-windows-cve-2023-36424.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1068",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/microsoft-windows-cve-2023-36424.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1068",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/microsoft-windows-cve-2025-60710.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1068",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/microsoft-windows-cve-2025-60710.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1068",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/microsoft-windows-cve-2025-60710.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1068",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "error",
+      "category": "revoked-technique",
+      "label": "site/src/content/zero-days/microsoft-windows-cve-2026-32202.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1562",
+      "officialName": "Impair Defenses",
+      "message": "T1562 is revoked in pinned ATT&CK Enterprise v19.0."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/microsoft-windows-cve-2026-32202.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1562",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/microsoft-windows-cve-2026-32202.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1562",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/microsoft-windows-cve-2026-32202.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1562",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/zero-days/microsoft-windows-cve-2026-32202.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1562",
+      "current": "Defense Evasion",
+      "recommended": "Stealth",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Stealth."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/palo-alto-pan-os-cve-2024-3400.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/palo-alto-pan-os-cve-2024-3400.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/palo-alto-pan-os-cve-2024-3400.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/papercut-ng-mf-cve-2023-27351.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/papercut-ng-mf-cve-2023-27351.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/papercut-ng-mf-cve-2023-27351.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/papercut-ng-mf-cve-2023-27351.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1589.001",
+      "current": "Gather Victim Identity Information: Credentials",
+      "recommended": "Credentials",
+      "message": "Technique name should match ATT&CK v19.0: Credentials."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/papercut-ng-mf-cve-2023-27351.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1589.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/papercut-ng-mf-cve-2023-27351.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1589.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/papercut-ng-mf-cve-2023-27351.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1589.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/quest-kace-systems-management-appliance-sma--cve-2025-32975.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/quest-kace-systems-management-appliance-sma--cve-2025-32975.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/quest-kace-systems-management-appliance-sma--cve-2025-32975.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/samsung-magicinfo-9-server-cve-2024-7399.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/samsung-magicinfo-9-server-cve-2024-7399.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/samsung-magicinfo-9-server-cve-2024-7399.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/samsung-magicinfo-9-server-cve-2024-7399.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1505.003",
+      "current": "Server Software Component: Web Shell",
+      "recommended": "Web Shell",
+      "message": "Technique name should match ATT&CK v19.0: Web Shell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/samsung-magicinfo-9-server-cve-2024-7399.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1505.003",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/samsung-magicinfo-9-server-cve-2024-7399.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1505.003",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/samsung-magicinfo-9-server-cve-2024-7399.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1505.003",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/samsung-magicinfo-9-server-cve-2024-7399.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.007",
+      "current": "Command and Scripting Interpreter: JavaScript",
+      "recommended": "JavaScript",
+      "message": "Technique name should match ATT&CK v19.0: JavaScript."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/samsung-magicinfo-9-server-cve-2024-7399.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.007",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/samsung-magicinfo-9-server-cve-2024-7399.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.007",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/samsung-magicinfo-9-server-cve-2024-7399.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.007",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/simplehelp-simplehelp-cve-2024-57726.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1548",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/simplehelp-simplehelp-cve-2024-57726.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1548",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/simplehelp-simplehelp-cve-2024-57726.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1548",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/simplehelp-simplehelp-cve-2024-57726.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1098",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/simplehelp-simplehelp-cve-2024-57726.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1098",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/simplehelp-simplehelp-cve-2024-57726.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1098",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/simplehelp-simplehelp-cve-2024-57726.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/simplehelp-simplehelp-cve-2024-57726.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/simplehelp-simplehelp-cve-2024-57726.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/simplehelp-simplehelp-cve-2024-57728.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1505.003",
+      "current": "Server Software Component: Web Shell",
+      "recommended": "Web Shell",
+      "message": "Technique name should match ATT&CK v19.0: Web Shell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/simplehelp-simplehelp-cve-2024-57728.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1505.003",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/simplehelp-simplehelp-cve-2024-57728.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1505.003",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/simplehelp-simplehelp-cve-2024-57728.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1505.003",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/simplehelp-simplehelp-cve-2024-57728.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/simplehelp-simplehelp-cve-2024-57728.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/simplehelp-simplehelp-cve-2024-57728.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/simplehelp-simplehelp-cve-2024-57728.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1210",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/simplehelp-simplehelp-cve-2024-57728.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1210",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/simplehelp-simplehelp-cve-2024-57728.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1210",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/stuxnet-lnk-shortcut-cve-2010-2568.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1091",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/stuxnet-lnk-shortcut-cve-2010-2568.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1091",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/stuxnet-lnk-shortcut-cve-2010-2568.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1091",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/stuxnet-lnk-shortcut-cve-2010-2568.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1203",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/stuxnet-lnk-shortcut-cve-2010-2568.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1203",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/stuxnet-lnk-shortcut-cve-2010-2568.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1203",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "error",
+      "category": "unknown-technique-id",
+      "label": "site/src/content/zero-days/stuxnet-lnk-shortcut-cve-2010-2568.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T0831",
+      "message": "Technique ID is not present in pinned ATT&CK Enterprise v19.0."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/synacor-zimbra-collaboration-suite-zcs--cve-2025-48700.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.007",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/synacor-zimbra-collaboration-suite-zcs--cve-2025-48700.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.007",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/synacor-zimbra-collaboration-suite-zcs--cve-2025-48700.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.007",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/synacor-zimbra-collaboration-suite-zcs--cve-2025-48700.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1185",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/synacor-zimbra-collaboration-suite-zcs--cve-2025-48700.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1185",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/synacor-zimbra-collaboration-suite-zcs--cve-2025-48700.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1185",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/trueconf-cve-2026-3502.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1195.002",
+      "current": "Supply Chain Compromise: Compromise Software Supply Chain",
+      "recommended": "Compromise Software Supply Chain",
+      "message": "Technique name should match ATT&CK v19.0: Compromise Software Supply Chain."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/trueconf-cve-2026-3502.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1195.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/trueconf-cve-2026-3502.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/trueconf-cve-2026-3502.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1195.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "error",
+      "category": "revoked-technique",
+      "label": "site/src/content/zero-days/trueconf-cve-2026-3502.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1574.002",
+      "officialName": "DLL Side-Loading",
+      "message": "T1574.002 is revoked in pinned ATT&CK Enterprise v19.0."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/trueconf-cve-2026-3502.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1574.002",
+      "current": "Hijack Execution Flow: DLL Side-Loading",
+      "recommended": "DLL Side-Loading",
+      "message": "Technique name should match ATT&CK v19.0: DLL Side-Loading."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/trueconf-cve-2026-3502.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1574.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/trueconf-cve-2026-3502.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1574.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/trueconf-cve-2026-3502.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1574.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/zero-days/trueconf-cve-2026-3502.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1574.002",
+      "current": "Defense Evasion",
+      "recommended": "Execution, Stealth",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Execution, Stealth."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/trueconf-cve-2026-3502.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1071.001",
+      "current": "Application Layer Protocol: Web Protocols",
+      "recommended": "Web Protocols",
+      "message": "Technique name should match ATT&CK v19.0: Web Protocols."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/trueconf-cve-2026-3502.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1071.001",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/trueconf-cve-2026-3502.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1071.001",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/trueconf-cve-2026-3502.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1071.001",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/trueconf-cve-2026-3502.md#mitreMappings[3]",
+      "collection": "zero-days",
+      "techniqueId": "T1553.002",
+      "current": "Subvert Trust Controls: Code Signing",
+      "recommended": "Code Signing",
+      "message": "Technique name should match ATT&CK v19.0: Code Signing."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/trueconf-cve-2026-3502.md#mitreMappings[3]",
+      "collection": "zero-days",
+      "techniqueId": "T1553.002",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/trueconf-cve-2026-3502.md#mitreMappings[3]",
+      "collection": "zero-days",
+      "techniqueId": "T1553.002",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/trueconf-cve-2026-3502.md#mitreMappings[3]",
+      "collection": "zero-days",
+      "techniqueId": "T1553.002",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/zero-days/trueconf-cve-2026-3502.md#mitreMappings[3]",
+      "collection": "zero-days",
+      "techniqueId": "T1553.002",
+      "current": "Defense Evasion",
+      "recommended": "Defense Impairment",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Defense Impairment."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/webpros-cpanel-and-whm-and-wp2-wordpress-sq-cve-2026-41940.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/webpros-cpanel-and-whm-and-wp2-wordpress-sq-cve-2026-41940.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/webpros-cpanel-and-whm-and-wp2-wordpress-sq-cve-2026-41940.md#mitreMappings[0]",
+      "collection": "zero-days",
+      "techniqueId": "T1190",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "fixable",
+      "category": "technique-name-mismatch",
+      "label": "site/src/content/zero-days/webpros-cpanel-and-whm-and-wp2-wordpress-sq-cve-2026-41940.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.004",
+      "current": "Command and Script Interpreter: Unix Shell",
+      "recommended": "Unix Shell",
+      "message": "Technique name should match ATT&CK v19.0: Unix Shell."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/webpros-cpanel-and-whm-and-wp2-wordpress-sq-cve-2026-41940.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.004",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/webpros-cpanel-and-whm-and-wp2-wordpress-sq-cve-2026-41940.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.004",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/webpros-cpanel-and-whm-and-wp2-wordpress-sq-cve-2026-41940.md#mitreMappings[1]",
+      "collection": "zero-days",
+      "techniqueId": "T1059.004",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-attack-version",
+      "label": "site/src/content/zero-days/webpros-cpanel-and-whm-and-wp2-wordpress-sq-cve-2026-41940.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1078",
+      "recommended": "v19.0",
+      "message": "Mapping is missing attackVersion/attack_version metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-confidence",
+      "label": "site/src/content/zero-days/webpros-cpanel-and-whm-and-wp2-wordpress-sq-cve-2026-41940.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing confidence metadata."
+    },
+    {
+      "severity": "metadata-gap",
+      "category": "missing-evidence",
+      "label": "site/src/content/zero-days/webpros-cpanel-and-whm-and-wp2-wordpress-sq-cve-2026-41940.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1078",
+      "message": "Mapping is missing evidence metadata."
+    },
+    {
+      "severity": "review-required",
+      "category": "v19-defense-evasion-split-candidate",
+      "label": "site/src/content/zero-days/webpros-cpanel-and-whm-and-wp2-wordpress-sq-cve-2026-41940.md#mitreMappings[2]",
+      "collection": "zero-days",
+      "techniqueId": "T1078",
+      "current": "Defense Evasion",
+      "recommended": "Initial Access, Persistence, Privilege Escalation, Stealth",
+      "message": "Mapped tactic \"Defense Evasion\" is not among ATT&CK v19.0 tactics: Initial Access, Persistence, Privilege Escalation, Stealth."
+    }
+  ]
+}

--- a/.github/pipeline/reports/framework-mapping-audit-2026-05-07.json
+++ b/.github/pipeline/reports/framework-mapping-audit-2026-05-07.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-07T13:11:08.564Z",
+  "generatedAt": "2026-05-07T13:32:57.421Z",
   "attackVersion": "v19.0",
   "source": {
     "url": "https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack-19.0.json",
@@ -70,7 +70,7 @@
       "collection": "campaigns",
       "techniqueId": "T1566.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -105,7 +105,7 @@
       "collection": "campaigns",
       "techniqueId": "T1204.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -140,7 +140,7 @@
       "collection": "campaigns",
       "techniqueId": "T1543.004",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -175,7 +175,7 @@
       "collection": "campaigns",
       "techniqueId": "T1071.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -200,7 +200,7 @@
       "collection": "campaigns",
       "techniqueId": "T1041",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -235,7 +235,7 @@
       "collection": "campaigns",
       "techniqueId": "T1566.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -270,7 +270,7 @@
       "collection": "campaigns",
       "techniqueId": "T1547.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -305,7 +305,7 @@
       "collection": "campaigns",
       "techniqueId": "T1056.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -340,7 +340,7 @@
       "collection": "campaigns",
       "techniqueId": "T1219",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -365,7 +365,7 @@
       "collection": "campaigns",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -400,7 +400,7 @@
       "collection": "campaigns",
       "techniqueId": "T1567.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -425,7 +425,7 @@
       "collection": "campaigns",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -450,7 +450,7 @@
       "collection": "campaigns",
       "techniqueId": "T1490",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -475,7 +475,7 @@
       "collection": "campaigns",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -500,7 +500,7 @@
       "collection": "campaigns",
       "techniqueId": "T1557",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -525,7 +525,7 @@
       "collection": "campaigns",
       "techniqueId": "T1528",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -550,7 +550,7 @@
       "collection": "campaigns",
       "techniqueId": "T1539",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -575,7 +575,7 @@
       "collection": "campaigns",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -610,7 +610,7 @@
       "collection": "campaigns",
       "techniqueId": "T1505.003",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -645,7 +645,7 @@
       "collection": "campaigns",
       "techniqueId": "T1059.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -670,7 +670,7 @@
       "collection": "campaigns",
       "techniqueId": "T1005",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -705,7 +705,7 @@
       "collection": "campaigns",
       "techniqueId": "T1566.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -730,7 +730,7 @@
       "collection": "campaigns",
       "techniqueId": "T1528",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -765,7 +765,7 @@
       "collection": "campaigns",
       "techniqueId": "T1550.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -810,7 +810,7 @@
       "collection": "campaigns",
       "techniqueId": "T1195.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -845,7 +845,7 @@
       "collection": "campaigns",
       "techniqueId": "T1003.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -870,7 +870,7 @@
       "collection": "campaigns",
       "techniqueId": "T1210",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -895,7 +895,7 @@
       "collection": "campaigns",
       "techniqueId": "T1047",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -940,7 +940,7 @@
       "collection": "campaigns",
       "techniqueId": "T1021.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -965,7 +965,7 @@
       "collection": "campaigns",
       "techniqueId": "T1485",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1000,7 +1000,7 @@
       "collection": "campaigns",
       "techniqueId": "T1566.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1025,7 +1025,7 @@
       "collection": "campaigns",
       "techniqueId": "T1189",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1050,7 +1050,7 @@
       "collection": "campaigns",
       "techniqueId": "T1203",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1075,7 +1075,7 @@
       "collection": "campaigns",
       "techniqueId": "T1005",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1100,7 +1100,7 @@
       "collection": "campaigns",
       "techniqueId": "T1199",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1135,7 +1135,7 @@
       "collection": "campaigns",
       "techniqueId": "T1566.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1160,7 +1160,7 @@
       "collection": "campaigns",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1205,7 +1205,7 @@
       "collection": "campaigns",
       "techniqueId": "T1071.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1230,7 +1230,7 @@
       "collection": "campaigns",
       "techniqueId": "T1195.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1264,7 +1264,7 @@
       "collection": "campaigns",
       "techniqueId": "T1574.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1299,7 +1299,7 @@
       "collection": "campaigns",
       "techniqueId": "T1021.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1324,7 +1324,7 @@
       "collection": "campaigns",
       "techniqueId": "T1071.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1391,7 +1391,7 @@
       "collection": "campaigns",
       "techniqueId": "T1195.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1426,7 +1426,7 @@
       "collection": "campaigns",
       "techniqueId": "T1071.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1461,7 +1461,7 @@
       "collection": "campaigns",
       "techniqueId": "T1098.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1496,7 +1496,7 @@
       "collection": "campaigns",
       "techniqueId": "T1484.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1541,7 +1541,7 @@
       "collection": "campaigns",
       "techniqueId": "T1114.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1576,7 +1576,7 @@
       "collection": "campaigns",
       "techniqueId": "T1195.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1611,7 +1611,7 @@
       "collection": "campaigns",
       "techniqueId": "T1552.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1636,7 +1636,7 @@
       "collection": "campaigns",
       "techniqueId": "T1199",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1661,7 +1661,7 @@
       "collection": "campaigns",
       "techniqueId": "T1027",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1696,7 +1696,7 @@
       "collection": "campaigns",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1721,7 +1721,7 @@
       "collection": "campaigns",
       "techniqueId": "T1210",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1746,7 +1746,7 @@
       "collection": "campaigns",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1781,7 +1781,7 @@
       "collection": "campaigns",
       "techniqueId": "T1059.003",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1816,7 +1816,7 @@
       "collection": "incidents",
       "techniqueId": "T1566.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1851,7 +1851,7 @@
       "collection": "incidents",
       "techniqueId": "T1204.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1886,7 +1886,7 @@
       "collection": "incidents",
       "techniqueId": "T1078.004",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1921,7 +1921,7 @@
       "collection": "incidents",
       "techniqueId": "T1530",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1946,7 +1946,7 @@
       "collection": "incidents",
       "techniqueId": "T1567",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -1981,7 +1981,7 @@
       "collection": "incidents",
       "techniqueId": "T1566.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2006,7 +2006,7 @@
       "collection": "incidents",
       "techniqueId": "T1071",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2031,7 +2031,7 @@
       "collection": "incidents",
       "techniqueId": "T1041",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2056,7 +2056,7 @@
       "collection": "incidents",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2091,7 +2091,7 @@
       "collection": "incidents",
       "techniqueId": "T1195.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2116,7 +2116,7 @@
       "collection": "incidents",
       "techniqueId": "T1068",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2141,7 +2141,7 @@
       "collection": "incidents",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2166,7 +2166,7 @@
       "collection": "incidents",
       "techniqueId": "T1005",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2191,7 +2191,7 @@
       "collection": "incidents",
       "techniqueId": "T1567",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2216,7 +2216,7 @@
       "collection": "incidents",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2251,7 +2251,7 @@
       "collection": "incidents",
       "techniqueId": "T1530",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2276,7 +2276,7 @@
       "collection": "incidents",
       "techniqueId": "T1567",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2301,7 +2301,7 @@
       "collection": "incidents",
       "techniqueId": "T1005",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2326,7 +2326,7 @@
       "collection": "incidents",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2351,7 +2351,7 @@
       "collection": "incidents",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2376,7 +2376,7 @@
       "collection": "incidents",
       "techniqueId": "T1041",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2401,7 +2401,7 @@
       "collection": "incidents",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2426,7 +2426,7 @@
       "collection": "incidents",
       "techniqueId": "T1567",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2451,7 +2451,7 @@
       "collection": "incidents",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2476,7 +2476,7 @@
       "collection": "incidents",
       "techniqueId": "T1189",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2501,7 +2501,7 @@
       "collection": "incidents",
       "techniqueId": "T1203",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2526,7 +2526,7 @@
       "collection": "incidents",
       "techniqueId": "T1203",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2561,7 +2561,7 @@
       "collection": "incidents",
       "techniqueId": "T1195.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2596,7 +2596,7 @@
       "collection": "incidents",
       "techniqueId": "T1552.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2621,7 +2621,7 @@
       "collection": "incidents",
       "techniqueId": "T1213",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2646,7 +2646,7 @@
       "collection": "incidents",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2681,7 +2681,7 @@
       "collection": "incidents",
       "techniqueId": "T1566.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2706,7 +2706,7 @@
       "collection": "incidents",
       "techniqueId": "T1498",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2731,7 +2731,7 @@
       "collection": "incidents",
       "techniqueId": "T1133",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2756,7 +2756,7 @@
       "collection": "incidents",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2781,7 +2781,7 @@
       "collection": "incidents",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2806,7 +2806,7 @@
       "collection": "incidents",
       "techniqueId": "T1490",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2831,7 +2831,7 @@
       "collection": "incidents",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2856,7 +2856,7 @@
       "collection": "incidents",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2881,7 +2881,7 @@
       "collection": "incidents",
       "techniqueId": "T1048",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2906,7 +2906,7 @@
       "collection": "incidents",
       "techniqueId": "T1005",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2931,7 +2931,7 @@
       "collection": "incidents",
       "techniqueId": "T1210",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2956,7 +2956,7 @@
       "collection": "incidents",
       "techniqueId": "T1110",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -2981,7 +2981,7 @@
       "collection": "incidents",
       "techniqueId": "T1091",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3006,7 +3006,7 @@
       "collection": "incidents",
       "techniqueId": "T1105",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3041,7 +3041,7 @@
       "collection": "incidents",
       "techniqueId": "T1195.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3076,7 +3076,7 @@
       "collection": "incidents",
       "techniqueId": "T1499.004",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3111,7 +3111,7 @@
       "collection": "incidents",
       "techniqueId": "T1561.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3136,7 +3136,7 @@
       "collection": "incidents",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3161,7 +3161,7 @@
       "collection": "incidents",
       "techniqueId": "T1048",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3186,7 +3186,7 @@
       "collection": "incidents",
       "techniqueId": "T1005",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3211,7 +3211,7 @@
       "collection": "incidents",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3236,7 +3236,7 @@
       "collection": "incidents",
       "techniqueId": "T1557",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3271,7 +3271,7 @@
       "collection": "incidents",
       "techniqueId": "T1588.004",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3296,7 +3296,7 @@
       "collection": "incidents",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3321,7 +3321,7 @@
       "collection": "incidents",
       "techniqueId": "T1213",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3356,7 +3356,7 @@
       "collection": "incidents",
       "techniqueId": "T1530",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3381,7 +3381,7 @@
       "collection": "incidents",
       "techniqueId": "T1565",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3406,7 +3406,7 @@
       "collection": "incidents",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3431,7 +3431,7 @@
       "collection": "incidents",
       "techniqueId": "T1083",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3456,7 +3456,7 @@
       "collection": "incidents",
       "techniqueId": "T1041",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3481,7 +3481,7 @@
       "collection": "incidents",
       "techniqueId": "T1498",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3516,7 +3516,7 @@
       "collection": "incidents",
       "techniqueId": "T1195.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3541,7 +3541,7 @@
       "collection": "incidents",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3576,7 +3576,7 @@
       "collection": "incidents",
       "techniqueId": "T1530",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3601,7 +3601,7 @@
       "collection": "incidents",
       "techniqueId": "T1567",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3626,7 +3626,7 @@
       "collection": "incidents",
       "techniqueId": "T1199",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3651,7 +3651,7 @@
       "collection": "incidents",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3676,7 +3676,7 @@
       "collection": "incidents",
       "techniqueId": "T1005",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3711,7 +3711,7 @@
       "collection": "incidents",
       "techniqueId": "T1195.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3736,7 +3736,7 @@
       "collection": "incidents",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3761,7 +3761,7 @@
       "collection": "incidents",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3786,7 +3786,7 @@
       "collection": "incidents",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3821,7 +3821,7 @@
       "collection": "incidents",
       "techniqueId": "T1566.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3856,7 +3856,7 @@
       "collection": "incidents",
       "techniqueId": "T1204.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3891,7 +3891,7 @@
       "collection": "incidents",
       "techniqueId": "T1059.005",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3916,7 +3916,7 @@
       "collection": "incidents",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3941,7 +3941,7 @@
       "collection": "incidents",
       "techniqueId": "T1490",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -3966,7 +3966,7 @@
       "collection": "incidents",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4001,7 +4001,7 @@
       "collection": "incidents",
       "techniqueId": "T1195.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4026,7 +4026,7 @@
       "collection": "incidents",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4061,7 +4061,7 @@
       "collection": "incidents",
       "techniqueId": "T1059.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4086,7 +4086,7 @@
       "collection": "incidents",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4121,7 +4121,7 @@
       "collection": "incidents",
       "techniqueId": "T1059.006",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4156,7 +4156,7 @@
       "collection": "incidents",
       "techniqueId": "T1552.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4181,7 +4181,7 @@
       "collection": "incidents",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4216,7 +4216,7 @@
       "collection": "incidents",
       "techniqueId": "T1552.005",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4251,7 +4251,7 @@
       "collection": "incidents",
       "techniqueId": "T1078.004",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4296,7 +4296,7 @@
       "collection": "incidents",
       "techniqueId": "T1530",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4321,7 +4321,7 @@
       "collection": "incidents",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4346,7 +4346,7 @@
       "collection": "incidents",
       "techniqueId": "T1059",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4381,7 +4381,7 @@
       "collection": "incidents",
       "techniqueId": "T1588.006",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4416,7 +4416,7 @@
       "collection": "incidents",
       "techniqueId": "T1566.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4441,7 +4441,7 @@
       "collection": "incidents",
       "techniqueId": "T1528",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4476,7 +4476,7 @@
       "collection": "incidents",
       "techniqueId": "T1550.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4511,7 +4511,7 @@
       "collection": "incidents",
       "techniqueId": "T1566.004",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4536,7 +4536,7 @@
       "collection": "incidents",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4561,7 +4561,7 @@
       "collection": "incidents",
       "techniqueId": "T1021.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4586,7 +4586,7 @@
       "collection": "incidents",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4611,7 +4611,7 @@
       "collection": "incidents",
       "techniqueId": "T1490",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4636,7 +4636,7 @@
       "collection": "incidents",
       "techniqueId": "T1071.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4661,7 +4661,7 @@
       "collection": "incidents",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4686,7 +4686,7 @@
       "collection": "incidents",
       "techniqueId": "T1005",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4711,7 +4711,7 @@
       "collection": "incidents",
       "techniqueId": "T1560",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4736,7 +4736,7 @@
       "collection": "incidents",
       "techniqueId": "T1071",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4761,7 +4761,7 @@
       "collection": "incidents",
       "techniqueId": "T1059",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4786,7 +4786,7 @@
       "collection": "incidents",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4821,7 +4821,7 @@
       "collection": "incidents",
       "techniqueId": "T1566.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4856,7 +4856,7 @@
       "collection": "incidents",
       "techniqueId": "T1204.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4881,7 +4881,7 @@
       "collection": "incidents",
       "techniqueId": "T1499",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4916,7 +4916,7 @@
       "collection": "incidents",
       "techniqueId": "T1195.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4941,7 +4941,7 @@
       "collection": "incidents",
       "techniqueId": "T1199",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -4976,7 +4976,7 @@
       "collection": "incidents",
       "techniqueId": "T1552.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5001,7 +5001,7 @@
       "collection": "incidents",
       "techniqueId": "T1567",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5026,7 +5026,7 @@
       "collection": "incidents",
       "techniqueId": "T1657",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5051,7 +5051,7 @@
       "collection": "incidents",
       "techniqueId": "T1210",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5076,7 +5076,7 @@
       "collection": "incidents",
       "techniqueId": "T1499",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5101,7 +5101,7 @@
       "collection": "incidents",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5126,7 +5126,7 @@
       "collection": "incidents",
       "techniqueId": "T1059.003",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5151,7 +5151,7 @@
       "collection": "incidents",
       "techniqueId": "T1005",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5176,7 +5176,7 @@
       "collection": "incidents",
       "techniqueId": "T1567.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5201,7 +5201,7 @@
       "collection": "incidents",
       "techniqueId": "T1588.006",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5236,7 +5236,7 @@
       "collection": "incidents",
       "techniqueId": "T1195.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5261,7 +5261,7 @@
       "collection": "incidents",
       "techniqueId": "T1210",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5296,7 +5296,7 @@
       "collection": "incidents",
       "techniqueId": "T1561.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5331,7 +5331,7 @@
       "collection": "incidents",
       "techniqueId": "T1003.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5366,7 +5366,7 @@
       "collection": "incidents",
       "techniqueId": "T1566.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5391,7 +5391,7 @@
       "collection": "incidents",
       "techniqueId": "T1189",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5416,7 +5416,7 @@
       "collection": "incidents",
       "techniqueId": "T1203",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5441,7 +5441,7 @@
       "collection": "incidents",
       "techniqueId": "T1005",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5476,7 +5476,7 @@
       "collection": "incidents",
       "techniqueId": "T1195.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5520,7 +5520,7 @@
       "collection": "incidents",
       "techniqueId": "T1574.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5555,7 +5555,7 @@
       "collection": "incidents",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5580,7 +5580,7 @@
       "collection": "incidents",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5605,7 +5605,7 @@
       "collection": "incidents",
       "techniqueId": "T1489",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5630,7 +5630,7 @@
       "collection": "incidents",
       "techniqueId": "T1485",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5665,7 +5665,7 @@
       "collection": "incidents",
       "techniqueId": "T1561.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5700,7 +5700,7 @@
       "collection": "incidents",
       "techniqueId": "T1195.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5735,7 +5735,7 @@
       "collection": "incidents",
       "techniqueId": "T1071.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5760,7 +5760,7 @@
       "collection": "incidents",
       "techniqueId": "T1027",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5795,7 +5795,7 @@
       "collection": "incidents",
       "techniqueId": "T1036",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5830,7 +5830,7 @@
       "collection": "incidents",
       "techniqueId": "T1083",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5855,7 +5855,7 @@
       "collection": "incidents",
       "techniqueId": "T1005",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5880,7 +5880,7 @@
       "collection": "incidents",
       "techniqueId": "T1485",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5905,7 +5905,7 @@
       "collection": "incidents",
       "techniqueId": "T1566.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5930,7 +5930,7 @@
       "collection": "incidents",
       "techniqueId": "T1210",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5955,7 +5955,7 @@
       "collection": "incidents",
       "techniqueId": "T1046",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -5980,7 +5980,7 @@
       "collection": "incidents",
       "techniqueId": "T1498",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6005,7 +6005,7 @@
       "collection": "incidents",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6030,7 +6030,7 @@
       "collection": "incidents",
       "techniqueId": "T1072",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6055,7 +6055,7 @@
       "collection": "incidents",
       "techniqueId": "T1485",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6080,7 +6080,7 @@
       "collection": "incidents",
       "techniqueId": "T1091",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6105,7 +6105,7 @@
       "collection": "incidents",
       "techniqueId": "T1203",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6138,7 +6138,7 @@
       "collection": "incidents",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6163,7 +6163,7 @@
       "collection": "incidents",
       "techniqueId": "T1041",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6188,7 +6188,7 @@
       "collection": "incidents",
       "techniqueId": "T1195.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6213,7 +6213,7 @@
       "collection": "incidents",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6238,7 +6238,7 @@
       "collection": "incidents",
       "techniqueId": "T1552.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6273,7 +6273,7 @@
       "collection": "incidents",
       "techniqueId": "T1566.004",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6298,7 +6298,7 @@
       "collection": "incidents",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6323,7 +6323,7 @@
       "collection": "incidents",
       "techniqueId": "T1098",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6358,7 +6358,7 @@
       "collection": "incidents",
       "techniqueId": "T1566.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6393,7 +6393,7 @@
       "collection": "incidents",
       "techniqueId": "T1059.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6428,7 +6428,7 @@
       "collection": "incidents",
       "techniqueId": "T1021.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6453,7 +6453,7 @@
       "collection": "incidents",
       "techniqueId": "T1489",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6486,7 +6486,7 @@
       "collection": "incidents",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6511,7 +6511,7 @@
       "collection": "incidents",
       "techniqueId": "T1213",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6536,7 +6536,7 @@
       "collection": "incidents",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6561,7 +6561,7 @@
       "collection": "incidents",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6586,7 +6586,7 @@
       "collection": "incidents",
       "techniqueId": "T1087",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6611,7 +6611,7 @@
       "collection": "incidents",
       "techniqueId": "T1021",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6636,7 +6636,7 @@
       "collection": "incidents",
       "techniqueId": "T1567",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6661,7 +6661,7 @@
       "collection": "incidents",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6686,7 +6686,7 @@
       "collection": "incidents",
       "techniqueId": "T1531",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6711,7 +6711,7 @@
       "collection": "incidents",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6746,7 +6746,7 @@
       "collection": "incidents",
       "techniqueId": "T1003.003",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6781,7 +6781,7 @@
       "collection": "incidents",
       "techniqueId": "T1090.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6806,7 +6806,7 @@
       "collection": "incidents",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6831,7 +6831,7 @@
       "collection": "incidents",
       "techniqueId": "T1210",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6856,7 +6856,7 @@
       "collection": "incidents",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6881,7 +6881,7 @@
       "collection": "incidents",
       "techniqueId": "T1570",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6906,7 +6906,7 @@
       "collection": "incidents",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6931,7 +6931,7 @@
       "collection": "incidents",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6956,7 +6956,7 @@
       "collection": "incidents",
       "techniqueId": "T1490",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -6991,7 +6991,7 @@
       "collection": "incidents",
       "techniqueId": "T1195.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7016,7 +7016,7 @@
       "collection": "incidents",
       "techniqueId": "T1554",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7041,7 +7041,7 @@
       "collection": "incidents",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7076,7 +7076,7 @@
       "collection": "incidents",
       "techniqueId": "T1566.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7101,7 +7101,7 @@
       "collection": "incidents",
       "techniqueId": "T1539",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7126,7 +7126,7 @@
       "collection": "incidents",
       "techniqueId": "T1114",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7151,7 +7151,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7176,7 +7176,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1133",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7211,7 +7211,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1059.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7246,7 +7246,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1560.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7281,7 +7281,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1567.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7306,7 +7306,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7331,7 +7331,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1490",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7366,7 +7366,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1566.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7401,7 +7401,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1059.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7426,7 +7426,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1003",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7451,7 +7451,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1199",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7486,7 +7486,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1560.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7521,7 +7521,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1071.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7546,7 +7546,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7581,7 +7581,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1505.003",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7625,7 +7625,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1574.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7670,7 +7670,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1566.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7705,7 +7705,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1071.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7740,7 +7740,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1588.006",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7765,7 +7765,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7800,7 +7800,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1195.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7835,7 +7835,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1484.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7880,7 +7880,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1078.004",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7915,7 +7915,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1550.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7940,7 +7940,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -7975,7 +7975,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1566.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8010,7 +8010,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1071.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8035,7 +8035,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1657",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8070,7 +8070,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1059.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8095,7 +8095,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1485",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8120,7 +8120,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8155,7 +8155,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1505.003",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8180,7 +8180,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1003",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8215,7 +8215,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1195.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8250,7 +8250,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1059.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8294,7 +8294,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1574.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8329,7 +8329,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8354,7 +8354,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8379,7 +8379,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1490",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8404,7 +8404,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8439,7 +8439,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1567.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8464,7 +8464,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1489",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8489,7 +8489,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8514,7 +8514,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8549,7 +8549,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1567.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8574,7 +8574,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8599,7 +8599,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8634,7 +8634,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1021.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8659,7 +8659,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8694,7 +8694,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1566.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8719,7 +8719,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1055",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8764,7 +8764,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1566.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8789,7 +8789,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1528",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8824,7 +8824,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1550.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8859,7 +8859,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8884,7 +8884,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8919,7 +8919,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1566.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8944,7 +8944,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -8979,7 +8979,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1059.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9004,7 +9004,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9039,7 +9039,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1566.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9074,7 +9074,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1059.005",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9099,7 +9099,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1657",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9124,7 +9124,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9149,7 +9149,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1611",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9184,7 +9184,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1530",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9219,7 +9219,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1567.003",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9244,7 +9244,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1485",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9279,7 +9279,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1566.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9314,7 +9314,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1491.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9349,7 +9349,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1566.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9384,7 +9384,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1195.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9409,7 +9409,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1657",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9434,7 +9434,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1485",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9459,7 +9459,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9484,7 +9484,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1490",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9509,7 +9509,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9534,7 +9534,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9559,7 +9559,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9584,7 +9584,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1490",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9609,7 +9609,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1657",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9634,7 +9634,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1213",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9659,7 +9659,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1589",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9694,7 +9694,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1566.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9719,7 +9719,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9754,7 +9754,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1059.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9789,7 +9789,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1003.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9814,7 +9814,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1105",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9839,7 +9839,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1074",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9864,7 +9864,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1041",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9889,7 +9889,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9914,7 +9914,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9939,7 +9939,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9964,7 +9964,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -9999,7 +9999,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1567.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10024,7 +10024,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10049,7 +10049,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1490",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10074,7 +10074,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10109,7 +10109,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1021.004",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10153,7 +10153,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1562.004",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10188,7 +10188,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1567",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10213,7 +10213,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10238,7 +10238,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10263,7 +10263,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1557",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10288,7 +10288,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1014",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10323,7 +10323,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1485",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10358,7 +10358,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1059.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10393,7 +10393,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1195.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10437,7 +10437,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1562.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10482,7 +10482,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1566.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10507,7 +10507,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1621",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10541,7 +10541,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1656",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10586,7 +10586,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1078.004",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10611,7 +10611,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1213",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10646,7 +10646,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1530",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10671,7 +10671,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1567",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10696,7 +10696,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1657",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10731,7 +10731,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1566.003",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10766,7 +10766,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1528",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10801,7 +10801,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1098.005",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10836,7 +10836,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1071.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10871,7 +10871,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1566.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10906,7 +10906,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1059.005",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10931,7 +10931,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -10966,7 +10966,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1195.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11001,7 +11001,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1552.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11026,7 +11026,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1199",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11061,7 +11061,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1071.004",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11086,7 +11086,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1027",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11131,7 +11131,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1505.003",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11166,7 +11166,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1566.004",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11201,7 +11201,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1556.006",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11226,7 +11226,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1213",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11251,7 +11251,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1657",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11276,7 +11276,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1218",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11321,7 +11321,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1090.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11346,7 +11346,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11371,7 +11371,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11406,7 +11406,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1059.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11431,7 +11431,7 @@
       "collection": "threat-actors",
       "techniqueId": "T1055",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11466,7 +11466,7 @@
       "collection": "zero-days",
       "techniqueId": "T1203",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11501,7 +11501,7 @@
       "collection": "zero-days",
       "techniqueId": "T1566.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11526,7 +11526,7 @@
       "collection": "zero-days",
       "techniqueId": "T1189",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11551,7 +11551,7 @@
       "collection": "zero-days",
       "techniqueId": "T1059",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11576,7 +11576,7 @@
       "collection": "zero-days",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11601,7 +11601,7 @@
       "collection": "zero-days",
       "techniqueId": "T1059",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11626,7 +11626,7 @@
       "collection": "zero-days",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11651,7 +11651,7 @@
       "collection": "zero-days",
       "techniqueId": "T1068",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11676,7 +11676,7 @@
       "collection": "zero-days",
       "techniqueId": "T1189",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11701,7 +11701,7 @@
       "collection": "zero-days",
       "techniqueId": "T1068",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11726,7 +11726,7 @@
       "collection": "zero-days",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11761,7 +11761,7 @@
       "collection": "zero-days",
       "techniqueId": "T1565.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11786,7 +11786,7 @@
       "collection": "zero-days",
       "techniqueId": "T1548",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11811,7 +11811,7 @@
       "collection": "zero-days",
       "techniqueId": "T1552.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11836,7 +11836,7 @@
       "collection": "zero-days",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11871,7 +11871,7 @@
       "collection": "zero-days",
       "techniqueId": "T1083",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11896,7 +11896,7 @@
       "collection": "zero-days",
       "techniqueId": "T1005",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11921,7 +11921,7 @@
       "collection": "zero-days",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11946,7 +11946,7 @@
       "collection": "zero-days",
       "techniqueId": "T1059",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11971,7 +11971,7 @@
       "collection": "zero-days",
       "techniqueId": "T1133",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -11996,7 +11996,7 @@
       "collection": "zero-days",
       "techniqueId": "T1649",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12021,7 +12021,7 @@
       "collection": "zero-days",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12046,7 +12046,7 @@
       "collection": "zero-days",
       "techniqueId": "T1083",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12081,7 +12081,7 @@
       "collection": "zero-days",
       "techniqueId": "T1505.003",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12106,7 +12106,7 @@
       "collection": "zero-days",
       "techniqueId": "T1210",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12131,7 +12131,7 @@
       "collection": "zero-days",
       "techniqueId": "T1486",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12156,7 +12156,7 @@
       "collection": "zero-days",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12191,7 +12191,7 @@
       "collection": "zero-days",
       "techniqueId": "T1059.004",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12226,7 +12226,7 @@
       "collection": "zero-days",
       "techniqueId": "T1498.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12251,7 +12251,7 @@
       "collection": "zero-days",
       "techniqueId": "T1210",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12276,7 +12276,7 @@
       "collection": "zero-days",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12301,7 +12301,7 @@
       "collection": "zero-days",
       "techniqueId": "T1059",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12326,7 +12326,7 @@
       "collection": "zero-days",
       "techniqueId": "T1072",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12351,7 +12351,7 @@
       "collection": "zero-days",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12386,7 +12386,7 @@
       "collection": "zero-days",
       "techniqueId": "T1059.004",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12411,7 +12411,7 @@
       "collection": "zero-days",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12436,7 +12436,7 @@
       "collection": "zero-days",
       "techniqueId": "T1059",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12461,7 +12461,7 @@
       "collection": "zero-days",
       "techniqueId": "T1083",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12486,7 +12486,7 @@
       "collection": "zero-days",
       "techniqueId": "T1552",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12511,7 +12511,7 @@
       "collection": "zero-days",
       "techniqueId": "T1005",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12546,7 +12546,7 @@
       "collection": "zero-days",
       "techniqueId": "T1552.004",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12571,7 +12571,7 @@
       "collection": "zero-days",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12606,7 +12606,7 @@
       "collection": "zero-days",
       "techniqueId": "T1059.004",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12641,7 +12641,7 @@
       "collection": "zero-days",
       "techniqueId": "T1505.003",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12666,7 +12666,7 @@
       "collection": "zero-days",
       "techniqueId": "T1496",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12691,7 +12691,7 @@
       "collection": "zero-days",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12726,7 +12726,7 @@
       "collection": "zero-days",
       "techniqueId": "T1136.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12761,7 +12761,7 @@
       "collection": "zero-days",
       "techniqueId": "T1505.003",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12786,7 +12786,7 @@
       "collection": "zero-days",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12811,7 +12811,7 @@
       "collection": "zero-days",
       "techniqueId": "T1068",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12846,7 +12846,7 @@
       "collection": "zero-days",
       "techniqueId": "T1059.004",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12881,7 +12881,7 @@
       "collection": "zero-days",
       "techniqueId": "T1548.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12906,7 +12906,7 @@
       "collection": "zero-days",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12931,7 +12931,7 @@
       "collection": "zero-days",
       "techniqueId": "T1105",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12956,7 +12956,7 @@
       "collection": "zero-days",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -12981,7 +12981,7 @@
       "collection": "zero-days",
       "techniqueId": "T1059",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13016,7 +13016,7 @@
       "collection": "zero-days",
       "techniqueId": "T1552.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13041,7 +13041,7 @@
       "collection": "zero-days",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13066,7 +13066,7 @@
       "collection": "zero-days",
       "techniqueId": "T1059",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13091,7 +13091,7 @@
       "collection": "zero-days",
       "techniqueId": "T1203",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13126,7 +13126,7 @@
       "collection": "zero-days",
       "techniqueId": "T1566.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13151,7 +13151,7 @@
       "collection": "zero-days",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13176,7 +13176,7 @@
       "collection": "zero-days",
       "techniqueId": "T1059",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13211,7 +13211,7 @@
       "collection": "zero-days",
       "techniqueId": "T1574.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13256,7 +13256,7 @@
       "collection": "zero-days",
       "techniqueId": "T1204.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13281,7 +13281,7 @@
       "collection": "zero-days",
       "techniqueId": "T1068",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13306,7 +13306,7 @@
       "collection": "zero-days",
       "techniqueId": "T1068",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13340,7 +13340,7 @@
       "collection": "zero-days",
       "techniqueId": "T1562",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13375,7 +13375,7 @@
       "collection": "zero-days",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13400,7 +13400,7 @@
       "collection": "zero-days",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13435,7 +13435,7 @@
       "collection": "zero-days",
       "techniqueId": "T1589.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13460,7 +13460,7 @@
       "collection": "zero-days",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13485,7 +13485,7 @@
       "collection": "zero-days",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13520,7 +13520,7 @@
       "collection": "zero-days",
       "techniqueId": "T1505.003",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13555,7 +13555,7 @@
       "collection": "zero-days",
       "techniqueId": "T1059.007",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13580,7 +13580,7 @@
       "collection": "zero-days",
       "techniqueId": "T1548",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13605,7 +13605,7 @@
       "collection": "zero-days",
       "techniqueId": "T1098",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13630,7 +13630,7 @@
       "collection": "zero-days",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13665,7 +13665,7 @@
       "collection": "zero-days",
       "techniqueId": "T1505.003",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13690,7 +13690,7 @@
       "collection": "zero-days",
       "techniqueId": "T1059",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13715,7 +13715,7 @@
       "collection": "zero-days",
       "techniqueId": "T1210",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13740,7 +13740,7 @@
       "collection": "zero-days",
       "techniqueId": "T1091",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13765,7 +13765,7 @@
       "collection": "zero-days",
       "techniqueId": "T1203",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13798,7 +13798,7 @@
       "collection": "zero-days",
       "techniqueId": "T1059.007",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13823,7 +13823,7 @@
       "collection": "zero-days",
       "techniqueId": "T1185",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13858,7 +13858,7 @@
       "collection": "zero-days",
       "techniqueId": "T1195.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13902,7 +13902,7 @@
       "collection": "zero-days",
       "techniqueId": "T1574.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13947,7 +13947,7 @@
       "collection": "zero-days",
       "techniqueId": "T1071.001",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -13982,7 +13982,7 @@
       "collection": "zero-days",
       "techniqueId": "T1553.002",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -14017,7 +14017,7 @@
       "collection": "zero-days",
       "techniqueId": "T1190",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -14052,7 +14052,7 @@
       "collection": "zero-days",
       "techniqueId": "T1059.004",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",
@@ -14077,7 +14077,7 @@
       "collection": "zero-days",
       "techniqueId": "T1078",
       "recommended": "v19.0",
-      "message": "Mapping is missing attackVersion/attack_version metadata."
+      "message": "Mapping is missing attack-version metadata."
     },
     {
       "severity": "metadata-gap",

--- a/.github/pipeline/reports/framework-mapping-audit-2026-05-07.json
+++ b/.github/pipeline/reports/framework-mapping-audit-2026-05-07.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-07T13:32:57.421Z",
+  "generatedAt": "2026-05-07T15:55:30.758Z",
   "attackVersion": "v19.0",
   "source": {
     "url": "https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack-19.0.json",

--- a/.github/pipeline/reports/framework-mapping-audit-2026-05-07.md
+++ b/.github/pipeline/reports/framework-mapping-audit-2026-05-07.md
@@ -1,0 +1,282 @@
+# Framework Mapping Corpus Audit
+
+Generated: 2026-05-07T01:31:25.686Z
+
+Pinned framework data:
+
+- ATT&CK Enterprise: v19.0
+- Source URL: https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack-19.0.json
+- Source SHA-256: df520ea0775a57db7bff760145b02fed89290802913e056b7ed5970b02f3626a
+
+Scope:
+
+- Report mode only. No article frontmatter was modified.
+- The audit compares existing corpus mitreMappings against pinned ATT&CK Enterprise v19.0.
+- Technique-name normalization is mechanically checkable, but tactic reclassification still needs article-supported review before content changes.
+- ATLAS coverage is not migrated here; atlasMappings remain optional and should only be added when article evidence supports adversarial AI/ML behavior.
+
+## Summary
+
+- Content files scanned: 161
+- Files with MITRE mappings: 161
+- MITRE mappings scanned: 484
+- Findings: 1646
+
+## Findings By Severity
+
+| Count | Category |
+|---:|---|
+| 1431 | metadata-gap |
+| 170 | fixable |
+| 27 | review-required |
+| 16 | error |
+| 2 | warning |
+
+## Findings By Category
+
+| Count | Category |
+|---:|---|
+| 477 | missing-attack-version |
+| 477 | missing-confidence |
+| 477 | missing-evidence |
+| 170 | technique-name-mismatch |
+| 27 | v19-defense-evasion-split-candidate |
+| 9 | revoked-technique |
+| 7 | unknown-technique-id |
+| 2 | tactic-mismatch |
+
+## Collection Coverage
+
+| Collection | Files | Files with mappings | Mappings |
+|---|---:|---:|---:|
+| campaigns | 14 | 14 | 59 |
+| incidents | 67 | 67 | 192 |
+| threat-actors | 40 | 40 | 140 |
+| zero-days | 40 | 40 | 93 |
+
+## Mechanically Fixable Candidates
+
+| Severity | Category | Location | Finding |
+|---|---|---|---|
+| fixable | technique-name-mismatch | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[0] | Technique name should match ATT&CK v19.0: Spearphishing Link. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[1] | Technique name should match ATT&CK v19.0: Malicious File. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[2] | Technique name should match ATT&CK v19.0: Launch Daemon. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[3] | Technique name should match ATT&CK v19.0: Web Protocols. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[0] | Technique name should match ATT&CK v19.0: Spearphishing Attachment. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[1] | Technique name should match ATT&CK v19.0: Registry Run Keys / Startup Folder. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[2] | Technique name should match ATT&CK v19.0: Keylogging. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[3] | Technique name should match ATT&CK v19.0: Remote Access Tools. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[1] | Technique name should match ATT&CK v19.0: Exfiltration to Cloud Storage. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[1] | Technique name should match ATT&CK v19.0: Web Shell. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[2] | Technique name should match ATT&CK v19.0: PowerShell. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[0] | Technique name should match ATT&CK v19.0: Spearphishing Link. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[2] | Technique name should match ATT&CK v19.0: Application Access Token. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[0] | Technique name should match ATT&CK v19.0: Compromise Software Supply Chain. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[1] | Technique name should match ATT&CK v19.0: LSASS Memory. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[4] | Technique name should match ATT&CK v19.0: SMB/Windows Admin Shares. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[0] | Technique name should match ATT&CK v19.0: Spearphishing Link. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/operation-cloud-hopper-msp-espionage-campaign.md#mitreMappings[1] | Technique name should match ATT&CK v19.0: Spearphishing Attachment. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/operation-cloud-hopper-msp-espionage-campaign.md#mitreMappings[3] | Technique name should match ATT&CK v19.0: Web Protocols. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[0] | Technique name should match ATT&CK v19.0: Compromise Software Supply Chain. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[1] | Technique name should match ATT&CK v19.0: Web Protocols. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[2] | Technique name should match ATT&CK v19.0: Additional Cloud Credentials. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[3] | Technique name should match ATT&CK v19.0: Trust Modification. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[4] | Technique name should match ATT&CK v19.0: Remote Email Collection. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/teampcp-supply-chain-campaign-2026.md#mitreMappings[0] | Technique name should match ATT&CK v19.0: Compromise Software Supply Chain. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/teampcp-supply-chain-campaign-2026.md#mitreMappings[1] | Technique name should match ATT&CK v19.0: Credentials In Files. |
+| fixable | technique-name-mismatch | site/src/content/campaigns/wannacry-ransomware-campaign-2017.md#mitreMappings[3] | Technique name should match ATT&CK v19.0: Windows Command Shell. |
+| fixable | technique-name-mismatch | site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[0] | Technique name should match ATT&CK v19.0: Spearphishing Attachment. |
+| fixable | technique-name-mismatch | site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[1] | Technique name should match ATT&CK v19.0: Malicious File. |
+| fixable | technique-name-mismatch | site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[2] | Technique name should match ATT&CK v19.0: Cloud Accounts. |
+| fixable | technique-name-mismatch | site/src/content/incidents/adobe-mr-raccoon-breach-2026.md#mitreMappings[3] | Technique name should match ATT&CK v19.0: Data from Cloud Storage. |
+| fixable | technique-name-mismatch | site/src/content/incidents/anthem-health-data-breach-2015.md#mitreMappings[0] | Technique name should match ATT&CK v19.0: Spearphishing Link. |
+| fixable | technique-name-mismatch | site/src/content/incidents/axios-unc1069-compromise.md#mitreMappings[1] | Technique name should match ATT&CK v19.0: Compromise Software Supply Chain. |
+| fixable | technique-name-mismatch | site/src/content/incidents/cegedim-sante-health-breach-2026.md#mitreMappings[1] | Technique name should match ATT&CK v19.0: Data from Cloud Storage. |
+| fixable | technique-name-mismatch | site/src/content/incidents/cisco-trivy-supply-chain-breach-2026.md#mitreMappings[0] | Technique name should match ATT&CK v19.0: Compromise Software Supply Chain. |
+| fixable | technique-name-mismatch | site/src/content/incidents/cisco-trivy-supply-chain-breach-2026.md#mitreMappings[1] | Technique name should match ATT&CK v19.0: Credentials In Files. |
+| fixable | technique-name-mismatch | site/src/content/incidents/code-red-nimda-worm-outbreaks-2001.md#mitreMappings[1] | Technique name should match ATT&CK v19.0: Spearphishing Attachment. |
+| fixable | technique-name-mismatch | site/src/content/incidents/crowdstrike-falcon-global-bsod-outage-2024.md#mitreMappings[0] | Technique name should match ATT&CK v19.0: Compromise Software Supply Chain. |
+| fixable | technique-name-mismatch | site/src/content/incidents/crowdstrike-falcon-global-bsod-outage-2024.md#mitreMappings[1] | Technique name should match ATT&CK v19.0: Application or System Exploitation. |
+| fixable | technique-name-mismatch | site/src/content/incidents/crowdstrike-falcon-global-bsod-outage-2024.md#mitreMappings[2] | Technique name should match ATT&CK v19.0: Disk Structure Wipe. |
+| fixable | technique-name-mismatch | site/src/content/incidents/diginotar-certificate-authority-compromise-2011.md#mitreMappings[1] | Technique name should match ATT&CK v19.0: Digital Certificates. |
+| fixable | technique-name-mismatch | site/src/content/incidents/docketwise-immigration-data-breach-2026.md#mitreMappings[2] | Technique name should match ATT&CK v19.0: Data from Cloud Storage. |
+| fixable | technique-name-mismatch | site/src/content/incidents/european-commission-trivy-breach-2026.md#mitreMappings[0] | Technique name should match ATT&CK v19.0: Compromise Software Supply Chain. |
+| fixable | technique-name-mismatch | site/src/content/incidents/european-commission-trivy-breach-2026.md#mitreMappings[2] | Technique name should match ATT&CK v19.0: Data from Cloud Storage. |
+| fixable | technique-name-mismatch | site/src/content/incidents/fireeye-red-team-tools-breach-2020.md#mitreMappings[0] | Technique name should match ATT&CK v19.0: Compromise Software Supply Chain. |
+| fixable | technique-name-mismatch | site/src/content/incidents/iloveyou-worm-outbreak-2000.md#mitreMappings[0] | Technique name should match ATT&CK v19.0: Spearphishing Attachment. |
+| fixable | technique-name-mismatch | site/src/content/incidents/iloveyou-worm-outbreak-2000.md#mitreMappings[1] | Technique name should match ATT&CK v19.0: Malicious File. |
+| fixable | technique-name-mismatch | site/src/content/incidents/iloveyou-worm-outbreak-2000.md#mitreMappings[2] | Technique name should match ATT&CK v19.0: Visual Basic. |
+| fixable | technique-name-mismatch | site/src/content/incidents/kaseya-vsa-supply-chain-attack-2021.md#mitreMappings[0] | Technique name should match ATT&CK v19.0: Compromise Software Supply Chain. |
+| fixable | technique-name-mismatch | site/src/content/incidents/kaseya-vsa-supply-chain-attack-2021.md#mitreMappings[2] | Technique name should match ATT&CK v19.0: PowerShell. |
+
+
+_120 additional finding(s) omitted from this table; see JSON output if generated._
+
+## Review-Required ATT&CK v19 Tactic Split Candidates
+
+| Severity | Category | Location | Finding |
+|---|---|---|---|
+| review-required | v19-defense-evasion-split-candidate | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[2] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Lateral Movement. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/campaigns/operation-cloud-hopper-msp-espionage-campaign.md#mitreMappings[2] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Initial Access, Persistence, Privilege Escalation, Stealth. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/campaigns/operation-truechaos.md#mitreMappings[1] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Execution, Stealth. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/campaigns/solarwinds-supply-chain-campaign.md#mitreMappings[3] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Defense Impairment, Privilege Escalation. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/campaigns/teampcp-supply-chain-campaign-2026.md#mitreMappings[3] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Stealth. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/incidents/lexisnexis-react2shell-breach-2026.md#mitreMappings[2] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Initial Access, Persistence, Privilege Escalation, Stealth. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/incidents/m365-oauth-device-code-phishing-2026.md#mitreMappings[2] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Lateral Movement. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/incidents/operation-truechaos-trueconf-zero-day-2026.md#mitreMappings[1] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Execution, Stealth. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[2] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Stealth. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/incidents/solarwinds-orion-supply-chain-compromise-2020.md#mitreMappings[3] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Stealth. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/threat-actors/apt27.md#mitreMappings[2] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Execution, Stealth. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/threat-actors/apt29.md#mitreMappings[1] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Defense Impairment, Privilege Escalation. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/threat-actors/apt41.md#mitreMappings[2] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Execution, Stealth. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/threat-actors/evil-corp.md#mitreMappings[2] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Privilege Escalation, Stealth. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/threat-actors/eviltokens.md#mitreMappings[2] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Lateral Movement. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/threat-actors/ransomhouse.md#mitreMappings[2] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Stealth. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/threat-actors/salt-typhoon.md#mitreMappings[2] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Stealth. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/threat-actors/sandworm.md#mitreMappings[3] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Stealth. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/threat-actors/scattered-spider.md#mitreMappings[2] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Stealth. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/threat-actors/turla.md#mitreMappings[1] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Stealth. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/threat-actors/volt-typhoon.md#mitreMappings[0] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Stealth. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/threat-actors/wizard-spider.md#mitreMappings[2] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Privilege Escalation, Stealth. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/zero-days/cisco-catalyst-sd-wan-manager-cve-2026-20128.md#mitreMappings[1] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Initial Access, Persistence, Privilege Escalation, Stealth. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/zero-days/microsoft-windows-cve-2026-32202.md#mitreMappings[0] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Stealth. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/zero-days/trueconf-cve-2026-3502.md#mitreMappings[1] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Execution, Stealth. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/zero-days/trueconf-cve-2026-3502.md#mitreMappings[3] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Defense Impairment. |
+| review-required | v19-defense-evasion-split-candidate | site/src/content/zero-days/webpros-cpanel-and-whm-and-wp2-wordpress-sq-cve-2026-41940.md#mitreMappings[2] | Mapped tactic "Defense Evasion" is not among ATT&CK v19.0 tactics: Initial Access, Persistence, Privilege Escalation, Stealth. |
+
+
+## Errors And Warnings
+
+| Severity | Category | Location | Finding |
+|---|---|---|---|
+| warning | tactic-mismatch | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[3] | Mapped tactic "Lateral Movement" is not among ATT&CK v19.0 tactics: Execution. |
+| error | revoked-technique | site/src/content/campaigns/operation-truechaos.md#mitreMappings[1] | T1574.002 is revoked in pinned ATT&CK Enterprise v19.0. |
+| error | unknown-technique-id | site/src/content/campaigns/sandworm-ukraine-power-grid-campaign-2015.md#mitreMappings[0] | Technique ID is not present in pinned ATT&CK Enterprise v19.0. |
+| error | unknown-technique-id | site/src/content/campaigns/sandworm-ukraine-power-grid-campaign-2015.md#mitreMappings[1] | Technique ID is not present in pinned ATT&CK Enterprise v19.0. |
+| error | unknown-technique-id | site/src/content/campaigns/sandworm-ukraine-power-grid-campaign-2015.md#mitreMappings[2] | Technique ID is not present in pinned ATT&CK Enterprise v19.0. |
+| error | unknown-technique-id | site/src/content/campaigns/sandworm-ukraine-power-grid-campaign-2015.md#mitreMappings[3] | Technique ID is not present in pinned ATT&CK Enterprise v19.0. |
+| error | revoked-technique | site/src/content/incidents/operation-truechaos-trueconf-zero-day-2026.md#mitreMappings[1] | T1574.002 is revoked in pinned ATT&CK Enterprise v19.0. |
+| error | unknown-technique-id | site/src/content/incidents/stuxnet-iran-nuclear-sabotage-2010.md#mitreMappings[2] | Technique ID is not present in pinned ATT&CK Enterprise v19.0. |
+| error | unknown-technique-id | site/src/content/incidents/ukraine-power-grid-industroyer-2016.md#mitreMappings[0] | Technique ID is not present in pinned ATT&CK Enterprise v19.0. |
+| error | revoked-technique | site/src/content/threat-actors/apt27.md#mitreMappings[2] | T1574.002 is revoked in pinned ATT&CK Enterprise v19.0. |
+| error | revoked-technique | site/src/content/threat-actors/apt41.md#mitreMappings[2] | T1574.002 is revoked in pinned ATT&CK Enterprise v19.0. |
+| error | revoked-technique | site/src/content/threat-actors/ransomhouse.md#mitreMappings[2] | T1562.004 is revoked in pinned ATT&CK Enterprise v19.0. |
+| error | revoked-technique | site/src/content/threat-actors/sandworm.md#mitreMappings[3] | T1562.001 is revoked in pinned ATT&CK Enterprise v19.0. |
+| error | revoked-technique | site/src/content/threat-actors/scattered-spider.md#mitreMappings[2] | T1656 is revoked in pinned ATT&CK Enterprise v19.0. |
+| warning | tactic-mismatch | site/src/content/zero-days/microsoft-visual-basic-for-applications-vba--cve-2012-1854.md#mitreMappings[0] | Mapped tactic "Persistence" is not among ATT&CK v19.0 tactics: Execution, Stealth. |
+| error | revoked-technique | site/src/content/zero-days/microsoft-windows-cve-2026-32202.md#mitreMappings[0] | T1562 is revoked in pinned ATT&CK Enterprise v19.0. |
+| error | unknown-technique-id | site/src/content/zero-days/stuxnet-lnk-shortcut-cve-2010-2568.md#mitreMappings[2] | Technique ID is not present in pinned ATT&CK Enterprise v19.0. |
+| error | revoked-technique | site/src/content/zero-days/trueconf-cve-2026-3502.md#mitreMappings[1] | T1574.002 is revoked in pinned ATT&CK Enterprise v19.0. |
+
+
+## Metadata Gaps
+
+| Severity | Category | Location | Finding |
+|---|---|---|---|
+| metadata-gap | missing-attack-version | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[0] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[0] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[0] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[1] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[1] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[1] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[2] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[2] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[2] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[3] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[3] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[3] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[4] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[4] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[4] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[0] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[0] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[0] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[1] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[1] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[1] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[2] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[2] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[2] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[3] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[3] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[3] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[0] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[0] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[0] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[1] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[1] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[1] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[2] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[2] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[2] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[3] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[3] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[3] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[0] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[0] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[0] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[1] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[1] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[1] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[2] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[2] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[2] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[3] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[3] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[3] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[0] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[0] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[0] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[1] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[1] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[1] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[2] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[2] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[2] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[3] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[3] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[3] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[0] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[0] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[0] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[1] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[1] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[1] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[2] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[2] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[2] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[0] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[0] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[0] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[1] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[1] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[1] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[2] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[2] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[2] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[3] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[3] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[3] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[4] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[4] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[4] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[5] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[5] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[5] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[0] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[0] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[0] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[1] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[1] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[1] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[2] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-confidence | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[2] | Mapping is missing confidence metadata. |
+| metadata-gap | missing-evidence | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[2] | Mapping is missing evidence metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[3] | Mapping is missing attackVersion/attack_version metadata. |
+
+
+_1331 additional finding(s) omitted from this table; see JSON output if generated._
+
+## Recommended Next Step
+
+Open a follow-up migration PR that applies only mechanically safe technique-name corrections first. Handle v19 tactic split candidates in a separate source-supported review pass; do not bulk-reclassify Defense Evasion mappings without checking article evidence.

--- a/.github/pipeline/reports/framework-mapping-audit-2026-05-07.md
+++ b/.github/pipeline/reports/framework-mapping-audit-2026-05-07.md
@@ -1,6 +1,6 @@
 # Framework Mapping Corpus Audit
 
-Generated: 2026-05-07T01:31:25.686Z
+Generated: 2026-05-07T13:11:08.564Z
 
 Pinned framework data:
 

--- a/.github/pipeline/reports/framework-mapping-audit-2026-05-07.md
+++ b/.github/pipeline/reports/framework-mapping-audit-2026-05-07.md
@@ -1,6 +1,6 @@
 # Framework Mapping Corpus Audit
 
-Generated: 2026-05-07T13:11:08.564Z
+Generated: 2026-05-07T13:32:57.421Z
 
 Pinned framework data:
 
@@ -173,106 +173,106 @@ _120 additional finding(s) omitted from this table; see JSON output if generated
 
 | Severity | Category | Location | Finding |
 |---|---|---|---|
-| metadata-gap | missing-attack-version | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[0] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[0] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[0] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[0] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[1] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[1] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[1] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[1] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[2] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[2] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[2] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[2] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[3] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[3] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[3] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[3] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[4] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[4] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[4] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/applejeus-dprk-cryptocurrency-targeting-campaign.md#mitreMappings[4] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[0] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[0] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[0] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[0] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[1] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[1] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[1] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[1] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[2] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[2] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[2] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[2] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[3] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[3] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[3] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/carbanak-banking-campaign-2013.md#mitreMappings[3] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[0] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[0] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[0] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[0] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[1] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[1] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[1] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[1] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[2] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[2] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[2] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[2] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[3] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[3] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[3] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/dragonforce-ransomware-campaign-april-2026.md#mitreMappings[3] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[0] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[0] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[0] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[0] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[1] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[1] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[1] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[1] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[2] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[2] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[2] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[2] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[3] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[3] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[3] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[3] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[0] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[0] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[0] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[0] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[1] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[1] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[1] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[1] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[2] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[2] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[2] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[2] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[3] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[3] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[3] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[3] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[0] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[0] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[0] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[0] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[1] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[1] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[1] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[1] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[2] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[2] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[2] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[2] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[0] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[0] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[0] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[0] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[1] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[1] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[1] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[1] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[2] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[2] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[2] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[2] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[3] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[3] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[3] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[3] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[4] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[4] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[4] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[4] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[5] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[5] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[5] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[5] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[0] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[0] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[0] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[0] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[1] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[1] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[1] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[1] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[2] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[2] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[2] | Mapping is missing confidence metadata. |
 | metadata-gap | missing-evidence | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[2] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[3] | Mapping is missing attackVersion/attack_version metadata. |
+| metadata-gap | missing-attack-version | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[3] | Mapping is missing attack-version metadata. |
 
 
 _1331 additional finding(s) omitted from this table; see JSON output if generated._

--- a/.github/pipeline/reports/framework-mapping-audit-2026-05-07.md
+++ b/.github/pipeline/reports/framework-mapping-audit-2026-05-07.md
@@ -1,6 +1,6 @@
 # Framework Mapping Corpus Audit
 
-Generated: 2026-05-07T13:32:57.421Z
+Generated: 2026-05-07T15:55:30.758Z
 
 Pinned framework data:
 
@@ -223,59 +223,9 @@ _120 additional finding(s) omitted from this table; see JSON output if generated
 | metadata-gap | missing-evidence | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[2] | Mapping is missing evidence metadata. |
 | metadata-gap | missing-attack-version | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[3] | Mapping is missing attack-version metadata. |
 | metadata-gap | missing-confidence | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[3] | Mapping is missing confidence metadata. |
-| metadata-gap | missing-evidence | site/src/content/campaigns/frostarmada-soho-dns-hijacking-2026.md#mitreMappings[3] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[0] | Mapping is missing attack-version metadata. |
-| metadata-gap | missing-confidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[0] | Mapping is missing confidence metadata. |
-| metadata-gap | missing-evidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[0] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[1] | Mapping is missing attack-version metadata. |
-| metadata-gap | missing-confidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[1] | Mapping is missing confidence metadata. |
-| metadata-gap | missing-evidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[1] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[2] | Mapping is missing attack-version metadata. |
-| metadata-gap | missing-confidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[2] | Mapping is missing confidence metadata. |
-| metadata-gap | missing-evidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[2] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[3] | Mapping is missing attack-version metadata. |
-| metadata-gap | missing-confidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[3] | Mapping is missing confidence metadata. |
-| metadata-gap | missing-evidence | site/src/content/campaigns/hafnium-exchange-server-exploitation-campaign-2021.md#mitreMappings[3] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[0] | Mapping is missing attack-version metadata. |
-| metadata-gap | missing-confidence | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[0] | Mapping is missing confidence metadata. |
-| metadata-gap | missing-evidence | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[0] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[1] | Mapping is missing attack-version metadata. |
-| metadata-gap | missing-confidence | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[1] | Mapping is missing confidence metadata. |
-| metadata-gap | missing-evidence | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[1] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[2] | Mapping is missing attack-version metadata. |
-| metadata-gap | missing-confidence | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[2] | Mapping is missing confidence metadata. |
-| metadata-gap | missing-evidence | site/src/content/campaigns/m365-oauth-device-code-phishing-2026.md#mitreMappings[2] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[0] | Mapping is missing attack-version metadata. |
-| metadata-gap | missing-confidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[0] | Mapping is missing confidence metadata. |
-| metadata-gap | missing-evidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[0] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[1] | Mapping is missing attack-version metadata. |
-| metadata-gap | missing-confidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[1] | Mapping is missing confidence metadata. |
-| metadata-gap | missing-evidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[1] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[2] | Mapping is missing attack-version metadata. |
-| metadata-gap | missing-confidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[2] | Mapping is missing confidence metadata. |
-| metadata-gap | missing-evidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[2] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[3] | Mapping is missing attack-version metadata. |
-| metadata-gap | missing-confidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[3] | Mapping is missing confidence metadata. |
-| metadata-gap | missing-evidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[3] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[4] | Mapping is missing attack-version metadata. |
-| metadata-gap | missing-confidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[4] | Mapping is missing confidence metadata. |
-| metadata-gap | missing-evidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[4] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[5] | Mapping is missing attack-version metadata. |
-| metadata-gap | missing-confidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[5] | Mapping is missing confidence metadata. |
-| metadata-gap | missing-evidence | site/src/content/campaigns/notpetya-destructive-campaign-2017.md#mitreMappings[5] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[0] | Mapping is missing attack-version metadata. |
-| metadata-gap | missing-confidence | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[0] | Mapping is missing confidence metadata. |
-| metadata-gap | missing-evidence | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[0] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[1] | Mapping is missing attack-version metadata. |
-| metadata-gap | missing-confidence | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[1] | Mapping is missing confidence metadata. |
-| metadata-gap | missing-evidence | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[1] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[2] | Mapping is missing attack-version metadata. |
-| metadata-gap | missing-confidence | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[2] | Mapping is missing confidence metadata. |
-| metadata-gap | missing-evidence | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[2] | Mapping is missing evidence metadata. |
-| metadata-gap | missing-attack-version | site/src/content/campaigns/operation-aurora-espionage-campaign-2009.md#mitreMappings[3] | Mapping is missing attack-version metadata. |
 
 
-_1331 additional finding(s) omitted from this table; see JSON output if generated._
+_1381 additional finding(s) omitted from this table; see JSON output if generated._
 
 ## Recommended Next Step
 

--- a/scripts/audit-framework-mappings.mjs
+++ b/scripts/audit-framework-mappings.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
 import { dirname, join, relative, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import yaml from 'js-yaml';
@@ -47,9 +47,19 @@ function parseArgs(argv) {
       usage();
       process.exit(0);
     } else if (arg === '--markdown-out') {
-      args.markdownOut = resolve(ROOT, argv[++i] || '');
+      const value = argv[++i];
+      if (!value) {
+        console.error('--markdown-out requires a path');
+        process.exit(1);
+      }
+      args.markdownOut = resolve(ROOT, value);
     } else if (arg === '--json-out') {
-      args.jsonOut = resolve(ROOT, argv[++i] || '');
+      const value = argv[++i];
+      if (!value) {
+        console.error('--json-out requires a path');
+        process.exit(1);
+      }
+      args.jsonOut = resolve(ROOT, value);
     } else {
       console.error(`Unknown argument: ${arg}`);
       usage();
@@ -76,7 +86,7 @@ function listContentFiles(dir = CONTENT_ROOT) {
 
 function parseFrontmatter(filePath) {
   const content = readFileSync(filePath, 'utf8');
-  const match = content.match(/^---\n([\s\S]*?)\n---\n?/);
+  const match = content.match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/);
   if (!match) {
     return { data: null, error: 'No YAML frontmatter found' };
   }

--- a/scripts/audit-framework-mappings.mjs
+++ b/scripts/audit-framework-mappings.mjs
@@ -26,6 +26,7 @@ const FRONTMATTER_REGEX = /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/;
 const CANONICAL_ID_REGEX = new RegExp(SCHEMA_MITRE_TECHNIQUE_ID_PATTERN);
 const ATTACK_VERSION_REGEX = new RegExp(SCHEMA_ATTACK_VERSION_PATTERN);
 const DEFAULT_FINDINGS_TABLE_LIMIT = 50;
+const NONCANONICAL_SUBTECHNIQUE_ID_REGEX = /^T\d{4}[-–]\d{3}$/;
 
 const TACTIC_SLUG_BY_NAME = new Map(
   SCHEMA_MITRE_TACTICS.map((name) => [name, name.toLowerCase().replace(/\s+/g, '-')]),
@@ -138,8 +139,8 @@ function analyzeMapping(file, collection, mapping, index) {
 
   let effectiveTechniqueId = techniqueId;
   if (!CANONICAL_ID_REGEX.test(techniqueId)) {
-    if (/^T\d{4}-\d{3}$/.test(techniqueId)) {
-      effectiveTechniqueId = techniqueId.replace('-', '.');
+    if (NONCANONICAL_SUBTECHNIQUE_ID_REGEX.test(techniqueId)) {
+      effectiveTechniqueId = techniqueId.replace(/[-–]/, '.');
       findings.push({
         severity: 'fixable',
         category: 'noncanonical-technique-id-separator',

--- a/scripts/audit-framework-mappings.mjs
+++ b/scripts/audit-framework-mappings.mjs
@@ -1,0 +1,420 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname, join, relative, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import yaml from 'js-yaml';
+
+import {
+  getAttackEnterpriseData,
+  getAttackEnterpriseTechnique,
+  isPinnedAttackVersion,
+  normalizeFrameworkName,
+} from './framework-data.mjs';
+import { SCHEMA_MITRE_TACTICS } from './pipeline-schema.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const CONTENT_ROOT = resolve(ROOT, 'site/src/content');
+const DEFAULT_MARKDOWN_OUT = resolve(ROOT, '.github/pipeline/reports/framework-mapping-audit-2026-05-07.md');
+
+const TACTIC_SLUG_BY_NAME = new Map(
+  SCHEMA_MITRE_TACTICS.map((name) => [name, name.toLowerCase().replace(/\s+/g, '-')]),
+);
+const TACTIC_NAME_BY_SLUG = new Map(
+  SCHEMA_MITRE_TACTICS.map((name) => [name.toLowerCase().replace(/\s+/g, '-'), name]),
+);
+
+function usage() {
+  console.log(`Usage:
+  node scripts/audit-framework-mappings.mjs [--markdown-out <path>] [--json-out <path>]
+
+Options:
+  --markdown-out  Write a Markdown report. Defaults to ${relative(ROOT, DEFAULT_MARKDOWN_OUT)}
+  --json-out      Optional path for machine-readable audit results
+`);
+}
+
+function parseArgs(argv) {
+  const args = {
+    markdownOut: DEFAULT_MARKDOWN_OUT,
+    jsonOut: null,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      usage();
+      process.exit(0);
+    } else if (arg === '--markdown-out') {
+      args.markdownOut = resolve(ROOT, argv[++i] || '');
+    } else if (arg === '--json-out') {
+      args.jsonOut = resolve(ROOT, argv[++i] || '');
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      usage();
+      process.exit(1);
+    }
+  }
+
+  return args;
+}
+
+function listContentFiles(dir = CONTENT_ROOT) {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listContentFiles(fullPath));
+    } else if (entry.isFile() && /\.(md|mdx)$/.test(entry.name)) {
+      files.push(fullPath);
+    }
+  }
+  return files.sort();
+}
+
+function parseFrontmatter(filePath) {
+  const content = readFileSync(filePath, 'utf8');
+  const match = content.match(/^---\n([\s\S]*?)\n---\n?/);
+  if (!match) {
+    return { data: null, error: 'No YAML frontmatter found' };
+  }
+
+  try {
+    return { data: yaml.load(match[1]) || {}, error: null };
+  } catch (error) {
+    return { data: null, error: `YAML parse error: ${error.message}` };
+  }
+}
+
+function collectionForFile(filePath) {
+  const rel = relative(CONTENT_ROOT, filePath);
+  return rel.split('/')[0] || 'unknown';
+}
+
+function displayTactics(slugs) {
+  return slugs.map((slug) => TACTIC_NAME_BY_SLUG.get(slug) || slug).join(', ');
+}
+
+function analyzeMapping(file, collection, mapping, index) {
+  const findings = [];
+  const techniqueId = normalizeFrameworkName(mapping?.techniqueId);
+  const techniqueName = normalizeFrameworkName(mapping?.techniqueName);
+  const tactic = normalizeFrameworkName(mapping?.tactic);
+  const attackVersion = mapping?.attackVersion ?? mapping?.attack_version;
+  const label = `${relative(ROOT, file)}#mitreMappings[${index}]`;
+
+  if (!techniqueId) {
+    findings.push({
+      severity: 'error',
+      category: 'missing-technique-id',
+      label,
+      collection,
+      message: 'Missing techniqueId.',
+    });
+    return findings;
+  }
+
+  if (/^T\d{4}-\d{3}$/.test(techniqueId)) {
+    findings.push({
+      severity: 'fixable',
+      category: 'noncanonical-technique-id-separator',
+      label,
+      collection,
+      techniqueId,
+      message: `Use canonical dot separator: ${techniqueId.replace('-', '.')}.`,
+    });
+  }
+
+  if (!isPinnedAttackVersion(attackVersion)) {
+    findings.push({
+      severity: 'info',
+      category: 'legacy-or-nonpinned-attack-version',
+      label,
+      collection,
+      techniqueId,
+      attackVersion,
+      message: `Mapping declares non-pinned ATT&CK version ${JSON.stringify(attackVersion)}; v19 comparison skipped.`,
+    });
+    return findings;
+  }
+
+  const technique = getAttackEnterpriseTechnique(techniqueId);
+  if (!technique) {
+    findings.push({
+      severity: 'error',
+      category: 'unknown-technique-id',
+      label,
+      collection,
+      techniqueId,
+      message: `Technique ID is not present in pinned ATT&CK Enterprise ${getAttackEnterpriseData().version}.`,
+    });
+    return findings;
+  }
+
+  if (technique.revoked || technique.deprecated) {
+    findings.push({
+      severity: 'error',
+      category: technique.revoked ? 'revoked-technique' : 'deprecated-technique',
+      label,
+      collection,
+      techniqueId,
+      officialName: technique.name,
+      message: `${techniqueId} is ${technique.revoked ? 'revoked' : 'deprecated'} in pinned ATT&CK Enterprise ${getAttackEnterpriseData().version}.`,
+    });
+  }
+
+  const officialName = normalizeFrameworkName(technique.name);
+  if (techniqueName && techniqueName !== officialName) {
+    findings.push({
+      severity: 'fixable',
+      category: 'technique-name-mismatch',
+      label,
+      collection,
+      techniqueId,
+      current: techniqueName,
+      recommended: officialName,
+      message: `Technique name should match ATT&CK ${getAttackEnterpriseData().version}: ${officialName}.`,
+    });
+  }
+
+  if (!attackVersion) {
+    findings.push({
+      severity: 'metadata-gap',
+      category: 'missing-attack-version',
+      label,
+      collection,
+      techniqueId,
+      recommended: getAttackEnterpriseData().version,
+      message: `Mapping is missing attackVersion/attack_version metadata.`,
+    });
+  }
+
+  if (!mapping?.confidence) {
+    findings.push({
+      severity: 'metadata-gap',
+      category: 'missing-confidence',
+      label,
+      collection,
+      techniqueId,
+      message: 'Mapping is missing confidence metadata.',
+    });
+  }
+
+  if (!mapping?.evidence) {
+    findings.push({
+      severity: 'metadata-gap',
+      category: 'missing-evidence',
+      label,
+      collection,
+      techniqueId,
+      message: 'Mapping is missing evidence metadata.',
+    });
+  }
+
+  if (tactic && technique.tactics.length > 0) {
+    const tacticSlug = TACTIC_SLUG_BY_NAME.get(tactic);
+    if (!tacticSlug) {
+      findings.push({
+        severity: 'error',
+        category: 'unknown-tactic',
+        label,
+        collection,
+        techniqueId,
+        current: tactic,
+        message: `Tactic is not in the current schema enum.`,
+      });
+    } else if (!technique.tactics.includes(tacticSlug)) {
+      const officialTactics = displayTactics(technique.tactics);
+      findings.push({
+        severity: tactic === 'Defense Evasion' ? 'review-required' : 'warning',
+        category: tactic === 'Defense Evasion' ? 'v19-defense-evasion-split-candidate' : 'tactic-mismatch',
+        label,
+        collection,
+        techniqueId,
+        current: tactic,
+        recommended: officialTactics,
+        message: `Mapped tactic "${tactic}" is not among ATT&CK ${getAttackEnterpriseData().version} tactics: ${officialTactics}.`,
+      });
+    }
+  }
+
+  return findings;
+}
+
+function auditCorpus() {
+  const files = listContentFiles();
+  const findings = [];
+  let mappedFiles = 0;
+  let mappingCount = 0;
+  const collectionCounts = {};
+
+  for (const file of files) {
+    const collection = collectionForFile(file);
+    collectionCounts[collection] = collectionCounts[collection] || { files: 0, mappedFiles: 0, mappings: 0 };
+    collectionCounts[collection].files += 1;
+
+    const parsed = parseFrontmatter(file);
+    if (parsed.error) {
+      findings.push({
+        severity: 'error',
+        category: 'frontmatter-parse-error',
+        label: relative(ROOT, file),
+        collection,
+        message: parsed.error,
+      });
+      continue;
+    }
+
+    const mappings = Array.isArray(parsed.data.mitreMappings) ? parsed.data.mitreMappings : [];
+    if (mappings.length > 0) {
+      mappedFiles += 1;
+      collectionCounts[collection].mappedFiles += 1;
+    }
+    mappingCount += mappings.length;
+    collectionCounts[collection].mappings += mappings.length;
+
+    for (let i = 0; i < mappings.length; i += 1) {
+      findings.push(...analyzeMapping(file, collection, mappings[i], i));
+    }
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    attackVersion: getAttackEnterpriseData().version,
+    source: getAttackEnterpriseData().source,
+    summary: {
+      files: files.length,
+      mappedFiles,
+      mappings: mappingCount,
+      findings: findings.length,
+    },
+    collectionCounts,
+    findingCounts: countBy(findings, 'category'),
+    severityCounts: countBy(findings, 'severity'),
+    findings,
+  };
+}
+
+function countBy(items, key) {
+  const counts = {};
+  for (const item of items) {
+    counts[item[key]] = (counts[item[key]] || 0) + 1;
+  }
+  return Object.fromEntries(Object.entries(counts).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+function markdownTable(rows) {
+  if (rows.length === 0) return '_None._\n';
+  return [
+    '| Count | Category |',
+    '|---:|---|',
+    ...rows.map(([category, count]) => `| ${count} | ${category} |`),
+    '',
+  ].join('\n');
+}
+
+function renderFindings(findings, predicate, limit = 50) {
+  const selected = findings.filter(predicate);
+  if (selected.length === 0) return '_None._\n';
+
+  const rows = selected.slice(0, limit).map((finding) => (
+    `| ${finding.severity} | ${finding.category} | ${finding.label} | ${finding.message.replace(/\|/g, '\\|')} |`
+  ));
+  const suffix = selected.length > limit
+    ? `\n\n_${selected.length - limit} additional finding(s) omitted from this table; see JSON output if generated._\n`
+    : '\n';
+
+  return [
+    '| Severity | Category | Location | Finding |',
+    '|---|---|---|---|',
+    ...rows,
+    suffix,
+  ].join('\n');
+}
+
+function renderMarkdown(report) {
+  const sortedFindingCounts = Object.entries(report.findingCounts).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  const sortedSeverityCounts = Object.entries(report.severityCounts).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+
+  return `# Framework Mapping Corpus Audit
+
+Generated: ${report.generatedAt}
+
+Pinned framework data:
+
+- ATT&CK Enterprise: ${report.attackVersion}
+- Source URL: ${report.source.url}
+- Source SHA-256: ${report.source.sha256}
+
+Scope:
+
+- Report mode only. No article frontmatter was modified.
+- The audit compares existing corpus mitreMappings against pinned ATT&CK Enterprise ${report.attackVersion}.
+- Technique-name normalization is mechanically checkable, but tactic reclassification still needs article-supported review before content changes.
+- ATLAS coverage is not migrated here; atlasMappings remain optional and should only be added when article evidence supports adversarial AI/ML behavior.
+
+## Summary
+
+- Content files scanned: ${report.summary.files}
+- Files with MITRE mappings: ${report.summary.mappedFiles}
+- MITRE mappings scanned: ${report.summary.mappings}
+- Findings: ${report.summary.findings}
+
+## Findings By Severity
+
+${markdownTable(sortedSeverityCounts)}
+## Findings By Category
+
+${markdownTable(sortedFindingCounts)}
+## Collection Coverage
+
+| Collection | Files | Files with mappings | Mappings |
+|---|---:|---:|---:|
+${Object.entries(report.collectionCounts)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([collection, counts]) => `| ${collection} | ${counts.files} | ${counts.mappedFiles} | ${counts.mappings} |`)
+    .join('\n')}
+
+## Mechanically Fixable Candidates
+
+${renderFindings(report.findings, (finding) => finding.severity === 'fixable')}
+## Review-Required ATT&CK v19 Tactic Split Candidates
+
+${renderFindings(report.findings, (finding) => finding.severity === 'review-required')}
+## Errors And Warnings
+
+${renderFindings(report.findings, (finding) => ['error', 'warning'].includes(finding.severity))}
+## Metadata Gaps
+
+${renderFindings(report.findings, (finding) => finding.severity === 'metadata-gap', 100)}
+## Recommended Next Step
+
+Open a follow-up migration PR that applies only mechanically safe technique-name corrections first. Handle v19 tactic split candidates in a separate source-supported review pass; do not bulk-reclassify Defense Evasion mappings without checking article evidence.
+`;
+}
+
+function writeOutput(filePath, content) {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const report = auditCorpus();
+
+  if (args.markdownOut) {
+    writeOutput(args.markdownOut, renderMarkdown(report));
+    console.log(`Wrote ${relative(ROOT, args.markdownOut)}`);
+  }
+
+  if (args.jsonOut) {
+    writeOutput(args.jsonOut, `${JSON.stringify(report, null, 2)}\n`);
+    console.log(`Wrote ${relative(ROOT, args.jsonOut)}`);
+  }
+
+  console.log(JSON.stringify(report.summary));
+}
+
+main();

--- a/scripts/audit-framework-mappings.mjs
+++ b/scripts/audit-framework-mappings.mjs
@@ -25,6 +25,7 @@ const DEFAULT_MARKDOWN_OUT = resolve(ROOT, `.github/pipeline/reports/framework-m
 const FRONTMATTER_REGEX = /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/;
 const CANONICAL_ID_REGEX = new RegExp(SCHEMA_MITRE_TECHNIQUE_ID_PATTERN);
 const ATTACK_VERSION_REGEX = new RegExp(SCHEMA_ATTACK_VERSION_PATTERN);
+const DEFAULT_FINDINGS_TABLE_LIMIT = 50;
 
 const TACTIC_SLUG_BY_NAME = new Map(
   SCHEMA_MITRE_TACTICS.map((name) => [name, name.toLowerCase().replace(/\s+/g, '-')]),
@@ -352,7 +353,7 @@ function markdownTable(rows) {
   ].join('\n');
 }
 
-function renderFindings(findings, predicate, limit = 50) {
+function renderFindings(findings, predicate, limit = DEFAULT_FINDINGS_TABLE_LIMIT) {
   const selected = findings.filter(predicate);
   if (selected.length === 0) return '_None._\n';
 
@@ -425,7 +426,7 @@ ${renderFindings(report.findings, (finding) => finding.severity === 'review-requ
 ${renderFindings(report.findings, (finding) => ['error', 'warning'].includes(finding.severity))}
 ## Metadata Gaps
 
-${renderFindings(report.findings, (finding) => finding.severity === 'metadata-gap', 100)}
+${renderFindings(report.findings, (finding) => finding.severity === 'metadata-gap')}
 ## Recommended Next Step
 
 Open a follow-up migration PR that applies only mechanically safe technique-name corrections first. Handle v19 tactic split candidates in a separate source-supported review pass; do not bulk-reclassify Defense Evasion mappings without checking article evidence.

--- a/scripts/audit-framework-mappings.mjs
+++ b/scripts/audit-framework-mappings.mjs
@@ -11,12 +11,20 @@ import {
   isPinnedAttackVersion,
   normalizeFrameworkName,
 } from './framework-data.mjs';
-import { SCHEMA_MITRE_TACTICS } from './pipeline-schema.mjs';
+import {
+  SCHEMA_ATTACK_VERSION_PATTERN,
+  SCHEMA_MITRE_TACTICS,
+  SCHEMA_MITRE_TECHNIQUE_ID_PATTERN,
+} from './pipeline-schema.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
 const CONTENT_ROOT = resolve(ROOT, 'site/src/content');
-const DEFAULT_MARKDOWN_OUT = resolve(ROOT, '.github/pipeline/reports/framework-mapping-audit-2026-05-07.md');
+const REPORT_DATE = new Date().toISOString().slice(0, 10);
+const DEFAULT_MARKDOWN_OUT = resolve(ROOT, `.github/pipeline/reports/framework-mapping-audit-${REPORT_DATE}.md`);
+const FRONTMATTER_REGEX = /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/;
+const CANONICAL_ID_REGEX = new RegExp(SCHEMA_MITRE_TECHNIQUE_ID_PATTERN);
+const ATTACK_VERSION_REGEX = new RegExp(SCHEMA_ATTACK_VERSION_PATTERN);
 
 const TACTIC_SLUG_BY_NAME = new Map(
   SCHEMA_MITRE_TACTICS.map((name) => [name, name.toLowerCase().replace(/\s+/g, '-')]),
@@ -86,7 +94,7 @@ function listContentFiles(dir = CONTENT_ROOT) {
 
 function parseFrontmatter(filePath) {
   const content = readFileSync(filePath, 'utf8');
-  const match = content.match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/);
+  const match = content.match(FRONTMATTER_REGEX);
   if (!match) {
     return { data: null, error: 'No YAML frontmatter found' };
   }
@@ -112,7 +120,8 @@ function analyzeMapping(file, collection, mapping, index) {
   const techniqueId = normalizeFrameworkName(mapping?.techniqueId);
   const techniqueName = normalizeFrameworkName(mapping?.techniqueName);
   const tactic = normalizeFrameworkName(mapping?.tactic);
-  const attackVersion = mapping?.attackVersion ?? mapping?.attack_version;
+  const attackVersion = mapping?.['attack-version'] ?? mapping?.attackVersion ?? mapping?.attack_version;
+  const normalizedAttackVersion = attackVersion == null ? '' : String(attackVersion).trim();
   const label = `${relative(ROOT, file)}#mitreMappings[${index}]`;
 
   if (!techniqueId) {
@@ -126,18 +135,36 @@ function analyzeMapping(file, collection, mapping, index) {
     return findings;
   }
 
-  if (/^T\d{4}-\d{3}$/.test(techniqueId)) {
+  let effectiveTechniqueId = techniqueId;
+  if (!CANONICAL_ID_REGEX.test(techniqueId)) {
+    if (/^T\d{4}-\d{3}$/.test(techniqueId)) {
+      effectiveTechniqueId = techniqueId.replace('-', '.');
+      findings.push({
+        severity: 'fixable',
+        category: 'noncanonical-technique-id-separator',
+        label,
+        collection,
+        techniqueId,
+        recommended: effectiveTechniqueId,
+        message: `Use canonical dot separator: ${effectiveTechniqueId}.`,
+      });
+    }
+  }
+
+  if (normalizedAttackVersion && !ATTACK_VERSION_REGEX.test(normalizedAttackVersion)) {
     findings.push({
-      severity: 'fixable',
-      category: 'noncanonical-technique-id-separator',
+      severity: 'error',
+      category: 'invalid-attack-version',
       label,
       collection,
       techniqueId,
-      message: `Use canonical dot separator: ${techniqueId.replace('-', '.')}.`,
+      attackVersion,
+      message: 'attack-version must match vNN[.N].',
     });
+    return findings;
   }
 
-  if (!isPinnedAttackVersion(attackVersion)) {
+  if (normalizedAttackVersion && !isPinnedAttackVersion(normalizedAttackVersion)) {
     findings.push({
       severity: 'info',
       category: 'legacy-or-nonpinned-attack-version',
@@ -150,14 +177,14 @@ function analyzeMapping(file, collection, mapping, index) {
     return findings;
   }
 
-  const technique = getAttackEnterpriseTechnique(techniqueId);
+  const technique = getAttackEnterpriseTechnique(effectiveTechniqueId);
   if (!technique) {
     findings.push({
       severity: 'error',
       category: 'unknown-technique-id',
       label,
       collection,
-      techniqueId,
+      techniqueId: effectiveTechniqueId,
       message: `Technique ID is not present in pinned ATT&CK Enterprise ${getAttackEnterpriseData().version}.`,
     });
     return findings;
@@ -169,9 +196,9 @@ function analyzeMapping(file, collection, mapping, index) {
       category: technique.revoked ? 'revoked-technique' : 'deprecated-technique',
       label,
       collection,
-      techniqueId,
+      techniqueId: effectiveTechniqueId,
       officialName: technique.name,
-      message: `${techniqueId} is ${technique.revoked ? 'revoked' : 'deprecated'} in pinned ATT&CK Enterprise ${getAttackEnterpriseData().version}.`,
+      message: `${effectiveTechniqueId} is ${technique.revoked ? 'revoked' : 'deprecated'} in pinned ATT&CK Enterprise ${getAttackEnterpriseData().version}.`,
     });
   }
 
@@ -182,7 +209,7 @@ function analyzeMapping(file, collection, mapping, index) {
       category: 'technique-name-mismatch',
       label,
       collection,
-      techniqueId,
+      techniqueId: effectiveTechniqueId,
       current: techniqueName,
       recommended: officialName,
       message: `Technique name should match ATT&CK ${getAttackEnterpriseData().version}: ${officialName}.`,
@@ -195,9 +222,9 @@ function analyzeMapping(file, collection, mapping, index) {
       category: 'missing-attack-version',
       label,
       collection,
-      techniqueId,
+      techniqueId: effectiveTechniqueId,
       recommended: getAttackEnterpriseData().version,
-      message: `Mapping is missing attackVersion/attack_version metadata.`,
+      message: `Mapping is missing attack-version metadata.`,
     });
   }
 
@@ -207,7 +234,7 @@ function analyzeMapping(file, collection, mapping, index) {
       category: 'missing-confidence',
       label,
       collection,
-      techniqueId,
+      techniqueId: effectiveTechniqueId,
       message: 'Mapping is missing confidence metadata.',
     });
   }
@@ -218,7 +245,7 @@ function analyzeMapping(file, collection, mapping, index) {
       category: 'missing-evidence',
       label,
       collection,
-      techniqueId,
+      techniqueId: effectiveTechniqueId,
       message: 'Mapping is missing evidence metadata.',
     });
   }
@@ -231,7 +258,7 @@ function analyzeMapping(file, collection, mapping, index) {
         category: 'unknown-tactic',
         label,
         collection,
-        techniqueId,
+        techniqueId: effectiveTechniqueId,
         current: tactic,
         message: `Tactic is not in the current schema enum.`,
       });
@@ -242,7 +269,7 @@ function analyzeMapping(file, collection, mapping, index) {
         category: tactic === 'Defense Evasion' ? 'v19-defense-evasion-split-candidate' : 'tactic-mismatch',
         label,
         collection,
-        techniqueId,
+        techniqueId: effectiveTechniqueId,
         current: tactic,
         recommended: officialTactics,
         message: `Mapped tactic "${tactic}" is not among ATT&CK ${getAttackEnterpriseData().version} tactics: ${officialTactics}.`,

--- a/scripts/framework-mapping-validation.mjs
+++ b/scripts/framework-mapping-validation.mjs
@@ -2,6 +2,7 @@ import {
   SCHEMA_ATTACK_VERSION_PATTERN,
   SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN,
   SCHEMA_ATLAS_VERSION_PATTERN,
+  SCHEMA_FRAMEWORK_MAPPING_VALUES,
   SCHEMA_MAPPING_CONFIDENCE_VALUES,
   SCHEMA_MITRE_TECHNIQUE_ID_PATTERN,
 } from './pipeline-schema.mjs';
@@ -28,6 +29,22 @@ function trimOptionalString(value) {
   return value ? String(value).trim() : '';
 }
 
+function getAttackVersion(mapping) {
+  return mapping['attack-version'] ?? mapping.attackVersion ?? mapping.attack_version;
+}
+
+function getAtlasVersion(mapping) {
+  return mapping['atlas-version'] ?? mapping.atlasVersion ?? mapping.atlas_version;
+}
+
+function getFrameworkMappingId(mapping) {
+  return trimOptionalString(mapping['mapping-id'] ?? mapping.mappingId);
+}
+
+function getFrameworkMappingName(mapping) {
+  return normalizeFrameworkName(mapping['mapping-name'] ?? mapping.mappingName);
+}
+
 export function getMitreMappingValidationIssues(mappings, options = {}) {
   const labelPrefix = options.labelPrefix || 'MITRE mapping';
   const issues = [];
@@ -37,7 +54,7 @@ export function getMitreMappingValidationIssues(mappings, options = {}) {
     const label = mappingLabel(labelPrefix, i);
     const mapping = mappings[i] || {};
     const techniqueId = trimOptionalString(mapping.techniqueId);
-    const attackVersion = mapping.attackVersion ?? mapping.attack_version;
+    const attackVersion = getAttackVersion(mapping);
 
     if (/^T\d{4}-\d{3}$/.test(techniqueId)) {
       issues.push(`${label}: techniqueId "${techniqueId}" should use canonical "." separator (${techniqueId.replace('-', '.')})`);
@@ -66,7 +83,7 @@ export function getMitreMappingValidationIssues(mappings, options = {}) {
     if (attackVersion !== undefined) {
       const version = typeof attackVersion === 'string' ? attackVersion.trim() : '';
       if (!ATTACK_VERSION_RE.test(version)) {
-        issues.push(`${label}: attackVersion must match vNN[.N]`);
+        issues.push(`${label}: attack-version must match vNN[.N]`);
       }
     }
 
@@ -99,7 +116,7 @@ export function getAtlasMappingValidationIssues(atlasMappings, options = {}) {
       const label = mappingLabel(labelPrefix, i);
       const mapping = atlasMappings[i] || {};
       const techniqueId = trimOptionalString(mapping.techniqueId);
-      const atlasVersion = mapping.atlasVersion ?? mapping.atlas_version;
+      const atlasVersion = getAtlasVersion(mapping);
 
       if (!ATLAS_TECHNIQUE_ID_RE.test(techniqueId)) {
         issues.push(`${label}: invalid techniqueId "${techniqueId}" — expected format AML.T####[.###]`);
@@ -133,13 +150,79 @@ export function getAtlasMappingValidationIssues(atlasMappings, options = {}) {
       if (atlasVersion != null && atlasVersion !== '') {
         const version = typeof atlasVersion === 'string' ? atlasVersion.trim() : '';
         if (!ATLAS_VERSION_RE.test(version)) {
-          issues.push(`${label}: atlasVersion must match N.N.N`);
+          issues.push(`${label}: atlas-version must match N.N.N`);
         }
       }
 
       if (mapping.evidence !== undefined && (typeof mapping.evidence !== 'string' || mapping.evidence.trim() === '')) {
         issues.push(`${label}: evidence must be a non-empty string`);
       }
+    }
+  }
+
+  return issues;
+}
+
+export function getFrameworkMappingValidationIssues(frameworkMappings, options = {}) {
+  const labelPrefix = options.labelPrefix || 'framework mapping';
+  const issues = [];
+  const atlasData = getAtlasData();
+
+  if (frameworkMappings !== undefined && !Array.isArray(frameworkMappings)) {
+    issues.push('framework-mappings must be an array when present');
+  }
+
+  if (!Array.isArray(frameworkMappings)) {
+    return issues;
+  }
+
+  for (let i = 0; i < frameworkMappings.length; i += 1) {
+    const label = mappingLabel(labelPrefix, i);
+    const mapping = frameworkMappings[i] || {};
+    const framework = trimOptionalString(mapping.framework);
+    const version = trimOptionalString(mapping.version);
+    const mappingId = getFrameworkMappingId(mapping);
+    const mappingName = getFrameworkMappingName(mapping);
+
+    if (!SCHEMA_FRAMEWORK_MAPPING_VALUES.includes(framework)) {
+      issues.push(`${label}: framework must be ${SCHEMA_FRAMEWORK_MAPPING_VALUES.join(' | ')}`);
+      continue;
+    }
+
+    if (!ATLAS_TECHNIQUE_ID_RE.test(mappingId)) {
+      issues.push(`${label}: invalid mapping-id "${mappingId}" — expected format AML.T####[.###]`);
+    } else {
+      const shouldUsePinnedAtlasData = isPinnedAtlasVersion(version);
+      const technique = shouldUsePinnedAtlasData ? getAtlasTechnique(mappingId) : null;
+      if (shouldUsePinnedAtlasData && !technique) {
+        issues.push(`${label}: mapping-id "${mappingId}" is not present in MITRE ATLAS ${atlasData.version}`);
+      } else if (technique?.revoked || technique?.deprecated) {
+        issues.push(`${label}: mapping-id "${mappingId}" is ${technique.revoked ? 'revoked' : 'deprecated'} in MITRE ATLAS ${atlasData.version}`);
+      } else if (technique) {
+        const officialName = normalizeFrameworkName(technique.name);
+        if (mappingName && mappingName !== officialName) {
+          issues.push(`${label}: mapping-name "${mappingName}" should match MITRE ATLAS ${atlasData.version} name "${officialName}"`);
+        }
+      }
+    }
+
+    if (!mappingName) {
+      issues.push(`${label}: missing mapping-name`);
+    }
+
+    if (version && !ATLAS_VERSION_RE.test(version)) {
+      issues.push(`${label}: version must match N.N.N`);
+    }
+
+    if (
+      mapping.confidence !== undefined &&
+      !SCHEMA_MAPPING_CONFIDENCE_VALUES.includes(String(mapping.confidence).trim())
+    ) {
+      issues.push(`${label}: confidence must be ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')}`);
+    }
+
+    if (mapping.evidence !== undefined && (typeof mapping.evidence !== 'string' || mapping.evidence.trim() === '')) {
+      issues.push(`${label}: evidence must be a non-empty string`);
     }
   }
 

--- a/scripts/framework-mapping-validation.mjs
+++ b/scripts/framework-mapping-validation.mjs
@@ -168,11 +168,11 @@ export function getFrameworkMappingValidationIssues(frameworkMappings, options =
   const issues = [];
   const atlasData = getAtlasData();
 
-  if (frameworkMappings !== undefined && !Array.isArray(frameworkMappings)) {
-    issues.push('framework-mappings must be an array when present');
+  if (frameworkMappings === undefined) {
+    return issues;
   }
-
   if (!Array.isArray(frameworkMappings)) {
+    issues.push('framework-mappings must be an array when present');
     return issues;
   }
 

--- a/scripts/framework-mapping-validation.mjs
+++ b/scripts/framework-mapping-validation.mjs
@@ -189,9 +189,9 @@ export function getFrameworkMappingValidationIssues(frameworkMappings, options =
       continue;
     }
 
-    if (!ATLAS_TECHNIQUE_ID_RE.test(mappingId)) {
+    if (framework === 'mitre-atlas' && !ATLAS_TECHNIQUE_ID_RE.test(mappingId)) {
       issues.push(`${label}: invalid mapping-id "${mappingId}" — expected format AML.T####[.###]`);
-    } else {
+    } else if (framework === 'mitre-atlas') {
       const shouldUsePinnedAtlasData = isPinnedAtlasVersion(version);
       const technique = shouldUsePinnedAtlasData ? getAtlasTechnique(mappingId) : null;
       if (shouldUsePinnedAtlasData && !technique) {

--- a/scripts/pipeline-run-task.mjs
+++ b/scripts/pipeline-run-task.mjs
@@ -118,7 +118,7 @@ const MITRE_MAPPING_SCHEMA = `    Each MITRE ATT&CK mapping requires:
       evidence: string (optional, source-supported rationale)
       notes: string (optional, context for this article)`;
 
-const ATLAS_MAPPING_SCHEMA = `  framework-mappings: array of generic framework mapping objects (optional; currently only for article-supported adversarial AI/ML behavior)
+const FRAMEWORK_MAPPING_SCHEMA = `  framework-mappings: array of generic framework mapping objects (optional; currently only for article-supported adversarial AI/ML behavior)
     For MITRE ATLAS mappings:
       framework: "mitre-atlas"
       version: string (optional, e.g., "5.6.0")
@@ -156,7 +156,7 @@ const SCHEMAS = {
 ${SOURCE_SCHEMA}
   mitreMappings: array of MITRE ATT&CK mapping objects — MINIMUM 1
 ${MITRE_MAPPING_SCHEMA}
-${ATLAS_MAPPING_SCHEMA}`,
+${FRAMEWORK_MAPPING_SCHEMA}`,
     bodySpec: `Required H2 sections (minimum 5):
   ## Summary — 2-3 paragraphs: what happened, who was affected, scope
   ## Technical Analysis — attack mechanism, tools used, vulnerability details
@@ -195,7 +195,7 @@ ${ATLAS_MAPPING_SCHEMA}`,
 ${SOURCE_SCHEMA}
   mitreMappings: array of MITRE ATT&CK mapping objects — MINIMUM 1
 ${MITRE_MAPPING_SCHEMA}
-${ATLAS_MAPPING_SCHEMA}`,
+${FRAMEWORK_MAPPING_SCHEMA}`,
     bodySpec: `Required H2 sections (minimum 6):
   ## Executive Summary — campaign overview, objectives, scope, current status
   ## Technical Analysis — tools, techniques, infrastructure, operator workflow
@@ -224,7 +224,7 @@ ${ATLAS_MAPPING_SCHEMA}`,
   tools: array of strings — known malware and tools
   mitreMappings: array of MITRE ATT&CK mapping objects — MINIMUM 3
 ${MITRE_MAPPING_SCHEMA}
-${ATLAS_MAPPING_SCHEMA}
+${FRAMEWORK_MAPPING_SCHEMA}
   attributionConfidence: enum (optional) — A1 through A6
   attributionRationale: string (optional, max 500 chars)
   reviewStatus: constrained by task acceptance (see ACCEPTANCE CRITERIA below)
@@ -272,7 +272,7 @@ ${SOURCE_SCHEMA}`,
 ${SOURCE_SCHEMA}
   mitreMappings: array of MITRE ATT&CK mapping objects — MINIMUM 1
 ${MITRE_MAPPING_SCHEMA}
-${ATLAS_MAPPING_SCHEMA}`,
+${FRAMEWORK_MAPPING_SCHEMA}`,
     bodySpec: `Required H2 sections (minimum 5):
   ## Severity Assessment — Exploitability, Impact, Weaponization Risk, Patch Urgency, Detection Coverage (scored X/10)
   ## Summary — what the vulnerability is, scope of affected systems, significance

--- a/scripts/pipeline-run-task.mjs
+++ b/scripts/pipeline-run-task.mjs
@@ -39,6 +39,7 @@ import {
 } from './pipeline-schema.mjs';
 import {
   getAtlasMappingValidationIssues,
+  getFrameworkMappingValidationIssues,
   getMitreMappingValidationIssues,
 } from './framework-mapping-validation.mjs';
 import { getPublicProseGuardrailIssues } from './public-prose-guardrails.mjs';
@@ -112,20 +113,23 @@ const MITRE_MAPPING_SCHEMA = `    Each MITRE ATT&CK mapping requires:
       techniqueId: string (e.g., "T1566.001")
       techniqueName: string (e.g., "Phishing: Spearphishing Attachment")
       tactic: string (optional, canonical ATT&CK tactic casing)
-      attackVersion: string (optional, e.g., "v19"; attack_version is tolerated for legacy DATA-STANDARDS text)
+      attack-version: string (optional, e.g., "v19"; attackVersion and attack_version are tolerated only as compatibility aliases)
       confidence: enum (optional) — ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')}
       evidence: string (optional, source-supported rationale)
       notes: string (optional, context for this article)`;
 
-const ATLAS_MAPPING_SCHEMA = `  atlasMappings: array of MITRE ATLAS mapping objects (optional; only for article-supported adversarial AI/ML behavior)
-    Each ATLAS mapping requires:
-      techniqueId: string (e.g., "AML.T0042")
-      techniqueName: string
-      tactic: string (optional)
-      atlasVersion: string (optional, e.g., "5.6.0")
+const ATLAS_MAPPING_SCHEMA = `  framework-mappings: array of generic framework mapping objects (optional; currently only for article-supported adversarial AI/ML behavior)
+    For MITRE ATLAS mappings:
+      framework: "mitre-atlas"
+      version: string (optional, e.g., "5.6.0")
+      mapping-id: string (e.g., "AML.T0042")
+      mapping-name: string
+      tactic-id: string (optional)
+      tactic-name: string (optional)
       confidence: enum (optional) — ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')}
       evidence: string (optional, source-supported rationale)
-      notes: string (optional)`;
+      notes: string (optional)
+    atlasMappings is tolerated only as a compatibility alias while old PRs are migrated`;
 
 // ── Schemas per content type ────────────────────────────────────────────────
 const SCHEMAS = {
@@ -311,8 +315,8 @@ function buildRules(task) {
      — Every frontmatter source URL must appear in the body exactly once
      — No orphan sources: every body source entry must have a matching frontmatter source object
      — No plain-text sources: every body entry must be a markdown hyperlink
-  11. MITRE tactic casing must use the canonical ATT&CK vocabulary; optional metadata must use attackVersion vNN[.N], confidence ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')}, and non-empty evidence when present
-  12. atlasMappings are optional and only allowed for source-supported adversarial AI/ML behavior; techniqueId must match AML.T####[.###]
+  11. MITRE tactic casing must use the canonical ATT&CK vocabulary; optional metadata must use attack-version vNN[.N], confidence ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')}, and non-empty evidence when present
+  12. framework-mappings are optional and currently only allowed for source-supported adversarial AI/ML behavior; MITRE ATLAS entries require framework: mitre-atlas and mapping-id AML.T####[.###]
   13. Canonical publisher aliases must be normalized in frontmatter and body
   14. The Astro build must pass: cd site && npm run build`;
 }
@@ -1239,6 +1243,8 @@ function validateOutput(task, explicitFile) {
 
     const atlasMappings = frontmatter.atlasMappings;
     issues.push(...getAtlasMappingValidationIssues(atlasMappings));
+    const frameworkMappings = frontmatter['framework-mappings'] ?? frontmatter.frameworkMappings;
+    issues.push(...getFrameworkMappingValidationIssues(frameworkMappings));
 
     // ── 8. Exact H2 section headings ───────────────────────────────────────
     const requiredH2 = SCHEMA_REQUIRED_H2_BY_TYPE[task.type] || [];

--- a/scripts/pipeline-schema.mjs
+++ b/scripts/pipeline-schema.mjs
@@ -68,6 +68,10 @@ export const SCHEMA_MAPPING_CONFIDENCE_VALUES = Object.freeze([
   'possible',
 ]);
 
+export const SCHEMA_FRAMEWORK_MAPPING_VALUES = Object.freeze([
+  'mitre-atlas',
+]);
+
 export const SCHEMA_ATTACK_VERSION_PATTERN = '^v\\d+(?:\\.\\d+)?$';
 export const SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN = '^AML\\.T\\d{4}(?:\\.\\d{3})?$';
 export const SCHEMA_ATLAS_VERSION_PATTERN = '^\\d+\\.\\d+\\.\\d+$';
@@ -155,6 +159,7 @@ export const SCHEMA = Object.freeze({
   reviewStatuses: SCHEMA_REVIEW_STATUSES,
   mitreTactics: SCHEMA_MITRE_TACTICS,
   mappingConfidenceValues: SCHEMA_MAPPING_CONFIDENCE_VALUES,
+  frameworkMappingValues: SCHEMA_FRAMEWORK_MAPPING_VALUES,
   attackVersionPattern: SCHEMA_ATTACK_VERSION_PATTERN,
   atlasTechniqueIdPattern: SCHEMA_ATLAS_TECHNIQUE_ID_PATTERN,
   atlasVersionPattern: SCHEMA_ATLAS_VERSION_PATTERN,

--- a/scripts/validate-content-corpus.mjs
+++ b/scripts/validate-content-corpus.mjs
@@ -14,6 +14,7 @@ import {
 } from './pipeline-schema.mjs';
 import {
   getAtlasMappingValidationIssues,
+  getFrameworkMappingValidationIssues,
   getMitreMappingValidationIssues,
 } from './framework-mapping-validation.mjs';
 import {
@@ -437,6 +438,19 @@ function validateFile(file, newFiles) {
       : atlasIssues.join(' | '),
   });
   if (atlasIssues.length > 0) pass = false;
+
+  const frameworkMappings = fm['framework-mappings'] ?? fm.frameworkMappings;
+  const frameworkIssues = getFrameworkMappingValidationIssues(frameworkMappings, {
+    labelPrefix: 'mapping',
+  });
+  checks.push({
+    name: 'Generic framework mappings',
+    pass: frameworkIssues.length === 0,
+    detail: frameworkIssues.length === 0
+      ? `${Array.isArray(frameworkMappings) ? frameworkMappings.length : 0} optional mapping(s)`
+      : frameworkIssues.join(' | '),
+  });
+  if (frameworkIssues.length > 0) pass = false;
 
   const sources = Array.isArray(fm.sources) ? fm.sources : [];
   const publisherAliasViolations = [];

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -76,6 +76,7 @@ const mitreMapping = z.object({
   techniqueId: z.string().regex(/^T\d{4}(?:\.\d{3})?$/),
   techniqueName: z.string(),
   tactic: mitreTactic.optional(),
+  'attack-version': z.string().regex(/^v\d+(?:\.\d+)?$/).optional(),
   attackVersion: z.string().regex(/^v\d+(?:\.\d+)?$/).optional(),
   attack_version: z.string().regex(/^v\d+(?:\.\d+)?$/).optional(),
   confidence: mappingConfidence.optional(),
@@ -88,8 +89,22 @@ const atlasMapping = z.object({
   techniqueId: z.string().regex(/^AML\.T\d{4}(?:\.\d{3})?$/),
   techniqueName: z.string(),
   tactic: z.string().optional(),
+  'atlas-version': z.string().regex(/^\d+\.\d+\.\d+$/).optional(),
   atlasVersion: z.string().regex(/^\d+\.\d+\.\d+$/).optional(),
   atlas_version: z.string().regex(/^\d+\.\d+\.\d+$/).optional(),
+  confidence: mappingConfidence.optional(),
+  evidence: z.string().min(1).optional(),
+  notes: z.string().optional(),
+});
+
+/** Generic framework mapping schema; ATLAS is the first supported framework. */
+const frameworkMapping = z.object({
+  framework: z.enum(['mitre-atlas']),
+  version: z.string().regex(/^\d+\.\d+\.\d+$/).optional(),
+  'mapping-id': z.string().regex(/^AML\.T\d{4}(?:\.\d{3})?$/),
+  'mapping-name': z.string(),
+  'tactic-id': z.string().optional(),
+  'tactic-name': z.string().optional(),
   confidence: mappingConfidence.optional(),
   evidence: z.string().min(1).optional(),
   notes: z.string().optional(),
@@ -134,6 +149,7 @@ const incidents = defineCollection({
     // MITRE
     mitreMappings: z.array(mitreMapping).default([]),
     atlasMappings: z.array(atlasMapping).default([]),
+    'framework-mappings': z.array(frameworkMapping).default([]),
   }),
 });
 
@@ -178,6 +194,7 @@ const campaigns = defineCollection({
     // MITRE
     mitreMappings: z.array(mitreMapping).min(1),
     atlasMappings: z.array(atlasMapping).default([]),
+    'framework-mappings': z.array(frameworkMapping).default([]),
   }).superRefine((data, ctx) => {
     if (data.ongoing && data.endDate) {
       ctx.addIssue({
@@ -236,6 +253,7 @@ const threatActors = defineCollection({
     tools: z.array(z.string()).default([]),
     mitreMappings: z.array(mitreMapping).default([]),
     atlasMappings: z.array(atlasMapping).default([]),
+    'framework-mappings': z.array(frameworkMapping).default([]),
 
     // Quality
     attributionConfidence: attributionConfidence.optional(),
@@ -289,6 +307,7 @@ const zeroDays = defineCollection({
     // MITRE
     mitreMappings: z.array(mitreMapping).default([]),
     atlasMappings: z.array(atlasMapping).default([]),
+    'framework-mappings': z.array(frameworkMapping).default([]),
   }),
 });
 


### PR DESCRIPTION
## Summary

Adds a report-mode corpus audit for the ATT&CK v19 migration slice.

This PR does not modify article frontmatter. It adds:

- scripts/audit-framework-mappings.mjs
- .github/pipeline/reports/framework-mapping-audit-2026-05-07.md
- .github/pipeline/reports/framework-mapping-audit-2026-05-07.json

Audit result:

- Content files scanned: 161
- Files with MITRE mappings: 161
- MITRE mappings scanned: 484
- Findings: 1646
- Mechanically fixable official-name candidates: 170
- ATT&CK v19 Defense Evasion split candidates requiring review: 27
- Revoked or unknown technique errors: 16
- Tactic mismatch warnings: 2
- Legacy metadata gaps: 1431

## Validation

- npm --prefix scripts ci --no-audit --no-fund
- node --check scripts/audit-framework-mappings.mjs
- node scripts/pipeline-schema.mjs
- node scripts/audit-framework-mappings.mjs --json-out .github/pipeline/reports/framework-mapping-audit-2026-05-07.json
- git diff --check
- npm --prefix site ci
- npm --prefix site run build

## Notes

- Report mode only; no article mapping changes are made in this PR.
- The next migration PR should apply only mechanically safe official technique-name corrections first.
- ATT&CK v19 tactic split candidates should remain separate because those changes need article-supported review.
