### PR TITLE
chore(pipeline): requeue TASK-2026-0291 Bangladesh Bank SWIFT Heist

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0291.json
+++ b/.github/pipeline/tasks/TASK-2026-0291.json
@@ -3,9 +3,9 @@
   "stage": "draft",
   "type": "incident",
   "priority": "P0",
-  "status": "complete",
+  "status": "pending",
   "created": "2026-05-17T04:07:47.674Z",
-  "updated": "2026-05-17T04:37:49.358Z",
+  "updated": "2026-05-17T05:12:47.667Z",
   "source": "backfill",
   "submitted_by": "Kernel K",
   "locked_by": null,
@@ -75,8 +75,14 @@
       "to": "complete",
       "agent": "pipeline-task-state",
       "note": "PR #740 merged (916750b)."
+    },
+    {
+      "timestamp": "2026-05-17T05:12:47.667Z",
+      "action": "requeued",
+      "from": "complete",
+      "to": "pending",
+      "agent": "Kernel K",
+      "note": "Requeued because PR #740 was a task-seed PR only; no article was created at the task output path."
     }
-  ],
-  "pr_number": 740,
-  "merged_at": "2026-05-17T04:37:49.358Z"
+  ]
 }

--- a/.github/pipeline/tasks/TASK-2026-0291.json
+++ b/.github/pipeline/tasks/TASK-2026-0291.json
@@ -81,7 +81,7 @@
       "action": "requeued",
       "from": "complete",
       "to": "pending",
-      "agent": "Kernel K",
+      "agent": "MahdiHedhli",
       "note": "Requeued because PR #740 was a task-seed PR only; no article was created at the task output path."
     }
   ]


### PR DESCRIPTION
## Summary
- Requeues TASK-2026-0291 after the seed-only PR #740 marked the task complete without creating the incident article.
- Removes seed PR completion markers so the normal task runner can lock and draft the article in a follow-up pass.

## Validation
- PASS: `cd scripts && npm ci --no-audit --no-fund`
- PASS: `node scripts/pipeline-schema.mjs`
- PASS: `jq empty .github/pipeline/tasks/TASK-2026-0291.json`
- PASS: `git diff --check`
- EXPECTED NOT RUN: `node scripts/pipeline-run-task.mjs --task TASK-2026-0291 --validate` requires the article output file and correctly refuses before drafting.

## Review
- DangerMouse review requested for task-state requeue.