### PR TITLE
chore(pipeline): add Mistral AI PyPI compromise task

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0264.json
+++ b/.github/pipeline/tasks/TASK-2026-0264.json
@@ -1,0 +1,64 @@
+{
+  "task_id": "TASK-2026-0264",
+  "stage": "draft",
+  "type": "incident",
+  "priority": "P0",
+  "status": "pending",
+  "created": "2026-05-12T04:01:44.000Z",
+  "updated": "2026-05-12T04:01:44.000Z",
+  "source": "manual_submission",
+  "submitted_by": "kernel-k-manual-intake",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "Mistral AI Python SDK PyPI Package v2.4.6 Backdoor, May 2026",
+    "sources": [
+      "https://github.com/mistralai/client-python/issues/523",
+      "https://pypi.org/project/mistralai/",
+      "https://github.com/mistralai/client-python/releases",
+      "https://github.com/mistralai/client-python/releases/tag/v2.4.5"
+    ],
+    "candidate_data": {
+      "date": "2026-05-12",
+      "severity": "critical",
+      "sector": "Open-source software / AI developer tooling",
+      "geography": "Global",
+      "threat_actor": "Unknown",
+      "attack_type": "Software supply-chain compromise / malicious PyPI package publication"
+    },
+    "notes": "Manual intake from a Microsoft Threat Intelligence screenshot supplied by Kernel K. The screenshot states that Microsoft is investigating compromise of `mistralai` PyPI package v2.4.6, with malicious code in `mistralai/client/__init__.py` that executes on import, downloads `https://83.142.209.194/transformers.pyz` to `/tmp/transformers.pyz`, and launches a second-stage payload on Linux. Public corroboration found during intake: Mistral client-python issue #523 reports the same v2.4.6 backdoor, hardcoded payload URL, Linux-only import-time execution, `MISTRAL_INIT` guard, and tarball SHA256 `6dbaa43bf2f3c0d3cddbca74967e952da563fb974c1ef9d4ecbb2e58e41fe81b`; PyPI's current project page no longer lists v2.4.6 and shows 2.4.5 as the latest visible release; GitHub releases show v2.4.5 as the latest release at intake. No public Microsoft post permalink, Mistral advisory, PyPI advisory, OSV entry, CVE, or government source confirming this exact event was found during intake. Drafting worker must re-check for official Microsoft/Mistral/PyPI advisory material before article PR and block if the event remains single-source plus GitHub issue only. Do not state the screenshot's credential-stealer, Russian-language avoidance, Israel/Iran destructive-branch, `pgmonitor.py`, or `pgsql-monitor.service` claims unless a citable Microsoft permalink or independent technical analysis confirms them. Treat attacker identity as Unknown unless later evidence supports attribution."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md \u00a714A",
+    "INGESTION-SPEC.md \u00a72"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 5,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/incidents/{slug}.md",
+    "branch": "pipeline/TASK-2026-0264",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-05-12T04:01:44.000Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "kernel-k-manual-intake",
+      "note": "Manual link/image submission for mistralai PyPI v2.4.6 compromise; public corroboration currently limited to Mistral GitHub issue plus package/release metadata."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `TASK-2026-0264` for the reported `mistralai` PyPI package v2.4.6 compromise. This is seeded as an incident candidate with explicit source-gap guardrails.

## Evidence Notes

- Intake originated from a Microsoft Threat Intelligence screenshot supplied by Kernel K.
- Public corroboration found during intake: Mistral client-python issue #523 reports the v2.4.6 backdoor in `src/mistralai/client/__init__.py`, the hardcoded `83.142.209.194/transformers.pyz` payload URL, Linux import-time execution, `MISTRAL_INIT` guard, and tarball SHA256.
- PyPI currently does not list v2.4.6; the visible latest release is v2.4.5.
- GitHub releases currently show v2.4.5 as the latest Mistral Python SDK release.

## Guardrails In Task

- No public Microsoft permalink, Mistral advisory, PyPI advisory, OSV entry, CVE, or government source was found during intake.
- Drafting worker must re-check for official Microsoft/Mistral/PyPI advisory material before article PR and block if the event remains single-source plus GitHub issue only.
- Do not publish the screenshot-only credential-stealer, Russian-language avoidance, Israel/Iran destructive branch, `pgmonitor.py`, or `pgsql-monitor.service` claims unless a citable Microsoft permalink or independent technical analysis confirms them.
- Treat attacker identity as `Unknown` unless later evidence supports attribution.

## Validation

- `node -e` JSON parse check for `.github/pipeline/tasks/TASK-2026-0264.json`
- `node scripts/pipeline-schema.mjs`
- `npm --prefix scripts ci --no-audit --no-fund`
- `node scripts/pipeline-run-task.mjs --task TASK-2026-0264`
- `git diff --check`
