### PR TITLE
Add gated X article sharing automation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,3 +52,54 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  social-share-x:
+    name: Draft X share posts
+    runs-on: ubuntu-latest
+    needs: deploy
+    if: github.event_name == 'push'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: scripts/package-lock.json
+
+      - name: Install scripts dependencies
+        run: npm --prefix scripts ci --no-audit --no-fund
+
+      - name: Prepare or post X share drafts
+        env:
+          SITE_URL: https://threatpedia.wiki
+          X_SHARE_MODE: ${{ vars.X_SHARE_MODE }}
+          X_POSTING_ENABLED: ${{ secrets.X_POSTING_ENABLED }}
+          X_USER_ACCESS_TOKEN: ${{ secrets.X_USER_ACCESS_TOKEN }}
+          X_API_KEY: ${{ secrets.X_API_KEY }}
+          X_API_SECRET: ${{ secrets.X_API_SECRET }}
+          X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
+          X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
+          X_SHARE_REVIEW_STATUSES: ${{ vars.X_SHARE_REVIEW_STATUSES }}
+          X_SHARE_MAX_POSTS: ${{ vars.X_SHARE_MAX_POSTS }}
+        run: |
+          set -euo pipefail
+
+          BASE="${{ github.event.before }}"
+          HEAD="${{ github.sha }}"
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            BASE="$(git rev-parse "${HEAD}^" 2>/dev/null || echo "$HEAD")"
+          fi
+
+          MODE="${X_SHARE_MODE:-dry-run}"
+          node scripts/social-share-x.mjs \
+            --base "$BASE" \
+            --head "$HEAD" \
+            --mode "$MODE" \
+            --summary "$GITHUB_STEP_SUMMARY"

--- a/docs/SOCIAL-SHARING.md
+++ b/docs/SOCIAL-SHARING.md
@@ -1,0 +1,91 @@
+# Threatpedia Social Sharing
+
+Threatpedia prepares X share posts after the GitHub Pages deploy job completes.
+The automation is intentionally safe by default: it runs in `dry-run` mode until
+live posting is explicitly enabled in repository configuration.
+
+## Current X Integration
+
+- Script: `scripts/social-share-x.mjs`
+- Workflow hook: `.github/workflows/deploy.yml`, job `social-share-x`
+- Trigger: push to `main`, after the Pages deploy job succeeds
+- Default behavior: write deterministic post drafts to the GitHub Actions job
+  summary; do not call the X API
+
+The script detects newly added Markdown/MDX files in:
+
+- `site/src/content/incidents/`
+- `site/src/content/campaigns/`
+- `site/src/content/threat-actors/`
+- `site/src/content/zero-days/`
+
+It generates one post per new shareable article:
+
+```text
+New Threatpedia incident: Example Article Title
+https://threatpedia.wiki/incidents/example-article/
+#Threatpedia #Cybersecurity
+```
+
+## Live Posting Gate
+
+Live posting requires all of the following:
+
+1. Repository variable `X_SHARE_MODE` set to `post`.
+2. Repository secret `X_POSTING_ENABLED` set exactly to `true`.
+3. X user-context credentials with write permission.
+
+Preferred credential option:
+
+- `X_USER_ACCESS_TOKEN` - OAuth 2.0 user access token with write scope.
+
+Supported OAuth 1.0a fallback:
+
+- `X_API_KEY`
+- `X_API_SECRET`
+- `X_ACCESS_TOKEN`
+- `X_ACCESS_TOKEN_SECRET`
+
+Do not store X credentials in repo files, workflow logs, PR bodies, or local
+notes. Use GitHub repository secrets.
+
+## Optional Controls
+
+- `X_SHARE_REVIEW_STATUSES`: comma-separated review statuses eligible for
+  sharing. Default: `draft_ai,draft_human,under_review,certified`.
+- `X_SHARE_MAX_POSTS`: maximum posts allowed in one run. Default: `10`.
+- `X_ALLOW_RERUN_POSTS`: set to `true` only when deliberately reposting from a
+  rerun after checking duplicate-post risk.
+
+## Local Dry Run
+
+Run from the public repo root after installing script dependencies:
+
+```bash
+npm --prefix scripts ci --no-audit --no-fund
+npm --prefix scripts run social:share-x -- \
+  --files site/src/content/incidents/example.md \
+  --mode dry-run \
+  --json
+```
+
+To test a commit range:
+
+```bash
+npm --prefix scripts run social:share-x -- \
+  --base HEAD~1 \
+  --head HEAD \
+  --mode dry-run \
+  --json
+```
+
+## Operational Notes
+
+- The workflow runs after deployment so shared URLs should exist before any live
+  post is attempted.
+- The script does not invent a parallel state store. It uses the merge range to
+  find newly added content files.
+- Re-running a live-post workflow can duplicate posts. The script blocks GitHub
+  rerun attempts unless `X_ALLOW_RERUN_POSTS=true`.
+- Keep post copy conservative. The generated text includes only the article
+  type, title, URL, and neutral hashtags.

