### PR TITLE
Requeue TASK-2026-0296 after task seed merge

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0296.json
+++ b/.github/pipeline/tasks/TASK-2026-0296.json
@@ -3,9 +3,9 @@
   "stage": "draft",
   "type": "incident",
   "priority": "P0",
-  "status": "complete",
+  "status": "pending",
   "created": "2026-05-17T14:55:12Z",
-  "updated": "2026-05-17T15:08:08.085Z",
+  "updated": "2026-05-17T15:53:34Z",
   "source": "backfill",
   "submitted_by": "Kernel K",
   "locked_by": null,
@@ -76,8 +76,14 @@
       "to": "complete",
       "agent": "pipeline-task-state",
       "note": "PR #770 merged (ed41d7c)."
+    },
+    {
+      "timestamp": "2026-05-17T15:53:34Z",
+      "action": "requeued",
+      "from": "complete",
+      "to": "pending",
+      "agent": "MahdiHedhli",
+      "note": "Requeued because PR #770 was a task-seed PR only; no article was created at the task output path."
     }
-  ],
-  "pr_number": 770,
-  "merged_at": "2026-05-17T15:08:08.085Z"
+  ]
 }


### PR DESCRIPTION
## Summary

Requeues `TASK-2026-0296` after the task-only seed PR #770 was merged and task-state sync marked the task `complete` even though no article exists at the task output path.

## Scope

- Restores `TASK-2026-0296` to `pending`.
- Removes the seed-PR completion fields so the normal dispatcher/article path can claim the task.
- Adds a history entry documenting why the task was requeued.

## Validation

- `npm --prefix scripts ci --no-audit --no-fund`
- `node scripts/pipeline-schema.mjs`
- `node scripts/validate-pipeline-tasks.mjs --files-file /tmp/task-0296-requeue-files.txt --new-files-file /tmp/task-0296-requeue-new-files.txt`
- `git diff --check`

Skipped site build because this PR changes only public pipeline task JSON.