### PR TITLE
fix(review-gate): stop push-time race runs

### DIFF
--- a/.github/workflows/pipeline-review-gate.yml
+++ b/.github/workflows/pipeline-review-gate.yml
@@ -1,16 +1,6 @@
 name: "Pipeline: Review Gate"
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - "site/src/**"
-      - "site/package*.json"
-      - "site/astro.config.*"
-      - "scripts/**"
-      - ".github/workflows/**"
-      - ".github/pipeline/config.yml"
-      - "docs/PIPELINE.md"
   pull_request_review:
     types: [submitted, dismissed]
   issue_comment:
@@ -38,7 +28,6 @@ concurrency:
 jobs:
   review-gate:
     if: |
-      github.event_name == 'pull_request' ||
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request_review' &&


### PR DESCRIPTION
## Summary

- removes the `pull_request` trigger from `Pipeline: Review Gate`
- keeps review-gate evaluation on configured AI review events, explicit `/review-gate` commands, and manual dispatch
- aligns the workflow with `docs/PIPELINE.md`, which says push-time runs should not race current-head validation and current-head AI review creation

## Failure Class

- Area: `review-gate`
- Failure class: `workflow-failure`
- Decision: `simplify`
- Reason: removing the premature trigger prevents deterministic red checks without weakening the current-head AI review requirement itself

## Validation

- `git diff --check`
- `node --check scripts/pipeline-review-gate.mjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pipeline-review-gate.yml"); puts "ok"'`

## Out of Scope

- does not add `ernestpenfold-bot` as an accepted AI reviewer
- does not bypass unresolved AI review threads
- does not merge or modify content PRs currently blocked by actionable review feedback
