### PR TITLE
chore(pipeline): add Seedworm campaign task

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0286.json
+++ b/.github/pipeline/tasks/TASK-2026-0286.json
@@ -21,7 +21,7 @@
       "threat_actor": "Seedworm / MuddyWater",
       "geography": "South Korea and additional global targets",
       "sector": "Electronics manufacturing and related organizations",
-      "first_seen": "2026-02",
+      "active_since": "2026-02",
       "source_caveat": "Symantec did not name the South Korean electronics victim in public reporting"
     },
     "notes": "Manual Risky Bulletin intake from the May 13, 2026 bulletin. This lead was previously branch-only as TASK-2026-0282 in closed PR #699; it is re-seeded with a fresh task ID because #699 was closed unmerged. Draft as a campaign only if the Symantec reporting supports continuity across the named South Korean electronics intrusion and the additional global targets. Existing Threatpedia corpus includes a MuddyWater/Seedworm actor profile; avoid duplicating that actor page. Add government or authoritative actor-context sources such as CISA AA22-055A only if they are used for attribution context and do not imply government confirmation of this specific 2026 campaign."

--- a/.github/pipeline/tasks/TASK-2026-0286.json
+++ b/.github/pipeline/tasks/TASK-2026-0286.json
@@ -1,0 +1,63 @@
+{
+  "task_id": "TASK-2026-0286",
+  "stage": "draft",
+  "type": "campaign",
+  "priority": "P2",
+  "status": "pending",
+  "created": "2026-05-14T08:56:04.022Z",
+  "updated": "2026-05-14T08:56:04.022Z",
+  "source": "manual_submission",
+  "submitted_by": "threatpedia-risky-bulletin-discovery-worker",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "Seedworm cyber-espionage campaign against South Korean electronics maker and global targets, 2026",
+    "sources": [
+      "https://news.risky.biz/risky-bulletin-rubygems-disables-sign-ups-after-attack-on-staff/",
+      "https://www.security.com/threat-intelligence/iran-seedworm-electronics"
+    ],
+    "candidate_data": {
+      "severity": "high",
+      "threat_actor": "Seedworm / MuddyWater",
+      "geography": "South Korea and additional global targets",
+      "sector": "Electronics manufacturing and related organizations",
+      "first_seen": "2026-02",
+      "source_caveat": "Symantec did not name the South Korean electronics victim in public reporting"
+    },
+    "notes": "Manual Risky Bulletin intake from the May 13, 2026 bulletin. This lead was previously branch-only as TASK-2026-0282 in closed PR #699; it is re-seeded with a fresh task ID because #699 was closed unmerged. Draft as a campaign only if the Symantec reporting supports continuity across the named South Korean electronics intrusion and the additional global targets. Existing Threatpedia corpus includes a MuddyWater/Seedworm actor profile; avoid duplicating that actor page. Add government or authoritative actor-context sources such as CISA AA22-055A only if they are used for attribution context and do not imply government confirmation of this specific 2026 campaign."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "INGESTION-SPEC.md §2"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 7,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50",
+    "campaign lane active count below 5 at discovery time"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/campaigns/{slug}.md",
+    "branch": "pipeline/TASK-2026-0286",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-05-14T08:56:04.022Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "threatpedia-risky-bulletin-discovery-worker",
+      "note": "Manual Risky Bulletin link submission; pipeline-submit-link dry-run found no URL duplicates when run against the Risky/Symantec source set, but direct task JSON was used to avoid reusing branch-only task IDs from closed PR #699."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds TASK-2026-0286 for the Seedworm/MuddyWater cyber-espionage campaign lead from the May 13 Risky Bulletin.

## Notes

- Source: Risky Bulletin and Symantec reporting.
- This lead was branch-only as TASK-2026-0282 in closed PR #699. It is re-seeded with a fresh task ID because #699 was closed unmerged and its task IDs should not be reused.
- Guardrail: draft as a campaign only if source evidence supports continuity across the South Korean electronics intrusion and additional global targets. Avoid duplicating the existing MuddyWater/Seedworm actor profile.

## Validation

- pipeline-submit-link dry-run against Risky/Symantec source set: no URL duplicates found
- node JSON parse for TASK-2026-0286
- node scripts/pipeline-schema.mjs
- git diff --check