### PR TITLE
chore(pipeline): cancel RubyGems task pending source gate

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0304.json
+++ b/.github/pipeline/tasks/TASK-2026-0304.json
@@ -3,9 +3,9 @@
   "stage": "draft",
   "type": "incident",
   "priority": "P1",
-  "status": "pending",
+  "status": "cancelled",
   "created": "2026-05-19T19:44:52.602Z",
-  "updated": "2026-05-26T22:00:24.941Z",
+  "updated": "2026-05-28T03:51:02Z",
   "source": "manual_submission",
   "submitted_by": "MahdiHedhli",
   "locked_by": null,
@@ -72,6 +72,14 @@
       "to": "pending",
       "agent": "dispatcher",
       "note": "Dispatched as Issue #874"
+    },
+    {
+      "timestamp": "2026-05-28T03:51:02Z",
+      "action": "cancelled",
+      "from": "pending",
+      "to": "cancelled",
+      "agent": "kernel-k",
+      "note": "Kernel K review of Issue #874 found this task is not draft-ready under the current source gate. The source set contains RubyGems status, The Hacker News, and Mend reporting, but no incident-specific public government, regulator, law-enforcement, or public-institution source was found. Requeue only if a qualifying public source appears or a reviewed source-gate policy change authorizes an exception path."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Cancels `TASK-2026-0304` after Kernel K review of https://github.com/MahdiHedhli/threatpedia/issues/874.
- Records that the current RubyGems source set is vendor/media/research plus RubyGems status, with no incident-specific public government, regulator, law-enforcement, or public-institution source found.
- Requeue condition: add a qualifying public source or merge a reviewed source-gate policy change that authorizes an exception path.

## Validation
- `jq empty .github/pipeline/tasks/TASK-2026-0304.json`
- `node scripts/validate-pipeline-tasks.mjs --files-file changed-tasks.txt --new-files-file new-tasks.txt --json-out task-validation.json`
- `git diff --check`

## Related
- Issue: https://github.com/MahdiHedhli/threatpedia/issues/874
- Prior task-state unblock PR: https://github.com/MahdiHedhli/threatpedia/pull/892