### PR TITLE
chore(pipeline): add TanStack npm compromise task

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0263.json
+++ b/.github/pipeline/tasks/TASK-2026-0263.json
@@ -1,0 +1,67 @@
+{
+  "task_id": "TASK-2026-0263",
+  "stage": "draft",
+  "type": "incident",
+  "priority": "P0",
+  "status": "pending",
+  "created": "2026-05-12T03:46:51.000Z",
+  "updated": "2026-05-12T03:46:51.000Z",
+  "source": "manual_submission",
+  "submitted_by": "kernel-k-manual-intake",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "TanStack npm Package Compromise in Mini Shai-Hulud Supply-Chain Attack, May 2026",
+    "sources": [
+      "https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack",
+      "https://tanstack.com/blog/npm-supply-chain-compromise-postmortem",
+      "https://github.com/TanStack/router/security/advisories/GHSA-g7cv-rxg3-hmpx",
+      "https://github.com/TanStack/router/issues/7383",
+      "https://www.stepsecurity.io/blog/mini-shai-hulud-is-back-a-self-spreading-supply-chain-attack-hits-the-npm-ecosystem",
+      "https://socket.dev/supply-chain-attacks/mini-shai-hulud",
+      "https://www.cisa.gov/news-events/alerts/2025/09/23/widespread-supply-chain-compromise-impacting-npm-ecosystem"
+    ],
+    "candidate_data": {
+      "date": "2026-05-11",
+      "severity": "critical",
+      "sector": "Open-source software / developer tooling",
+      "geography": "Global",
+      "threat_actor": "Mini Shai-Hulud / TeamPCP-linked activity (vendor-assessed)",
+      "attack_type": "Software supply-chain compromise / malicious npm package publication"
+    },
+    "notes": "Manual intake from Socket's TanStack report. Treat this as a bounded incident covering the May 2026 compromise of TanStack npm packages, not as a replacement for the broader TeamPCP/Mini Shai-Hulud campaign article. TanStack's postmortem and GHSA-g7cv-rxg3-hmpx are primary sources: on 2026-05-11, approximately 19:20-19:26 UTC, 84 malicious versions across 42 @tanstack/* packages were published through the legitimate GitHub Actions OIDC trusted-publisher binding for TanStack/router. The documented attack chain combines pull_request_target workflow trust-boundary abuse, GitHub Actions cache poisoning, and runtime OIDC token extraction from the Actions runner process. The malicious payload is described as router_init.js, an obfuscated credential stealer that harvested cloud credentials, GitHub tokens, npm credentials, Vault/Kubernetes material, and SSH keys, exfiltrated through Session/Oxen infrastructure, and attempted npm worm propagation. All affected versions are reported deprecated, npm security was engaged to pull tarballs where unpublish was unavailable, and clean patched versions are listed in the GitHub Security Advisory. Use Socket and StepSecurity for independent analysis and the Mini Shai-Hulud campaign context, but do not overstate attribution: TeamPCP linkage is vendor-assessed, not government-confirmed in the sources checked during intake. Existing Threatpedia corpus contains TeamPCP campaign and actor coverage; link this incident to that campaign only if the drafting worker confirms the current corpus slug and can support the relationship without conflating actor, campaign, and incident layers. Current source caveat: no public government source confirming this exact TanStack May 2026 incident was found during intake; the CISA 2025 npm Shai-Hulud alert is included only as background on the earlier Shai-Hulud npm worm pattern and must not be used as confirmation of this TanStack event."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md \u00a714A",
+    "INGESTION-SPEC.md \u00a72"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 5,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/incidents/{slug}.md",
+    "branch": "pipeline/TASK-2026-0263",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-05-12T03:46:51.000Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "kernel-k-manual-intake",
+      "note": "Manual link submission for TanStack npm compromise; corroborated with TanStack postmortem, GHSA, Socket, StepSecurity, and campaign-context sources."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `TASK-2026-0263` for the May 2026 TanStack npm package compromise in the Mini Shai-Hulud supply-chain activity. This is seeded as a bounded incident task, not a replacement for broader campaign coverage.

## Evidence Notes

- Socket reported 84 compromised TanStack npm package artifacts modified with suspected CI credential-stealing malware.
- TanStack published a postmortem stating 84 malicious versions across 42 `@tanstack/*` packages were published on 2026-05-11 between about 19:20 and 19:26 UTC.
- GitHub Security Advisory `GHSA-g7cv-rxg3-hmpx` lists affected packages/versions, patched versions, mechanism, IOCs, and remediation guidance.
- StepSecurity and Socket campaign tracking support the Mini Shai-Hulud context.

## Guardrails In Task

- Treat TeamPCP linkage as vendor-assessed unless later government or primary attribution confirms it.
- Link to existing TeamPCP/Mini Shai-Hulud corpus only if the drafting worker confirms the current slug and keeps incident, campaign, and actor layers distinct.
- CISA 2025 Shai-Hulud alert is included only as background on the earlier npm worm pattern; it must not be used as confirmation of this May 2026 TanStack event.

## Validation

- `node -e` JSON parse check for `.github/pipeline/tasks/TASK-2026-0263.json`
- `node scripts/pipeline-schema.mjs`
- `npm --prefix scripts ci --no-audit --no-fund`
- `node scripts/pipeline-run-task.mjs --task TASK-2026-0263`
