### PR TITLE
feat(pipeline): TASK-2026-0303 — FreeBSD dhclient local-network root remote code execution vulnerability (CVE-2026-...

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0303.json
+++ b/.github/pipeline/tasks/TASK-2026-0303.json
@@ -3,13 +3,13 @@
   "stage": "draft",
   "type": "zero-day",
   "priority": "P1",
-  "status": "locked",
+  "status": "pr_open",
   "created": "2026-05-19T19:44:20.647Z",
-  "updated": "2026-05-26T19:21:13.722Z",
+  "updated": "2026-05-26T19:23:58.174Z",
   "source": "manual_submission",
   "submitted_by": "MahdiHedhli",
-  "locked_by": "MahdiHedhli",
-  "locked_at": "2026-05-26T19:21:13.721Z",
+  "locked_by": null,
+  "locked_at": null,
   "input": {
     "topic": "FreeBSD dhclient local-network root remote code execution vulnerability (CVE-2026-42511)",
     "sources": [
@@ -74,6 +74,16 @@
       "to": "locked",
       "agent": "MahdiHedhli",
       "note": "Locked for execution"
+    },
+    {
+      "timestamp": "2026-05-26T19:23:58.173Z",
+      "from": "locked",
+      "to": "pr_open",
+      "agent": "MahdiHedhli",
+      "action": "pr_opened",
+      "note": "Article generated, validated, and recorded against PR #870"
     }
-  ]
+  ],
+  "pr_number": 870,
+  "pr_url": "https://github.com/MahdiHedhli/threatpedia/pull/870"
 }

--- a/.github/pipeline/tasks/TASK-2026-0303.json
+++ b/.github/pipeline/tasks/TASK-2026-0303.json
@@ -3,13 +3,13 @@
   "stage": "draft",
   "type": "zero-day",
   "priority": "P1",
-  "status": "pending",
+  "status": "locked",
   "created": "2026-05-19T19:44:20.647Z",
-  "updated": "2026-05-19T20:10:17.797Z",
+  "updated": "2026-05-26T19:21:13.722Z",
   "source": "manual_submission",
   "submitted_by": "MahdiHedhli",
-  "locked_by": null,
-  "locked_at": null,
+  "locked_by": "MahdiHedhli",
+  "locked_at": "2026-05-26T19:21:13.721Z",
   "input": {
     "topic": "FreeBSD dhclient local-network root remote code execution vulnerability (CVE-2026-42511)",
     "sources": [
@@ -67,6 +67,13 @@
       "to": "pending",
       "agent": "dispatcher",
       "note": "Dispatched as Issue #810"
+    },
+    {
+      "timestamp": "2026-05-26T19:21:13.722Z",
+      "from": "pending",
+      "to": "locked",
+      "agent": "MahdiHedhli",
+      "note": "Locked for execution"
     }
   ]
 }

--- a/site/src/content/zero-days/freebsd-dhclient-cve-2026-42511.md
+++ b/site/src/content/zero-days/freebsd-dhclient-cve-2026-42511.md
@@ -44,10 +44,17 @@ sources:
     publicationDate: "2026-05-01"
     accessDate: "2026-05-26"
     archived: false
+  - url: "https://aisle.com/blog/aisle-discovers-cve-2026-42511-a-21-year-old-freebsd-remote-command-execution-vulnerability"
+    publisher: "AISLE"
+    publisherType: research
+    reliability: R2
+    publicationDate: "2026-05-07"
+    accessDate: "2026-05-26"
+    archived: false
 mitreMappings:
-  - techniqueId: "T1190"
-    techniqueName: "Exploit Public-Facing Application"
-    tactic: "Initial Access"
+  - techniqueId: "T1203"
+    techniqueName: "Exploitation for Client Execution"
+    tactic: "Execution"
     attack-version: "v19"
     confidence: probable
     evidence: "The BOOTP field injection occurs in the DHCP client request/response path in dhclient and enables malformed network input to inject directives into dhclient.conf parsing logic."
@@ -112,7 +119,7 @@ FreeBSD published Security Advisory `SA-26:12.dhclient`, naming CVE-2026-42511 a
 
 The National Vulnerability Database added a public CVE record for CVE-2026-42511 with high severity under CVSS 3.1 and referenced the BOOTP field injection and reparse-to-script evaluation chain.
 
