### PR TITLE
chore(pipeline): add GreenPlasma zero-day task

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0284.json
+++ b/.github/pipeline/tasks/TASK-2026-0284.json
@@ -21,9 +21,9 @@
       "severity": "high",
       "zero_day_name": "GreenPlasma",
       "platform": "Microsoft Windows 11 and Windows Server 2022/2026, per public researcher claims",
-      "vulnerability_type": "Windows CTFMON arbitrary section creation / local privilege escalation",
-      "cve": "No public CVE assigned as of 2026-05-14",
-      "disclosed_date": "2026-05-12",
+      "attack_type": "Windows CTFMON arbitrary section creation / local privilege escalation",
+      "cve": "Pending",
+      "disclosure_date": "2026-05-12",
       "exploit_status": "Public partial proof-of-concept; researcher states full SYSTEM shell code was stripped"
     },
     "notes": "Manual Risky Bulletin intake from the May 13, 2026 bulletin. Draft conservatively from the Risky Bulletin, the public GreenPlasma repository, and independent reporting. Do not invent a CVE, Microsoft advisory, patch status, exploitation in the wild, or full exploit capability. If Microsoft or NVD publishes a CVE before drafting, update the zero-day metadata from primary/vendor/government sources. If no identifier is available, preserve the public name and explicitly state that no CVE had been publicly assigned at drafting time."

--- a/.github/pipeline/tasks/TASK-2026-0284.json
+++ b/.github/pipeline/tasks/TASK-2026-0284.json
@@ -1,0 +1,65 @@
+{
+  "task_id": "TASK-2026-0284",
+  "stage": "draft",
+  "type": "zero-day",
+  "priority": "P2",
+  "status": "pending",
+  "created": "2026-05-14T08:56:04.022Z",
+  "updated": "2026-05-14T08:56:04.022Z",
+  "source": "manual_submission",
+  "submitted_by": "threatpedia-risky-bulletin-discovery-worker",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "GreenPlasma Windows CTFMON privilege-escalation zero-day disclosure, May 2026",
+    "sources": [
+      "https://news.risky.biz/risky-bulletin-rubygems-disables-sign-ups-after-attack-on-staff/",
+      "https://github.com/Nightmare-Eclipse/GreenPlasma",
+      "https://www.securityweek.com/researcher-drops-yellowkey-greenplasma-windows-zero-days/"
+    ],
+    "candidate_data": {
+      "severity": "high",
+      "zero_day_name": "GreenPlasma",
+      "platform": "Microsoft Windows 11 and Windows Server 2022/2026, per public researcher claims",
+      "vulnerability_type": "Windows CTFMON arbitrary section creation / local privilege escalation",
+      "cve": "No public CVE assigned as of 2026-05-14",
+      "disclosed_date": "2026-05-12",
+      "exploit_status": "Public partial proof-of-concept; researcher states full SYSTEM shell code was stripped"
+    },
+    "notes": "Manual Risky Bulletin intake from the May 13, 2026 bulletin. Draft conservatively from the Risky Bulletin, the public GreenPlasma repository, and independent reporting. Do not invent a CVE, Microsoft advisory, patch status, exploitation in the wild, or full exploit capability. If Microsoft or NVD publishes a CVE before drafting, update the zero-day metadata from primary/vendor/government sources. If no identifier is available, preserve the public name and explicitly state that no CVE had been publicly assigned at drafting time."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "INGESTION-SPEC.md §2"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 5,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50",
+    "zero-day lane active count below 5 at discovery time"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/zero-days/{slug}.md",
+    "branch": "pipeline/TASK-2026-0284",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-05-14T08:56:04.022Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "threatpedia-risky-bulletin-discovery-worker",
+      "note": "Manual Risky Bulletin link submission; pipeline-submit-link dry-run found no URL duplicates, but direct task JSON was used to avoid reusing branch-only task IDs from closed PR #699."
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0284.json
+++ b/.github/pipeline/tasks/TASK-2026-0284.json
@@ -36,7 +36,7 @@
   "acceptance_criteria": {
     "frontmatter_valid": true,
     "min_sources": 3,
-    "min_h2_sections": 5,
+    "min_h2_sections": 7,
     "min_mitre_mappings": 1,
     "review_status": "draft_ai",
     "schema_validation": "pass",


### PR DESCRIPTION
## Summary

Adds TASK-2026-0284 for the GreenPlasma Windows CTFMON privilege-escalation zero-day lead from the May 13 Risky Bulletin.

## Notes

- Source: Risky Bulletin, public GreenPlasma repository, and SecurityWeek corroboration.
- Guardrail: no public CVE, Microsoft advisory, patch status, or in-the-wild exploitation claim was found during intake. The task instructs the drafter not to invent those fields.
- Fresh task ID used because PR #699 was closed unmerged and its branch-only task IDs must not be reused.

## Validation

- pipeline-submit-link dry-run: no URL duplicates found
- node JSON parse for TASK-2026-0284
- node scripts/pipeline-schema.mjs
- git diff --check