### PR TITLE
feat(pipeline): TASK-2026-0358 — Mirasvit Full Page Cache Warmer Deserialization of Untrusted Data Vulnerability (C...

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0358.json
+++ b/.github/pipeline/tasks/TASK-2026-0358.json
@@ -3,13 +3,13 @@
   "stage": "draft",
   "type": "zero-day",
   "priority": "P0",
-  "status": "pending",
+  "status": "locked",
   "created": "2026-06-03T20:49:30.179Z",
-  "updated": "2026-06-03T20:49:30.179Z",
+  "updated": "2026-06-04T05:51:00.425Z",
   "source": "auto_discovery",
   "submitted_by": "pipeline-discovery",
-  "locked_by": null,
-  "locked_at": null,
+  "locked_by": "dangermouse-bot",
+  "locked_at": "2026-06-04T05:51:00.425Z",
   "input": {
     "topic": "Mirasvit Full Page Cache Warmer Deserialization of Untrusted Data Vulnerability (CVE-2026-45247)",
     "sources": [
@@ -77,6 +77,13 @@
       "to": "pending",
       "agent": "pipeline-discovery",
       "note": "Auto-discovered from CISA KEV (score: 100)"
+    },
+    {
+      "timestamp": "2026-06-04T05:51:00.425Z",
+      "from": "pending",
+      "to": "locked",
+      "agent": "dangermouse-bot",
+      "note": "Locked for execution"
     }
   ]
 }

--- a/.github/pipeline/tasks/TASK-2026-0358.json
+++ b/.github/pipeline/tasks/TASK-2026-0358.json
@@ -3,13 +3,13 @@
   "stage": "draft",
   "type": "zero-day",
   "priority": "P0",
-  "status": "locked",
+  "status": "pr_open",
   "created": "2026-06-03T20:49:30.179Z",
-  "updated": "2026-06-04T05:51:00.425Z",
+  "updated": "2026-06-04T05:55:09.677Z",
   "source": "auto_discovery",
   "submitted_by": "pipeline-discovery",
-  "locked_by": "dangermouse-bot",
-  "locked_at": "2026-06-04T05:51:00.425Z",
+  "locked_by": null,
+  "locked_at": null,
   "input": {
     "topic": "Mirasvit Full Page Cache Warmer Deserialization of Untrusted Data Vulnerability (CVE-2026-45247)",
     "sources": [
@@ -84,6 +84,16 @@
       "to": "locked",
       "agent": "dangermouse-bot",
       "note": "Locked for execution"
+    },
+    {
+      "timestamp": "2026-06-04T05:55:09.676Z",
+      "from": "locked",
+      "to": "pr_open",
+      "agent": "dangermouse-bot",
+      "action": "pr_opened",
+      "note": "Article generated, validated, and recorded against PR #988"
     }
-  ]
+  ],
+  "pr_number": 988,
+  "pr_url": "https://github.com/MahdiHedhli/threatpedia/pull/988"
 }

