### PR TITLE
chore(pipeline): resolve blocked task queue items

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0236.json
+++ b/.github/pipeline/tasks/TASK-2026-0236.json
@@ -3,9 +3,9 @@
   "stage": "draft",
   "type": "incident",
   "priority": "P0",
-  "status": "blocked",
+  "status": "pending",
   "created": "2026-05-08T15:29:07.000Z",
-  "updated": "2026-05-08T17:14:00.000Z",
+  "updated": "2026-05-28T02:33:02.000Z",
   "source": "manual_submission",
   "submitted_by": "kernel-k-manual-intake",
   "locked_by": null,
@@ -14,6 +14,8 @@
     "topic": "Instructure Canvas Free-For-Teacher Account Compromise and ShinyHunters Extortion, May 2026",
     "sources": [
       "https://status.instructure.com/incidents/9wm4knj2r64z",
+      "https://fsapartners.ed.gov/knowledge-center/library/electronic-announcements/2026-05-12/technology-security-alert-ongoing-cybersecurity-incident-involving-canvas-learning-management-system",
+      "https://www.ic3.gov/PSA/2026/PSA260515",
       "https://apnews.com/article/446c240d5aeb1b1a1e3795fb92237563",
       "https://www.bleepingcomputer.com/news/security/canvas-login-portals-hacked-in-mass-shinyhunters-extortion-campaign/",
       "https://www.theverge.com/tech/926458/canvas-shinyhunters-breach",
@@ -27,7 +29,7 @@
       "actor_name": "ShinyHunters",
       "attack_type": "Data Breach"
     },
-    "notes": "Manual intake from BleepingComputer and The Verge, corroborated with Instructure status, AP, and TechCrunch. Official Instructure status confirms unauthorized access to a small number of Free-For-Teacher user accounts and states that exposed data may include names, email addresses, user roles, institution names, and Canvas IDs; it states that passwords, course content, assignments, grades, and payment information were not identified as exposed. Media reporting attributes the login-page defacement and extortion demand to ShinyHunters based on the group's claim; keep attribution phrased as claimed unless a primary source confirms it. AP reported on 2026-05-08 that Canvas service was restored and that the Instructure/Canvas listing had been removed from the extortion group's leak site. Do not state that the threatened data was actually leaked unless a later reliable source confirms publication. Treat victim counts, data-volume claims, ransom deadlines, and institution counts as threat-actor claims unless independently corroborated. Current source gap: no public government source confirming this exact event was found during intake; drafting worker must search again for government, regulator, law-enforcement, or public-institution notices before article PR, and must block rather than misclassify a non-government source if the validator requirement cannot be met."
+    "notes": "Manual intake from BleepingComputer and The Verge, corroborated with Instructure status, AP, TechCrunch, Federal Student Aid, and FBI IC3. Official Instructure status confirms unauthorized access to a small number of Free-For-Teacher user accounts and states that exposed data may include names, email addresses, user roles, institution names, and Canvas IDs; it states that passwords, course content, assignments, grades, and payment information were not identified as exposed. Federal Student Aid GENERAL-26-27 confirms the Canvas incident, unauthorized access to LMS data, ShinyHunters ransom defacements, Free-For-Teacher compromise, and ED engagement with Instructure. FBI IC3 PSA I-051526-PSA confirms ShinyHunters activity against an online LMS and disruption to educational institutions. Media reporting attributes the login-page defacement and extortion demand to ShinyHunters based on the group's claim; keep attribution phrased as claimed unless a primary source confirms it. AP reported on 2026-05-08 that Canvas service was restored and that the Instructure/Canvas listing had been removed from the extortion group's leak site. Do not state that threatened data was actually leaked unless a reliable source confirms publication. Treat victim counts, data-volume claims, ransom deadlines, payment terms, and institution counts as threat-actor claims or company statements unless independently corroborated. Source gate is resolved as of 2026-05-28 by Federal Student Aid and FBI IC3; use a fresh branch because the old closed article branch is stale."
   },
   "specs": [
     "DATA-STANDARDS-v1.0.md",
@@ -45,12 +47,11 @@
   },
   "depends_on": [],
   "preconditions": [
-    "editorial queue depth < 50",
-    "public government, regulator, law-enforcement, or public-institution source confirms the incident"
+    "editorial queue depth < 50"
   ],
   "output": {
     "file_pattern": "site/src/content/incidents/{slug}.md",
-    "branch": "pipeline/TASK-2026-0236",
+    "branch": "pipeline/TASK-2026-0236-rerun",
     "pr": true
   },
   "history": [
@@ -77,6 +78,14 @@
       "to": "blocked",
       "agent": "kernel-k",
       "note": "Blocked dispatch until a qualifying public government, regulator, law-enforcement, or public-institution source exists; current intake sources are vendor/media only and the article validator requires a government source."
+    },
+    {
+      "timestamp": "2026-05-28T02:33:02.000Z",
+      "action": "unblocked",
+      "from": "blocked",
+      "to": "pending",
+      "agent": "kernel-k",
+      "note": "Federal Student Aid GENERAL-26-27 and FBI IC3 PSA I-051526-PSA now provide qualifying government/law-enforcement sources for the Canvas LMS incident. Requeued on fresh branch pipeline/TASK-2026-0236-rerun; do not reuse stale closed PR #556 branch."
     }
   ]
 }

--- a/.github/pipeline/tasks/TASK-2026-0268.json
+++ b/.github/pipeline/tasks/TASK-2026-0268.json
@@ -3,12 +3,12 @@
   "stage": "draft",
   "type": "incident",
   "priority": "P1",
