### PR TITLE
Add pipeline task TASK-2026-0274 for YellowKey zero-day submission

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0274.json
+++ b/.github/pipeline/tasks/TASK-2026-0274.json
@@ -1,0 +1,52 @@
+{
+  "task_id": "TASK-2026-0274",
+  "stage": "draft",
+  "type": "zero-day",
+  "priority": "P2",
+  "status": "pending",
+  "created": "2026-05-13T21:14:37.042Z",
+  "updated": "2026-05-13T21:14:37.042Z",
+  "source": "manual_submission",
+  "submitted_by": "manual-cli",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "YellowKey",
+    "sources": [
+      "https://github.com/Nightmare-Eclipse/YellowKey"
+    ]
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "INGESTION-SPEC.md §2"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 5,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/zero-days/{slug}.md",
+    "branch": "pipeline/TASK-2026-0274",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-05-13T21:14:37.042Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "manual-cli",
+      "note": "Manual link submission via scripts/pipeline-submit-link.mjs"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Add a manual pipeline task to register the provided YellowKey repository as a zero-day candidate so the discovery/dispatcher pipeline can pick it up and route editorial work. 

### Description
- Added `.github/pipeline/tasks/TASK-2026-0274.json` defining a `zero-day` task with `task_id: TASK-2026-0274`, `status: pending`, `priority: P2`, input topic `YellowKey`, and source URL `https://github.com/Nightmare-Eclipse/YellowKey`. 
- The task file includes canonical `acceptance_criteria`, `output` branch/file pattern (`pipeline/TASK-2026-0274` / `site/src/content/zero-days/{slug}.md`), `specs`, and an initial `history` creation entry. 

### Testing
- Ran the submission script `node scripts/pipeline-submit-link.mjs --url https://github.com/Nightmare-Eclipse/YellowKey --type zero-day --topic "YellowKey" --execute` which completed and created the task file. 
- Verified the new task file exists at `./.github/pipeline/tasks/TASK-2026-0274.json` and inspected its contents with `sed -n '1,220p' .github/pipeline/tasks/TASK-2026-0274.json` and `nl -ba .github/pipeline/tasks/TASK-2026-0274.json | sed -n '1,220p'`, both of which showed the expected JSON fields and values.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04e9684784832fa489d5178bd6a416)