### PR TITLE
chore(pipeline): requeue TASK-2026-0290 after seed-only merge

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0290.json
+++ b/.github/pipeline/tasks/TASK-2026-0290.json
@@ -3,9 +3,9 @@
   "stage": "draft",
   "type": "incident",
   "priority": "P0",
-  "status": "complete",
+  "status": "pending",
   "created": "2026-05-17T00:56:46.373Z",
-  "updated": "2026-05-17T01:16:42.235Z",
+  "updated": "2026-05-17T01:57:16.542Z",
   "source": "backfill",
   "submitted_by": "Kernel K",
   "locked_by": null,
@@ -77,8 +77,14 @@
       "to": "complete",
       "agent": "pipeline-task-state",
       "note": "PR #736 merged (3ecb908)."
+    },
+    {
+      "timestamp": "2026-05-17T01:57:16.542Z",
+      "action": "requeued",
+      "from": "complete",
+      "to": "pending",
+      "agent": "Kernel K",
+      "note": "Requeued because PR #736 was a task-seed PR only; no article was created at the task output path."
     }
-  ],
-  "pr_number": 736,
-  "merged_at": "2026-05-17T01:16:42.235Z"
+  ]
 }


### PR DESCRIPTION
## Task-State Repair

- Task: `TASK-2026-0290`
- Source List: `historical-corpus`
- Candidate: `TRITON / TRISIS Safety-System Attack, 2017`
- Lane: `incident`
- Repair: reset task from `complete` back to `pending` because PR #736 only seeded the task and no article exists at the output path.

## Validation

- `node scripts/pipeline-schema.mjs`
- `node scripts/validate-pipeline-tasks.mjs --files-file <TASK-2026-0290>`
- `git diff --cached --check`

This keeps the existing task ID and avoids creating a duplicate TRITON/TRISIS task.
