### PR TITLE
fix(pipeline): block generation metadata prose leaks

### DIFF
--- a/scripts/public-prose-guardrails.mjs
+++ b/scripts/public-prose-guardrails.mjs
@@ -17,7 +17,7 @@ const PUBLIC_PROSE_GUARDRAILS = [
   },
   {
     label: 'internal generation-metadata leakage',
-    regex: /\b(?:generation\s+metadata|model\s+provenance\s+metadata|generatedBy|promptProfile|prompt\s+profile|generation\.(?:provider|model|tool|agent|promptProfile)|model\s+used\s+to\s+generate\s+this\s+(?:article|report|assessment|write[- \u2013\u2014]?up))\b/i,
+    regex: /\b(?:generation[-\s\u2013\u2014]*metadata|model[-\s\u2013\u2014]*provenance[-\s\u2013\u2014]*metadata|generated(?:By|Date)|generation\.(?:provider|model|tool|agent|promptProfile)|prompt[-\s\u2013\u2014]*profile|model\s+used\s+to\s+generate\s+this\s+(?:article|report|assessment|write[- \u2013\u2014]?ups?))\b/i,
   },
 ];
 

--- a/scripts/public-prose-guardrails.mjs
+++ b/scripts/public-prose-guardrails.mjs
@@ -15,6 +15,10 @@ const PUBLIC_PROSE_GUARDRAILS = [
     label: 'internal content-model leakage',
     regex: /\bThreatpedia(?:'s)?\b|\b(?:related[- \u2013\u2014])?(?:incident|campaign|threat[- \u2013\u2014]actor|zero[- \u2013\u2014]day)s?[-\s\u2013\u2014]+(?:articles?|pages?|collections?|lists?|reports?|assessments?|entry|entries|write[- \u2013\u2014]?ups?)\b|\b(?:this\s+page\s+treats|leaves?\s+room\s+for\s+victim[- \u2013\u2014]specific\s+incident\s+articles?)\b|\b(?:frontmatter|slugs?)\b/i,
   },
+  {
+    label: 'internal generation-metadata leakage',
+    regex: /\b(?:generation\s+metadata|model\s+provenance\s+metadata|generatedBy|promptProfile|prompt\s+profile|generation\.(?:provider|model|tool|agent|promptProfile)|model\s+used\s+to\s+generate\s+this\s+(?:article|report|assessment|write[- \u2013\u2014]?up))\b/i,
+  },
 ];
 
 export function maskTextPreservingNewlines(value) {


### PR DESCRIPTION
## Summary
- Adds a public-prose guardrail for internal generation metadata terms introduced by the model provenance schema.
- Blocks explicit metadata leakage such as `generation metadata`, `generatedBy`, `promptProfile`, and `generation.model` in article bodies.
- Keeps the rule narrow so legitimate cybersecurity prose such as random address generation or ML model provenance remains allowed.

## Pipeline Hardening Status

- Area: `validator`
- Failure class: `quality-gate-miss`
- Decision: `patch`
- Reason: `The schema now permits internal generation metadata, so the existing prose guardrail should reject that metadata only when it leaks into public body text.`
- Branch: `codex/generation-prose-guardrail`
- Commit: `ff18c5a789e596da6a2384ed40e870e79f2420b4`
- PR: `#795 https://github.com/MahdiHedhli/threatpedia/pull/795`
- Local Validation: `PASS`
- GitHub Checks: `NOT RUN`
- AI Review: `PENDING`
- Rerun Result: `NOT NEEDED`
- Outcome: `opened_pr`
- Blocker: `review required; no GitHub checks reported for this script-only branch`
- Next: `Await Ernest/current-head review; do not merge without review because this is validator behavior.`

## Validation
- `cd scripts && npm ci --no-audit --no-fund`
- `node --check scripts/public-prose-guardrails.mjs`
- `node scripts/pipeline-schema.mjs --key generationMetadata`
- targeted `node --input-type=module -e ...` guardrail assertion for blocked and allowed phrases
- `node scripts/validate-content-corpus.mjs --files-file /private/tmp/threatpedia-hardening-775.rT1vCB/empty-files.txt`
- `cd site && npm ci`
- `npm run build`
- `git diff --check`

## Out of scope
- Does not change the model provenance schema that merged in #775.
- Does not hard-fail broad words like generation or model because they appear in legitimate incident prose.