### PR TITLE
fix(review-gate): include task JSON PRs

### DIFF
--- a/.github/workflows/pipeline-review-gate.yml
+++ b/.github/workflows/pipeline-review-gate.yml
@@ -40,6 +40,7 @@ jobs:
   review-gate:
     if: |
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'pull_request' ||
       (
         github.event_name == 'pull_request_review' &&
         contains(

--- a/.github/workflows/pipeline-review-gate.yml
+++ b/.github/workflows/pipeline-review-gate.yml
@@ -10,6 +10,7 @@ on:
       - "scripts/**"
       - ".github/workflows/**"
       - ".github/pipeline/config.yml"
+      - ".github/pipeline/tasks/TASK-*.json"
       - "docs/PIPELINE.md"
   pull_request_review:
     types: [submitted, dismissed]

--- a/scripts/pipeline-review-gate.mjs
+++ b/scripts/pipeline-review-gate.mjs
@@ -15,7 +15,7 @@ const DEFAULT_AI_REVIEW_LOGINS = [
 ];
 const CONTENT_FILE_RE = /^site\/src\/content\/(?:incidents|campaigns|threat-actors|zero-days)\/.+\.mdx?$/;
 const PUBLIC_SITE_FILE_RE = /^site\/(?:src\/|package(?:-lock)?\.json$|astro\.config\.)/;
-const PIPELINE_FILE_RE = /^(?:scripts\/|\.github\/workflows\/|\.github\/pipeline\/config\.yml|docs\/PIPELINE\.md|site\/src\/content\.config\.ts)/;
+const PIPELINE_FILE_RE = /^(?:scripts\/|\.github\/workflows\/|\.github\/pipeline\/config\.yml|\.github\/pipeline\/tasks\/TASK-\d{4}-\d{4}\.json$|docs\/PIPELINE\.md|site\/src\/content\.config\.ts)/;
 
 function parseArgs(argv) {
   const parsed = {

--- a/scripts/pipeline-review-gate.mjs
+++ b/scripts/pipeline-review-gate.mjs
@@ -8,6 +8,8 @@
  * rebase, or failed AI review attempt.
  */
 
+import { PIPELINE_TASK_FILE_PATH_RE } from './pipeline-task-patterns.mjs';
+
 const DEFAULT_AI_REVIEW_LOGINS = [
   'gemini-code-assist',
   'gemini-code-assist[bot]',
@@ -15,7 +17,7 @@ const DEFAULT_AI_REVIEW_LOGINS = [
 ];
 const CONTENT_FILE_RE = /^site\/src\/content\/(?:incidents|campaigns|threat-actors|zero-days)\/.+\.mdx?$/;
 const PUBLIC_SITE_FILE_RE = /^site\/(?:src\/|package(?:-lock)?\.json$|astro\.config\.)/;
-const PIPELINE_FILE_RE = /^(?:scripts\/|\.github\/workflows\/|\.github\/pipeline\/config\.yml$|\.github\/pipeline\/tasks\/TASK-\d{4}-\d+\.json$|docs\/PIPELINE\.md$|site\/src\/content\.config\.ts$)/;
+const PIPELINE_FILE_RE = /^(?:scripts\/|\.github\/workflows\/|\.github\/pipeline\/config\.yml$|docs\/PIPELINE\.md$|site\/src\/content\.config\.ts$)/;
 
 function parseArgs(argv) {
   const parsed = {
@@ -85,7 +87,10 @@ function isAiLogin(login, aiLogins) {
 }
 
 function isRelevantFile(path) {
-  return CONTENT_FILE_RE.test(path) || PUBLIC_SITE_FILE_RE.test(path) || PIPELINE_FILE_RE.test(path);
+  return CONTENT_FILE_RE.test(path)
+    || PUBLIC_SITE_FILE_RE.test(path)
+    || PIPELINE_FILE_RE.test(path)
+    || PIPELINE_TASK_FILE_PATH_RE.test(path);
 }
 
 function isContentFile(path) {

--- a/scripts/pipeline-review-gate.mjs
+++ b/scripts/pipeline-review-gate.mjs
@@ -15,7 +15,7 @@ const DEFAULT_AI_REVIEW_LOGINS = [
 ];
 const CONTENT_FILE_RE = /^site\/src\/content\/(?:incidents|campaigns|threat-actors|zero-days)\/.+\.mdx?$/;
 const PUBLIC_SITE_FILE_RE = /^site\/(?:src\/|package(?:-lock)?\.json$|astro\.config\.)/;
-const PIPELINE_FILE_RE = /^(?:scripts\/|\.github\/workflows\/|\.github\/pipeline\/config\.yml|\.github\/pipeline\/tasks\/TASK-\d{4}-\d{4}\.json$|docs\/PIPELINE\.md|site\/src\/content\.config\.ts)/;
+const PIPELINE_FILE_RE = /^(?:scripts\/|\.github\/workflows\/|\.github\/pipeline\/config\.yml$|\.github\/pipeline\/tasks\/TASK-\d{4}-\d+\.json$|docs\/PIPELINE\.md$|site\/src\/content\.config\.ts$)/;
 
 function parseArgs(argv) {
   const parsed = {

--- a/scripts/pipeline-task-patterns.mjs
+++ b/scripts/pipeline-task-patterns.mjs
@@ -1,0 +1,12 @@
+/**
+ * Shared task identifier and task-file path patterns for pipeline tooling.
+ *
+ * Keep these as string patterns plus RegExp exports so workflow gates and
+ * validators can reuse one canonical task JSON shape without duplicating it.
+ */
+
+export const PIPELINE_TASK_ID_PATTERN = 'TASK-\\d{4}-\\d+';
+export const PIPELINE_TASK_FILE_NAME_PATTERN = `${PIPELINE_TASK_ID_PATTERN}\\.json`;
+export const PIPELINE_TASK_FILE_PATH_PATTERN = `\\.github\\/pipeline\\/tasks\\/${PIPELINE_TASK_FILE_NAME_PATTERN}`;
+
+export const PIPELINE_TASK_FILE_PATH_RE = new RegExp(`^${PIPELINE_TASK_FILE_PATH_PATTERN}$`);


### PR DESCRIPTION
## Summary

- Include canonical `.github/pipeline/tasks/TASK-*.json` files in the review-gate workflow path filter.
- Treat canonical task JSON files as relevant pipeline files inside `scripts/pipeline-review-gate.mjs`.
- Keep the match narrow so rejection memory and other bookkeeping files do not become gated accidentally.

## Failure Class

Observed PR #589 changed only a task JSON file. A manual review-gate run evaluated the current head but returned `Applicable: no`, so task-intake instructions could avoid current-head second-review gating even though they shape future article generation.

Decision: patch. This closes the objective gate miss directly instead of adding operator instructions or another stale-state cleanup step.

## Validation

- `npm ci --no-audit --no-fund` in `scripts`: PASS
- `node pipeline-schema.mjs`: PASS
- `node validate-content-corpus.mjs --files-file /dev/null`: PASS
- `node --check scripts/pipeline-review-gate.mjs`: PASS
- `git diff --check`: PASS
- Targeted regex check for canonical task JSON relevance: PASS

Skipped: `site npm ci` and `site npm run build` were not run because this patch changes only the review-gate workflow and script, not site or content files.

## Pipeline Hardening Status

- Area: `review-gate`
- Failure class: `quality-gate-miss`
- Decision: `patch`
- Reason: `Task JSON shapes future article generation, so it should be gated by the same current-head second-review rule as other pipeline changes.`
- Branch: `codex/review-gate-task-json`
- Commit: `f2fcd54`
- PR: `#591 https://github.com/MahdiHedhli/threatpedia/pull/591`
- Local Validation: `PASS`
- GitHub Checks: `PENDING`
- AI Review: `PENDING`
- Rerun Result: `NOT NEEDED`
- Outcome: `opened_pr`
- Blocker: `none`
- Next: `wait for GitHub checks and AI review on the current head`