### PR TITLE
Ignore local gh device ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ Icon
 
 # Claude Code session artifacts
 .claude/
+.local/state/gh/device-id
 .com.apple.timemachine.donotpresent
 .AppleDB
 .AppleDesktop

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ Icon
 
 # Claude Code session artifacts
 .claude/
-.local/state/gh/device-id
+.local/
 .com.apple.timemachine.donotpresent
 .AppleDB
 .AppleDesktop


### PR DESCRIPTION
## Summary
- ignore local GitHub CLI device ID state under .local/state/gh/device-id

## Validation
- git diff --check

## Notes
This keeps local auth/device state out of public repository commits.