### PR TITLE
feat(site): add Plausible analytics

### DIFF
--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -8,7 +8,7 @@ interface Props {
 
 const { title, description = 'The Definitive Cyber Threat Encyclopedia' } = Astro.props;
 const enablePlausibleAnalytics = import.meta.env.PROD;
-const plausibleDomain = 'threatpedia.wiki';
+const plausibleDomain = Astro.site?.hostname ?? 'threatpedia.wiki';
 
 // Build ticker items from all collections
 interface TickerItem {

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -8,10 +8,13 @@ interface Props {
 
 const { title, description = 'The Definitive Cyber Threat Encyclopedia' } = Astro.props;
 const enablePlausibleAnalytics = import.meta.env.PROD;
-if (!Astro.site) {
-  throw new Error('Astro site config is required for Plausible analytics.');
+let plausibleDomain = '';
+if (enablePlausibleAnalytics) {
+  if (!Astro.site) {
+    throw new Error('Astro site config is required for Plausible analytics.');
+  }
+  plausibleDomain = Astro.site.hostname;
 }
-const plausibleDomain = Astro.site.hostname;
 
 // Build ticker items from all collections
 interface TickerItem {

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -7,13 +7,11 @@ interface Props {
 }
 
 const { title, description = 'The Definitive Cyber Threat Encyclopedia' } = Astro.props;
-const enablePlausibleAnalytics = import.meta.env.PROD;
-let plausibleDomain = '';
-if (enablePlausibleAnalytics) {
-  if (!Astro.site) {
-    throw new Error('Astro site config is required for Plausible analytics.');
-  }
-  plausibleDomain = Astro.site.hostname;
+const enablePlausibleAnalytics = import.meta.env.PROD && Boolean(Astro.site);
+const plausibleDomain = Astro.site?.hostname ?? '';
+
+if (import.meta.env.PROD && !Astro.site) {
+  console.warn('Plausible analytics disabled: site config is missing in astro.config.mjs');
 }
 
 // Build ticker items from all collections

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -8,7 +8,10 @@ interface Props {
 
 const { title, description = 'The Definitive Cyber Threat Encyclopedia' } = Astro.props;
 const enablePlausibleAnalytics = import.meta.env.PROD;
-const plausibleDomain = Astro.site?.hostname ?? 'threatpedia.wiki';
+if (!Astro.site) {
+  throw new Error('Astro site config is required for Plausible analytics.');
+}
+const plausibleDomain = Astro.site.hostname;
 
 // Build ticker items from all collections
 interface TickerItem {
@@ -2400,7 +2403,7 @@ try {
 
   .footer-links a {
     font-family: var(--font-mono);
-    font-size: 0.65rem;
+    font-size: 0.75rem;
     letter-spacing: 0.12em;
     text-transform: uppercase;
     color: var(--muted);

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -2399,6 +2399,10 @@ try {
   }
 
   .footer-links {
+    display: flex;
+    justify-content: center;
+    gap: 24px;
+    flex-wrap: wrap;
     margin-bottom: 12px;
   }
 

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -7,12 +7,8 @@ interface Props {
 }
 
 const { title, description = 'The Definitive Cyber Threat Encyclopedia' } = Astro.props;
-const enablePlausibleAnalytics = import.meta.env.PROD && Boolean(Astro.site);
-const plausibleDomain = Astro.site?.hostname ?? '';
-
-if (import.meta.env.PROD && !Astro.site) {
-  console.warn('Plausible analytics disabled: site config is missing in astro.config.mjs');
-}
+const enablePlausibleAnalytics = import.meta.env.PROD;
+const plausibleScriptSrc = 'https://plausible.io/js/pa-JU90GDszdzYfdcQawYHNo.js';
 
 // Build ticker items from all collections
 interface TickerItem {
@@ -100,7 +96,13 @@ try {
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;0,900;1,700;1,900&family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@300;400;500;600&display=swap" rel="stylesheet" />
     {enablePlausibleAnalytics && (
-      <script defer data-domain={plausibleDomain} src="https://plausible.io/js/script.js"></script>
+      <>
+        <script async src={plausibleScriptSrc}></script>
+        <script is:inline>
+          window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+          plausible.init()
+        </script>
+      </>
     )}
     <title>{title} — Threatpedia</title>
   </head>

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -7,6 +7,8 @@ interface Props {
 }
 
 const { title, description = 'The Definitive Cyber Threat Encyclopedia' } = Astro.props;
+const enablePlausibleAnalytics = import.meta.env.PROD;
+const plausibleDomain = 'threatpedia.wiki';
 
 // Build ticker items from all collections
 interface TickerItem {
@@ -93,6 +95,9 @@ try {
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;0,900;1,700;1,900&family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@300;400;500;600&display=swap" rel="stylesheet" />
+    {enablePlausibleAnalytics && (
+      <script defer data-domain={plausibleDomain} src="https://plausible.io/js/script.js"></script>
+    )}
     <title>{title} — Threatpedia</title>
   </head>
   <body>
@@ -146,6 +151,7 @@ try {
         <a href="/zero-days/">Zero-Days</a>
         <a href="/glossary/">Glossary</a>
         <a href="/roadmap/">Roadmap</a>
+        <a href="/privacy/">Privacy</a>
       </div>
     </div>
 
@@ -166,6 +172,9 @@ try {
       <div class="footer-domains">
         <div class="footer-domain">threatpedia.wiki</div>
         <div class="footer-domain">threatpedia.net</div>
+      </div>
+      <div class="footer-links">
+        <a href="/privacy/">Privacy</a>
       </div>
       <div class="footer-copy">&copy; 2026 — All Rights Reserved</div>
     </footer>
@@ -2383,6 +2392,24 @@ try {
     font-size: 0.65rem;
     letter-spacing: 0.1em;
     color: var(--muted);
+  }
+
+  .footer-links {
+    margin-bottom: 12px;
+  }
+
+  .footer-links a {
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--muted);
+    text-decoration: none;
+    transition: color 0.2s;
+  }
+
+  .footer-links a:hover {
+    color: var(--amber);
   }
 
   .footer-copy {

--- a/site/src/pages/privacy.astro
+++ b/site/src/pages/privacy.astro
@@ -49,8 +49,6 @@ import Base from '../layouts/Base.astro';
       <p>
         Plausible publishes its analytics data policy at
         <a href="https://plausible.io/data-policy" target="_blank" rel="noopener noreferrer">plausible.io/data-policy</a>.
-        If Threatpedia adds additional analytics, advertising, or user-account features in the future, this page should
-        be updated before those features are deployed.
       </p>
     </section>
   </article>

--- a/site/src/pages/privacy.astro
+++ b/site/src/pages/privacy.astro
@@ -145,6 +145,7 @@ import Base from '../layouts/Base.astro';
 
   a {
     color: var(--amber);
+    text-decoration: underline;
     text-decoration-color: rgba(232, 160, 32, 0.4);
     text-underline-offset: 3px;
   }

--- a/site/src/pages/privacy.astro
+++ b/site/src/pages/privacy.astro
@@ -58,7 +58,7 @@ import Base from '../layouts/Base.astro';
   .privacy-page {
     max-width: 920px;
     margin: 0 auto;
-    padding: 96px 24px 72px;
+    padding: 48px 0 72px;
   }
 
   .hero-eyebrow {
@@ -154,7 +154,7 @@ import Base from '../layouts/Base.astro';
 
   @media (max-width: 720px) {
     .privacy-page {
-      padding-top: 72px;
+      padding-top: 48px;
     }
 
     .privacy-grid {

--- a/site/src/pages/privacy.astro
+++ b/site/src/pages/privacy.astro
@@ -1,0 +1,165 @@
+---
+import Base from '../layouts/Base.astro';
+---
+
+<Base title="Privacy" description="Threatpedia privacy and analytics disclosure.">
+  <article class="privacy-page">
+    <div class="hero-eyebrow">Privacy</div>
+    <h1>Privacy &amp; Analytics</h1>
+    <p class="subtitle">
+      Threatpedia uses privacy-preserving analytics to understand which pages are useful,
+      improve the corpus, and spot broken navigation without tracking individual people.
+    </p>
+
+    <section class="privacy-card">
+      <h2>Analytics Provider</h2>
+      <p>
+        Threatpedia uses <a href="https://plausible.io/" target="_blank" rel="noopener noreferrer">Plausible Analytics</a>
+        on the public production site. Plausible provides aggregate site metrics such as page views,
+        referral sources, top pages, country-level location, device type, operating system, and browser.
+      </p>
+      <p>
+        Plausible is designed to work without cookies, local storage, cross-site identifiers, or behavioral
+        advertising profiles. It does not give Threatpedia a way to identify a specific visitor.
+      </p>
+    </section>
+
+    <section class="privacy-grid">
+      <div class="privacy-panel">
+        <h2>What We Use It For</h2>
+        <ul>
+          <li>Understanding which articles and corpus areas receive the most traffic.</li>
+          <li>Finding navigation gaps, search problems, and broken discovery paths.</li>
+          <li>Prioritizing editorial and pipeline work using aggregate usage trends.</li>
+        </ul>
+      </div>
+
+      <div class="privacy-panel">
+        <h2>What We Do Not Do</h2>
+        <ul>
+          <li>We do not use advertising pixels or retargeting trackers.</li>
+          <li>We do not sell analytics data.</li>
+          <li>We do not use analytics to profile individual visitors.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="privacy-card">
+      <h2>More Detail</h2>
+      <p>
+        Plausible publishes its analytics data policy at
+        <a href="https://plausible.io/data-policy" target="_blank" rel="noopener noreferrer">plausible.io/data-policy</a>.
+        If Threatpedia adds additional analytics, advertising, or user-account features in the future, this page should
+        be updated before those features are deployed.
+      </p>
+    </section>
+  </article>
+</Base>
+
+<style>
+  .privacy-page {
+    max-width: 920px;
+    margin: 0 auto;
+    padding: 96px 24px 72px;
+  }
+
+  .hero-eyebrow {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.28em;
+    color: var(--amber);
+    text-transform: uppercase;
+    margin-bottom: 18px;
+  }
+
+  h1 {
+    font-family: var(--font-serif);
+    font-size: clamp(3rem, 9vw, 6rem);
+    line-height: 0.95;
+    color: var(--text);
+    margin: 0 0 24px;
+  }
+
+  .subtitle {
+    font-family: var(--font-sans);
+    font-size: clamp(1rem, 2vw, 1.2rem);
+    line-height: 1.8;
+    color: var(--muted);
+    max-width: 720px;
+    margin: 0 0 48px;
+  }
+
+  .privacy-card,
+  .privacy-panel {
+    border: 1px solid var(--border);
+    background:
+      linear-gradient(135deg, rgba(232, 160, 32, 0.08), transparent 42%),
+      rgba(13, 18, 26, 0.82);
+    padding: 28px;
+  }
+
+  .privacy-card {
+    margin-bottom: 24px;
+  }
+
+  .privacy-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 24px;
+    margin-bottom: 24px;
+  }
+
+  h2 {
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--amber);
+    margin: 0 0 16px;
+  }
+
+  p,
+  li {
+    font-family: var(--font-sans);
+    font-size: 0.98rem;
+    line-height: 1.75;
+    color: var(--text);
+  }
+
+  p {
+    margin: 0 0 16px;
+  }
+
+  p:last-child {
+    margin-bottom: 0;
+  }
+
+  ul {
+    margin: 0;
+    padding-left: 20px;
+  }
+
+  li + li {
+    margin-top: 10px;
+  }
+
+  a {
+    color: var(--amber);
+    text-decoration-color: rgba(232, 160, 32, 0.4);
+    text-underline-offset: 3px;
+  }
+
+  a:hover {
+    text-decoration-color: var(--amber);
+  }
+
+  @media (max-width: 720px) {
+    .privacy-page {
+      padding-top: 72px;
+    }
+
+    .privacy-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- add production-only Plausible Analytics script for threatpedia.wiki
- add public privacy and analytics disclosure at /privacy/
- add Privacy links to the site menu and footer

## Validation
- npm --prefix site ci
- npm --prefix site run build
- browser preview check: /privacy/ renders and one Plausible script tag is present

## Notes
- Plausible account setup still needs threatpedia.wiki added or verified in the Plausible dashboard before live traffic appears.