### PR TITLE
fix(review-gate): remove pull request trigger

### DIFF
--- a/.github/workflows/pipeline-review-gate.yml
+++ b/.github/workflows/pipeline-review-gate.yml
@@ -1,17 +1,6 @@
 name: "Pipeline: Review Gate"
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - "site/src/**"
-      - "site/package*.json"
-      - "site/astro.config.*"
-      - "scripts/**"
-      - ".github/workflows/**"
-      - ".github/pipeline/config.yml"
-      - ".github/pipeline/tasks/TASK-*.json"
-      - "docs/PIPELINE.md"
   pull_request_review:
     types: [submitted, dismissed]
   issue_comment:
@@ -40,7 +29,6 @@ jobs:
   review-gate:
     if: |
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'pull_request' ||
       (
         github.event_name == 'pull_request_review' &&
         contains(
@@ -74,9 +62,6 @@ jobs:
           case "${{ github.event_name }}" in
             workflow_dispatch)
               number="${{ inputs.pr_number }}"
-              ;;
-            pull_request)
-              number="${{ github.event.pull_request.number }}"
               ;;
             pull_request_review)
               number="${{ github.event.pull_request.number }}"


### PR DESCRIPTION
## Summary

Remove the `pull_request` event path from `Pipeline: Review Gate`.

## Failure Class

- Area: `review-gate`
- Failure class: `overfitted-fix`
- Decision: `simplify`

## Why

Recent PRs are repeatedly failing review-gate on PR open/synchronize before current-head AI review can exist. That contradicts `docs/PIPELINE.md`, which says review-gate should run on configured AI review events, explicit `/review-gate` commands, or manual dispatch.

This keeps task JSON PRs covered by review-gate when an AI review or explicit gate command exists, without generating predictable push-time failures.

## Validation

- `cd scripts && npm ci --no-audit --no-fund`
- `node scripts/pipeline-schema.mjs`
- `node --check scripts/pipeline-review-gate.mjs`
- `git diff --check`

Skipped site build and corpus validation because this PR changes only the review-gate workflow trigger wiring and no site/content files.
