### PR TITLE
chore(pipeline): seed TASK-2026-0269 Betterment incident

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0269.json
+++ b/.github/pipeline/tasks/TASK-2026-0269.json
@@ -5,7 +5,7 @@
   "priority": "P2",
   "status": "pending",
   "created": "2026-05-13T14:25:50.575Z",
-  "updated": "2026-05-13T14:44:06.722Z",
+  "updated": "2026-05-13T14:51:13.000Z",
   "source": "manual_submission",
   "submitted_by": "risky-bulletin-discovery-worker",
   "locked_by": null,
@@ -21,7 +21,8 @@
       "severity": "medium",
       "date": "2026-01-09",
       "attack_type": "Social Engineering",
-      "sector": "Financial Services"
+      "sector": "Financial Services",
+      "geography": "United States"
     },
     "notes": "Risky Bulletin discovery item from 2026-04-08. Betterment's own post-mortem says a social engineering attack against an employee enabled access to a marketing platform that was used to send waves of cryptocurrency-scam emails to customers. Scope as a discrete Betterment incident; keep actor unknown unless stronger sources name one. The Jan. 14 Risky Bulletin/private backlog item was deferred pending a primary source; the Apr. 8 bulletin links the company post-mortem that resolves that source gap. Drafting agent must add a government or regulator source if one is available; if none can be found, mark the task blocked instead of forcing an unsupported source."
   },
@@ -63,6 +64,14 @@
       "to": "pending",
       "agent": "risky-bulletin-discovery-worker",
       "note": "Addressed Gemini task metadata feedback: normalized incident candidate_data, aligned min_h2_sections with incident schema, removed unused schema_validation acceptance field, and documented government-source requirement for drafting."
+    },
+    {
+      "timestamp": "2026-05-13T14:51:13.000Z",
+      "action": "updated",
+      "from": "pending",
+      "to": "pending",
+      "agent": "Kernel K",
+      "note": "Addressed Gemini incident metadata feedback by adding candidate_data.geography."
     }
   ]
 }

--- a/.github/pipeline/tasks/TASK-2026-0269.json
+++ b/.github/pipeline/tasks/TASK-2026-0269.json
@@ -18,7 +18,9 @@
       "https://news.risky.biz/risky-bulletin-cybercrime-losses-passed-20-billion-last-year"
     ],
     "candidate_data": {
-      "severity": "medium"
+      "severity": "medium",
+      "attack_type": "Social engineering / marketing platform account compromise",
+      "sector": "Financial technology"
     },
     "notes": "Risky Bulletin discovery item from 2026-04-08. Betterment's own post-mortem says a social engineering attack against an employee enabled access to a marketing platform that was used to send waves of cryptocurrency-scam emails to customers. Scope as a discrete Betterment incident; keep actor unknown unless stronger sources name one. The Jan. 14 Risky Bulletin/private backlog item was deferred pending a primary source; the Apr. 8 bulletin links the company post-mortem that resolves that source gap."
   },

--- a/.github/pipeline/tasks/TASK-2026-0269.json
+++ b/.github/pipeline/tasks/TASK-2026-0269.json
@@ -5,7 +5,7 @@
   "priority": "P2",
   "status": "pending",
   "created": "2026-05-13T14:25:50.575Z",
-  "updated": "2026-05-13T14:25:50.575Z",
+  "updated": "2026-05-13T14:44:06.722Z",
   "source": "manual_submission",
   "submitted_by": "risky-bulletin-discovery-worker",
   "locked_by": null,
@@ -19,10 +19,11 @@
     ],
     "candidate_data": {
       "severity": "medium",
-      "attack_type": "Social engineering / marketing platform account compromise",
-      "sector": "Financial technology"
+      "date": "2026-01-09",
+      "attack_type": "Social Engineering",
+      "sector": "Financial Services"
     },