--- a/site/src/content/zero-days/mirasvit-mirasvit-full-page-cache-warmer-cve-2026-45247.md
+++ b/site/src/content/zero-days/mirasvit-mirasvit-full-page-cache-warmer-cve-2026-45247.md
@@ -1,0 +1,140 @@
+---
+exploitId: TP-EXP-2026-0312
+title: "Mirasvit Full Page Cache Warmer Deserialization of Untrusted Data Vulnerability (CVE-2026-45247)"
+cve: CVE-2026-45247
+type: "Remote Code Execution"
+platform: "Mirasvit Mirasvit Full Page Cache Warmer for Magento 2"
+severity: critical
+status: patched
+isZeroDay: true
+disclosedDate: 2026-05-26
+patchDate: 2026-05-25
+researcher: "Unknown"
+confirmedBy: "NVD, CISA, Mirasvit"
+daysInTheWild: null
+cisaKev: true
+reviewStatus: draft_ai
+generatedBy: dangermouse-bot
+generatedDate: 2026-06-04
+relatedIncidents: []
+relatedActors: []
+tags:
+  - mirasvit
+  - magento
+  - mpcw
+  - cve-2026-45247
+  - cwe-502
+  - php-object-injection
+  - session-cookie-deserialization
+  - cisa-kev
+sources:
+  - url: https://www.cisa.gov/known-exploited-vulnerabilities-catalog
+    publisher: "Cybersecurity and Infrastructure Security Agency"
+    publisherType: government
+    reliability: R1
+    publicationDate: "2026-06-03"
+    accessDate: "2026-06-04"
+    archived: false
+  - url: https://nvd.nist.gov/vuln/detail/CVE-2026-45247
+    publisher: "National Vulnerability Database"
+    publisherType: government
+    reliability: R1
+    publicationDate: "2026-05-26"
+    accessDate: "2026-06-04"
+    archived: false
+  - url: https://mirasvit.com/package/changelog/?package=mirasvit/module-cache-warmer
+    publisher: "Mirasvit"
+    publisherType: vendor
+    reliability: R1
+    publicationDate: "2026-05-25"
+    accessDate: "2026-06-04"
+    archived: false
+mitreMappings:
+  - techniqueId: T1190
+    techniqueName: "Exploit Public-Facing Application"
+    tactic: Initial Access
+    attack-version: v19.0
+    confidence: confirmed
+    evidence: NVD describes unauthenticated network exploitation leading to remote code execution through a deserialization flaw in an internet-facing Magento extension.
+generation:
+  provider: openai
+  model: gpt-5.3
+  tool: codex
+  agent: dangermouse-bot
+  promptProfile: dangermouse-zero-day-p0
+framework-mappings: []
+atlasMappings: []
+---
+
+## Severity Assessment
+
+- **Exploitability**: 10/10 — NVD scores CVE-2026-45247 at CVSS 3.1 9.8 (CRITICAL) with an unauthenticated remote attack path and low complexity.
+- **Impact**: 10/10 — Successful exploitation allows arbitrary code execution through insecure deserialization behavior.
+- **Weaponization Risk**: 8/10 — Publicly available remediation notes confirm the flaw in session-cookie deserialization paths before version 1.11.12, and exploit conditions are directly described as unauthenticated remote abuse.
+- **Patch Urgency**: 10/10 — The issue is in CISA KEV with a mandated remediation due date, and a patch version is identified.
+- **Detection Coverage**: 5/10 — Logs and deployment hygiene checks can detect suspicious behavior, but stable IOC sets are not widely publicized.
+
+## Summary
+
+CVE-2026-45247 is a deserialization-of-untrusted-data flaw in Mirasvit Full Page Cache Warmer for Magento 2. NVD describes the vulnerability as PHP object injection in session cookie deserialization that can be triggered by an unauthenticated attacker providing a crafted serialized object in the CacheWarmer cookie. The advisory path indicates the vulnerability can lead to remote code execution.
+
+Mirasvit fixed the issue in release 1.11.12. Affected versions are those up to (but excluding) 1.11.12. The flaw is classified as CWE-502.
+
+The vulnerability is listed in CISA KEV. CISA-added metadata indicates the required response window and supports urgent patching or equivalent mitigations.
+
+## Exploit Chain
+
+### Stage 1: Reach an exposed Magento extension endpoint
+
+An internet-facing Magento 2 environment using an unpatched Mirasvit Full Page Cache Warmer extension can be reached over the network with no pre-authenticated session required.
+
+### Stage 2: Deliver crafted serialized input
+
+Attackers supply a crafted serialized PHP object into the CacheWarmer session-cookie pathway.
+
+### Stage 3: Trigger unsafe deserialization
+
+The vulnerable code path performs a permissive or unsafe deserialization process, creating gadget-chain opportunities with existing Magento and dependency objects.
+
+### Stage 4: Execute arbitrary server-side code
+
+The deserialization flaw allows code execution conditions that can be used for unauthorized command execution or deeper host compromise.
+
+## Detection Guidance
+
+1. Validate inventory and patch level for Magento 2 instances using Mirasvit Full Page Cache Warmer; verify all are on version 1.11.12 or later.
+2. Search web-server and PHP application logs for abnormal patterns in cache-warmer session cookie values tied to deserialization or object-related warnings.
+3. Review application exception logs for spikes in warnings before and after warm-up activity where crafted payload-like payload markers appear.
+4. Segment and harden management planes for Magento infrastructure so cache-warmer or warm-up routes are not broadly exposed without strict ACLs.
+5. Run immediate incident-response triage if unexpected admin-side changes, shell activity, or unknown scheduler/cron behavior appears after suspicious traffic.
+
+## Indicators of Compromise
+
+Public sources do not publish stable malware, domain, or hash indicators specific to this CVE.
+
+Operational indicators may include:
+
+- Unusually malformed or non-standard CacheWarmer cookie values in application logs.
+- Unexpected PHP deserialization warnings or warnings involving session-cookie handling.
+- Sudden admin-privileged or process-level behavior changes on Magento application hosts running unpatched versions.
+- Anomalous outbound or scheduled tasks appearing shortly after cache-warmer warm-up windows.
+
+## Disclosure Timeline
+
+### 2026-05-25 — Mirasvit released 1.11.12 fix
+
+Mirasvit changelog entries for module `full_page_cache_warmer` show a fix entry for PHP Object Injection vulnerability in session cookie deserialization and associated warning cleanup in version 1.11.12.
+
+### 2026-05-26 — CVE published with impact details
+
+NVD published CVE-2026-45247 details with CVSS 3.1 score 9.8 CRITICAL (`AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`) and CWE-502 classification.
+
+### 2026-06-03 — CISA KEV inclusion
+
+CISA added CVE-2026-45247 to the Known Exploited Vulnerabilities catalog, with a required action date of 2026-06-06.
+
+## Sources & References
+
+- [Cybersecurity and Infrastructure Security Agency: Known Exploited Vulnerabilities Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) — Cybersecurity and Infrastructure Security Agency, 2026-06-03
+- [National Vulnerability Database: CVE-2026-45247](https://nvd.nist.gov/vuln/detail/CVE-2026-45247) — National Vulnerability Database, 2026-05-26
+- [Mirasvit: Full Page Cache Warmer changelog](https://mirasvit.com/package/changelog/?package=mirasvit/module-cache-warmer) — Mirasvit, 2026-05-25


### PR DESCRIPTION
## Pipeline Task

- Task: `TASK-2026-0358`
- Type: `zero-day`
- Topic: Mirasvit Full Page Cache Warmer Deserialization of Untrusted Data Vulnerability (CVE-2026-45247)
- Output file: `site/src/content/zero-days/mirasvit-mirasvit-full-page-cache-warmer-cve-2026-45247.md`

## Validation

- Local validator: `node scripts/pipeline-run-task.mjs --task TASK-2026-0358 --validate`
- Minimum sources: `3`
- Minimum H2 sections: `5`
- Minimum MITRE mappings: `1`

Opened via the one-step pipeline wrapper so PR creation and task-state recording stay in sync.