-### 2026-04-30 to 2026-04-29 — CVE metadata and ADP enrichment
+### 2026-04-30 to 2026-05-01 — CVE metadata and ADP enrichment
 
 MITRE's CVE Program API record identifies the vulnerability as affecting FreeBSD `dhclient`, includes the FreeBSD advisory as source reference, and records the same underlying attack behavior for cross-source reconciliation.
 
@@ -121,3 +128,4 @@ MITRE's CVE Program API record identifies the vulnerability as affecting FreeBSD
 - [FreeBSD Project: Security Advisory SA-26:12.dhclient](https://security.freebsd.org/advisories/FreeBSD-SA-26:12.dhclient.asc) — FreeBSD Project, 2026-04-29
 - [National Vulnerability Database: CVE-2026-42511](https://nvd.nist.gov/vuln/detail/CVE-2026-42511) — National Vulnerability Database, 2026-04-30
 - [MITRE CVE Program: CVE-2026-42511 API Record](https://cveawg.mitre.org/api/cve/CVE-2026-42511) — MITRE CVE Program, 2026-05-01
+- [AISLE: AISLE Discovers CVE-2026-42511: A 21-Year-Old FreeBSD Remote Command Execution Vulnerability](https://aisle.com/blog/aisle-discovers-cve-2026-42511-a-21-year-old-freebsd-remote-command-execution-vulnerability) — AISLE, 2026-05-07

--- a/site/src/content/zero-days/freebsd-dhclient-cve-2026-42511.md
+++ b/site/src/content/zero-days/freebsd-dhclient-cve-2026-42511.md
@@ -1,0 +1,123 @@
+---
+exploitId: TP-EXP-2026-0023
+title: FreeBSD dhclient Remote Code Execution via DHCP BOOTP File Field Injection (CVE-2026-42511)
+cve: CVE-2026-42511
+type: Remote Code Execution
+platform: FreeBSD 13.5, 14.3, 14.4, and 15.0 (supported stable and releng branches)
+severity: high
+status: patched
+isZeroDay: false
+disclosedDate: 2026-04-29
+patchDate: 2026-04-29
+researcher: "Joshua Rogers (AISLE Research Team)"
+confirmedBy: "FreeBSD Security Team"
+daysInTheWild: null
+cisaKev: false
+reviewStatus: draft_ai
+generatedBy: dangermouse-bot
+generatedDate: 2026-05-26
+tags:
+  - freebsd
+  - dhclient
+  - dhcp
+  - remote-code-execution
+  - vulnerability
+sources:
+  - url: "https://security.freebsd.org/advisories/FreeBSD-SA-26:12.dhclient.asc"
+    publisher: "FreeBSD Project"
+    publisherType: vendor
+    reliability: R2
+    publicationDate: "2026-04-29"
+    accessDate: "2026-05-26"
+    archived: false
+  - url: "https://nvd.nist.gov/vuln/detail/CVE-2026-42511"
+    publisher: "National Vulnerability Database"
+    publisherType: government
+    reliability: R1
+    publicationDate: "2026-04-30"
+    accessDate: "2026-05-26"
+    archived: false
+  - url: "https://cveawg.mitre.org/api/cve/CVE-2026-42511"
+    publisher: "MITRE CVE Program"
+    publisherType: community
+    reliability: R2
+    publicationDate: "2026-05-01"
+    accessDate: "2026-05-26"
+    archived: false
+mitreMappings:
+  - techniqueId: "T1190"
+    techniqueName: "Exploit Public-Facing Application"
+    tactic: "Initial Access"
+    attack-version: "v19"
+    confidence: probable
+    evidence: "The BOOTP field injection occurs in the DHCP client request/response path in dhclient and enables malformed network input to inject directives into dhclient.conf parsing logic."
+---
+
+## Severity Assessment
+
+- Exploitability: 7/10
+- Impact: 9/10
+- Weaponization Risk: 8/10
+- Patch Urgency: 9/10
+- Detection Coverage: 3/10
+
+## Summary
+
+CVE-2026-42511 is a vulnerability in FreeBSD's `dhclient(8)` DHCP client where the BOOTP `file` field is written into the lease file without escaping embedded double quotes. When a malformed lease is later re-parsed, attacker-controlled content can reach `dhclient-script(8)`, which evaluates directives and can allow unintended command execution as root.
+
+FreeBSD classifies the flaw as remote code execution with a high severity classification. The advisory indicates affected installations include supported versions of FreeBSD. Publicly available advisory data does not require a specific remote precondition beyond the attacker being reachable as a DHCP responder on the local segment.
+
+Attackers would need local network access on the same broadcast domain and to deliver crafted DHCP responses; this requirement is described in the official advisory and is reflected in FreeBSD's remediation guidance.
+
+## Exploit Chain
+
+### Stage 1: Malformed DHCP lease data received
+
+A rogue DHCP server on the same broadcast network sends a lease response containing a crafted BOOTP `file` field that includes unescaped quoting characters.
+
+### Stage 2: Unsafe lease writing by dhclient
+
+`dhclient` writes the BOOTP file value directly to the lease file. Because quoting is not sanitized, this malformed field is preserved and can carry control-like text.
+
+### Stage 3: Reparse and directive injection path
+
+On restart or subsequent processing, `dhclient` reparses the lease file and forwards values to `dhclient-script(8)`, where the injected content can be interpreted as directives.
+
+### Stage 4: Script evaluation under privileged context
+
+The advisory reports that crafted input in this path can allow execution of arbitrary root-level code, consistent with a remote code execution chain where the attacker controls DHCP options in a privileged system service flow.
+
+## Detection Guidance
+
+1. Enforce DHCP source controls on managed networks. Restrict unauthorized DHCP servers using VLAN segmentation, DHCP snooping, and trusted uplink binding where available.
+2. Inventory and monitor hosts running `dhclient` on local network segments where untrusted DHCP servers may be present.
+3. Compare lease file behavior and content changes around DHCP renewal events for injected or malformed BOOTP `file` values containing unexpected quoting.
+4. Harden endpoint logging for DHCP client renewals and restart behavior to catch repeated lease reparsing with abnormal `dhclient-script` invocation patterns.
+5. Apply FreeBSD patches from official branches as soon as supported maintenance windows allow.
+
+## Indicators of Compromise
+
+- DHCP transactions on a segment showing unexpected rogue `DHCP Offer` or `DHCP Ack` sources during sensitive network transitions.
+- Repeated unexpected `dhclient` lease file rewrites carrying atypical quoting in BOOTP `file` values before service restart/reparse.
+- Privileged script execution paths triggered during network interface renewals without normal administrative initiation.
+- Systems receiving DHCP responses from unknown infrastructure where `dhclient-script` behavior changes in unexpected ways.
+
+## Disclosure Timeline
+
+### 2026-04-29 — FreeBSD Security Advisory published
+
+FreeBSD published Security Advisory `SA-26:12.dhclient`, naming CVE-2026-42511 and identifying a remote code execution risk via malicious DHCP options. The advisory published no workaround and noted required patching paths for supported branches.
+
+### 2026-04-30 — NVD entry published
+
+The National Vulnerability Database added a public CVE record for CVE-2026-42511 with high severity under CVSS 3.1 and referenced the BOOTP field injection and reparse-to-script evaluation chain.
+
+### 2026-04-30 to 2026-04-29 — CVE metadata and ADP enrichment
+
+MITRE's CVE Program API record identifies the vulnerability as affecting FreeBSD `dhclient`, includes the FreeBSD advisory as source reference, and records the same underlying attack behavior for cross-source reconciliation.
+
+## Sources & References
+
+- [FreeBSD Project: Security Advisory SA-26:12.dhclient](https://security.freebsd.org/advisories/FreeBSD-SA-26:12.dhclient.asc) — FreeBSD Project, 2026-04-29
+- [National Vulnerability Database: CVE-2026-42511](https://nvd.nist.gov/vuln/detail/CVE-2026-42511) — National Vulnerability Database, 2026-04-30
+- [MITRE CVE Program: CVE-2026-42511 API Record](https://cveawg.mitre.org/api/cve/CVE-2026-42511) — MITRE CVE Program, 2026-05-01


### PR DESCRIPTION
## Pipeline Task

- Task: `TASK-2026-0303`
- Type: `zero-day`
- Topic: FreeBSD dhclient local-network root remote code execution vulnerability (CVE-2026-42511)
- Output file: `site/src/content/zero-days/freebsd-dhclient-cve-2026-42511.md`

## Validation

- Local validator: `node scripts/pipeline-run-task.mjs --task TASK-2026-0303 --validate`
- Minimum sources: `3`
- Minimum H2 sections: `5`
- Minimum MITRE mappings: `1`

Opened via the one-step pipeline wrapper so PR creation and task-state recording stay in sync.
