### PR TITLE
docs(frameworks): align generation rules with ATT&CK v19

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,8 @@
 ### For Incident Reports
 - [ ] Title follows convention: `Org/Target — Attack Type (TP-YYYY-NNNN)`
 - [ ] At least 2 independent sources cited
-- [ ] MITRE ATT&CK techniques mapped (where applicable)
+- [ ] MITRE ATT&CK v19 techniques mapped where source-supported; uncertain mappings omitted
+- [ ] MITRE ATLAS added only through `framework-mappings` when article evidence shows adversarial AI/ML behavior
 - [ ] Threat actor attribution includes confidence level
 - [ ] Severity rating justified in the report body
 - [ ] No sensitive/embargoed information disclosed prematurely

--- a/.github/REVIEW-WORKFLOW.md
+++ b/.github/REVIEW-WORKFLOW.md
@@ -43,7 +43,8 @@ The `incident-review.yml` workflow then:
    - Are sources credible and independently verifiable?
    - Is the threat actor attribution accurate? Is the confidence level appropriate?
    - Is the severity rating justified?
-   - Are MITRE ATT&CK mappings correct?
+   - Are MITRE ATT&CK v19 mappings source-supported and correctly named?
+   - Are ATLAS mappings present only when the article evidence supports adversarial AI/ML behavior?
    - Are cross-links to related incidents present and bidirectional?
 3. Approve, request changes, or comment
 4. Once approved by a CODEOWNERS reviewer, merge to `main`

--- a/docs/DATA-STANDARDS-v1.0.md
+++ b/docs/DATA-STANDARDS-v1.0.md
@@ -284,7 +284,7 @@ This is the field that would have caught the BlueHammer Chaotic Eclipse error: a
   "technique_id": "T1190",
   "technique_name": "Exploit Public-Facing Application",
   "tactic": "Initial Access",
-  "attack_version": "v19.0",
+  "attack-version": "v19.0",
   "confidence": "confirmed",
   "evidence": "CVE-2023-50224 exploited per DOJ press release"
 }
@@ -292,7 +292,7 @@ This is the field that would have caught the BlueHammer Chaotic Eclipse error: a
 
 **`confidence` enum:** `confirmed` | `probable` | `possible`. Required.
 
-**Required:** `technique_id`, `attack_version`, `confidence`, `evidence`. Speculative mappings without evidence are rejected (RULE-009, RULE-012).
+**Required:** `technique_id`, `attack-version`, `confidence`, `evidence`. Speculative mappings without evidence are rejected (RULE-009, RULE-012).
 
 **Current pipeline rule:** New article work uses ATT&CK Enterprise v19.0 by default. Legacy `attackVersion` / `attack_version` aliases may be tolerated by validators during migration, but new frontmatter should use `attack-version` where the public Astro schema supports it.
 

--- a/docs/DATA-STANDARDS-v1.0.md
+++ b/docs/DATA-STANDARDS-v1.0.md
@@ -284,7 +284,7 @@ This is the field that would have caught the BlueHammer Chaotic Eclipse error: a
   "technique_id": "T1190",
   "technique_name": "Exploit Public-Facing Application",
   "tactic": "Initial Access",
-  "attack_version": "v15.1",
+  "attack_version": "v19.0",
   "confidence": "confirmed",
   "evidence": "CVE-2023-50224 exploited per DOJ press release"
 }
@@ -293,6 +293,28 @@ This is the field that would have caught the BlueHammer Chaotic Eclipse error: a
 **`confidence` enum:** `confirmed` | `probable` | `possible`. Required.
 
 **Required:** `technique_id`, `attack_version`, `confidence`, `evidence`. Speculative mappings without evidence are rejected (RULE-009, RULE-012).
