### PR TITLE
Add optional model provenance metadata

### DIFF
--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -157,8 +157,13 @@ discovery queues are open, validated, and stable.
      rules plus exact section/schema normalization: canonical H2 headings,
      exact source-line format, frontmatter/body source URL parity, canonical
      MITRE tactic casing, canonical publisher aliases, canonical
-     `generatedBy` values, and public-prose guardrails that block internal
+     `generatedBy` values, optional non-rendered `generation` model provenance
+     metadata, and public-prose guardrails that block internal
      editorial/process language from article body text.
+   - Article frontmatter may include an optional `generation` object for
+     internal auditability. When present, it must include non-empty `provider`
+     and `model` fields and may include `tool`, `agent`, and `promptProfile`.
+     This metadata is not rendered in the public article UI.
    - Framework mappings are validated against the public schema mirror and
      pinned framework data where available. New ATT&CK mappings should declare
      `attack-version: "v19"` or `attack-version: "v19.0"` unless the task is
@@ -279,8 +284,10 @@ same queue/validation path as discovery-generated tasks.
 **Public prose guardrails:** generated article body text must not leak internal
 workflow language such as "this article," "this report," `reviewStatus`,
 `draft_ai`, "attribution confidence," or "confidence grade." Those values can
-exist in frontmatter or operator notes where appropriate, but public article
-prose should describe the evidence basis directly rather than narrating
+exist in frontmatter or operator notes where appropriate. Optional `generation`
+model provenance metadata can also exist in frontmatter for auditability, but
+must not be narrated in public prose. Public article prose should describe the
+evidence basis directly rather than narrating
 Threatpedia's internal scoring or editorial process.
 
 **Config authority:** `pipeline-dispatcher.yml` now reads thresholds from

