### PR TITLE
fix(pipeline): block Canvas intake pending gov source

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0236.json
+++ b/.github/pipeline/tasks/TASK-2026-0236.json
@@ -3,9 +3,9 @@
   "stage": "draft",
   "type": "incident",
   "priority": "P0",
-  "status": "pending",
+  "status": "blocked",
   "created": "2026-05-08T15:29:07.000Z",
-  "updated": "2026-05-08T16:11:00.000Z",
+  "updated": "2026-05-08T17:14:00.000Z",
   "source": "manual_submission",
   "submitted_by": "kernel-k-manual-intake",
   "locked_by": null,
@@ -45,7 +45,8 @@
   },
   "depends_on": [],
   "preconditions": [
-    "editorial queue depth < 50"
+    "editorial queue depth < 50",
+    "public government, regulator, law-enforcement, or public-institution source confirms the incident"
   ],
   "output": {
     "file_pattern": "site/src/content/incidents/{slug}.md",
@@ -68,6 +69,14 @@
       "to": "pending",
       "agent": "dangermouse-bot",
       "note": "Applied 3 Gemini candidate_data fixes: sector->Education & Research, threat_actor key->actor_name (removed (claimed) suffix), attack_type->Data Breach."
+    },
+    {
+      "timestamp": "2026-05-08T17:14:00.000Z",
+      "action": "blocked",
+      "from": "pending",
+      "to": "blocked",
+      "agent": "kernel-k",
+      "note": "Blocked dispatch until a qualifying public government, regulator, law-enforcement, or public-institution source exists; current intake sources are vendor/media only and the article validator requires a government source."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Blocks TASK-2026-0236 instead of leaving it dispatcher-eligible while its own pre-draft check says no qualifying government/regulator/law-enforcement/public-institution source is available yet.

## Failure Class

- Area: queue-state
- Failure class: queue-drift
- Decision: housekeeping
- Reason: This is a task-state correction for a known ineligible draft task, not a new validator or workflow layer.

## Validation

- npm ci --no-audit --no-fund in scripts
- node scripts/pipeline-schema.mjs
- node scripts/pipeline-run-task.mjs --task TASK-2026-0236
- JSON parse/status/precondition check

## Out of Scope

- No article drafting.
- No source classification changes.
- No workflow/schema changes.

Note: Git push reported existing default-branch Dependabot alerts: 1 high and 1 moderate. Not addressed in this queue-state PR.