+
+**Current pipeline rule:** New article work uses ATT&CK Enterprise v19.0 by default. Legacy `attackVersion` / `attack_version` aliases may be tolerated by validators during migration, but new frontmatter should use `attack-version` where the public Astro schema supports it.
+
+**ATT&CK v19 caution:** Do not bulk-preserve or reassign `Defense Evasion` tactic mappings after the v19 tactic split without article-supported review. If the source evidence does not support a tactic, omit the mapping instead of guessing.
+
+### 4.4.1 Generic Framework and MITRE ATLAS Mapping
+
+MITRE ATLAS is a separate framework from ATT&CK. ATLAS mappings are optional and apply only when article evidence shows adversarial AI/ML behavior, such as an AI/ML system being targeted, abused as attacker tooling, bypassed as a security control, or compromised in the ML supply chain.
+
+Current Astro frontmatter uses the generic `framework-mappings` array for ATLAS:
+
+```yaml
+framework-mappings:
+  - framework: "mitre-atlas"
+    version: "5.6.0"
+    mapping-id: "AML.T0042"
+    mapping-name: "Example ATLAS technique name"
+    confidence: "possible"
+    evidence: "Source-supported rationale for why this article maps to the ATLAS technique."
+```
+
+Do not put ATLAS `AML.*` identifiers in `mitreMappings`; ATT&CK and ATLAS mappings remain additive and separate.
 
 ### 4.5 Source Schema
 

--- a/docs/DATA-STANDARDS-v1.0.md
+++ b/docs/DATA-STANDARDS-v1.0.md
@@ -281,8 +281,8 @@ This is the field that would have caught the BlueHammer Chaotic Eclipse error: a
 
 ```json
 {
-  "technique_id": "T1190",
-  "technique_name": "Exploit Public-Facing Application",
+  "techniqueId": "T1190",
+  "techniqueName": "Exploit Public-Facing Application",
   "tactic": "Initial Access",
   "attack-version": "v19.0",
   "confidence": "confirmed",
@@ -292,7 +292,7 @@ This is the field that would have caught the BlueHammer Chaotic Eclipse error: a
 
 **`confidence` enum:** `confirmed` | `probable` | `possible`. Required.
 
-**Required:** `technique_id`, `attack-version`, `confidence`, `evidence`. Speculative mappings without evidence are rejected (RULE-009, RULE-012).
+**Required:** `techniqueId`, `techniqueName`, `attack-version`, `confidence`, `evidence`. Speculative mappings without evidence are rejected (RULE-009, RULE-012).
 
 **Current pipeline rule:** New article work uses ATT&CK Enterprise v19.0 by default. Legacy `attackVersion` / `attack_version` aliases may be tolerated by validators during migration, but new frontmatter should use `attack-version` where the public Astro schema supports it.
 
@@ -484,7 +484,7 @@ The confidence score is a 0–100 integer computed from deterministic, externall
 | Source count (3-6 = 10pts, 6-9 = 18pts, 10+ = 25pts) | 25 | RULE-004 |
 | Source publisher diversity (gov + media + vendor + research) | 15 | publisher_type field |
 | All CVEs validated against NVD | 15 | NVD API at compute time |
-| All ATT&CK techniques exist in declared `attack_version` | 15 | ATT&CK STIX bundle |
+| All ATT&CK techniques exist in declared `attack-version` | 15 | ATT&CK STIX bundle |
 | Attribution confidence | 10 | Admiralty A1=10, A2=8, A3=6, A4=4, A5=2, A6=0 |
 | All sources have valid `archived_url` | 10 | RULE-011 |
 | All required sections present | 10 | §6 |
@@ -611,10 +611,10 @@ Sightings rows are immutable. Corrections happen by inserting a new row with `co
 | RULE-006 | `attribution_rationale` required if confidence is A1–A4 | v0.1 |
 | RULE-007 | `target_countries` must use ISO 3166-1 α-2 | v0.1 |
 | RULE-008 | `cves_exploited` entries match `CVE-YYYY-NNNNN` | v0.1 |
-| RULE-009 | All ATT&CK `technique_id` values must exist in declared `attack_version` | v0.1 |
+| RULE-009 | All ATT&CK `techniqueId` values must exist in declared `attack-version` | v0.1 |
 | RULE-010 | `impact_severity` required before article enters review queue | v0.1 |
 | RULE-011 | `archived_url` required for all sources at certification | v0.1 |
-| RULE-012 | `attack_version` required on all ATT&CK technique mappings | v0.1 |
+| RULE-012 | `attack-version` required on all ATT&CK technique mappings | v0.1 |
 | RULE-013 | `last_observed`, `current`, `ongoing_status` are not writable on entities | v1.0 |
 | RULE-014 | Sightings table is append-only | v1.0 |
 | RULE-015 | Incidents with `status=ongoing` and `date_start` >180 days ago are flagged | v1.0 |

