### PR TITLE
fix(pipeline): add discovery validation dispatch fallback

### DIFF
--- a/.github/workflows/pipeline-discovery.yml
+++ b/.github/workflows/pipeline-discovery.yml
@@ -69,9 +69,12 @@ jobs:
   discover:
     runs-on: ubuntu-latest
     permissions:
+      actions: write
+      checks: read
       contents: write
       issues: write
       pull-requests: write
+      statuses: write
 
     steps:
       - uses: actions/checkout@v6
@@ -318,3 +321,16 @@ jobs:
               }
               console.log(`Opened PR #${pr.number}: ${pr.html_url}`);
             }
+
+      - name: Dispatch discovery task validation
+        if: ${{ inputs.execute != 'false' && steps.commit.outputs.has_changes == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          node scripts/pipeline-discovery-validation-dispatch.mjs \
+            --branch "${DISCOVERY_BRANCH}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --workflow "pipeline-validate-tasks.yml" \
+            --wait-seconds 30

--- a/.github/workflows/pipeline-validate-tasks.yml
+++ b/.github/workflows/pipeline-validate-tasks.yml
@@ -1,5 +1,7 @@
 name: "Pipeline: Validate Task PR"
 
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('Validate task PR #{0}', inputs.pr_number) || github.event.pull_request.title }}
+
 on:
   pull_request:
     types: [opened, synchronize]
@@ -8,6 +10,16 @@ on:
       - ".github/workflows/pipeline-validate-tasks.yml"
       - "scripts/validate-pipeline-tasks.mjs"
       - "scripts/pipeline-schema.mjs"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Discovery/task pull request number to validate"
+        required: true
+        type: number
+      head_ref:
+        description: "Pull request head branch or ref to validate"
+        required: true
+        type: string
 
 jobs:
   validate-tasks:
@@ -20,6 +32,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.head_ref || github.ref }}
 
       - uses: actions/setup-node@v6
         with:
@@ -32,8 +45,14 @@ jobs:
 
       - name: Identify changed task files
         id: changed
+        env:
+          VALIDATION_PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}
+          VALIDATION_HEAD_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.head_ref || github.head_ref || github.ref_name }}
         run: |
           set -euo pipefail
+
+          echo "Validation PR: ${VALIDATION_PR_NUMBER}"
+          echo "Validation head ref: ${VALIDATION_HEAD_REF}"
 
           ALL=$(git diff --name-only --diff-filter=d origin/main...HEAD -- '.github/pipeline/tasks/*.json')
           NEW=$(git diff --name-only --diff-filter=A origin/main...HEAD -- '.github/pipeline/tasks/*.json')
@@ -62,12 +81,19 @@ jobs:
         env:
           PIPELINE_TASK_VALIDATION_JSON: ${{ runner.temp }}/pipeline_task_validation.json
           VALIDATION_OUTCOME: ${{ steps.validate.outcome }}
+          VALIDATION_PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}
         with:
           script: |
             const fs = require('fs');
 
             const reportPath = process.env.PIPELINE_TASK_VALIDATION_JSON;
             const validationOutcome = process.env.VALIDATION_OUTCOME || 'failure';
+            const issueNumber = Number(process.env.VALIDATION_PR_NUMBER || context.issue.number);
+            if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+              core.setFailed('Could not resolve PR number for task validation report.');
+              return;
+            }
+
             let payload;
 
             if (fs.existsSync(reportPath)) {
@@ -85,7 +111,7 @@ jobs:
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: issueNumber,
             });
 
             const botComment = comments.find((comment) =>
@@ -103,7 +129,7 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: issueNumber,
                 body,
               });
             }

--- a/.github/workflows/pipeline-validate-tasks.yml
+++ b/.github/workflows/pipeline-validate-tasks.yml
@@ -1,7 +1,5 @@
 name: "Pipeline: Validate Task PR"
 
-run-name: ${{ github.event_name == 'workflow_dispatch' && format('Validate task PR #{0}', inputs.pr_number) || github.event.pull_request.title }}
-
 on:
   pull_request:
     types: [opened, synchronize]

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -100,6 +100,13 @@ discovery queues are open, validated, and stable.
      reference, and topic. **Merge** to accept the whole batch; **close without
      merging** to discard the staged batch. To make a rejection durable across
      future discovery runs, use the rejection-memory workflow and merge its PR.