-    "notes": "Risky Bulletin discovery item from 2026-04-08. Betterment's own post-mortem says a social engineering attack against an employee enabled access to a marketing platform that was used to send waves of cryptocurrency-scam emails to customers. Scope as a discrete Betterment incident; keep actor unknown unless stronger sources name one. The Jan. 14 Risky Bulletin/private backlog item was deferred pending a primary source; the Apr. 8 bulletin links the company post-mortem that resolves that source gap."
+    "notes": "Risky Bulletin discovery item from 2026-04-08. Betterment's own post-mortem says a social engineering attack against an employee enabled access to a marketing platform that was used to send waves of cryptocurrency-scam emails to customers. Scope as a discrete Betterment incident; keep actor unknown unless stronger sources name one. The Jan. 14 Risky Bulletin/private backlog item was deferred pending a primary source; the Apr. 8 bulletin links the company post-mortem that resolves that source gap. Drafting agent must add a government or regulator source if one is available; if none can be found, mark the task blocked instead of forcing an unsupported source."
   },
   "specs": [
     "DATA-STANDARDS-v1.0.md",
@@ -32,10 +33,9 @@
   "acceptance_criteria": {
     "frontmatter_valid": true,
     "min_sources": 3,
-    "min_h2_sections": 5,
+    "min_h2_sections": 8,
     "min_mitre_mappings": 1,
     "review_status": "draft_ai",
-    "schema_validation": "pass",
     "astro_build": true
   },
   "depends_on": [],
@@ -55,6 +55,14 @@
       "to": "pending",
       "agent": "risky-bulletin-discovery-worker",
       "note": "Manual link submission via scripts/pipeline-submit-link.mjs"
+    },
+    {
+      "timestamp": "2026-05-13T14:44:06.722Z",
+      "action": "updated",
+      "from": "pending",
+      "to": "pending",
+      "agent": "risky-bulletin-discovery-worker",
+      "note": "Addressed Gemini task metadata feedback: normalized incident candidate_data, aligned min_h2_sections with incident schema, removed unused schema_validation acceptance field, and documented government-source requirement for drafting."
     }
   ]
 }

--- a/.github/pipeline/tasks/TASK-2026-0269.json
+++ b/.github/pipeline/tasks/TASK-2026-0269.json
@@ -1,0 +1,58 @@
+{
+  "task_id": "TASK-2026-0269",
+  "stage": "draft",
+  "type": "incident",
+  "priority": "P2",
+  "status": "pending",
+  "created": "2026-05-13T14:25:50.575Z",
+  "updated": "2026-05-13T14:25:50.575Z",
+  "source": "manual_submission",
+  "submitted_by": "risky-bulletin-discovery-worker",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "Betterment marketing-platform social engineering incident, January 2026",
+    "sources": [
+      "https://www.betterment.com/resources/security-incident-report-january-2026",
+      "https://www.theverge.com/news/860106/betterment-crypto-scam-notification",
+      "https://news.risky.biz/risky-bulletin-cybercrime-losses-passed-20-billion-last-year"
+    ],
+    "candidate_data": {
+      "severity": "medium"
+    },
+    "notes": "Risky Bulletin discovery item from 2026-04-08. Betterment's own post-mortem says a social engineering attack against an employee enabled access to a marketing platform that was used to send waves of cryptocurrency-scam emails to customers. Scope as a discrete Betterment incident; keep actor unknown unless stronger sources name one. The Jan. 14 Risky Bulletin/private backlog item was deferred pending a primary source; the Apr. 8 bulletin links the company post-mortem that resolves that source gap."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "INGESTION-SPEC.md §2"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 5,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/incidents/{slug}.md",
+    "branch": "pipeline/TASK-2026-0269",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-05-13T14:25:50.575Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "risky-bulletin-discovery-worker",
+      "note": "Manual link submission via scripts/pipeline-submit-link.mjs"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Seeds TASK-2026-0269 for the Betterment January 2026 marketing-platform social engineering incident.
- Sources include Betterment's post-mortem, The Verge's initial reporting, and the April 8 Risky Bulletin that surfaced the post-mortem.

## Notes
- Task-only seed PR; no article prose drafted.
- Seed branch intentionally does not match the future article output branch (`pipeline/TASK-2026-0269`) so task-state sync should not treat this PR as article completion.
- Scope instruction: keep actor unknown unless stronger sources name one.