--- a/docs/SOCIAL-SHARING.md
+++ b/docs/SOCIAL-SHARING.md
@@ -83,6 +83,9 @@ npm --prefix scripts run social:share-x -- \
 
 - The workflow runs after deployment so shared URLs should exist before any live
   post is attempted.
+- X counts each URL as 23 characters for post-length enforcement. The sharing
+  script uses that weighting instead of raw URL string length when drafting
+  posts.
 - The script does not invent a parallel state store. It uses the merge range to
   find newly added content files.
 - Re-running a live-post workflow can duplicate posts. The script blocks GitHub

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "social:share-x": "node social-share-x.mjs",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/scripts/social-share-x.mjs
+++ b/scripts/social-share-x.mjs
@@ -18,9 +18,13 @@ const DEFAULT_SHARE_STATUSES = new Set(['draft_ai', 'draft_human', 'under_review
 const DEFAULT_ENDPOINT = 'https://api.x.com/2/tweets';
 const DEFAULT_HASHTAGS = '#Threatpedia #Cybersecurity';
 const MAX_POST_LENGTH = 280;
+const DEFAULT_X_POST_TIMEOUT_MS = 15000;
 const X_URL_LENGTH = 23;
 const URL_PATTERN = /https?:\/\/[^\s]+/g;
 const FRONTMATTER_REGEX = /^---[ \t]*(?:\r?\n)([\s\S]*?)(?:\r?\n)---[ \t]*(?:\r?\n|$)/;
+const WINDOWS_SEPARATOR_PATTERN = /\\/g;
+const LEADING_DOT_SLASH_PATTERN = /^\.\//;
+const SURROUNDING_QUOTE_PATTERN = /^"(.*)"$/s;
 const REPO_ROOT = findRepoRoot();
 
 function findRepoRoot() {
@@ -48,6 +52,7 @@ function parseArgs(argv) {
     siteUrl: process.env.SITE_URL || DEFAULT_SITE_URL,
     summary: process.env.GITHUB_STEP_SUMMARY || '',
     json: false,
+    explicitFiles: false,
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -62,8 +67,14 @@ function parseArgs(argv) {
 
     if (arg === '--base') args.base = next();
     else if (arg === '--head') args.head = next();
-    else if (arg === '--files') args.files.push(...splitFiles(next()));
-    else if (arg === '--file') args.files.push(next());
+    else if (arg === '--files') {
+      args.explicitFiles = true;
+      args.files.push(...splitFiles(next()));
+    }
+    else if (arg === '--file') {
+      args.explicitFiles = true;
+      args.files.push(next());
+    }
     else if (arg === '--mode') args.mode = next();
     else if (arg === '--site-url') args.siteUrl = next();
     else if (arg === '--summary') args.summary = next();
@@ -110,9 +121,19 @@ function splitFiles(value) {
 }
 
 function normalizeRepoPath(file) {
-  const normalized = file.replace(/\\/g, '/').replace(/^\.\//, '');
-  if (!path.isAbsolute(normalized)) return normalized;
-  return path.relative(REPO_ROOT, normalized).replace(/\\/g, '/');
+  let normalized = String(file || '')
+    .trim()
+    .replace(WINDOWS_SEPARATOR_PATTERN, '/')
+    .replace(LEADING_DOT_SLASH_PATTERN, '');
+  const quoted = normalized.match(SURROUNDING_QUOTE_PATTERN);
+  if (quoted) {
+    normalized = quoted[1];
+  }
+
+  const absolute = path.isAbsolute(normalized) ? normalized : path.resolve(REPO_ROOT, normalized);
+  const relative = path.relative(REPO_ROOT, absolute).replace(WINDOWS_SEPARATOR_PATTERN, '/');
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return relative;
 }
 
 function getAddedContentFiles(base, head) {
@@ -323,6 +344,7 @@ function assertPostingAllowed(count) {
 
 async function postToX(draft) {
   const endpoint = process.env.X_POST_ENDPOINT || DEFAULT_ENDPOINT;
+  const timeoutMs = Number.parseInt(process.env.X_POST_TIMEOUT_MS || `${DEFAULT_X_POST_TIMEOUT_MS}`, 10);
   const response = await fetch(endpoint, {
     method: 'POST',
     headers: {
@@ -330,6 +352,7 @@ async function postToX(draft) {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({ text: draft.text }),
+    signal: AbortSignal.timeout(Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : DEFAULT_X_POST_TIMEOUT_MS),
   });
 
   const responseText = await response.text();
@@ -361,7 +384,7 @@ function markdownSummary(result) {
   if (result.drafts.length) {
     lines.push('### Drafts', '');
     for (const draft of result.drafts) {
-      const status = draft.posted ? `posted: ${draft.postId}` : 'not posted';
+      const status = draft.posted ? `posted: ${draft.postId}` : (draft.error ? `FAILED: ${draft.error}` : 'not posted');
       lines.push(`- \`${draft.file}\` - ${status}`);
       lines.push('');
       lines.push('```text');
@@ -385,18 +408,26 @@ function markdownSummary(result) {
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const statuses = allowedStatuses();
-  const files = args.files.length ? args.files : getAddedContentFiles(args.base, args.head);
+  const files = args.explicitFiles ? args.files : getAddedContentFiles(args.base, args.head);
   const draftResults = await Promise.all(files.map((file) => buildDraft(file, args.siteUrl, statuses)));
   const skipped = draftResults.filter((result) => result.skipped);
   const drafts = draftResults.filter((result) => !result.skipped);
+  let hasPostFailures = false;
 
   if (args.mode === 'post' && drafts.length) {
     assertPostingAllowed(drafts.length);
     for (const draft of drafts) {
-      const response = await postToX(draft);
-      draft.posted = true;
-      draft.postResponse = response;
-      draft.postId = response?.data?.id || 'unknown';
+      try {
+        const response = await postToX(draft);
+        draft.posted = true;
+        draft.postResponse = response;
+        draft.postId = response?.data?.id || 'unknown';
+      } catch (error) {
+        draft.posted = false;
+        draft.error = error.message;
+        hasPostFailures = true;
+        console.error(`Failed to post ${draft.file}: ${error.message}`);
+      }
     }
   }
 
@@ -417,6 +448,10 @@ async function main() {
     console.log(JSON.stringify(result, null, 2));
   } else {
     console.log(`Prepared ${drafts.length} X share draft(s); skipped ${skipped.length}.`);
+  }
+
+  if (hasPostFailures) {
+    process.exitCode = 1;
   }
 }
 

--- a/scripts/social-share-x.mjs
+++ b/scripts/social-share-x.mjs
@@ -16,8 +16,11 @@ const COLLECTIONS = new Map([
 const DEFAULT_SITE_URL = 'https://threatpedia.wiki';
 const DEFAULT_SHARE_STATUSES = new Set(['draft_ai', 'draft_human', 'under_review', 'certified']);
 const DEFAULT_ENDPOINT = 'https://api.x.com/2/tweets';
+const DEFAULT_HASHTAGS = '#Threatpedia #Cybersecurity';
 const MAX_POST_LENGTH = 280;
-const YAML_FRONTMATTER_PATTERN = /^---[ \t]*(?:\r?\n)([\s\S]*?)(?:\r?\n)---[ \t]*(?:\r?\n|$)/;
+const X_URL_LENGTH = 23;
+const URL_PATTERN = /https?:\/\/[^\s]+/g;
+const FRONTMATTER_REGEX = /^---[ \t]*(?:\r?\n)([\s\S]*?)(?:\r?\n)---[ \t]*(?:\r?\n|$)/;
 const REPO_ROOT = findRepoRoot();
 
 function findRepoRoot() {
@@ -152,7 +155,7 @@ function parseContentPath(file) {
 
 async function readFrontmatter(file) {
   const content = await readFile(path.join(REPO_ROOT, file), 'utf8');
-  const match = content.match(YAML_FRONTMATTER_PATTERN);
+  const match = content.match(FRONTMATTER_REGEX);
   if (!match) {
     throw new Error(`${file} is missing valid YAML frontmatter delimiters.`);
   }
@@ -176,24 +179,41 @@ function makeArticleUrl(siteUrl, route, slug) {
 
 function truncateText(value, limit) {
   const text = String(value || '');
+  const chars = Array.from(text);
   if (limit <= 0) return '';
-  if (text.length <= limit) return text;
-  if (limit <= 3) return text.slice(0, limit);
-  return `${text.slice(0, limit - 3).trimEnd()}...`;
+  if (chars.length <= limit) return text;
+  if (limit <= 3) return chars.slice(0, limit).join('');
+  return `${chars.slice(0, limit - 3).join('').trimEnd()}...`;
+}
+
+function xWeightedLength(text) {
+  let length = 0;
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(URL_PATTERN)) {
+    length += Array.from(text.slice(lastIndex, match.index)).length;
+    length += X_URL_LENGTH;
+    lastIndex = match.index + match[0].length;
+  }
+
+  return length + Array.from(text.slice(lastIndex)).length;
 }
 
 function buildPostText(article) {
   const prefix = `New Threatpedia ${article.label}: `;
   const suffixes = [
-    `\n${article.url}\n#Threatpedia #Cybersecurity`,
+    `\n${article.url}\n${DEFAULT_HASHTAGS}`,
     `\n${article.url}`,
   ];
 
   for (const suffix of suffixes) {
-    const remaining = MAX_POST_LENGTH - prefix.length - suffix.length;
+    const remaining = MAX_POST_LENGTH - Array.from(prefix).length - xWeightedLength(suffix);
     if (remaining <= 0) continue;
     const title = truncateText(article.title, remaining);
-    return `${prefix}${title}${suffix}`;
+    const post = `${prefix}${title}${suffix}`;
+    if (xWeightedLength(post) <= MAX_POST_LENGTH) {
+      return post;
+    }
   }
 
   throw new Error(`Cannot build an X post within ${MAX_POST_LENGTH} characters for ${article.url}`);

--- a/scripts/social-share-x.mjs
+++ b/scripts/social-share-x.mjs
@@ -1,0 +1,399 @@
+#!/usr/bin/env node
+import crypto from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { readFile, appendFile } from 'node:fs/promises';
+import path from 'node:path';
+import yaml from 'js-yaml';
+
+const COLLECTIONS = new Map([
+  ['incidents', { label: 'incident', route: 'incidents', titleField: 'title' }],
+  ['campaigns', { label: 'campaign', route: 'campaigns', titleField: 'title' }],
+  ['threat-actors', { label: 'threat actor profile', route: 'threat-actors', titleField: 'name' }],
+  ['zero-days', { label: 'zero-day', route: 'zero-days', titleField: 'title' }],
+]);
+
+const DEFAULT_SITE_URL = 'https://threatpedia.wiki';
+const DEFAULT_SHARE_STATUSES = new Set(['draft_ai', 'draft_human', 'under_review', 'certified']);
+const DEFAULT_ENDPOINT = 'https://api.x.com/2/tweets';
+const MAX_POST_LENGTH = 280;
+const REPO_ROOT = findRepoRoot();
+
+function findRepoRoot() {
+  let current = process.cwd();
+  for (let depth = 0; depth < 6; depth += 1) {
+    if (
+      existsSync(path.join(current, 'site/src/content.config.ts')) &&
+      existsSync(path.join(current, 'scripts/package.json'))
+    ) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return process.cwd();
+}
+
+function parseArgs(argv) {
+  const args = {
+    base: '',
+    head: '',
+    files: [],
+    mode: process.env.X_SHARE_MODE || 'dry-run',
+    siteUrl: process.env.SITE_URL || DEFAULT_SITE_URL,
+    summary: process.env.GITHUB_STEP_SUMMARY || '',
+    json: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      i += 1;
+      if (i >= argv.length) {
+        throw new Error(`Missing value for ${arg}`);
+      }
+      return argv[i];
+    };
+
+    if (arg === '--base') args.base = next();
+    else if (arg === '--head') args.head = next();
+    else if (arg === '--files') args.files.push(...splitFiles(next()));
+    else if (arg === '--file') args.files.push(next());
+    else if (arg === '--mode') args.mode = next();
+    else if (arg === '--site-url') args.siteUrl = next();
+    else if (arg === '--summary') args.summary = next();
+    else if (arg === '--json') args.json = true;
+    else if (arg === '--help' || arg === '-h') {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  args.mode = args.mode || 'dry-run';
+  if (!['dry-run', 'post'].includes(args.mode)) {
+    throw new Error(`Unsupported --mode value: ${args.mode}`);
+  }
+  args.siteUrl = args.siteUrl.replace(/\/+$/, '');
+  args.files = [...new Set(args.files.map(normalizeRepoPath).filter(Boolean))];
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/social-share-x.mjs --base <sha> --head <sha> [--mode dry-run|post]
+  node scripts/social-share-x.mjs --files <path[,path...]> [--mode dry-run|post]
+
+Options:
+  --base       Base commit for detecting newly added content files.
+  --head       Head commit for detecting newly added content files.
+  --files      Explicit comma/newline-separated content files to process.
+  --file       Explicit content file to process. May be repeated.
+  --mode       dry-run (default) or post.
+  --site-url   Public site URL. Defaults to ${DEFAULT_SITE_URL}.
+  --summary    Markdown summary output path. Defaults to GITHUB_STEP_SUMMARY.
+  --json       Print JSON output.
+`);
+}
+
+function splitFiles(value) {
+  return value
+    .split(/[\n,]/)
+    .map((file) => file.trim())
+    .filter(Boolean);
+}
+
+function normalizeRepoPath(file) {
+  const normalized = file.replace(/\\/g, '/').replace(/^\.\//, '');
+  if (!path.isAbsolute(normalized)) return normalized;
+  return path.relative(REPO_ROOT, normalized).replace(/\\/g, '/');
+}
+
+function getAddedContentFiles(base, head) {
+  if (!base || !head) {
+    throw new Error('Either --files or both --base and --head are required.');
+  }
+
+  const output = execFileSync(
+    'git',
+    [
+      'diff',
+      '--name-only',
+      '--diff-filter=A',
+      base,
+      head,
+      '--',
+      'site/src/content/**/*.md',
+      'site/src/content/**/*.mdx',
+    ],
+    { encoding: 'utf8', cwd: REPO_ROOT },
+  );
+
+  return output
+    .split('\n')
+    .map((file) => file.trim())
+    .filter(Boolean)
+    .map(normalizeRepoPath);
+}
+
+function parseContentPath(file) {
+  const match = file.match(/^site\/src\/content\/([^/]+)\/(.+)\.mdx?$/);
+  if (!match) return null;
+
+  const [, collection, slug] = match;
+  const config = COLLECTIONS.get(collection);
+  if (!config) return null;
+
+  return { collection, slug, ...config };
+}
+
+async function readFrontmatter(file) {
+  const content = await readFile(path.join(REPO_ROOT, file), 'utf8');
+  if (!content.startsWith('---\n')) {
+    throw new Error(`${file} does not start with YAML frontmatter.`);
+  }
+
+  const end = content.indexOf('\n---', 4);
+  if (end === -1) {
+    throw new Error(`${file} is missing a closing frontmatter delimiter.`);
+  }
+
+  const frontmatter = content.slice(4, end);
+  return yaml.load(frontmatter) || {};
+}
+
+function allowedStatuses() {
+  const configured = process.env.X_SHARE_REVIEW_STATUSES;
+  if (!configured) return DEFAULT_SHARE_STATUSES;
+  return new Set(configured.split(',').map((status) => status.trim()).filter(Boolean));
+}
+
+function makeArticleUrl(siteUrl, route, slug) {
+  const encodedSlug = slug
+    .split('/')
+    .map((part) => encodeURIComponent(part))
+    .join('/');
+  return `${siteUrl}/${route}/${encodedSlug}/`;
+}
+
+function truncateText(value, limit) {
+  if (value.length <= limit) return value;
+  if (limit <= 3) return value.slice(0, limit);
+  return `${value.slice(0, limit - 3).trimEnd()}...`;
+}
+
+function buildPostText(article) {
+  const suffix = `\n${article.url}\n#Threatpedia #Cybersecurity`;
+  const prefix = `New Threatpedia ${article.label}: `;
+  const remaining = MAX_POST_LENGTH - prefix.length - suffix.length;
+  const title = truncateText(article.title, Math.max(20, remaining));
+  return `${prefix}${title}${suffix}`;
+}
+
+async function buildDraft(file, siteUrl, statuses) {
+  const parsed = parseContentPath(file);
+  if (!parsed) {
+    return { file, skipped: true, reason: 'not a supported content collection path' };
+  }
+
+  const data = await readFrontmatter(file);
+  const reviewStatus = String(data.reviewStatus || 'draft_ai');
+  if (!statuses.has(reviewStatus)) {
+    return { file, skipped: true, reason: `reviewStatus ${reviewStatus} is not shareable` };
+  }
+
+  const title = String(data[parsed.titleField] || data.title || data.name || parsed.slug).trim();
+  const url = makeArticleUrl(siteUrl, parsed.route, parsed.slug);
+  const article = {
+    file,
+    collection: parsed.collection,
+    label: parsed.label,
+    slug: parsed.slug,
+    title,
+    reviewStatus,
+    url,
+  };
+
+  return {
+    ...article,
+    text: buildPostText(article),
+  };
+}
+
+function oauthPercent(value) {
+  return encodeURIComponent(value)
+    .replace(/[!'()*]/g, (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`);
+}
+
+function buildOAuth1Header(method, endpoint) {
+  const consumerKey = process.env.X_API_KEY || '';
+  const consumerSecret = process.env.X_API_SECRET || '';
+  const token = process.env.X_ACCESS_TOKEN || '';
+  const tokenSecret = process.env.X_ACCESS_TOKEN_SECRET || '';
+
+  if (!consumerKey || !consumerSecret || !token || !tokenSecret) {
+    return '';
+  }
+
+  const oauth = {
+    oauth_consumer_key: consumerKey,
+    oauth_nonce: crypto.randomBytes(16).toString('hex'),
+    oauth_signature_method: 'HMAC-SHA1',
+    oauth_timestamp: Math.floor(Date.now() / 1000).toString(),
+    oauth_token: token,
+    oauth_version: '1.0',
+  };
+
+  const parameterString = Object.entries(oauth)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${oauthPercent(key)}=${oauthPercent(value)}`)
+    .join('&');
+
+  const signatureBase = [
+    method.toUpperCase(),
+    oauthPercent(endpoint),
+    oauthPercent(parameterString),
+  ].join('&');
+  const signingKey = `${oauthPercent(consumerSecret)}&${oauthPercent(tokenSecret)}`;
+  const signature = crypto.createHmac('sha1', signingKey).update(signatureBase).digest('base64');
+
+  return `OAuth ${Object.entries({ ...oauth, oauth_signature: signature })
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${oauthPercent(key)}="${oauthPercent(value)}"`)
+    .join(', ')}`;
+}
+
+function authHeader(endpoint) {
+  if (process.env.X_USER_ACCESS_TOKEN) {
+    return `Bearer ${process.env.X_USER_ACCESS_TOKEN}`;
+  }
+
+  const oauth1Header = buildOAuth1Header('POST', endpoint);
+  if (oauth1Header) return oauth1Header;
+
+  throw new Error(
+    'Live posting requires X_USER_ACCESS_TOKEN or OAuth 1.0a credentials: X_API_KEY, X_API_SECRET, X_ACCESS_TOKEN, X_ACCESS_TOKEN_SECRET.',
+  );
+}
+
+function assertPostingAllowed(count) {
+  if (process.env.X_POSTING_ENABLED !== 'true') {
+    throw new Error('Refusing to post: X_POSTING_ENABLED must be exactly "true".');
+  }
+
+  const runAttempt = Number(process.env.GITHUB_RUN_ATTEMPT || '1');
+  if (runAttempt > 1 && process.env.X_ALLOW_RERUN_POSTS !== 'true') {
+    throw new Error('Refusing to post on a rerun. Set X_ALLOW_RERUN_POSTS=true only after checking duplicate-post risk.');
+  }
+
+  const maxPosts = Number(process.env.X_SHARE_MAX_POSTS || '10');
+  if (Number.isFinite(maxPosts) && count > maxPosts) {
+    throw new Error(`Refusing to post ${count} articles; X_SHARE_MAX_POSTS is ${maxPosts}.`);
+  }
+}
+
+async function postToX(draft) {
+  const endpoint = process.env.X_POST_ENDPOINT || DEFAULT_ENDPOINT;
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      Authorization: authHeader(endpoint),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ text: draft.text }),
+  });
+
+  const responseText = await response.text();
+  let payload;
+  try {
+    payload = responseText ? JSON.parse(responseText) : {};
+  } catch {
+    payload = { raw: responseText };
+  }
+
+  if (!response.ok) {
+    throw new Error(`X API post failed for ${draft.file}: HTTP ${response.status} ${JSON.stringify(payload)}`);
+  }
+
+  return payload;
+}
+
+function markdownSummary(result) {
+  const lines = [
+    '## X Article Sharing',
+    '',
+    `- Mode: \`${result.mode}\``,
+    `- New content files: \`${result.files.length}\``,
+    `- Share drafts: \`${result.drafts.length}\``,
+    `- Skipped: \`${result.skipped.length}\``,
+    '',
+  ];
+
+  if (result.drafts.length) {
+    lines.push('### Drafts', '');
+    for (const draft of result.drafts) {
+      const status = draft.posted ? `posted: ${draft.postId}` : 'not posted';
+      lines.push(`- \`${draft.file}\` - ${status}`);
+      lines.push('');
+      lines.push('```text');
+      lines.push(draft.text);
+      lines.push('```');
+      lines.push('');
+    }
+  }
+
+  if (result.skipped.length) {
+    lines.push('### Skipped', '');
+    for (const skipped of result.skipped) {
+      lines.push(`- \`${skipped.file}\`: ${skipped.reason}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const statuses = allowedStatuses();
+  const files = args.files.length ? args.files : getAddedContentFiles(args.base, args.head);
+  const draftResults = await Promise.all(files.map((file) => buildDraft(file, args.siteUrl, statuses)));
+  const skipped = draftResults.filter((result) => result.skipped);
+  const drafts = draftResults.filter((result) => !result.skipped);
+
+  if (args.mode === 'post' && drafts.length) {
+    assertPostingAllowed(drafts.length);
+    for (const draft of drafts) {
+      const response = await postToX(draft);
+      draft.posted = true;
+      draft.postResponse = response;
+      draft.postId = response?.data?.id || 'unknown';
+    }
+  }
+
+  const result = {
+    mode: args.mode,
+    base: args.base,
+    head: args.head,
+    files,
+    drafts,
+    skipped,
+  };
+
+  if (args.summary) {
+    await appendFile(args.summary, `${markdownSummary(result)}\n`);
+  }
+
+  if (args.json || !args.summary) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(`Prepared ${drafts.length} X share draft(s); skipped ${skipped.length}.`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/scripts/social-share-x.mjs
+++ b/scripts/social-share-x.mjs
@@ -17,6 +17,7 @@ const DEFAULT_SITE_URL = 'https://threatpedia.wiki';
 const DEFAULT_SHARE_STATUSES = new Set(['draft_ai', 'draft_human', 'under_review', 'certified']);
 const DEFAULT_ENDPOINT = 'https://api.x.com/2/tweets';
 const MAX_POST_LENGTH = 280;
+const YAML_FRONTMATTER_PATTERN = /^---[ \t]*(?:\r?\n)([\s\S]*?)(?:\r?\n)---[ \t]*(?:\r?\n|$)/;
 const REPO_ROOT = findRepoRoot();
 
 function findRepoRoot() {
@@ -151,17 +152,12 @@ function parseContentPath(file) {
 
 async function readFrontmatter(file) {
   const content = await readFile(path.join(REPO_ROOT, file), 'utf8');
-  if (!content.startsWith('---\n')) {
-    throw new Error(`${file} does not start with YAML frontmatter.`);
+  const match = content.match(YAML_FRONTMATTER_PATTERN);
+  if (!match) {
+    throw new Error(`${file} is missing valid YAML frontmatter delimiters.`);
   }
 
-  const end = content.indexOf('\n---', 4);
-  if (end === -1) {
-    throw new Error(`${file} is missing a closing frontmatter delimiter.`);
-  }
-
-  const frontmatter = content.slice(4, end);
-  return yaml.load(frontmatter) || {};
+  return yaml.load(match[1]) || {};
 }
 
 function allowedStatuses() {
@@ -179,17 +175,28 @@ function makeArticleUrl(siteUrl, route, slug) {
 }
 
 function truncateText(value, limit) {
-  if (value.length <= limit) return value;
-  if (limit <= 3) return value.slice(0, limit);
-  return `${value.slice(0, limit - 3).trimEnd()}...`;
+  const text = String(value || '');
+  if (limit <= 0) return '';
+  if (text.length <= limit) return text;
+  if (limit <= 3) return text.slice(0, limit);
+  return `${text.slice(0, limit - 3).trimEnd()}...`;
 }
 
 function buildPostText(article) {
-  const suffix = `\n${article.url}\n#Threatpedia #Cybersecurity`;
   const prefix = `New Threatpedia ${article.label}: `;
-  const remaining = MAX_POST_LENGTH - prefix.length - suffix.length;
-  const title = truncateText(article.title, Math.max(20, remaining));
-  return `${prefix}${title}${suffix}`;
+  const suffixes = [
+    `\n${article.url}\n#Threatpedia #Cybersecurity`,
+    `\n${article.url}`,
+  ];
+
+  for (const suffix of suffixes) {
+    const remaining = MAX_POST_LENGTH - prefix.length - suffix.length;
+    if (remaining <= 0) continue;
+    const title = truncateText(article.title, remaining);
+    return `${prefix}${title}${suffix}`;
+  }
+
+  throw new Error(`Cannot build an X post within ${MAX_POST_LENGTH} characters for ${article.url}`);
 }
 
 async function buildDraft(file, siteUrl, statuses) {

--- a/site/src/pages/roadmap.astro
+++ b/site/src/pages/roadmap.astro
@@ -288,13 +288,14 @@ const fmt = (n: number) => n.toLocaleString('en-US');
       </div>
 
       <div class="item">
-        <div class="item-status todo">&#9675;</div>
+        <div class="item-status wip">&#9673;</div>
         <div class="item-body">
           <div class="item-title">X/Twitter Syndication</div>
-          <div class="item-desc">Automated social syndication of newly published incidents, campaigns, and zero-days to <a href="https://x.com/threatpedia" target="_blank" rel="noopener">@threatpedia</a>. Short-form threat intel posts with severity badges and direct article links. The signal channel for the soft launch.</div>
+          <div class="item-desc">Post-deploy share drafting for newly published incidents, campaigns, threat actors, and zero-days to <a href="https://x.com/threatpedia" target="_blank" rel="noopener">@threatpedia</a>. Live posting remains explicitly gated behind repository secrets and operator configuration.</div>
           <div class="item-meta">
             <span class="item-tag">@threatpedia</span>
-            <span class="item-tag">auto-syndication</span>
+            <span class="item-tag">post-deploy</span>
+            <span class="item-tag">dry-run first</span>
             <span class="item-tag">soft launch</span>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Adds a safe first slice for X article sharing automation:

- post-deploy `social-share-x` job in the existing GitHub Pages deploy workflow
- reusable `scripts/social-share-x.mjs` draft/post helper
- operator docs for secrets, dry-run testing, and live-post guardrails
- public roadmap status update from todo to work-in-progress

Live posting is disabled by default. The workflow only posts when `X_SHARE_MODE=post`, secret `X_POSTING_ENABLED=true`, and valid X user-context credentials are configured.

## Validation

- `npm --prefix scripts ci --no-audit --no-fund`
- `node scripts/social-share-x.mjs --files site/src/content/threat-actors/fin7.md --mode dry-run --json`
- `node scripts/social-share-x.mjs --base HEAD --head HEAD --mode dry-run --json`
- `node scripts/social-share-x.mjs --files site/src/content/threat-actors/fin7.md --mode post --json` refused without `X_POSTING_ENABLED=true`
- `node scripts/pipeline-schema.mjs`
- workflow YAML parsed with `js-yaml`
- `npm --prefix site run build`
- `git diff --check`

## Security Notes

- No credentials are stored in code.
- Live posting requires a secret-only enable flag.
- Rerun posting is blocked unless `X_ALLOW_RERUN_POSTS=true` is deliberately set.
- Post copy is deterministic and conservative: article type, title, URL, and neutral hashtags only.