--- a/docs/DATA-STANDARDS.md
+++ b/docs/DATA-STANDARDS.md
@@ -203,8 +203,8 @@ Each source is a structured object. URL strings alone are not acceptable.
 
 ```json
 {
-  "technique_id": "T1566.001",
-  "technique_name": "Spearphishing Attachment",
+  "techniqueId": "T1566.001",
+  "techniqueName": "Spearphishing Attachment",
   "tactic": "Initial Access",
   "confidence": "confirmed | probable | possible",
   "evidence": "Free text describing evidence for this mapping",
@@ -302,10 +302,10 @@ Automatically enforced before any article enters the human review queue.
 | RULE-006 | `attribution_rationale` required if confidence is A1–A4 |
 | RULE-007 | `target_countries` must be valid ISO 3166-1 alpha-2 codes |
 | RULE-008 | `cves_exploited` entries must match `CVE-YYYY-NNNNN` format |
-| RULE-009 | All ATT&CK `technique_id` values must exist in the declared `attack_version` |
+| RULE-009 | All ATT&CK `techniqueId` values must exist in the declared `attack-version` |
 | RULE-010 | `impact_severity` required before article enters review queue |
 | RULE-011 | `archived_url` required for all sources at certification (not submission) |
-| RULE-012 | `attack_version` required on all ATT&CK technique mappings |
+| RULE-012 | `attack-version` required on all ATT&CK technique mappings |
 
 ---
 

--- a/docs/DATA-STANDARDS.md
+++ b/docs/DATA-STANDARDS.md
@@ -208,7 +208,7 @@ Each source is a structured object. URL strings alone are not acceptable.
   "tactic": "Initial Access",
   "confidence": "confirmed | probable | possible",
   "evidence": "Free text describing evidence for this mapping",
-  "attack_version": "v19.0",
+  "attack-version": "v19.0",
   "mapped_by": "reviewer_id",
   "mapped_date": "YYYY-MM-DD",
   "source_refs": ["SRC-0001", "SRC-0002"]

--- a/docs/DATA-STANDARDS.md
+++ b/docs/DATA-STANDARDS.md
@@ -208,7 +208,7 @@ Each source is a structured object. URL strings alone are not acceptable.
   "tactic": "Initial Access",
   "confidence": "confirmed | probable | possible",
   "evidence": "Free text describing evidence for this mapping",
-  "attack_version": "v15",
+  "attack_version": "v19.0",
   "mapped_by": "reviewer_id",
   "mapped_date": "YYYY-MM-DD",
   "source_refs": ["SRC-0001", "SRC-0002"]
@@ -226,9 +226,26 @@ Each source is a structured object. URL strings alone are not acceptable.
 ### Mapping Rules
 
 - Every technique mapping must include an `evidence` field — speculative mappings without evidence are rejected
-- The `attack_version` field is required — ATT&CK evolves and mappings must be versioned to remain accurate
+- New technique mappings should use ATT&CK Enterprise v19.0 unless a task explicitly preserves an older article version; ATT&CK evolves and mappings must be versioned to remain accurate
 - Kill Chain stage is derived automatically from ATT&CK tactic — reviewers do not enter both manually
 - Sub-techniques (e.g., `T1566.001`) are preferred over parent techniques where evidence supports specificity
+- ATT&CK v19 split cases, especially legacy `Defense Evasion` mappings, require source-supported review before reclassification
+
+### MITRE ATLAS and Generic Framework Mappings
+
+ATLAS is separate from ATT&CK and uses `AML.*` identifiers. Add ATLAS only when article evidence supports adversarial AI/ML behavior: an AI/ML system was targeted, abused as attacker tooling, bypassed as a security control, or compromised in the ML supply chain.
+
+Current Astro frontmatter stores ATLAS in `framework-mappings`, not `mitreMappings`:
+
+```yaml
+framework-mappings:
+  - framework: "mitre-atlas"
+    version: "5.6.0"
+    mapping-id: "AML.T0042"
+    mapping-name: "Example ATLAS technique name"
+    confidence: "possible"
+    evidence: "Source-supported rationale for this ATLAS mapping."
+```
 
 ---
 

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -154,6 +154,20 @@ for the pipeline.
      MITRE tactic casing, canonical publisher aliases, canonical
      `generatedBy` values, and public-prose guardrails that block internal
      editorial/process language from article body text.
+   - Framework mappings are validated against the public schema mirror and
+     pinned framework data where available. New ATT&CK mappings should declare
+     `attack-version: "v19"` or `attack-version: "v19.0"` unless the task is
+     deliberately preserving an older article version. `attackVersion` and
+     `attack_version` remain compatibility aliases for legacy content and
+     in-flight PRs.
+   - ATT&CK v19 split cases, especially legacy `Defense Evasion` mappings,
+     require source-supported review before reclassification. Workers should
+     omit uncertain mappings rather than bulk-reassigning tactics.
+   - MITRE ATLAS is modeled separately through optional `framework-mappings`
+     entries with `framework: "mitre-atlas"` and `mapping-id:
+     "AML.T####[.###]"`. Add ATLAS only when article evidence supports
+     adversarial AI/ML behavior; do not use ATLAS for merely AI-adjacent
+     topics.
    - Failure leaves the task locked for agent iteration; success allows the
      agent to record a real open PR number, which moves the task to
      `status: pr_open`.

--- a/scripts/generate-article.mjs
+++ b/scripts/generate-article.mjs
@@ -113,6 +113,9 @@ YAML frontmatter fields (all required unless marked optional):
     - techniqueId: string (T1234 or T1234.001)
       techniqueName: string
       tactic: string (Initial Access, Execution, Persistence, etc.)
+      attack-version: string (use "v19" or "v19.0" for new mappings)
+      confidence: confirmed | probable | possible
+      evidence: string (source-supported rationale)
       notes: string (evidence for this mapping)`,
     bodySpec: `
 Required H2 sections IN THIS ORDER (use exactly these headings):
@@ -189,7 +192,7 @@ YAML frontmatter fields (all required unless marked optional):
   relatedIncidents: array of strings (optional) — linked incident slugs; campaigns should reference confirmed constituent incidents where available
   tags: array of strings
   sources: array of source objects (minimum 3, same schema as incidents; at least 1 government source)
-  mitreMappings: array of MITRE objects (minimum 1, same schema as incidents)`,
+  mitreMappings: array of MITRE objects (minimum 1, same schema as incidents; use ATT&CK v19 for new mappings)`,
     bodySpec: `
 Required H2 sections IN THIS ORDER:
 