-  "status": "blocked",
+  "status": "cancelled",
   "pr_number": null,
   "pr_url": null,
   "merged_at": null,
   "created": "2026-05-13T12:10:38.423Z",
-  "updated": "2026-05-13T15:20:30.000Z",
+  "updated": "2026-05-28T02:33:02.000Z",
   "source": "manual_submission",
   "submitted_by": "risky-bulletin-discovery-worker",
   "locked_by": null,
@@ -86,6 +86,14 @@
       "to": "blocked",
       "agent": "dangermouse-bot",
       "note": "Validation blocked: Only 0 MITRE mapping(s) in frontmatter (need 1+). Public Hasbro sources confirm unauthorized network access and business-system disruption but do not identify a confirmed ATT&CK Enterprise v19 technique; no mapping was added."
+    },
+    {
+      "timestamp": "2026-05-28T02:33:02.000Z",
+      "action": "cancelled",
+      "from": "blocked",
+      "to": "cancelled",
+      "agent": "kernel-k",
+      "note": "Fresh Kernel K review of the SEC filing and TechCrunch reporting still found no source-supported ATT&CK Enterprise v19 technique. Do not force a MITRE mapping from generic unauthorized access or Hasbro's defensive decision to take systems offline. Requeue only if a primary or strong corroborating source identifies an access vector, malware, ransomware, exfiltration method, or another concrete technique, or if a reviewed pipeline policy later supports no-MITRE incident exceptions."
     }
   ]
 }

--- a/.github/pipeline/tasks/TASK-2026-0269.json
+++ b/.github/pipeline/tasks/TASK-2026-0269.json
@@ -3,9 +3,9 @@
   "stage": "draft",
   "type": "incident",
   "priority": "P2",
-  "status": "blocked",
+  "status": "cancelled",
   "created": "2026-05-13T14:25:50.575Z",
-  "updated": "2026-05-13T16:02:10.000Z",
+  "updated": "2026-05-28T02:33:02.000Z",
   "source": "manual_submission",
   "submitted_by": "risky-bulletin-discovery-worker",
   "locked_by": null,
@@ -88,6 +88,14 @@
       "to": "blocked",
       "agent": "dangermouse-bot",
       "note": "Blocked before drafting: task brief requires at least one government source, but no incident-specific public government or regulator source was found in reachable checks of Maine, California, Washington, Massachusetts, and state-AG search results. Existing Betterment and media sources support the incident and ATT&CK mapping, but not the government-source gate."
+    },
+    {
+      "timestamp": "2026-05-28T02:33:02.000Z",
+      "action": "cancelled",
+      "from": "blocked",
+      "to": "cancelled",
+      "agent": "kernel-k",
+      "note": "Fresh Kernel K review confirmed Betterment's primary report supports the incident and technique candidates, including voice phishing, credential/MFA capture, Okta SSO access, marketing-platform access, fraudulent crypto messaging, DDoS pressure, and temporary leak-site publication. No incident-specific public government, regulator, law-enforcement, or public-institution source was found; a private IC3 report referenced by Betterment is not a public source. Requeue only if a public regulator, state AG, law-enforcement notice, or reviewed source-gate policy change becomes available."
     }
   ]
 }

--- a/.github/pipeline/tasks/TASK-2026-0283.json
+++ b/.github/pipeline/tasks/TASK-2026-0283.json
@@ -3,9 +3,9 @@
   "stage": "draft",
   "type": "incident",
   "priority": "P1",
-  "status": "blocked",
+  "status": "cancelled",
   "created": "2026-05-14T03:49:35.000Z",
-  "updated": "2026-05-16T21:56:30.000Z",
+  "updated": "2026-05-28T02:33:02.000Z",
   "source": "manual_submission",
   "submitted_by": "kernel-k-manual-intake",
   "locked_by": null,
@@ -77,6 +77,14 @@
       "to": "blocked",
       "agent": "kernel-k",
       "note": "Blocked before drafting: task brief requires an incident article with at least one government source, but live checks found no incident-specific public government, regulator, law-enforcement, or public-institution source for the Google GTIG AI-assisted 2FA-bypass zero-day disruption. Google and media sources support the event, but adding unrelated government AI or secure-by-design background would not satisfy the article source relevance bar."
+    },
+    {
+      "timestamp": "2026-05-28T02:33:02.000Z",
+      "action": "cancelled",
+      "from": "blocked",
+      "to": "cancelled",
+      "agent": "kernel-k",
+      "note": "Fresh Kernel K review found the Google GTIG report still supports a high-value security event, but not a merge-eligible Threatpedia article under current gates: no incident-specific public government source, no affected product/vendor, no CVE, no patch identifier, and no public victim or exploitation target. Do not invent product, CVE, affected version, actor, victim count, or government background source. Requeue only if the vendor/CVE/product becomes public, a government or regulator source confirms the exact event, or a reviewed pipeline policy creates an explicit exception path."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Requeue TASK-2026-0236 after source-gate resolution using Federal Student Aid GENERAL-26-27 and FBI IC3 PSA I-051526-PSA.
- Move TASK-2026-0268, TASK-2026-0269, and TASK-2026-0283 from blocked to cancelled with explicit Kernel K requeue conditions.
- Set TASK-2026-0236 output branch to `pipeline/TASK-2026-0236-rerun` because stale PR https://github.com/MahdiHedhli/threatpedia/pull/556 is closed and its branch should not be reused.

## Validation

- `jq empty` on all four task JSON files
- `node scripts/validate-pipeline-tasks.mjs --files-file changed-tasks.txt --new-files-file new-tasks.txt --json-out task-validation.json`
- `git diff --check`
