### PR TITLE
feat(pipeline): add Risky Bulletin event seeds

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0277.json
+++ b/.github/pipeline/tasks/TASK-2026-0277.json
@@ -1,0 +1,56 @@
+{
+  "task_id": "TASK-2026-0277",
+  "stage": "draft",
+  "type": "zero-day",
+  "priority": "P2",
+  "status": "pending",
+  "created": "2026-05-14T03:07:02.314Z",
+  "updated": "2026-05-14T03:07:02.314Z",
+  "source": "manual_submission",
+  "submitted_by": "risky-bulletin-discovery-worker",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "Dragon Breath APT-Q-27 dragoncore_k.sys BYOVD zero-day, May 2026",
+    "sources": [
+      "https://ransom-isac.org/blog/dragonbreath-dragon-in-the-kernel"
+    ],
+    "candidate_data": {
+      "severity": "high"
+    },
+    "notes": "Risky Bulletin May 6, 2026 lead. Ransom-ISAC reports APT-Q-27/Dragon Breath activity using a signed vulnerable dragoncore_k.sys driver as a bring-your-own-vulnerable-driver zero-day path. Draft should verify exploit chronology, vendor/product identity, signing certificate context, and attribution before making zero-day or actor claims."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "INGESTION-SPEC.md §2"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 5,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/zero-days/{slug}.md",
+    "branch": "pipeline/TASK-2026-0277",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-05-14T03:07:02.314Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "risky-bulletin-discovery-worker",
+      "note": "Manual link submission via scripts/pipeline-submit-link.mjs"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0278.json
+++ b/.github/pipeline/tasks/TASK-2026-0278.json
@@ -1,0 +1,56 @@
+{
+  "task_id": "TASK-2026-0278",
+  "stage": "draft",
+  "type": "threat-actor",
+  "priority": "P2",
+  "status": "pending",
+  "created": "2026-05-14T03:07:24.348Z",
+  "updated": "2026-05-14T03:07:24.348Z",
+  "source": "manual_submission",
+  "submitted_by": "risky-bulletin-discovery-worker",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "UAT-8302 China-nexus espionage cluster targeting government entities",
+    "sources": [
+      "https://blog.talosintelligence.com/uat-8302"
+    ],
+    "candidate_data": {
+      "severity": "medium"
+    },
+    "notes": "Risky Bulletin May 8, 2026 lead. Cisco Talos describes a China-nexus cluster tracked as UAT-8302 targeting government entities in South America and Southeastern Europe with NetDraft, CloudSorcerer, and operational infrastructure. Draft should profile the cluster neutrally and avoid over-attribution beyond the cited research."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "INGESTION-SPEC.md §2"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 6,
+    "min_mitre_mappings": 3,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/threat-actors/{slug}.md",
+    "branch": "pipeline/TASK-2026-0278",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-05-14T03:07:24.348Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "risky-bulletin-discovery-worker",
+      "note": "Manual link submission via scripts/pipeline-submit-link.mjs"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0279.json
+++ b/.github/pipeline/tasks/TASK-2026-0279.json
@@ -1,0 +1,56 @@
+{
+  "task_id": "TASK-2026-0279",
+  "stage": "draft",
+  "type": "threat-actor",
+  "priority": "P2",
+  "status": "pending",
+  "created": "2026-05-14T03:07:31.103Z",
+  "updated": "2026-05-14T03:07:31.103Z",
+  "source": "manual_submission",
+  "submitted_by": "risky-bulletin-discovery-worker",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "PCPJack cloud-worm actor replacing TeamPCP malware in compromised cloud environments",
+    "sources": [
+      "https://www.sentinelone.com/labs/cloud-worm-evicts-teampcp-and-steals-credentials-at-scale"
+    ],
+    "candidate_data": {
+      "severity": "medium"
+    },
+    "notes": "Risky Bulletin May 8, 2026 lead. SentinelOne reports a cloud-focused worm/actor tracked as PCPJack that evicts TeamPCP malware and steals credentials at scale in compromised cloud environments. Draft should establish whether this is best modeled as a threat actor profile or campaign before article generation."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "INGESTION-SPEC.md §2"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 6,
+    "min_mitre_mappings": 3,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/threat-actors/{slug}.md",
+    "branch": "pipeline/TASK-2026-0279",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-05-14T03:07:31.103Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "risky-bulletin-discovery-worker",
+      "note": "Manual link submission via scripts/pipeline-submit-link.mjs"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0280.json
+++ b/.github/pipeline/tasks/TASK-2026-0280.json
@@ -1,0 +1,58 @@
+{
+  "task_id": "TASK-2026-0280",
+  "stage": "draft",
+  "type": "campaign",
+  "priority": "P2",
+  "status": "pending",
+  "created": "2026-05-14T03:07:38.706Z",
+  "updated": "2026-05-14T03:07:38.706Z",
+  "source": "manual_submission",
+  "submitted_by": "risky-bulletin-discovery-worker",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "AI-assisted intrusion campaign targeting Mexican government and water utility, 2026",
+    "sources": [
+      "https://www.dragos.com/blog/ai-assisted-ics-attack-water-utility",
+      "https://gambit.security/blog-post/a-single-operator-two-ai-platforms-nine-government-agencies-the-full-technical-report",
+      "https://www.cybersecuritydive.com/news/anthropics-claude-compromise-mexican-water-utility/819710"
+    ],
+    "candidate_data": {
+      "severity": "high"
+    },
+    "notes": "Risky Bulletin May 11, 2026 lead. Dragos, Gambit, and Cybersecurity Dive describe one operator using AI platforms during intrusions against a Mexican water utility and government entities. Draft should verify official/victim-source corroboration, split any distinct incidents if needed, and keep AI-use claims tightly sourced."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "INGESTION-SPEC.md §2"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 7,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/campaigns/{slug}.md",
+    "branch": "pipeline/TASK-2026-0280",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-05-14T03:07:38.706Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "risky-bulletin-discovery-worker",
+      "note": "Manual link submission via scripts/pipeline-submit-link.mjs"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0281.json
+++ b/.github/pipeline/tasks/TASK-2026-0281.json
@@ -1,0 +1,56 @@
+{
+  "task_id": "TASK-2026-0281",
+  "stage": "draft",
+  "type": "campaign",
+  "priority": "P2",
+  "status": "pending",
+  "created": "2026-05-14T03:07:47.218Z",
+  "updated": "2026-05-14T03:07:47.218Z",
+  "source": "manual_submission",
+  "submitted_by": "risky-bulletin-discovery-worker",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "ScarCruft supply-chain compromise of Chinese gaming platform, 2024-2026",
+    "sources": [
+      "https://www.welivesecurity.com/en/eset-research/rigged-game-scarcruft-compromises-gaming-platform-supply-chain-attack"
+    ],
+    "candidate_data": {
+      "severity": "medium"
+    },
+    "notes": "Risky Bulletin May 8, 2026 lead. ESET reports a ScarCruft/APT37 supply-chain compromise involving a Chinese gaming platform and downstream targeting. Draft should avoid duplicating the existing APT37 threat-actor article and determine whether the available sources support a standalone campaign article."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "INGESTION-SPEC.md §2"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 7,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/campaigns/{slug}.md",
+    "branch": "pipeline/TASK-2026-0281",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-05-14T03:07:47.218Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "risky-bulletin-discovery-worker",
+      "note": "Manual link submission via scripts/pipeline-submit-link.mjs"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0282.json
+++ b/.github/pipeline/tasks/TASK-2026-0282.json
@@ -1,0 +1,56 @@
+{
+  "task_id": "TASK-2026-0282",
+  "stage": "draft",
+  "type": "campaign",
+  "priority": "P2",
+  "status": "pending",
+  "created": "2026-05-14T03:07:53.132Z",
+  "updated": "2026-05-14T03:07:53.132Z",
+  "source": "manual_submission",
+  "submitted_by": "risky-bulletin-discovery-worker",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "Seedworm cyber-espionage campaign against South Korean electronics maker and global targets, 2026",
+    "sources": [
+      "https://www.security.com/threat-intelligence/iran-seedworm-electronics"
+    ],
+    "candidate_data": {
+      "severity": "medium"
+    },
+    "notes": "Risky Bulletin May 13, 2026 lead. Symantec reports Seedworm activity against a South Korean electronics manufacturer with related global targeting. Draft should treat this as campaign coverage only if it adds material beyond the existing MuddyWater/Seedworm actor profile; otherwise route as enrichment."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "INGESTION-SPEC.md §2"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 7,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/campaigns/{slug}.md",
+    "branch": "pipeline/TASK-2026-0282",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-05-14T03:07:53.132Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "risky-bulletin-discovery-worker",
+      "note": "Manual link submission via scripts/pipeline-submit-link.mjs"
+    }
+  ]
+}


### PR DESCRIPTION
Risky Bulletin discovery seed PR.

Adds six pending pipeline tasks from the latest Risky Bulletin scan:

- TASK-2026-0277 zero-day: Dragon Breath APT-Q-27 dragoncore_k.sys BYOVD zero-day, May 2026
- TASK-2026-0278 threat-actor: UAT-8302 China-nexus espionage cluster targeting government entities
- TASK-2026-0279 threat-actor: PCPJack cloud-worm actor replacing TeamPCP malware in compromised cloud environments
- TASK-2026-0280 campaign: AI-assisted intrusion campaign targeting Mexican government and water utility, 2026
- TASK-2026-0281 campaign: ScarCruft supply-chain compromise of Chinese gaming platform, 2024-2026
- TASK-2026-0282 campaign: Seedworm cyber-espionage campaign against South Korean electronics maker and global targets, 2026

Preflight notes:

- Source window scanned: most recent Risky Bulletins dated May 6, May 8, May 11, and May 13, 2026, with primary-source URLs preserved in each task.
- Incident lane skipped for this seed because existing active incident tasks plus PR #685 meet the full-threshold rule for this run.
- Campaign submissions capped at 3, zero-day at 1, threat-actor at 2.
- Dedupe checked against current corpus/task URL and title indexes through pipeline-submit-link dry-runs before execution.

Validation performed:

- node scripts/pipeline-run-task.mjs --list --all
- git diff --cached --check
