### PR TITLE
chore(pipeline): seed TASK-2026-0299 BlackFile lead

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0299.json
+++ b/.github/pipeline/tasks/TASK-2026-0299.json
@@ -5,7 +5,7 @@
   "priority": "P1",
   "status": "pending",
   "created": "2026-05-18T07:30:05.833Z",
-  "updated": "2026-05-18T07:30:05.833Z",
+  "updated": "2026-05-18T07:39:30.172Z",
   "source": "manual_submission",
   "submitted_by": "risky-bulletin-discovery-worker",
   "locked_by": null,
@@ -18,7 +18,9 @@
       "https://rhisac.org/threat-intelligence/extortion-in-the-enterprise-defending-against-blackfile-attacks"
     ],
     "candidate_data": {
-      "severity": "medium"
+      "severity": "medium",
+      "origin": "Unknown",
+      "active_since": "Unknown"
     },
     "notes": "Risky Bulletin 2026-05-18 cites Google Cloud and RH-ISAC/Palo Alto reporting on UNC6671/BlackFile as a distinct data-extortion operation using ShinyHunters-like tactics. Draft conservatively as a threat-actor/cluster profile; distinguish Google tracking name UNC6671, BlackFile leak-site branding, and any vendor aliases only when source-supported."
   },
@@ -52,7 +54,7 @@
       "from": "none",
       "to": "pending",
       "agent": "risky-bulletin-discovery-worker",
-      "note": "Manual link submission via scripts/pipeline-submit-link.mjs"
+      "note": "Automated Risky Bulletin discovery submission via scripts/pipeline-submit-link.mjs"
     }
   ]
 }

--- a/.github/pipeline/tasks/TASK-2026-0299.json
+++ b/.github/pipeline/tasks/TASK-2026-0299.json
@@ -1,0 +1,58 @@
+{
+  "task_id": "TASK-2026-0299",
+  "stage": "draft",
+  "type": "threat-actor",
+  "priority": "P1",
+  "status": "pending",
+  "created": "2026-05-18T07:30:05.833Z",
+  "updated": "2026-05-18T07:30:05.833Z",
+  "source": "manual_submission",
+  "submitted_by": "risky-bulletin-discovery-worker",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "UNC6671 / BlackFile data extortion operation",
+    "sources": [
+      "https://news.risky.biz/risky-bulletin-indonesia-emerges-as-a-new-hub-for-cyber-scams",
+      "https://cloud.google.com/blog/topics/threat-intelligence/blackfile-vishing-extortion-operation",
+      "https://rhisac.org/threat-intelligence/extortion-in-the-enterprise-defending-against-blackfile-attacks"
+    ],
+    "candidate_data": {
+      "severity": "medium"
+    },
+    "notes": "Risky Bulletin 2026-05-18 cites Google Cloud and RH-ISAC/Palo Alto reporting on UNC6671/BlackFile as a distinct data-extortion operation using ShinyHunters-like tactics. Draft conservatively as a threat-actor/cluster profile; distinguish Google tracking name UNC6671, BlackFile leak-site branding, and any vendor aliases only when source-supported."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A",
+    "INGESTION-SPEC.md §2"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 6,
+    "min_mitre_mappings": 3,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 50"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/threat-actors/{slug}.md",
+    "branch": "pipeline/TASK-2026-0299",
+    "pr": true
+  },
+  "history": [
+    {
+      "timestamp": "2026-05-18T07:30:05.833Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "risky-bulletin-discovery-worker",
+      "note": "Manual link submission via scripts/pipeline-submit-link.mjs"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0299.json
+++ b/.github/pipeline/tasks/TASK-2026-0299.json
@@ -5,7 +5,7 @@
   "priority": "P1",
   "status": "pending",
   "created": "2026-05-18T07:30:05.833Z",
-  "updated": "2026-05-18T07:39:30.172Z",
+  "updated": "2026-05-18T07:46:00.000Z",
   "source": "manual_submission",
   "submitted_by": "risky-bulletin-discovery-worker",
   "locked_by": null,
@@ -53,8 +53,16 @@
       "action": "created",
       "from": "none",
       "to": "pending",
-      "agent": "risky-bulletin-discovery-worker",
-      "note": "Automated Risky Bulletin discovery submission via scripts/pipeline-submit-link.mjs"
+      "agent": "MahdiHedhli",
+      "note": "Automated Risky Bulletin discovery submission via scripts/pipeline-submit-link.mjs, reviewed and submitted by Kernel K."
+    },
+    {
+      "timestamp": "2026-05-18T07:46:00.000Z",
+      "action": "review-fix",
+      "from": "pending",
+      "to": "pending",
+      "agent": "MahdiHedhli",
+      "note": "Normalized task history agent metadata after Gemini review."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds TASK-2026-0299 for a threat-actor/cluster profile on UNC6671 / BlackFile.
- Sources come from the 2026-05-18 Risky Bulletin plus Google Cloud and RH-ISAC reporting.
- Drafting notes require conservative alias/branding handling and ShinyHunters separation.

## Validation
- Dry-run duplicate check passed before execute.
- Task-only PR; no article prose drafted in this discovery worker.