### PR TITLE
Fix dispatcher P0 priority ordering

### DIFF
--- a/scripts/pipeline-dispatcher-dispatch-step.cjs
+++ b/scripts/pipeline-dispatcher-dispatch-step.cjs
@@ -425,7 +425,7 @@ module.exports = async function runDispatcherDispatchStep({ github, context }) {
   const pendingTasks = allTasks
     .filter((t) => t.status === 'pending' && effectiveStage(t) === 'draft')
     .sort((a, b) => {
-      const pDiff = (priorityOrder[a.priority] || 9) - (priorityOrder[b.priority] || 9);
+      const pDiff = (priorityOrder[a.priority] ?? 9) - (priorityOrder[b.priority] ?? 9);
       if (pDiff !== 0) return pDiff;
 
       const aCreated = effectiveCreatedAt(a);


### PR DESCRIPTION
## Summary
- Preserve P0 dispatcher priority by using nullish fallback instead of boolean fallback.
- Keeps unknown priorities ranked after P0-P3.

## Verification
- `node --check scripts/pipeline-dispatcher-dispatch-step.cjs`
- Local pending-task sort check now places `TASK-2026-0355:P0` first.