@@ -233,7 +236,7 @@ YAML frontmatter fields (all required unless marked optional):
   targetGeographies: array of strings (optional)
   tools: array of strings (optional) — known malware/tool names
   knownTools: array of strings (optional) — same as tools, for schema compatibility
-  mitreMappings: array of MITRE objects (optional)
+  mitreMappings: array of MITRE objects (optional; use ATT&CK v19 for new mappings)
   reviewStatus: must be "draft_ai"
   generatedBy: must be "ai_ingestion"
   generatedDate: date — today's date
@@ -341,7 +344,9 @@ function buildSystemPrompt(type) {
 
 You produce factual, well-sourced articles. You NEVER fabricate sources — every URL, publisher, and date must be real and verifiable. If you cannot find real sources, use placeholder URLs with a <!-- FIXME: SOURCE RECOVERY REQUIRED --> comment.
 
-You NEVER fabricate MITRE ATT&CK technique IDs. Every T-code must be a real technique from ATT&CK v16+. If unsure, omit rather than guess.
+You NEVER fabricate MITRE ATT&CK technique IDs. Every T-code must be a real technique from pinned ATT&CK Enterprise v19.0 for new articles unless the task explicitly preserves a legacy article version. If unsure, omit rather than guess.
+
+You add MITRE ATLAS only when the article evidence shows adversarial AI/ML behavior: an AI/ML system was targeted, abused as attacker tooling, bypassed as a security control, or compromised in the ML supply chain. ATLAS is separate from ATT&CK; do not mix AML IDs into mitreMappings.
 
 FORMATTING RULES (EDITORIAL-WORKFLOW-SPEC §14A — strictly enforced):
 - Blank line before and after EVERY heading (## and ###)

--- a/scripts/generate-article.mjs
+++ b/scripts/generate-article.mjs
@@ -116,7 +116,14 @@ YAML frontmatter fields (all required unless marked optional):
       attack-version: string (use "v19" or "v19.0" for new mappings)
       confidence: confirmed | probable | possible
       evidence: string (source-supported rationale)
-      notes: string (evidence for this mapping)`,
+      notes: string (optional, context for this article)
+  framework-mappings: array of objects (optional; for ATLAS mappings)
+    - framework: "mitre-atlas"
+      version: string (optional, e.g., "5.6.0")
+      mapping-id: string (e.g., "AML.T0042")
+      mapping-name: string
+      confidence: confirmed | probable | possible
+      evidence: string (source-supported rationale)`,
     bodySpec: `
 Required H2 sections IN THIS ORDER (use exactly these headings):
 
@@ -192,7 +199,8 @@ YAML frontmatter fields (all required unless marked optional):
   relatedIncidents: array of strings (optional) — linked incident slugs; campaigns should reference confirmed constituent incidents where available
   tags: array of strings
   sources: array of source objects (minimum 3, same schema as incidents; at least 1 government source)
-  mitreMappings: array of MITRE objects (minimum 1, same schema as incidents; use ATT&CK v19 for new mappings)`,
+  mitreMappings: array of MITRE objects (minimum 1, same schema as incidents; use ATT&CK v19 for new mappings)
+  framework-mappings: array of objects (optional; same schema as incidents)`,
     bodySpec: `
 Required H2 sections IN THIS ORDER:
 
@@ -236,7 +244,8 @@ YAML frontmatter fields (all required unless marked optional):
   targetGeographies: array of strings (optional)
   tools: array of strings (optional) — known malware/tool names
   knownTools: array of strings (optional) — same as tools, for schema compatibility
-  mitreMappings: array of MITRE objects (optional; use ATT&CK v19 for new mappings)
+  mitreMappings: array of MITRE objects (optional; same schema as incidents; use ATT&CK v19 for new mappings)
+  framework-mappings: array of objects (optional; same schema as incidents)
   reviewStatus: must be "draft_ai"
   generatedBy: must be "ai_ingestion"
   generatedDate: date — today's date

--- a/scripts/pipeline-run-task.mjs
+++ b/scripts/pipeline-run-task.mjs
@@ -315,10 +315,12 @@ function buildRules(task) {
      — Every frontmatter source URL must appear in the body exactly once
      — No orphan sources: every body source entry must have a matching frontmatter source object
      — No plain-text sources: every body entry must be a markdown hyperlink
-  11. MITRE tactic casing must use the canonical ATT&CK vocabulary; optional metadata must use attack-version vNN[.N], confidence ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')}, and non-empty evidence when present
-  12. framework-mappings are optional and currently only allowed for source-supported adversarial AI/ML behavior; MITRE ATLAS entries require framework: mitre-atlas and mapping-id AML.T####[.###]
-  13. Canonical publisher aliases must be normalized in frontmatter and body
-  14. The Astro build must pass: cd site && npm run build`;
+  11. MITRE tactic casing must use the canonical ATT&CK vocabulary; new mappings should declare attack-version "v19" or "v19.0" unless preserving a legacy article version; optional metadata must use confidence ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')} and non-empty evidence when present
+  12. Do not bulk-assign or preserve Defense Evasion for ATT&CK v19 split cases without article-supported review; use the pinned v19 data and omit uncertain mappings rather than guessing
+  13. framework-mappings are optional and currently only allowed for source-supported adversarial AI/ML behavior; MITRE ATLAS entries require framework: mitre-atlas and mapping-id AML.T####[.###]
+  14. Do not add ATLAS because a topic is broadly AI-adjacent; require article evidence that an AI/ML system was targeted, abused as tooling, bypassed as a control, or compromised in the ML supply chain
+  15. Canonical publisher aliases must be normalized in frontmatter and body
+  16. The Astro build must pass: cd site && npm run build`;
 }
 
 // ── CLI Parsing ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

This is the framework sprint generation/rules slice after the ATT&CK v19 + ATLAS schema/validator work merged.

- Updates pipeline runner guidance so new ATT&CK mappings default to v19/v19.0 and v19 Defense Evasion split cases require article-supported review.
- Updates the legacy manual generator prompt to use pinned ATT&CK Enterprise v19.0 for new articles and keep ATLAS separate from mitreMappings.
- Documents ATLAS as optional framework-mappings only when article evidence supports adversarial AI/ML behavior.
- Refreshes PR/review checklist language to match the current framework mapping gates.

## Validation

- PASS: npm --prefix scripts ci --no-audit --no-fund
- PASS: node --check scripts/pipeline-run-task.mjs
- PASS: node --check scripts/generate-article.mjs
- PASS: node scripts/pipeline-schema.mjs
- PASS: node scripts/validate-content-corpus.mjs --files-file /private/tmp/threatpedia-no-content-files-518-rules.txt
- PASS: git diff --check
- NOT RUN: npm --prefix site run build; docs and generation prompt text only, no Astro/content rendering paths changed

## Scope

No article corpus files changed.