### PR TITLE
feat(pipeline): raise article throughput controls

### DIFF
--- a/.github/pipeline/config.yml
+++ b/.github/pipeline/config.yml
@@ -7,6 +7,8 @@ version: "1.0"
 
 # ── Queue Limits ──────────────────────────────────────────────────────────────
 queues:
+  dispatcher:
+    tasks_per_run: 6         # Maximum pending draft tasks dispatched per cycle
   editorial:
     max_pending: 50          # Maximum drafts awaiting review
     backpressure_resume: 40  # Resume discovery when queue drops below this

--- a/.github/pipeline/tasks/TASK-2026-0335.json
+++ b/.github/pipeline/tasks/TASK-2026-0335.json
@@ -3,9 +3,9 @@
   "stage": "draft",
   "type": "incident",
   "priority": "P2",
-  "status": "blocked",
+  "status": "pending",
   "created": "2026-05-23T06:08:42.300Z",
-  "updated": "2026-06-06T12:52:10.712Z",
+  "updated": "2026-06-07T01:14:47Z",
   "source": "manual_submission",
   "submitted_by": "MahdiHedhli",
   "locked_by": null,
@@ -64,7 +64,14 @@
       "to": "blocked",
       "agent": "dangermouse-bot",
       "note": "Blocked before lock/draft: SafeDep, Socket, and TechNadu provide vendor/media coverage, but no task-specific government or accepted official source was found for the art-template npm compromise. Do not draft until source packet is strengthened or Kernel K grants a schema-compatible official-source decision."
+    },
+    {
+      "timestamp": "2026-06-07T01:14:47Z",
+      "action": "source_policy_requeue",
+      "from": "blocked",
+      "to": "pending",
+      "agent": "kernel-k",
+      "note": "Requeued after Kernel K source-authority policy update: non-campaign incidents may proceed with at least two non-media sources unless one government source is present. Keep scope conservative and do not expand beyond cited SafeDep, Socket, and corroborating reporting."
     }
-  ],
-  "blocked_reason": "Source sufficiency inadequate for article drafting: listed sources are vendor/media only, and no task-specific government or accepted official source was found for the art-template npm compromise. The validator requires at least one government source; task notes explicitly instruct workers to block rather than inflate if sources are too thin."
+  ]
 }

--- a/.github/pipeline/tasks/TASK-2026-0337.json
+++ b/.github/pipeline/tasks/TASK-2026-0337.json
@@ -3,9 +3,9 @@
   "stage": "draft",
   "type": "incident",
   "priority": "P2",
-  "status": "blocked",
+  "status": "pending",
   "created": "2026-05-23T07:08:43.420Z",
-  "updated": "2026-06-06T13:51:18.974Z",
+  "updated": "2026-06-07T01:14:47Z",
   "source": "manual_submission",
   "submitted_by": "MahdiHedhli",
   "locked_by": null,
@@ -64,7 +64,14 @@
       "to": "blocked",
       "agent": "dangermouse-bot",
       "note": "Blocked before lock/draft: THORChain project/status sources and CryptoTimes reporting do not satisfy the schema-required government/official source requirement. Keep exploit/loss/outage claims conservative and do not draft until source packet is strengthened or Kernel K grants a schema-compatible official-source decision."
+    },
+    {
+      "timestamp": "2026-06-07T01:14:47Z",
+      "action": "source_policy_requeue",
+      "from": "blocked",
+      "to": "pending",
+      "agent": "kernel-k",
+      "note": "Requeued after Kernel K source-authority policy update: non-campaign incidents may proceed with at least two non-media sources unless one government source is present. Treat THORChain project/status material as bounded project evidence and keep loss, freeze-duration, and exploit-mechanics claims conservative."
     }
-  ],
-  "blocked_reason": "Source sufficiency inadequate for article drafting: listed sources are THORChain project/social-media evidence and media reporting, but no task-specific government or accepted official source was found. The validator requires at least one government source; do not draft until source packet is strengthened or Kernel K grants a schema-compatible official-source decision."
+  ]
 }