--- a/scripts/pipeline-run-task.mjs
+++ b/scripts/pipeline-run-task.mjs
@@ -31,6 +31,9 @@ import yaml from 'js-yaml';
 // authoritative definitions in site/src/content.config.ts manually.
 import {
   SCHEMA_CANONICAL_PUBLISHER_ALIASES,
+  SCHEMA_GENERATION_METADATA_FIELDS,
+  SCHEMA_GENERATION_METADATA_OPTIONAL_FIELDS,
+  SCHEMA_GENERATION_METADATA_REQUIRED_FIELDS,
   SCHEMA_GENERATED_BY_VALUES,
   SCHEMA_MAPPING_CONFIDENCE_VALUES,
   SCHEMA_MITRE_TACTICS,
@@ -131,6 +134,13 @@ const FRAMEWORK_MAPPING_SCHEMA = `  framework-mappings: array of generic framewo
       notes: string (optional)
     atlasMappings is tolerated only as a compatibility alias while old PRs are migrated`;
 
+const GENERATION_METADATA_SCHEMA = `  generation: object (optional; non-rendered model provenance)
+    provider: string (required when generation is present; e.g., "anthropic", "openai", "google", "xai", "local")
+    model: string (required when generation is present; exact model identifier used for drafting)
+    tool: string (optional; e.g., "claude-cli", "codex", "gemini-cli")
+    agent: string (optional; must be a canonical generatedBy identity)
+    promptProfile: string (optional; worker or prompt profile name)`;
+
 // ── Schemas per content type ────────────────────────────────────────────────
 const SCHEMAS = {
   incident: {
@@ -149,6 +159,7 @@ const SCHEMAS = {
   confidenceGrade: enum (optional, default C) — A through F
   generatedBy: string — your agent identity (e.g., "dangermouse-bot", "penfold-bot")
   generatedDate: date — today's date ISO 8601
+${GENERATION_METADATA_SCHEMA}
   cves: array of strings (optional)
   relatedSlugs: array of strings (optional) — slugs of related articles for cross-referencing
   tags: array of strings — lowercase, hyphenated keywords
@@ -188,6 +199,7 @@ ${FRAMEWORK_MAPPING_SCHEMA}`,
   confidenceGrade: enum (optional, default C) — A through F
   generatedBy: string — your agent identity
   generatedDate: date — today's date
+${GENERATION_METADATA_SCHEMA}
   cves: array of strings (optional)
   relatedIncidents: array of strings (optional) — incident slugs; campaigns should reference confirmed constituent incidents where available
   tags: array of strings
@@ -230,6 +242,7 @@ ${FRAMEWORK_MAPPING_SCHEMA}
   reviewStatus: constrained by task acceptance (see ACCEPTANCE CRITERIA below)
   generatedBy: string — your agent identity
   generatedDate: date — today's date
+${GENERATION_METADATA_SCHEMA}
   tags: array of strings
   sources: array of structured source objects — MINIMUM 3, at least 1 government source
 ${SOURCE_SCHEMA}`,
@@ -265,6 +278,7 @@ ${SOURCE_SCHEMA}`,
   reviewStatus: constrained by task acceptance (see ACCEPTANCE CRITERIA below)
   generatedBy: string — your agent identity
   generatedDate: date — today's date
+${GENERATION_METADATA_SCHEMA}
   relatedIncidents: array of strings (optional) — slugs of incident articles
   relatedActors: array of strings (optional) — slugs of threat actor articles
   tags: array of strings
@@ -318,9 +332,10 @@ function buildRules(task) {
   11. MITRE tactic casing must use the canonical ATT&CK vocabulary; new mappings should declare attack-version "v19" or "v19.0" unless preserving a legacy article version; optional metadata must use confidence ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')} and non-empty evidence when present
   12. Do not bulk-assign or preserve Defense Evasion for ATT&CK v19 split cases without article-supported review; use the pinned v19 data and omit uncertain mappings rather than guessing
   13. framework-mappings are optional and currently only allowed for source-supported adversarial AI/ML behavior; MITRE ATLAS entries require framework: mitre-atlas and mapping-id AML.T####[.###]
-  14. Do not add ATLAS because a topic is broadly AI-adjacent; require article evidence that an AI/ML system was targeted, abused as tooling, bypassed as a control, or compromised in the ML supply chain
-  15. Canonical publisher aliases must be normalized in frontmatter and body
-  16. The Astro build must pass: cd site && npm run build`;
+  14. Optional generation metadata is allowed only in frontmatter, not public prose; if present it must include non-empty provider and model fields
+  15. Do not add ATLAS because a topic is broadly AI-adjacent; require article evidence that an AI/ML system was targeted, abused as tooling, bypassed as a control, or compromised in the ML supply chain
+  16. Canonical publisher aliases must be normalized in frontmatter and body
+  17. The Astro build must pass: cd site && npm run build`;
 }
 
 // ── CLI Parsing ─────────────────────────────────────────────────────────────
@@ -439,6 +454,40 @@ function findCanonicalCaseMatch(value, allowedValues) {
   if (typeof value !== 'string') return null;
   const lower = value.trim().toLowerCase();
   return allowedValues.find(entry => entry.toLowerCase() === lower) || null;
+}
+
+function getGenerationMetadataIssues(value) {
+  if (value === undefined || value === null) return [];
+  const issues = [];
+
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    return ['generation must be an object when present'];
+  }
+
+  const allowedFields = new Set(SCHEMA_GENERATION_METADATA_FIELDS);
+  for (const field of Object.keys(value)) {
+    if (!allowedFields.has(field)) {
+      issues.push(`generation.${field} is not allowed`);
+    }
+  }
+
+  for (const field of SCHEMA_GENERATION_METADATA_REQUIRED_FIELDS) {
+    if (typeof value[field] !== 'string' || value[field].trim() === '') {
+      issues.push(`generation.${field} is required when generation is present`);
+    }
+  }
+
+  for (const field of SCHEMA_GENERATION_METADATA_OPTIONAL_FIELDS) {
+    if (value[field] !== undefined && (typeof value[field] !== 'string' || value[field].trim() === '')) {
+      issues.push(`generation.${field} must be a non-empty string when present`);
+    }
+  }
+
+  if (typeof value.agent === 'string' && !SCHEMA_GENERATED_BY_VALUES.includes(value.agent.trim())) {
+    issues.push(`generation.agent "${value.agent}" is not in the allowed generatedBy set`);
+  }
+
+  return issues;
 }
 
 function getBodyH2Headings(body) {
@@ -1218,6 +1267,11 @@ function validateOutput(task, explicitFile) {
           ? `generatedBy "${generatedBy}" should use canonical value "${canonical}"`
           : `generatedBy "${generatedBy}" is not in the allowed set (${SCHEMA_GENERATED_BY_VALUES.join(', ')})`
       );
+    }
+
+    const generationIssues = getGenerationMetadataIssues(frontmatter.generation);
+    for (const issue of generationIssues) {
+      issues.push(`generation metadata: ${issue}`);
     }
 
     // ── 5. ID format (if applicable) ──────────────────────────────────────

--- a/scripts/pipeline-schema.mjs
+++ b/scripts/pipeline-schema.mjs
@@ -93,6 +93,26 @@ export const SCHEMA_GENERATED_BY_VALUES = Object.freeze([
 ]);
 
 /**
+ * Optional non-rendered article model provenance block.
+ * Authoritative shape: site/src/content.config.ts — const generationMetadata.
+ */
+export const SCHEMA_GENERATION_METADATA_REQUIRED_FIELDS = Object.freeze([
+  'provider',
+  'model',
+]);
+
+export const SCHEMA_GENERATION_METADATA_OPTIONAL_FIELDS = Object.freeze([
+  'tool',
+  'agent',
+  'promptProfile',
+]);
+
+export const SCHEMA_GENERATION_METADATA_FIELDS = Object.freeze([
+  ...SCHEMA_GENERATION_METADATA_REQUIRED_FIELDS,
+  ...SCHEMA_GENERATION_METADATA_OPTIONAL_FIELDS,
+]);
+
+/**
  * Exact H2 headings required per content type.
  * These are the canonical section names used for generation and validation.
  */
@@ -165,6 +185,11 @@ export const SCHEMA = Object.freeze({
   atlasVersionPattern: SCHEMA_ATLAS_VERSION_PATTERN,
   mitreTechniqueIdPattern: SCHEMA_MITRE_TECHNIQUE_ID_PATTERN,
   generatedByValues: SCHEMA_GENERATED_BY_VALUES,
+  generationMetadata: Object.freeze({
+    requiredFields: SCHEMA_GENERATION_METADATA_REQUIRED_FIELDS,
+    optionalFields: SCHEMA_GENERATION_METADATA_OPTIONAL_FIELDS,
+    fields: SCHEMA_GENERATION_METADATA_FIELDS,
+  }),
   requiredH2ByType: SCHEMA_REQUIRED_H2_BY_TYPE,
   canonicalPublisherAliases: SCHEMA_CANONICAL_PUBLISHER_ALIASES,
 });
@@ -207,6 +232,18 @@ function selfTest() {
   for (const v of SCHEMA_GENERATED_BY_VALUES) {
     if (typeof v !== 'string' || !/^[a-z0-9_-]+$/.test(v)) {
       throw new Error(`SCHEMA_GENERATED_BY_VALUES element invalid: ${JSON.stringify(v)}`);
+    }
+  }
+
+  for (const required of ['provider', 'model']) {
+    if (!SCHEMA_GENERATION_METADATA_REQUIRED_FIELDS.includes(required)) {
+      throw new Error(`SCHEMA_GENERATION_METADATA_REQUIRED_FIELDS missing ${required}`);
+    }
+  }
+
+  for (const field of SCHEMA_GENERATION_METADATA_FIELDS) {
+    if (typeof field !== 'string' || !/^[A-Za-z][A-Za-z0-9]*$/.test(field)) {
+      throw new Error(`SCHEMA_GENERATION_METADATA_FIELDS element invalid: ${JSON.stringify(field)}`);
     }
   }
 

--- a/scripts/validate-content-corpus.mjs
+++ b/scripts/validate-content-corpus.mjs
@@ -7,6 +7,9 @@ import yaml from 'js-yaml';
 
 import {
   SCHEMA_CANONICAL_PUBLISHER_ALIASES,
+  SCHEMA_GENERATION_METADATA_FIELDS,
+  SCHEMA_GENERATION_METADATA_OPTIONAL_FIELDS,
+  SCHEMA_GENERATION_METADATA_REQUIRED_FIELDS,
   SCHEMA_GENERATED_BY_VALUES,
   SCHEMA_MITRE_TACTICS,
   SCHEMA_REQUIRED_H2_BY_TYPE,
@@ -131,6 +134,40 @@ function parseFrontmatter(content) {
       body: content.slice(match[0].length),
     };
   }
+}
+
+function getGenerationMetadataIssues(value) {
+  if (value === undefined || value === null) return [];
+  const issues = [];
+
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    return ['generation must be an object when present'];
+  }
+
+  const allowedFields = new Set(SCHEMA_GENERATION_METADATA_FIELDS);
+  for (const field of Object.keys(value)) {
+    if (!allowedFields.has(field)) {
+      issues.push(`generation.${field} is not allowed`);
+    }
+  }
+
+  for (const field of SCHEMA_GENERATION_METADATA_REQUIRED_FIELDS) {
+    if (typeof value[field] !== 'string' || value[field].trim() === '') {
+      issues.push(`generation.${field} is required when generation is present`);
+    }
+  }
+
+  for (const field of SCHEMA_GENERATION_METADATA_OPTIONAL_FIELDS) {
+    if (value[field] !== undefined && (typeof value[field] !== 'string' || value[field].trim() === '')) {
+      issues.push(`generation.${field} must be a non-empty string when present`);
+    }
+  }
+
+  if (typeof value.agent === 'string' && !SCHEMA_GENERATED_BY_VALUES.includes(value.agent.trim())) {
+    issues.push(`generation.agent "${value.agent}" is not in the allowed generatedBy set`);
+  }
+
+  return issues;
 }
 
 function getBodyH2Headings(body) {
@@ -327,6 +364,18 @@ function validateFile(file, newFiles) {
     detail: generatedBy || 'not found',
   });
   if (!SCHEMA_GENERATED_BY_VALUES.includes(generatedBy)) pass = false;
+
+  const generationIssues = getGenerationMetadataIssues(fm.generation);
+  checks.push({
+    name: 'generation model provenance',
+    pass: generationIssues.length === 0,
+    detail: fm.generation === undefined
+      ? 'not present (optional)'
+      : generationIssues.length
+        ? generationIssues.join(' · ')
+        : `${fm.generation.provider}/${fm.generation.model}`,
+  });
+  if (generationIssues.length) pass = false;
 
   const requiredH2 = SCHEMA_REQUIRED_H2_BY_TYPE[type] || [];
   const actualH2 = getBodyH2Headings(body);

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -37,6 +37,14 @@ const generatedBy = z.enum([
   'zero-day-tracker',
 ]);
 
+const generationMetadata = z.object({
+  provider: z.string().min(1),
+  model: z.string().min(1),
+  tool: z.string().min(1).optional(),
+  agent: generatedBy.optional(),
+  promptProfile: z.string().min(1).optional(),
+}).strict();
+
 const mitreTactic = z.enum([
   'Reconnaissance',
   'Resource Development',
@@ -137,6 +145,7 @@ const incidents = defineCollection({
     confidenceGrade: confidenceGrade.default('C'),
     generatedBy: generatedBy,
     generatedDate: z.coerce.date(),
+    generation: generationMetadata.optional(),
 
     // References
     cves: z.array(z.string()).default([]),
@@ -182,6 +191,7 @@ const campaigns = defineCollection({
     confidenceGrade: confidenceGrade.default('C'),
     generatedBy: generatedBy,
     generatedDate: z.coerce.date(),
+    generation: generationMetadata.optional(),
 
     // References
     cves: z.array(z.string()).default([]),
@@ -261,6 +271,7 @@ const threatActors = defineCollection({
     reviewStatus: reviewStatus.default('draft_ai'),
     generatedBy: generatedBy.default('dangermouse-bot'),
     generatedDate: z.coerce.date().default(new Date()),
+    generation: generationMetadata.optional(),
 
     tags: z.array(z.string()).default([]),
 
@@ -295,6 +306,7 @@ const zeroDays = defineCollection({
     reviewStatus: reviewStatus.default('draft_ai'),
     generatedBy: generatedBy.default('dangermouse-bot'),
     generatedDate: z.coerce.date().default(new Date()),
+    generation: generationMetadata.optional(),
 
     // Relations
     relatedIncidents: z.array(z.string()).default([]),


### PR DESCRIPTION
## Summary
- add optional non-rendered generation metadata to article frontmatter schema
- mirror the generation metadata shape in pipeline-schema
- validate optional generation metadata in corpus and task validators
- document that generation metadata is for auditability and is not public prose/UI

## Validation
- node --check scripts/pipeline-run-task.mjs
- node --check scripts/validate-content-corpus.mjs
- node scripts/pipeline-schema.mjs --key generationMetadata
- node scripts/validate-content-corpus.mjs --files-file <tmpfile> for site/src/content/incidents/tanstack-npm-supply-chain-compromise-2026.md
- npm ci in site
- npm run build in site