### PR TITLE
chore(pipeline): seed Hasbro incident task

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0268.json
+++ b/.github/pipeline/tasks/TASK-2026-0268.json
@@ -18,7 +18,15 @@
       "https://news.risky.biz/risky-bulletin-russia-will-revoke-licenses-for-unruly-isps"
     ],
     "candidate_data": {
-      "severity": "high"
+      "severity": "high",
+      "date": "2026-04-01",
+      "disclosure_date": "2026-04-01",
+      "attack_type": "Cyberattack",
+      "affected_organization": "Hasbro",
+      "sector": "Consumer products and entertainment",
+      "geography": "United States",
+      "threat_actor": "Unknown",
+      "known_impact": "Business-system disruption and multi-week recovery window reported by TechCrunch; scope should remain source-bound."
     },
     "notes": "Risky Bulletin discovery item. Scope as a discrete Hasbro incident based on the company SEC filing and TechCrunch reporting. Keep attribution unknown unless later primary sources name an actor; do not infer ransomware without source support. Discovery source: https://news.risky.biz/risky-bulletin-russia-will-revoke-licenses-for-unruly-isps/"
   },
@@ -30,7 +38,7 @@
   "acceptance_criteria": {
     "frontmatter_valid": true,
     "min_sources": 3,
-    "min_h2_sections": 5,
+    "min_h2_sections": 8,
     "min_mitre_mappings": 1,
     "review_status": "draft_ai",
     "astro_build": true

--- a/.github/pipeline/tasks/TASK-2026-0268.json
+++ b/.github/pipeline/tasks/TASK-2026-0268.json
@@ -1,0 +1,57 @@
+{
+  "task_id": "TASK-2026-0268",
+  "stage": "draft",
+  "type": "incident",
+  "priority": "P1",
+  "status": "pending",
+  "created": "2026-05-13T12:10:38.423Z",
+  "updated": "2026-05-13T12:10:38.423Z",
+  "source": "manual_submission",
+  "submitted_by": "risky-bulletin-discovery-worker",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "Hasbro cyberattack and business-system disruption, April 2026",
+    "sources": [
+      "https://www.sec.gov/Archives/edgar/data/46080/000004608026000013/has-20260401.htm",
+      "https://techcrunch.com/2026/04/01/hasbro-hacked-may-take-several-weeks-to-recover",
+      "https://news.risky.biz/risky-bulletin-russia-will-revoke-licenses-for-unruly-isps"
+    ],
+    "candidate_data": {
+      "severity": "high"
+    },
+    "notes": "Risky Bulletin discovery item. Scope as a discrete Hasbro incident based on the company SEC filing and TechCrunch reporting. Keep attribution unknown unless later primary sources name an actor; do not infer ransomware without source support. Discovery source: https://news.risky.biz/risky-bulletin-russia-will-revoke-licenses-for-unruly-isps/"
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "INGESTION-SPEC.md §2"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 5,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/incidents/{slug}.md",
+    "branch": "pipeline/TASK-2026-0268",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-05-13T12:10:38.423Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "risky-bulletin-discovery-worker",
+      "note": "Manual link submission via scripts/pipeline-submit-link.mjs"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `TASK-2026-0268` for the Hasbro April 2026 cyberattack and business-system disruption lead discovered from the April 3 Risky Bulletin.

## Notes

- Uses Hasbro's SEC filing as the primary source, TechCrunch as secondary reporting, and the Risky Bulletin as the discovery source.
- Scopes the task as an incident and keeps attribution unknown unless later sources support a named actor.
- Avoids inferring ransomware or other impact beyond the cited sources.

## Validation

- `pipeline-submit-link.mjs` default dry-run reported no duplicate URL matches.
- Generated one task JSON in a fresh temp clone from `origin/main`.
- Parsed the generated task JSON successfully with Node.
- Rechecked `origin/main` and remote branch state before push.