--- a/.github/workflows/pipeline-discovery.yml
+++ b/.github/workflows/pipeline-discovery.yml
@@ -49,9 +49,9 @@ on:
         required: false
         default: "14"
       limit:
-        description: "Max tasks to create per run (default: 5)"
+        description: "Max tasks to create per run (default: 8)"
         required: false
-        default: "5"
+        default: "8"
       execute:
         description: "Write task files (true) or dry-run (false)"
         required: false
@@ -148,7 +148,7 @@ jobs:
         env:
           MODE: ${{ inputs.mode || 'all' }}
           DAYS: ${{ inputs.days || '14' }}
-          LIMIT: ${{ inputs.limit || '5' }}
+          LIMIT: ${{ inputs.limit || '8' }}
           EXECUTE: ${{ inputs.execute || 'true' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -79,7 +79,7 @@ discovery queues are open, validated, and stable.
        cases collapse to: **reset the branch to `origin/main`** so discarded
        branch-only tasks do not linger on the long-lived discovery branch, and
        merged tasks aren't counted as new. Force-push the reset.
-   - Calls `node scripts/pipeline-discover.mjs --mode all --days 14 --limit 5 --execute`
+   - Calls `node scripts/pipeline-discover.mjs --mode all --days 14 --limit 8 --execute`
    - Script loads `.github/pipeline/config.yml`, installs lane-specific
      headroom limits, then runs the currently supported discovery lanes:
      - **zero-day:** CISA KEV + NVD CVSS enrichment
@@ -131,8 +131,9 @@ discovery queues are open, validated, and stable.
    - Tasks with unmet `depends_on[]` are moved to `status: blocked`.
 
 6. **Dispatch**
-   - Up to 3 `pending` tasks per cycle, sorted P0 → P3 then oldest-first,
-     get dispatched by opening an agent-pickup GitHub Issue. The agent
+   - Up to `queues.dispatcher.tasks_per_run` `pending` tasks per cycle
+     (default 6), sorted P0 → P3 then oldest-first, get dispatched by
+     opening an agent-pickup GitHub Issue. The agent
      (Claude Code / Gemini / human) claims the task by running
      `node scripts/pipeline-run-task.mjs --task TASK-XXXX --lock`, which
      marks `status: locked` with `locked_by` set and `locked_at`
@@ -173,6 +174,10 @@ discovery queues are open, validated, and stable.
      `generatedBy` values, optional non-rendered `generation` model provenance
      metadata, and public-prose guardrails that block internal
      editorial/process language from article body text.
+   - Source authority is type-aware: campaigns still require at least one
+     `publisherType: government` source to match the Astro campaign schema;
+     incidents, zero-days, and threat-actor articles require at least two
+     non-media sources unless one government source is present.
    - Article frontmatter may include an optional `generation` object for
      internal auditability. When present, it must include non-empty `provider`
      and `model` fields and may include `tool`, `agent`, and `promptProfile`.
@@ -346,10 +351,9 @@ Unlike the circuit breaker (which requires operator acknowledgement),
 backpressure auto-closes its Issue on the first cycle where the queue
 falls below the resume threshold.
 
-One operational value stays intentionally hardcoded: the per-run task
-dispatch ceiling (`pendingTasks.slice(0, 3)`) — deliberate cap, not a
-tuning knob. Future slice can promote it to `dispatcher.tasks_per_run`
-in `config.yml` if the dispatch volume pattern changes.
+The dispatcher task dispatch ceiling is configurable through
+`queues.dispatcher.tasks_per_run` in `.github/pipeline/config.yml`. Keep this
+below review backpressure thresholds; the default is 6 per dispatcher cycle.
 
 ---
 
@@ -580,14 +584,14 @@ task's rule is honest about whether the output is new or edited.
 
 ```bash
 # From repo root
-node scripts/pipeline-discover.mjs --mode all --days 14 --limit 5
+node scripts/pipeline-discover.mjs --mode all --days 14 --limit 8
 node scripts/pipeline-discover.mjs --mode incident --days 7 --limit 3
 ```
 
 **Run discovery for real** (writes tasks; commit yourself):
 
 ```bash
-node scripts/pipeline-discover.mjs --mode all --days 14 --limit 5 --execute
+node scripts/pipeline-discover.mjs --mode all --days 14 --limit 8 --execute
 git add .github/pipeline/tasks/
 git commit -m "chore(pipeline): manual discovery run"
 ```

--- a/scripts/pipeline-config.mjs
+++ b/scripts/pipeline-config.mjs
@@ -39,6 +39,7 @@ const DEFAULT_CONFIG_PATH = resolve(__dirname, '..', '.github', 'pipeline', 'con
  */
 export const DEFAULTS = Object.freeze({
   queues: {
+    dispatcher: { tasks_per_run: 6 },
     editorial: { max_pending: 50, backpressure_resume: 40 },
     by_type: {
       'zero-day': { max_pending: 20 },

--- a/scripts/pipeline-dispatcher-dispatch-step.cjs
+++ b/scripts/pipeline-dispatcher-dispatch-step.cjs
@@ -8,6 +8,7 @@ const DISPATCH_LABEL = 'pipeline/ready';
 
 module.exports = async function runDispatcherDispatchStep({ github, context }) {
   const DEFAULTS = {
+    tasksPerRun: 6,
     maxEditorial: 50,
     backpressureResume: 40,
     failureThreshold: 3,
@@ -21,7 +22,14 @@ module.exports = async function runDispatcherDispatchStep({ github, context }) {
       const raw = process.env.CONFIG_JSON || '';
       if (!raw) return { ...DEFAULTS, _source: 'defaults', _reason: 'no-env' };
       const cfg = JSON.parse(raw);
+      const configuredTasksPerRun = Number.parseInt(
+        cfg?.queues?.dispatcher?.tasks_per_run ?? DEFAULTS.tasksPerRun,
+        10
+      );
       return {
+        tasksPerRun: Number.isFinite(configuredTasksPerRun) && configuredTasksPerRun > 0
+          ? configuredTasksPerRun
+          : DEFAULTS.tasksPerRun,
         maxEditorial: cfg?.queues?.editorial?.max_pending ?? DEFAULTS.maxEditorial,
         backpressureResume: cfg?.queues?.editorial?.backpressure_resume ?? DEFAULTS.backpressureResume,
         failureThreshold: cfg?.circuit_breaker?.failure_threshold ?? DEFAULTS.failureThreshold,
@@ -44,6 +52,7 @@ module.exports = async function runDispatcherDispatchStep({ github, context }) {
 
   console.log('─── Dispatcher config (active thresholds) ───────────────');
   console.log(`  source:               ${config._source}${config._reason ? ' (' + config._reason + ')' : ''}${config._path ? ' · ' + config._path : ''}`);
+  console.log(`  tasksPerRun:          ${config.tasksPerRun}  (queues.dispatcher.tasks_per_run)`);
   console.log(`  maxEditorial:         ${config.maxEditorial}  (queues.editorial.max_pending)`);
   console.log(`  backpressureResume:   ${config.backpressureResume}  (queues.editorial.backpressure_resume)`);
   console.log(`  failureThreshold:     ${config.failureThreshold}  (circuit_breaker.failure_threshold)`);
@@ -440,7 +449,7 @@ module.exports = async function runDispatcherDispatchStep({ github, context }) {
   const requestedId = process.env.REQUESTED_TASK_ID || '';
   const tasksToRun = requestedId
     ? pendingTasks.filter((t) => t.task_id === requestedId)
-    : pendingTasks.slice(0, 3);
+    : pendingTasks.slice(0, config.tasksPerRun);
 
   if (tasksToRun.length === 0) {
     console.log('No pending tasks to dispatch.');

--- a/scripts/pipeline-run-task.mjs
+++ b/scripts/pipeline-run-task.mjs
@@ -61,6 +61,41 @@ const EDITORIAL_WORDS = [
 ];
 const EDITORIAL_RE = new RegExp(`\\b(${EDITORIAL_WORDS.join('|')})\\b`, 'gi');
 const SOURCE_BODY_LINE_RE = /^\s*-\s+\[(.+?):\s+(.+)\]\((https?:\/\/[^\s)]+)\)\s+([—–-])\s+(.+?),\s+(\d{4}-\d{2}-\d{2})\s*$/;
+const SOURCE_AUTHORITY_TYPES = new Set(['government', 'vendor', 'research', 'community']);
+
+function formatSourceAuthorityRule(taskType) {
+  if (taskType === 'campaign') {
+    return 'campaigns require at least 1 government source';
+  }
+  return 'non-campaign articles require at least 2 non-media sources unless 1 government source is present';
+}
+
+function getSourceAuthorityIssues(taskType, sources) {
+  if (!Array.isArray(sources) || sources.length === 0) return [];
+
+  const governmentCount = sources.filter(
+    (source) => String(source?.publisherType || '').trim() === 'government'
+  ).length;
+  const nonMediaCount = sources.filter((source) =>
+    SOURCE_AUTHORITY_TYPES.has(String(source?.publisherType || '').trim())
+  ).length;
+
+  if (taskType === 'campaign') {
+    return governmentCount > 0
+      ? []
+      : ['Campaign source policy: at least 1 source must have publisherType: "government".'];
+  }
+
+  if (nonMediaCount === 0) {
+    return ['Source authority policy: at least 1 source must be non-media (government, vendor, research, or community).'];
+  }
+
+  if (governmentCount === 0 && nonMediaCount < 2) {
+    return ['Source authority policy: non-campaign articles need at least 2 non-media sources unless 1 government source is present.'];
+  }
+
+  return [];
+}
 
 // ── Stage-aware reviewStatus rule matching ─────────────────────────────────
 // A task's acceptance.review_status is a declarative contract the validator
@@ -163,7 +198,7 @@ ${GENERATION_METADATA_SCHEMA}
   cves: array of strings (optional)
   relatedSlugs: array of strings (optional) — slugs of related articles for cross-referencing
   tags: array of strings — lowercase, hyphenated keywords
-  sources: array of structured source objects — MINIMUM 3, at least 1 government source
+  sources: array of structured source objects — MINIMUM 3, at least 2 non-media sources unless 1 government source is present
 ${SOURCE_SCHEMA}
   mitreMappings: array of MITRE ATT&CK mapping objects — MINIMUM 1
 ${MITRE_MAPPING_SCHEMA}
@@ -244,7 +279,7 @@ ${FRAMEWORK_MAPPING_SCHEMA}
   generatedDate: date — today's date
 ${GENERATION_METADATA_SCHEMA}
   tags: array of strings
-  sources: array of structured source objects — MINIMUM 3, at least 1 government source
+  sources: array of structured source objects — MINIMUM 3, at least 2 non-media sources unless 1 government source is present
 ${SOURCE_SCHEMA}`,
     bodySpec: `Required H2 sections (minimum 5):
   ## Executive Summary — group overview, significance, primary mandate
@@ -282,7 +317,7 @@ ${GENERATION_METADATA_SCHEMA}
   relatedIncidents: array of strings (optional) — slugs of incident articles
   relatedActors: array of strings (optional) — slugs of threat actor articles
   tags: array of strings
-  sources: array of structured source objects — MINIMUM 3, at least 1 government source
+  sources: array of structured source objects — MINIMUM 3, at least 2 non-media sources unless 1 government source is present
 ${SOURCE_SCHEMA}
   mitreMappings: array of MITRE ATT&CK mapping objects — MINIMUM 1
 ${MITRE_MAPPING_SCHEMA}
@@ -314,7 +349,7 @@ function buildRules(task) {
   2. generatedBy MUST be one of the canonical agent identities (${SCHEMA_GENERATED_BY_VALUES.join(', ')})
   3. sources MUST be structured objects in frontmatter (not just prose in body)
      — Minimum 3 source objects
-     — At least 1 must have publisherType: "government"
+     — ${formatSourceAuthorityRule(task.type)}
      — URLs must be real and verifiable (never fabricate)
      — Every source MUST have a publicationDate (for living resources like MITRE ATT&CK or NVD, use last-modified or access date)
   4. mitreMappings MUST be in frontmatter (not just mentioned in body text)
@@ -1113,7 +1148,8 @@ ${schema.bodySpec}
 ── ACCEPTANCE CRITERIA ────────────────────────────────────────────────────────
 
   frontmatter_valid:     ${acceptance.frontmatter_valid ?? true}
-  min_sources:           ${acceptance.min_sources ?? 3} (structured objects in frontmatter, ≥1 government)
+  min_sources:           ${acceptance.min_sources ?? 3} (structured objects in frontmatter)
+  source_authority:      ${formatSourceAuthorityRule(task.type)}
   min_h2_sections:       ${acceptance.min_h2_sections ?? 5}
   min_mitre_mappings:    ${acceptance.min_mitre_mappings ?? 1}
   review_status:         ${formatReviewStatusRule(acceptance.review_status)}
@@ -1291,9 +1327,7 @@ function validateOutput(task, explicitFile) {
       issues.push(`Only ${sourceCount} structured source(s) in frontmatter (need ${minSources}+). Sources must be YAML objects with url, publisher, publisherType, reliability — not just prose in the body.`);
     }
 
-    if (sourceCount > 0 && !sources.some(source => source?.publisherType === 'government')) {
-      issues.push('No government source found. At least 1 source must have publisherType: "government" (CISA, FBI, DOJ, etc.)');
-    }
+    issues.push(...getSourceAuthorityIssues(task.type, sources));
 
     for (let i = 0; i < sources.length; i++) {
       const source = sources[i] || {};

--- a/scripts/pipeline-run-task.mjs
+++ b/scripts/pipeline-run-task.mjs
@@ -86,10 +86,6 @@ function getSourceAuthorityIssues(taskType, sources) {
       : ['Campaign source policy: at least 1 source must have publisherType: "government".'];
   }
 
-  if (nonMediaCount === 0) {
-    return ['Source authority policy: at least 1 source must be non-media (government, vendor, research, or community).'];
-  }
-
   if (governmentCount === 0 && nonMediaCount < 2) {
     return ['Source authority policy: non-campaign articles need at least 2 non-media sources unless 1 government source is present.'];
   }


### PR DESCRIPTION
## Summary

- make dispatcher task batch size configurable and set the default to 6 per cycle
- raise scheduled discovery's default candidate limit from 5 to 8 per run
- replace the accidental all-article government-source validator gate with type-aware source authority:
  - campaigns still require `publisherType: government`
  - incidents, zero-days, and threat-actor articles require at least two non-media sources unless one government source is present
- requeue `TASK-2026-0335` and `TASK-2026-0337`, the two current blocked incident tasks that satisfy the new non-campaign source policy

## Kernel K Decision

The previous validator policy forced a government source for every article type even though the public Astro schema only hard-requires that for campaigns. That created avoidable source-sufficiency blocks for software supply-chain and project/vulnerability incidents with multiple non-media technical sources.

This PR does not bypass branch protection, current-head validation, review-gate, AI second review, or human merge policy. It only restores draft supply and increases scheduled intake/dispatch capacity.

## Validation

- `node --check scripts/pipeline-run-task.mjs`
- `node --check scripts/pipeline-dispatcher-dispatch-step.cjs`
- `node scripts/pipeline-config.mjs --section queues`
- `node scripts/validate-pipeline-tasks.mjs --all --json-out /tmp/threatpedia-throughput-task-validation-final.json`
- `node scripts/pipeline-run-task.mjs --list`
- `git diff --check`

## Expected Throughput Effect

- scheduled discovery supply ceiling rises from 20/day to 32/day
- dispatcher issue creation ceiling rises from 3/cycle to 6/cycle
- immediate pending queue after merge: 2 incident tasks (`TASK-2026-0335`, `TASK-2026-0337`)
- future non-campaign vendor/research/community-source incidents should block less often when they have at least two non-media sources