+   - After the PR is created or updated, discovery explicitly dispatches
+     `pipeline-validate-tasks.yml` with the PR number and `pipeline/discovery`
+     head ref. This covers the GitHub `GITHUB_TOKEN` anti-recursion case where
+     the normal `pull_request` validation trigger can be skipped. If dispatch
+     fails or no dispatched run appears quickly, discovery runs the same task
+     validator locally as a bounded fallback, updates the deduped validation
+     comment, and writes a fallback commit status on the PR head.
    - If no new candidates this run, no branch change, no PR churn.
 
 2. **Queue backpressure check** (next dispatcher tick)
@@ -272,7 +279,7 @@ same queue/validation path as discovery-generated tasks.
 | Discovery lane selection | workflow env `MODE` → `--mode` | `all` | Workflow input |
 | Discovery publishes via | `pipeline/discovery` branch + auto-PR | labeled `pipeline/discovery`, no direct push to `main` | Workflow |
 | Dispatcher publishes via | `pipeline/dispatcher` branch + auto-PR | labeled `pipeline/dispatcher`, no direct push to `main`; skips duplicate `pipeline/ready` Issues when one is already open | Workflow |
-| Task PR validation | `pipeline-validate-tasks.yml` + `scripts/validate-pipeline-tasks.mjs` | Validates changed `.github/pipeline/tasks/*.json`; new task files must use canonical `acceptance_criteria`, pending-state metadata, matching filenames, and valid source URLs | Workflow + script |
+| Task PR validation | `pipeline-validate-tasks.yml` + `scripts/validate-pipeline-tasks.mjs` + `scripts/pipeline-discovery-validation-dispatch.mjs` | Validates changed `.github/pipeline/tasks/*.json`; new task files must use canonical `acceptance_criteria`, pending-state metadata, matching filenames, and valid source URLs; discovery PRs explicitly dispatch validation and fall back to local validation plus a PR-head status if dispatch cannot be observed | Workflow + script |
 | PR batch review | Human merge (not auto-merge) | Nothing lands on `main` without review | Workflow + branch protection |
 | Review readiness gate | `pipeline-review-gate.yml` + `pipeline-review-gate.mjs` | Current-head validation for content PRs, current-head AI second review from Gemini Code Assist, `dangermouse-bot`, or `ernestpenfold-bot`, zero unresolved AI review threads; automatic PR-review runs are limited to configured AI reviewer logins; issue-comment runs require `/review-gate` or `/pipeline review-gate` | Live GitHub state |
 | Editorial queue backpressure (hysteresis) | `pipeline-dispatcher.yml` (via `scripts/pipeline-config.mjs`); state tracked via labeled GitHub Issue (`pipeline/backpressure`) | Pause at 50 pending · stay paused until queue < 40 (auto-resume + Issue auto-close) | `config.yml` (`queues.editorial.max_pending` / `backpressure_resume`) |

