### PR TITLE
Add Shellshock zero-day task

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0275.json
+++ b/.github/pipeline/tasks/TASK-2026-0275.json
@@ -1,0 +1,56 @@
+{
+  "task_id": "TASK-2026-0275",
+  "stage": "draft",
+  "type": "zero-day",
+  "priority": "P0",
+  "status": "pending",
+  "created": "2026-05-13T22:36:53.224Z",
+  "updated": "2026-05-13T22:36:53.224Z",
+  "source": "manual_submission",
+  "submitted_by": "threatpedia-soft-launch-corpus-worker",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "Shellshock Bash remote code execution vulnerability (CVE-2014-6271)",
+    "sources": [
+      "https://nvd.nist.gov/vuln/detail/CVE-2014-6271",
+      "https://www.cisa.gov/news-events/alerts/2014/09/24/bourne-again-shell-bash-remote-code-execution-vulnerability",
+      "https://www.redhat.com/en/blog/bash-specially-crafted-environment-variables-code-injection-attack",
+      "https://seclists.org/oss-sec/2014/q3/651"
+    ],
+    "notes": "Historical P0 zero-day gap from soft-launch corpus list HIST-ZD-001. Scope to CVE-2014-6271 / GNU Bash environment-variable command injection; mention related Shellshock follow-on CVEs only as context if source-supported."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "INGESTION-SPEC.md §2"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 5,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/zero-days/{slug}.md",
+    "branch": "pipeline/TASK-2026-0275",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-05-13T22:36:53.224Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "threatpedia-soft-launch-corpus-worker",
+      "note": "Manual link submission via scripts/pipeline-submit-link.mjs"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a P0 manual pipeline task for the Shellshock Bash remote code execution vulnerability (CVE-2014-6271), covering the soft-launch historical zero-day gap `HIST-ZD-001`.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('.github/pipeline/tasks/TASK-2026-0275.json','utf8')); console.log('json: ok')"`: PASS
- `node scripts/pipeline-schema.mjs`: PASS
- `git diff --check`: PASS

## Notes

This is task-state only. The article should be drafted after the task is accepted on `main`, because `pipeline-run-task.mjs --lock` refuses seed tasks that are not yet on `origin/main`.