--- a/scripts/pipeline-discovery-validation-dispatch.mjs
+++ b/scripts/pipeline-discovery-validation-dispatch.mjs
@@ -5,7 +5,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -150,7 +150,7 @@ async function getExistingValidationCheck({ token, owner, repo, headSha }) {
   const runs = Array.isArray(payload?.check_runs) ? payload.check_runs : [];
   return runs
     .filter(run => run.name === 'validate-tasks')
-    .sort((a, b) => Date.parse(b.started_at || b.created_at || 0) - Date.parse(a.started_at || a.created_at || 0))[0] || null;
+    .sort((a, b) => (Date.parse(b.started_at || b.created_at || '') || 0) - (Date.parse(a.started_at || a.created_at || '') || 0))[0] || null;
 }
 
 function sleep(ms) {
@@ -205,54 +205,58 @@ function runFallbackValidation() {
   run('git', ['fetch', 'origin', 'main', '--quiet']);
 
   const temp = mkdtempSync(join(tmpdir(), 'threatpedia-task-validation-'));
-  const changedPath = join(temp, 'pipeline_changed_tasks.txt');
-  const newPath = join(temp, 'pipeline_new_tasks.txt');
-  const reportPath = join(temp, 'pipeline_task_validation.json');
+  try {
+    const changedPath = join(temp, 'pipeline_changed_tasks.txt');
+    const newPath = join(temp, 'pipeline_new_tasks.txt');
+    const reportPath = join(temp, 'pipeline_task_validation.json');
 
-  const changed = gitLines(['diff', '--name-only', '--diff-filter=d', 'origin/main...HEAD', '--', '.github/pipeline/tasks/*.json']);
-  const added = gitLines(['diff', '--name-only', '--diff-filter=A', 'origin/main...HEAD', '--', '.github/pipeline/tasks/*.json']);
-  writeFileSync(changedPath, `${changed.join('\n')}\n`);
-  writeFileSync(newPath, `${added.join('\n')}\n`);
+    const changed = gitLines(['diff', '--name-only', '--diff-filter=d', 'origin/main...HEAD', '--', '.github/pipeline/tasks/*.json']);
+    const added = gitLines(['diff', '--name-only', '--diff-filter=A', 'origin/main...HEAD', '--', '.github/pipeline/tasks/*.json']);
+    writeFileSync(changedPath, `${changed.join('\n')}\n`);
+    writeFileSync(newPath, `${added.join('\n')}\n`);
 
-  const result = run(process.execPath, [
-    'scripts/validate-pipeline-tasks.mjs',
-    '--files-file',
-    changedPath,
-    '--new-files-file',
-    newPath,
-    '--json-out',
-    reportPath,
-  ], { allowFailure: true });
+    const result = run(process.execPath, [
+      'scripts/validate-pipeline-tasks.mjs',
+      '--files-file',
+      changedPath,
+      '--new-files-file',
+      newPath,
+      '--json-out',
+      reportPath,
+    ], { allowFailure: true });
 
-  let payload;
-  if (existsSync(reportPath)) {
-    payload = JSON.parse(readFileSync(reportPath, 'utf8'));
-  } else {
-    payload = {
-      allPass: false,
-      results: [],
-      markdown: [
-        '## Pipeline Task Validation Report',
-        '',
-        ':x: Task validator did not produce a report during discovery fallback validation.',
-      ].join('\n'),
+    let payload;
+    if (existsSync(reportPath)) {
+      payload = JSON.parse(readFileSync(reportPath, 'utf8'));
+    } else {
+      payload = {
+        allPass: false,
+        results: [],
+        markdown: [
+          '## Pipeline Task Validation Report',
+          '',
+          ':x: Task validator did not produce a report during discovery fallback validation.',
+        ].join('\n'),
+      };
+    }
+
+    return {
+      exitStatus: result.status,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      changed,
+      added,
+      payload,
     };
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
   }
-
-  return {
-    exitStatus: result.status,
-    stdout: result.stdout,
-    stderr: result.stderr,
-    changed,
-    added,
-    payload,
-  };
 }
 
 async function upsertValidationComment({ token, owner, repo, prNumber, body }) {
   const comments = await githubRequest(token, `/repos/${owner}/${repo}/issues/${prNumber}/comments?per_page=100`);
   const existing = comments.find(comment =>
-    comment.user?.type === 'Bot' && String(comment.body || '').includes('Pipeline Task Validation Report')
+    String(comment.body || '').includes('Pipeline Task Validation Report')
   );
 
   if (existing) {
@@ -333,7 +337,7 @@ async function main() {
     summary.existing_validation_status = 'none';
   }
 
-  const startedAtMs = Date.now() - 1000;
+  const startedAtMs = Date.now() - 30000;
   if (!summary.primary_dispatch_status.startsWith('existing_validation_non_success')) {
     try {
       await dispatchValidation({
@@ -413,6 +417,6 @@ async function main() {
 }
 
 main().catch((error) => {
-  console.error(`pipeline-discovery-validation-dispatch: ${error.message}`);
+  console.error('pipeline-discovery-validation-dispatch failed:', error);
   process.exit(1);
 });

--- a/scripts/pipeline-discovery-validation-dispatch.mjs
+++ b/scripts/pipeline-discovery-validation-dispatch.mjs
@@ -157,7 +157,7 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-async function findDispatchedRun({ token, owner, repo, workflow, prNumber, startedAtMs }) {
+async function findDispatchedRun({ token, owner, repo, workflow, startedAtMs }) {
   const payload = await githubRequest(
     token,
     `/repos/${owner}/${repo}/actions/workflows/${encodeURIComponent(workflow)}/runs?event=workflow_dispatch&branch=main&per_page=20`,
@@ -166,15 +166,14 @@ async function findDispatchedRun({ token, owner, repo, workflow, prNumber, start
   return runs.find((run) => {
     const createdAt = Date.parse(run.created_at || '');
     if (!Number.isFinite(createdAt) || createdAt < startedAtMs) return false;
-    const title = String(run.display_title || run.name || '');
-    return title.includes(`#${prNumber}`) || title.includes(`PR #${prNumber}`);
+    return true;
   }) || null;
 }
 
-async function waitForDispatchedRun({ token, owner, repo, workflow, prNumber, startedAtMs, waitSeconds }) {
+async function waitForDispatchedRun({ token, owner, repo, workflow, startedAtMs, waitSeconds }) {
   const deadline = Date.now() + waitSeconds * 1000;
   while (Date.now() <= deadline) {
-    const run = await findDispatchedRun({ token, owner, repo, workflow, prNumber, startedAtMs });
+    const run = await findDispatchedRun({ token, owner, repo, workflow, startedAtMs });
     if (run) return run;
     await sleep(5000);
   }
@@ -358,7 +357,6 @@ async function main() {
       owner,
       repo,
       workflow: args.workflow,
-      prNumber,
       startedAtMs,
       waitSeconds: args.waitSeconds,
     });

--- a/scripts/pipeline-discovery-validation-dispatch.mjs
+++ b/scripts/pipeline-discovery-validation-dispatch.mjs
@@ -1,0 +1,420 @@
+#!/usr/bin/env node
+/**
+ * Dispatch task validation for discovery PRs and run a bounded local fallback
+ * if the dispatch path is unavailable or does not materialize.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const DEFAULT_WORKFLOW = 'pipeline-validate-tasks.yml';
+const DEFAULT_WAIT_SECONDS = 30;
+const FALLBACK_STATUS_CONTEXT = 'Pipeline: Validate Task PR / fallback';
+
+function usage() {
+  console.log([
+    'Usage:',
+    '  node scripts/pipeline-discovery-validation-dispatch.mjs --branch <branch> [--repo owner/name] [--workflow file.yml] [--wait-seconds 30]',
+    '',
+    'Tries workflow_dispatch first. If no dispatched run appears, validates the',
+    'current checkout with scripts/validate-pipeline-tasks.mjs and reports a',
+    'deduped PR comment plus a commit status on the discovery PR head.',
+  ].join('\n'));
+}
+
+function parseArgs(argv) {
+  const args = {
+    branch: process.env.DISCOVERY_BRANCH || null,
+    repo: process.env.GITHUB_REPOSITORY || null,
+    workflow: DEFAULT_WORKFLOW,
+    waitSeconds: DEFAULT_WAIT_SECONDS,
+  };
+
+  for (let i = 2; i < argv.length; i += 1) {
+    const token = argv[i];
+    const next = argv[i + 1];
+    switch (token) {
+      case '--branch':
+        if (!next) throw new Error('Missing value for --branch');
+        args.branch = next;
+        i += 1;
+        break;
+      case '--repo':
+        if (!next) throw new Error('Missing value for --repo');
+        args.repo = next;
+        i += 1;
+        break;
+      case '--workflow':
+        if (!next) throw new Error('Missing value for --workflow');
+        args.workflow = next;
+        i += 1;
+        break;
+      case '--wait-seconds':
+        if (!next || !/^\d+$/.test(next)) throw new Error('Missing numeric value for --wait-seconds');
+        args.waitSeconds = Number(next);
+        i += 1;
+        break;
+      case '--help':
+      case '-h':
+        usage();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${token}`);
+    }
+  }
+
+  if (!args.branch) throw new Error('--branch is required');
+  if (!args.repo || !/^[^/]+\/[^/]+$/.test(args.repo)) throw new Error('--repo owner/name is required');
+  return args;
+}
+
+function getToken() {
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  if (!token) throw new Error('GITHUB_TOKEN or GH_TOKEN is required');
+  return token;
+}
+
+function repoParts(fullName) {
+  const [owner, repo] = fullName.split('/');
+  return { owner, repo };
+}
+
+async function githubRequest(token, path, options = {}) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'threatpedia-discovery-validation-dispatch',
+      ...(options.headers || {}),
+    },
+  });
+
+  if (response.status === 204) return null;
+
+  const text = await response.text();
+  let payload = null;
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      payload = { message: text };
+    }
+  }
+
+  if (!response.ok) {
+    const message = payload?.message || response.statusText;
+    const error = new Error(`GitHub API ${response.status}: ${message}`);
+    error.status = response.status;
+    error.payload = payload;
+    throw error;
+  }
+
+  return payload;
+}
+
+async function findOpenDiscoveryPr({ token, owner, repo, branch }) {
+  const head = encodeURIComponent(`${owner}:${branch}`);
+  const pulls = await githubRequest(token, `/repos/${owner}/${repo}/pulls?state=open&head=${head}&per_page=5`);
+  if (!Array.isArray(pulls) || pulls.length === 0) {
+    throw new Error(`No open PR found for ${owner}:${branch}`);
+  }
+  if (pulls.length > 1) {
+    throw new Error(`Multiple open PRs found for ${owner}:${branch}`);
+  }
+  return pulls[0];
+}
+
+async function dispatchValidation({ token, owner, repo, workflow, prNumber, branch }) {
+  await githubRequest(token, `/repos/${owner}/${repo}/actions/workflows/${encodeURIComponent(workflow)}/dispatches`, {
+    method: 'POST',
+    body: JSON.stringify({
+      ref: 'main',
+      inputs: {
+        pr_number: String(prNumber),
+        head_ref: branch,
+      },
+    }),
+  });
+}
+
+async function getExistingValidationCheck({ token, owner, repo, headSha }) {
+  const payload = await githubRequest(
+    token,
+    `/repos/${owner}/${repo}/commits/${headSha}/check-runs?check_name=validate-tasks&per_page=10`,
+  );
+  const runs = Array.isArray(payload?.check_runs) ? payload.check_runs : [];
+  return runs
+    .filter(run => run.name === 'validate-tasks')
+    .sort((a, b) => Date.parse(b.started_at || b.created_at || 0) - Date.parse(a.started_at || a.created_at || 0))[0] || null;
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function findDispatchedRun({ token, owner, repo, workflow, prNumber, startedAtMs }) {
+  const payload = await githubRequest(
+    token,
+    `/repos/${owner}/${repo}/actions/workflows/${encodeURIComponent(workflow)}/runs?event=workflow_dispatch&branch=main&per_page=20`,
+  );
+  const runs = Array.isArray(payload?.workflow_runs) ? payload.workflow_runs : [];
+  return runs.find((run) => {
+    const createdAt = Date.parse(run.created_at || '');
+    if (!Number.isFinite(createdAt) || createdAt < startedAtMs) return false;
+    const title = String(run.display_title || run.name || '');
+    return title.includes(`#${prNumber}`) || title.includes(`PR #${prNumber}`);
+  }) || null;
+}
+
+async function waitForDispatchedRun({ token, owner, repo, workflow, prNumber, startedAtMs, waitSeconds }) {
+  const deadline = Date.now() + waitSeconds * 1000;
+  while (Date.now() <= deadline) {
+    const run = await findDispatchedRun({ token, owner, repo, workflow, prNumber, startedAtMs });
+    if (run) return run;
+    await sleep(5000);
+  }
+  return null;
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    stdio: options.stdio || 'pipe',
+    env: process.env,
+  });
+  if (options.allowFailure) return result;
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} failed: ${result.stderr || result.stdout || `exit ${result.status}`}`);
+  }
+  return result;
+}
+
+function gitLines(args) {
+  const result = run('git', args);
+  return result.stdout
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean);
+}
+
+function runFallbackValidation() {
+  run('git', ['fetch', 'origin', 'main', '--quiet']);
+
+  const temp = mkdtempSync(join(tmpdir(), 'threatpedia-task-validation-'));
+  const changedPath = join(temp, 'pipeline_changed_tasks.txt');
+  const newPath = join(temp, 'pipeline_new_tasks.txt');
+  const reportPath = join(temp, 'pipeline_task_validation.json');
+
+  const changed = gitLines(['diff', '--name-only', '--diff-filter=d', 'origin/main...HEAD', '--', '.github/pipeline/tasks/*.json']);
+  const added = gitLines(['diff', '--name-only', '--diff-filter=A', 'origin/main...HEAD', '--', '.github/pipeline/tasks/*.json']);
+  writeFileSync(changedPath, `${changed.join('\n')}\n`);
+  writeFileSync(newPath, `${added.join('\n')}\n`);
+
+  const result = run(process.execPath, [
+    'scripts/validate-pipeline-tasks.mjs',
+    '--files-file',
+    changedPath,
+    '--new-files-file',
+    newPath,
+    '--json-out',
+    reportPath,
+  ], { allowFailure: true });
+
+  let payload;
+  if (existsSync(reportPath)) {
+    payload = JSON.parse(readFileSync(reportPath, 'utf8'));
+  } else {
+    payload = {
+      allPass: false,
+      results: [],
+      markdown: [
+        '## Pipeline Task Validation Report',
+        '',
+        ':x: Task validator did not produce a report during discovery fallback validation.',
+      ].join('\n'),
+    };
+  }
+
+  return {
+    exitStatus: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    changed,
+    added,
+    payload,
+  };
+}
+
+async function upsertValidationComment({ token, owner, repo, prNumber, body }) {
+  const comments = await githubRequest(token, `/repos/${owner}/${repo}/issues/${prNumber}/comments?per_page=100`);
+  const existing = comments.find(comment =>
+    comment.user?.type === 'Bot' && String(comment.body || '').includes('Pipeline Task Validation Report')
+  );
+
+  if (existing) {
+    await githubRequest(token, `/repos/${owner}/${repo}/issues/comments/${existing.id}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ body }),
+    });
+    return { action: 'updated', url: existing.html_url };
+  }
+
+  const created = await githubRequest(token, `/repos/${owner}/${repo}/issues/${prNumber}/comments`, {
+    method: 'POST',
+    body: JSON.stringify({ body }),
+  });
+  return { action: 'created', url: created.html_url };
+}
+
+async function createCommitStatus({ token, owner, repo, sha, state, description, targetUrl }) {
+  const body = {
+    state,
+    context: FALLBACK_STATUS_CONTEXT,
+    description: description.slice(0, 140),
+  };
+  if (targetUrl) body.target_url = targetUrl;
+
+  await githubRequest(token, `/repos/${owner}/${repo}/statuses/${sha}`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+function actionRunUrl(owner, repo) {
+  const runId = process.env.GITHUB_RUN_ID;
+  if (!runId) return null;
+  return `https://github.com/${owner}/${repo}/actions/runs/${runId}`;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const token = getToken();
+  const { owner, repo } = repoParts(args.repo);
+  const pr = await findOpenDiscoveryPr({ token, owner, repo, branch: args.branch });
+  const prNumber = pr.number;
+  const headSha = pr.head?.sha;
+  if (!headSha) throw new Error(`Could not resolve head SHA for PR #${prNumber}`);
+
+  const summary = {
+    pr_number: prNumber,
+    pr_url: pr.html_url,
+    head_ref: args.branch,
+    head_sha: headSha,
+    primary_dispatch_status: 'not_attempted',
+    primary_run_url: null,
+    existing_validation_status: 'not_checked',
+    fallback_attempted: false,
+    fallback_result: 'not_attempted',
+    blocker: null,
+  };
+
+  const existingCheck = await getExistingValidationCheck({ token, owner, repo, headSha });
+  if (existingCheck) {
+    summary.existing_validation_status = `${existingCheck.status}:${existingCheck.conclusion || 'pending'}`;
+    if (['queued', 'in_progress', 'waiting', 'pending', 'requested'].includes(existingCheck.status)) {
+      summary.primary_dispatch_status = 'existing_validation_in_progress';
+      summary.primary_run_url = existingCheck.html_url || existingCheck.details_url || null;
+      console.log(JSON.stringify(summary, null, 2));
+      return;
+    }
+    if (existingCheck.status === 'completed' && existingCheck.conclusion === 'success') {
+      summary.primary_dispatch_status = 'existing_validation_success';
+      summary.primary_run_url = existingCheck.html_url || existingCheck.details_url || null;
+      console.log(JSON.stringify(summary, null, 2));
+      return;
+    }
+    summary.primary_dispatch_status = `existing_validation_non_success:${existingCheck.conclusion || existingCheck.status}`;
+    summary.blocker = `Existing validate-tasks check is ${summary.existing_validation_status}.`;
+  } else {
+    summary.existing_validation_status = 'none';
+  }
+
+  const startedAtMs = Date.now() - 1000;
+  if (!summary.primary_dispatch_status.startsWith('existing_validation_non_success')) {
+    try {
+      await dispatchValidation({
+        token,
+        owner,
+        repo,
+        workflow: args.workflow,
+        prNumber,
+        branch: args.branch,
+      });
+      summary.primary_dispatch_status = 'dispatch_api_success';
+    } catch (error) {
+      summary.primary_dispatch_status = `dispatch_api_failed:${error.message}`;
+      summary.blocker = error.message;
+    }
+  }
+
+  if (summary.primary_dispatch_status === 'dispatch_api_success') {
+    const run = await waitForDispatchedRun({
+      token,
+      owner,
+      repo,
+      workflow: args.workflow,
+      prNumber,
+      startedAtMs,
+      waitSeconds: args.waitSeconds,
+    });
+    if (run) {
+      summary.primary_dispatch_status = 'dispatch_run_detected';
+      summary.primary_run_url = run.html_url;
+      summary.blocker = null;
+      console.log(JSON.stringify(summary, null, 2));
+      return;
+    }
+    summary.primary_dispatch_status = 'dispatch_run_not_detected';
+    summary.blocker = `No ${args.workflow} workflow_dispatch run appeared within ${args.waitSeconds}s.`;
+  }
+
+  summary.fallback_attempted = true;
+  const fallback = runFallbackValidation();
+  const fallbackPass = fallback.payload.allPass === true && fallback.exitStatus === 0;
+  summary.fallback_result = fallbackPass ? 'success' : 'failure';
+  summary.fallback_changed_task_count = fallback.changed.length;
+  summary.fallback_new_task_count = fallback.added.length;
+  if (!fallbackPass) {
+    summary.blocker = `Fallback validation failed for PR #${prNumber}.`;
+  }
+
+  const fallbackNote = [
+    '',
+    '---',
+    '',
+    '_Discovery validation fallback executed because the primary validation dispatch did not produce a detectable run._',
+    `_Primary dispatch status: ${summary.primary_dispatch_status}_`,
+    `_Fallback result: ${summary.fallback_result}_`,
+  ].join('\n');
+
+  await upsertValidationComment({
+    token,
+    owner,
+    repo,
+    prNumber,
+    body: `${String(fallback.payload.markdown || '').trim()}\n${fallbackNote}\n`,
+  });
+
+  await createCommitStatus({
+    token,
+    owner,
+    repo,
+    sha: headSha,
+    state: fallbackPass ? 'success' : 'failure',
+    description: fallbackPass ? 'Fallback task validation passed' : 'Fallback task validation failed',
+    targetUrl: actionRunUrl(owner, repo),
+  });
+
+  console.log(JSON.stringify(summary, null, 2));
+  if (!fallbackPass) process.exit(1);
+}
+
+main().catch((error) => {
+  console.error(`pipeline-discovery-validation-dispatch: ${error.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a bounded discovery validation fallback so discovery PRs do not stall when GitHub suppresses the normal `pull_request` validation trigger for `GITHUB_TOKEN`-authored workflow activity.

## Behavior

- `pipeline-validate-tasks.yml` now supports `workflow_dispatch` with `pr_number` and `head_ref`.
- Discovery runs `scripts/pipeline-discovery-validation-dispatch.mjs` after creating/updating a discovery PR.
- The helper checks for an existing `validate-tasks` check on the PR head to avoid duplicate dispatches.
- If no usable validation exists, it dispatches the task validation workflow and waits briefly for the run to appear.
- If dispatch fails or no run appears, it runs the existing task validator locally, updates the deduped validation report comment, and writes a fallback commit status to the PR head.
- It does not draft articles, create intake, change schedules, or change review-gate policy.

## Validation

- `node --check scripts/pipeline-discovery-validation-dispatch.mjs`
- `node --check scripts/validate-pipeline-tasks.mjs`
- `node scripts/pipeline-discovery-validation-dispatch.mjs --help`
- Ruby YAML parse for `pipeline-discovery.yml` and `pipeline-validate-tasks.yml`
- `node scripts/validate-pipeline-tasks.mjs --all` passed with existing legacy warnings
- `git diff --check`
- Confirmed no `site/src/content` files changed
