### PR TITLE
feat(pipeline): enable VulnCheck KEV source-packet intake

### DIFF
--- a/.github/pipeline/config.yml
+++ b/.github/pipeline/config.yml
@@ -74,12 +74,16 @@ discovery_sources:
     enabled: true
     url: "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
   vulncheck_kev:
-    enabled: false              # Dry-run/source-packet prefill only in ROAD-014 Slice 1
+    enabled: true               # Live source-packet/candidate prefill only; set false for rollback
     backup_url: "https://api.vulncheck.com/v3/backup/vulncheck-kev"
     lookback_days: 30
-    max_candidates: 25
+    max_candidates: 10          # 10 per 6-hour run = 40/day candidate supply ceiling
+    backlog_fill: true          # After recent items, continue older unhandled newest-to-oldest
+    sibling_limit_per_vendor_product_day: 4
     local_throttle_ms: 250      # 240/minute; intentionally below the 1,000/minute community limit
     cache_ttl_minutes: 60
+    source_packet_dir: ".github/pipeline/source-packets/vulncheck-kev"
+    candidate_index_path: ".github/pipeline/source-packets/vulncheck-kev/latest.json"
   nvd:
     enabled: true
     base_url: "https://services.nvd.nist.gov/rest/json/cves/2.0"

--- a/.github/pipeline/source-packets/README.md
+++ b/.github/pipeline/source-packets/README.md
@@ -23,12 +23,13 @@ claims beyond `claims[]` unless the packet is updated and preflight is rerun.
 
 ## VulnCheck KEV Prefill
 
-ROAD-014 Slice 1 uses the VulnCheck KEV community backup endpoint as a
-first-class but non-authoritative source for recent zero-day prioritization.
-The helper requests one backup descriptor, follows the published backup payload
-URL, sorts by top-level `date_added` descending, defaults to
-`lookback_days: 30` and `max_candidates: 25`, and filters CVEs already present
-in public task or zero-day state.
+ROAD-014 uses the VulnCheck KEV community backup endpoint as a first-class but
+non-authoritative source for recent zero-day prioritization. The helper
+requests one backup descriptor, follows the published backup payload URL, sorts
+by top-level `date_added` descending, defaults to `lookback_days: 30` and
+`max_candidates: 10`, and filters CVEs already present in public task,
+source-packet, or zero-day state. When the recent window is exhausted, live mode
+fills from older unhandled records newest-to-oldest.
 
 The helper output is deliberately not a source packet that can be drafted from
 directly. Each candidate is marked `drafting_allowed: false` and includes a
@@ -41,6 +42,10 @@ exploitation signals and supporting evidence.
 VulnCheck attribution is required when VulnCheck KEV data is surfaced to users.
 Use the label `VulnCheck KEV` near any user-visible data derived from this
 source.
+
+Live artifacts are written under `.github/pipeline/source-packets/vulncheck-kev/`
+and staged in the normal discovery PR. They are candidate/source-packet queue
+items, not article draft tasks.
 
 ## Preflight Coverage
 

--- a/.github/pipeline/source-packets/vulncheck-kev/latest.json
+++ b/.github/pipeline/source-packets/vulncheck-kev/latest.json
@@ -1,0 +1,1415 @@
+{
+  "schema_version": "vulncheck-kev-recent-intake/1",
+  "generated_at": "2026-06-12T18:51:24.460Z",
+  "mode": "live",
+  "drafting_enabled": false,
+  "source": {
+    "publisher": "VulnCheck",
+    "dataset": "VulnCheck KEV",
+    "backup_endpoint": "https://api.vulncheck.com/v3/backup/vulncheck-kev",
+    "attribution_required": true,
+    "attribution_label": "VulnCheck KEV",
+    "authority_boundary": "VulnCheck KEV is a non-authoritative exploitation signal for Threatpedia; CISA remains authoritative for official CISA KEV membership."
+  },
+  "config": {
+    "lookback_days": 30,
+    "max_candidates": 10,
+    "as_of": "2026-06-12",
+    "cutoff_date": "2026-05-13",
+    "sort": "date_added desc",
+    "seen_filter_enabled": true,
+    "backlog_fill_enabled": true,
+    "sibling_limit_per_vendor_product_day": 4
+  },
+  "summary": {
+    "records_loaded": 4952,
+    "records_with_date_added": 4952,
+    "candidates_in_lookback": 62,
+    "backlog_candidates_considered": 4890,
+    "already_seen_filtered": 113,
+    "sibling_dampened": 0,
+    "candidates_emitted": 10,
+    "recent_emitted": 10,
+    "backlog_emitted": 0
+  },
+  "candidates": [
+    {
+      "candidate_key": "vulncheck-kev:CVE-2026-35273:2026-06-11",
+      "cves": [
+        "CVE-2026-35273"
+      ],
+      "cwes": [
+        "CWE-306"
+      ],
+      "vendorProject": "Oracle",
+      "product": " PeopleSoft Enterprise PeopleTools",
+      "vulnerabilityName": "Oracle PeopleSoft Enterprise PeopleTools Missing Authentication for Critical Function Vulnerability",
+      "shortDescription": "Oracle PeopleSoft Enterprise PeopleTools contains a missing authentication for critical function vulnerability which could allow an unauthenticated attacker to obtain takeover of PeopleSoft Enterprise PeopleTools.",
+      "vulncheck_date_added": "2026-06-11",
+      "recency_bucket": "recent",
+      "already_seen": false,
+      "seen_cves": [],
+      "priority_score": 78,
+      "priority_reasons": [
+        "recent VulnCheck date_added",
+        "CISA date present in VulnCheck record; verify against CISA before official labeling",
+        "4 VulnCheck reported exploitation reference(s)",
+        "known ransomware campaign use field"
+      ],
+      "official_cisa_kev": {
+        "status_source": "cisa_date_added field from VulnCheck record; verify against CISA before official labeling",
+        "listed": true,
+        "date_added": "2026-06-12",
+        "due_date": "2026-06-15"
+      },
+      "vulncheck_exploitation_signal": {
+        "source": "VulnCheck KEV",
+        "non_authoritative": true,
+        "date_added": "2026-06-11",
+        "known_ransomware_campaign_use": "Known",
+        "reported_exploited_by_vulncheck_canaries": false,
+        "reported_exploitation_count": 4,
+        "xdb_count": 0,
+        "xdb_exploit_types": [],
+        "evidence_urls": [
+          "https://cloud.google.com/blog/topics/threat-intelligence/shinyhunters-targets-education-sector-oracle-exploit",
+          "https://www.linkedin.com/posts/charlescarmakal_urgent-multiple-0-day-vulnerabilities-share-7470696836803117057-mf6m/",
+          "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json",
+          "https://www.rapid7.com/blog/post/etr-active-exploitation-of-oracle-peoplesoft-zero-day-cve-2026-35273/"
+        ]
+      },
+      "source_packet_prefill": {
+        "status": "prefill_only",
+        "drafting_allowed": false,
+        "authority_boundary": {
+          "cve_identity_authority": "CVE.org / MITRE CVE Program",
+          "official_cisa_kev_authority": "CISA",
+          "vulncheck_role": "non-authoritative exploitation signal and supporting source",
+          "instruction": "Do not draft or apply official KEV labeling from VulnCheck alone; verify CISA KEV membership against CISA before publication."
+        },
+        "supporting_sources": [
+          {
+            "id": "src-vulncheck-kev",
+            "publisher": "VulnCheck",
+            "url": "https://api.vulncheck.com/v3/backup/vulncheck-kev",
+            "published_at": "2026-06-11",
+            "source_type": "vendor",
+            "role": "supporting",
+            "notes": "VulnCheck KEV community backup record; prominent VulnCheck KEV attribution required when data is surfaced."
+          }
+        ],
+        "source_quality": {
+          "has_government_source": false,
+          "has_vendor_source": true,
+          "has_primary_source": false,
+          "source_sufficiency": "needs_human_review"
+        },
+        "key_dates": {
+          "vulncheck_date_added": "2026-06-11",
+          "cisa_kev_added_at_from_vulncheck_record": "2026-06-12",
+          "cisa_due_date_from_vulncheck_record": "2026-06-15"
+        },
+        "affected_products": [
+          {
+            "vendor": "Oracle",
+            "product": " PeopleSoft Enterprise PeopleTools",
+            "versions": "unknown",
+            "source_refs": [
+              "src-vulncheck-kev"
+            ]
+          }
+        ],
+        "cves": [
+          {
+            "id": "CVE-2026-35273",
+            "source_refs": [
+              "src-vulncheck-kev"
+            ]
+          }
+        ],
+        "cwes": [
+          {
+            "id": "CWE-306",
+            "name": "Unknown",
+            "source_refs": [
+              "src-vulncheck-kev"
+            ]
+          }
+        ],
+        "preserved_vulncheck_fields": {
+          "vendorProject": "Oracle",
+          "product": " PeopleSoft Enterprise PeopleTools",
+          "vulnerabilityName": "Oracle PeopleSoft Enterprise PeopleTools Missing Authentication for Critical Function Vulnerability",
+          "shortDescription": "Oracle PeopleSoft Enterprise PeopleTools contains a missing authentication for critical function vulnerability which could allow an unauthenticated attacker to obtain takeover of PeopleSoft Enterprise PeopleTools.",
+          "required_action": "Apply mitigations in accordance with vendor instructions, ensuring compliance with CISA’s BOD 26-04 Prioritizing Security Updates Based on Risk (see URL in Notes) guidance and CISA’s “Forensics Triage Requirements” (see URL in Notes). Follow applicable BOD 26-04 guidance for cloud services or discontinue use of the product if mitigations are unavailable. Stakeholders are responsible for evaluating each asset's internet exposure and ensuring adherence to BOD 26-04 patching guidelines.",
+          "knownRansomwareCampaignUse": "Known",
+          "reported_exploited_by_vulncheck_canaries": false,
+          "vulncheck_reported_exploitation": [
+            {
+              "url": "https://cloud.google.com/blog/topics/threat-intelligence/shinyhunters-targets-education-sector-oracle-exploit",
+              "date_added": "2026-06-11T00:00:00Z"
+            },
+            {
+              "url": "https://www.linkedin.com/posts/charlescarmakal_urgent-multiple-0-day-vulnerabilities-share-7470696836803117057-mf6m/",
+              "date_added": "2026-06-11T00:00:00Z"
+            },
+            {
+              "url": "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json",
+              "date_added": "2026-06-12T00:00:00Z"
+            },
+            {
+              "url": "https://www.rapid7.com/blog/post/etr-active-exploitation-of-oracle-peoplesoft-zero-day-cve-2026-35273/",
+              "date_added": "2026-06-12T00:00:00Z"
+            }
+          ],
+          "vulncheck_xdb": [],
+          "date_added": "2026-06-11T00:00:00Z",
+          "cisa_date_added": "2026-06-12T00:00:00Z",
+          "dueDate": "2026-06-15T00:00:00Z"
+        },
+        "not_supported": [
+          {
+            "claim": "Official CISA KEV membership based solely on VulnCheck",
+            "reason": "CISA remains the authority for official CISA KEV status."
+          },
+          {
+            "claim": "Article-ready source sufficiency",
+            "reason": "This prefill contains VulnCheck supporting evidence only and must be joined with CISA, CVE/NVD, vendor, or other primary sources before drafting."
+          }
+        ]
+      },
+      "drafting_allowed": false,
+      "production_artifact": ".github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-35273-2026-06-11.json"
+    },
+    {
+      "candidate_key": "vulncheck-kev:CVE-2026-10795:2026-06-10",
+      "cves": [
+        "CVE-2026-10795"
+      ],
+      "cwes": [],
+      "vendorProject": "updraftplus",
+      "product": "updraftplus",
+      "vulnerabilityName": "updraftplus updraftplus Improper Verification of Cryptographic Signature",
+      "shortDescription": "The UpdraftPlus: WP Backup & Migration Plugin plugin for WordPress is vulnerable to Authentication Bypass in all versions up to, and including, 1.26.4 via the UpdraftPlus_Remote_Communications_V2::wp_loaded function. This is due to insufficient validation of the remote communications message format, where signature verification can be bypassed and unchecked decryption return values collapse to a predictable all-zero encryption key. This makes it possible for unauthenticated attackers to forge arbitrary RPC commands and run them as the connected administrator, such as uploading and activating a malicious plugin, which ultimately leads to remote code execution.",
+      "vulncheck_date_added": "2026-06-10",
+      "recency_bucket": "recent",
+      "already_seen": false,
+      "seen_cves": [],
+      "priority_score": 40,
+      "priority_reasons": [
+        "recent VulnCheck date_added",
+        "2 VulnCheck reported exploitation reference(s)",
+        "1 VulnCheck XDB reference(s)"
+      ],
+      "official_cisa_kev": {
+        "status_source": "cisa_date_added field from VulnCheck record; verify against CISA before official labeling",
+        "listed": false,
+        "date_added": null,
+        "due_date": null
+      },
+      "vulncheck_exploitation_signal": {
+        "source": "VulnCheck KEV",
+        "non_authoritative": true,
+        "date_added": "2026-06-10",
+        "known_ransomware_campaign_use": "Unknown",
+        "reported_exploited_by_vulncheck_canaries": false,
+        "reported_exploitation_count": 2,
+        "xdb_count": 1,
+        "xdb_exploit_types": [
+          "initial-access"
+        ],
+        "evidence_urls": [
+          "https://patchstack.com/database/wordpress/plugin/updraftplus/vulnerability/wordpress-updraftplus-wp-backup-migration-plugin-1-26-4-unauthenticated-authentication-bypass-via-updraftcentral-udrpc-vulnerability",
+          "https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/updraftplus/updraftplus-wp-backup-migration-plugin-1264-unauthenticated-authentication-bypass-via-updraftcentral-udrpc",
+          "https://vulncheck.com/xdb/8e9fd2ad3560"
+        ]
+      },
+      "source_packet_prefill": {
+        "status": "prefill_only",
+        "drafting_allowed": false,
+        "authority_boundary": {
+          "cve_identity_authority": "CVE.org / MITRE CVE Program",
+          "official_cisa_kev_authority": "CISA",
+          "vulncheck_role": "non-authoritative exploitation signal and supporting source",
+          "instruction": "Do not draft or apply official KEV labeling from VulnCheck alone; verify CISA KEV membership against CISA before publication."
+        },
+        "supporting_sources": [
+          {
+            "id": "src-vulncheck-kev",
+            "publisher": "VulnCheck",
+            "url": "https://api.vulncheck.com/v3/backup/vulncheck-kev",
+            "published_at": "2026-06-10",
+            "source_type": "vendor",
+            "role": "supporting",
+            "notes": "VulnCheck KEV community backup record; prominent VulnCheck KEV attribution required when data is surfaced."
+          }
+        ],
+        "source_quality": {
+          "has_government_source": false,
+          "has_vendor_source": true,
+          "has_primary_source": false,
+          "source_sufficiency": "needs_human_review"
+        },
+        "key_dates": {
+          "vulncheck_date_added": "2026-06-10",
+          "cisa_kev_added_at_from_vulncheck_record": null,
+          "cisa_due_date_from_vulncheck_record": null
+        },
+        "affected_products": [
+          {
+            "vendor": "updraftplus",
+            "product": "updraftplus",
+            "versions": "unknown",
+            "source_refs": [
+              "src-vulncheck-kev"
+            ]
+          }
+        ],
+        "cves": [
+          {
+            "id": "CVE-2026-10795",
+            "source_refs": [
+              "src-vulncheck-kev"
+            ]
+          }
+        ],
+        "cwes": [],
+        "preserved_vulncheck_fields": {
+          "vendorProject": "updraftplus",
+          "product": "updraftplus",
+          "vulnerabilityName": "updraftplus updraftplus Improper Verification of Cryptographic Signature",
+          "shortDescription": "The UpdraftPlus: WP Backup & Migration Plugin plugin for WordPress is vulnerable to Authentication Bypass in all versions up to, and including, 1.26.4 via the UpdraftPlus_Remote_Communications_V2::wp_loaded function. This is due to insufficient validation of the remote communications message format, where signature verification can be bypassed and unchecked decryption return values collapse to a predictable all-zero encryption key. This makes it possible for unauthenticated attackers to forge arbitrary RPC commands and run them as the connected administrator, such as uploading and activating a malicious plugin, which ultimately leads to remote code execution.",
+          "required_action": "Apply remediations or mitigations per vendor instructions or discontinue use of the product if remediation or mitigations are unavailable.",
+          "knownRansomwareCampaignUse": "Unknown",
+          "reported_exploited_by_vulncheck_canaries": false,
+          "vulncheck_reported_exploitation": [
+            {
+              "url": "https://patchstack.com/database/wordpress/plugin/updraftplus/vulnerability/wordpress-updraftplus-wp-backup-migration-plugin-1-26-4-unauthenticated-authentication-bypass-via-updraftcentral-udrpc-vulnerability",
+              "date_added": "2026-06-10T00:00:00Z"
+            },
+            {
+              "url": "https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/updraftplus/updraftplus-wp-backup-migration-plugin-1264-unauthenticated-authentication-bypass-via-updraftcentral-udrpc",
+              "date_added": "2026-06-11T00:00:00Z"
+            }
+          ],
+          "vulncheck_xdb": [
+            {
+              "xdb_id": "8e9fd2ad3560",
+              "xdb_url": "https://vulncheck.com/xdb/8e9fd2ad3560",
+              "date_added": "2026-06-11T10:06:29Z",
+              "exploit_type": "initial-access",
+              "clone_ssh_url": "git@github.com:izxci/CVE-2026-10795.git"
+            }
+          ],
+          "date_added": "2026-06-10T00:00:00Z",
+          "cisa_date_added": null,
+          "dueDate": null
+        },
+        "not_supported": [
+          {
+            "claim": "Official CISA KEV membership based solely on VulnCheck",
+            "reason": "CISA remains the authority for official CISA KEV status."
+          },
+          {
+            "claim": "Article-ready source sufficiency",
+            "reason": "This prefill contains VulnCheck supporting evidence only and must be joined with CISA, CVE/NVD, vendor, or other primary sources before drafting."
+          }
+        ]
+      },
+      "drafting_allowed": false,
+      "production_artifact": ".github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-10795-2026-06-10.json"
+    },
+    {
+      "candidate_key": "vulncheck-kev:CVE-2026-34908:2026-06-09",
+      "cves": [
+        "CVE-2026-34908"
+      ],
+      "cwes": [],
+      "vendorProject": "Ubiquiti Inc",
+      "product": "UniFi OS Server",
+      "vulnerabilityName": "  Improper Access Control",
+      "shortDescription": "A malicious actor with access to the network could exploit an Improper Access Control vulnerability found in UniFi OS devices to make unauthorized changes to the system.",
+      "vulncheck_date_added": "2026-06-09",
+      "recency_bucket": "recent",
+      "already_seen": false,
+      "seen_cves": [],
+      "priority_score": 34,
+      "priority_reasons": [
+        "recent VulnCheck date_added",
+        "1 VulnCheck reported exploitation reference(s)"
+      ],
+      "official_cisa_kev": {
+        "status_source": "cisa_date_added field from VulnCheck record; verify against CISA before official labeling",
+        "listed": false,
+        "date_added": null,
+        "due_date": null
+      },
+      "vulncheck_exploitation_signal": {
+        "source": "VulnCheck KEV",
+        "non_authoritative": true,
+        "date_added": "2026-06-09",
+        "known_ransomware_campaign_use": "Unknown",
+        "reported_exploited_by_vulncheck_canaries": false,
+        "reported_exploitation_count": 1,
+        "xdb_count": 0,
+        "xdb_exploit_types": [],
+        "evidence_urls": [
+          "https://www.pwndefend.com/2026/06/09/cve-2026-34910-exploitation-itw-building-a-botnet-mirai/"
+        ]
+      },
+      "source_packet_prefill": {
+        "status": "prefill_only",
+        "drafting_allowed": false,
+        "authority_boundary": {
+          "cve_identity_authority": "CVE.org / MITRE CVE Program",
+          "official_cisa_kev_authority": "CISA",
+          "vulncheck_role": "non-authoritative exploitation signal and supporting source",
+          "instruction": "Do not draft or apply official KEV labeling from VulnCheck alone; verify CISA KEV membership against CISA before publication."
+        },
+        "supporting_sources": [
+          {
+            "id": "src-vulncheck-kev",
+            "publisher": "VulnCheck",
+            "url": "https://api.vulncheck.com/v3/backup/vulncheck-kev",
+            "published_at": "2026-06-09",
+            "source_type": "vendor",
+            "role": "supporting",
+            "notes": "VulnCheck KEV community backup record; prominent VulnCheck KEV attribution required when data is surfaced."
+          }
+        ],
+        "source_quality": {
+          "has_government_source": false,
+          "has_vendor_source": true,
+          "has_primary_source": false,
+          "source_sufficiency": "needs_human_review"
+        },
+        "key_dates": {
+          "vulncheck_date_added": "2026-06-09",
+          "cisa_kev_added_at_from_vulncheck_record": null,
+          "cisa_due_date_from_vulncheck_record": null
+        },
+        "affected_products": [
+          {
+            "vendor": "Ubiquiti Inc",
+            "product": "UniFi OS Server",
+            "versions": "unknown",
+            "source_refs": [
+              "src-vulncheck-kev"
+            ]
+          }
+        ],
+        "cves": [
+          {
+            "id": "CVE-2026-34908",
+            "source_refs": [
+              "src-vulncheck-kev"
+            ]
+          }
+        ],
+        "cwes": [],
+        "preserved_vulncheck_fields": {
+          "vendorProject": "Ubiquiti Inc",
+          "product": "UniFi OS Server",
+          "vulnerabilityName": "  Improper Access Control",
+          "shortDescription": "A malicious actor with access to the network could exploit an Improper Access Control vulnerability found in UniFi OS devices to make unauthorized changes to the system.",
+          "required_action": "Apply remediations or mitigations per vendor instructions or discontinue use of the product if remediation or mitigations are unavailable.",
+          "knownRansomwareCampaignUse": "Unknown",
+          "reported_exploited_by_vulncheck_canaries": false,
+          "vulncheck_reported_exploitation": [
+            {
+              "url": "https://www.pwndefend.com/2026/06/09/cve-2026-34910-exploitation-itw-building-a-botnet-mirai/",
+              "date_added": "2026-06-09T00:00:00Z"
+            }
+          ],
+          "vulncheck_xdb": [],
+          "date_added": "2026-06-09T00:00:00Z",
+          "cisa_date_added": null,
+          "dueDate": null
+        },
+        "not_supported": [
+          {
+            "claim": "Official CISA KEV membership based solely on VulnCheck",
+            "reason": "CISA remains the authority for official CISA KEV status."
+          },
+          {
+            "claim": "Article-ready source sufficiency",
+            "reason": "This prefill contains VulnCheck supporting evidence only and must be joined with CISA, CVE/NVD, vendor, or other primary sources before drafting."
+          }
+        ]
+      },
+      "drafting_allowed": false,
+      "production_artifact": ".github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-34908-2026-06-09.json"
+    },
+    {
+      "candidate_key": "vulncheck-kev:CVE-2026-34910:2026-06-09",
+      "cves": [
+        "CVE-2026-34910"
+      ],
+      "cwes": [],
+      "vendorProject": "Ubiquiti Inc",
+      "product": "UniFi OS Server",
+      "vulnerabilityName": "  Improper Input Validation",
+      "shortDescription": "A malicious actor with access to the network could exploit an Improper Input Validation vulnerability found in UniFi OS devices to execute a Command Injection.",
+      "vulncheck_date_added": "2026-06-09",
+      "recency_bucket": "recent",
+      "already_seen": false,
+      "seen_cves": [],
+      "priority_score": 34,
+      "priority_reasons": [
+        "recent VulnCheck date_added",
+        "1 VulnCheck reported exploitation reference(s)"
+      ],
+      "official_cisa_kev": {
+        "status_source": "cisa_date_added field from VulnCheck record; verify against CISA before official labeling",
+        "listed": false,
+        "date_added": null,
+        "due_date": null
+      },
+      "vulncheck_exploitation_signal": {
+        "source": "VulnCheck KEV",
+        "non_authoritative": true,
+        "date_added": "2026-06-09",
+        "known_ransomware_campaign_use": "Unknown",
+        "reported_exploited_by_vulncheck_canaries": false,
+        "reported_exploitation_count": 1,
+        "xdb_count": 0,
+        "xdb_exploit_types": [],
+        "evidence_urls": [
+          "https://www.pwndefend.com/2026/06/09/cve-2026-34910-exploitation-itw-building-a-botnet-mirai/"
+        ]
+      },
+      "source_packet_prefill": {
+        "status": "prefill_only",
+        "drafting_allowed": false,
+        "authority_boundary": {
+          "cve_identity_authority": "CVE.org / MITRE CVE Program",
+          "official_cisa_kev_authority": "CISA",
+          "vulncheck_role": "non-authoritative exploitation signal and supporting source",
+          "instruction": "Do not draft or apply official KEV labeling from VulnCheck alone; verify CISA KEV membership against CISA before publication."
+        },
+        "supporting_sources": [
+          {
+            "id": "src-vulncheck-kev",
+            "publisher": "VulnCheck",
+            "url": "https://api.vulncheck.com/v3/backup/vulncheck-kev",
+            "published_at": "2026-06-09",
+            "source_type": "vendor",
+            "role": "supporting",
+            "notes": "VulnCheck KEV community backup record; prominent VulnCheck KEV attribution required when data is surfaced."
+          }
+        ],
+        "source_quality": {
+          "has_government_source": false,
+          "has_vendor_source": true,
+          "has_primary_source": false,
+          "source_sufficiency": "needs_human_review"
+        },
+        "key_dates": {
+          "vulncheck_date_added": "2026-06-09",
+          "cisa_kev_added_at_from_vulncheck_record": null,
+          "cisa_due_date_from_vulncheck_record": null
+        },
+        "affected_products": [
+          {
+            "vendor": "Ubiquiti Inc",
+            "product": "UniFi OS Server",
+            "versions": "unknown",
+            "source_refs": [
+              "src-vulncheck-kev"
+            ]
+          }
+        ],
+        "cves": [
+          {
+            "id": "CVE-2026-34910",
+            "source_refs": [
+              "src-vulncheck-kev"
+            ]
+          }
+        ],
+        "cwes": [],
+        "preserved_vulncheck_fields": {
+          "vendorProject": "Ubiquiti Inc",
+          "product": "UniFi OS Server",
+          "vulnerabilityName": "  Improper Input Validation",
+          "shortDescription": "A malicious actor with access to the network could exploit an Improper Input Validation vulnerability found in UniFi OS devices to execute a Command Injection.",
+          "required_action": "Apply remediations or mitigations per vendor instructions or discontinue use of the product if remediation or mitigations are unavailable.",
+          "knownRansomwareCampaignUse": "Unknown",
+          "reported_exploited_by_vulncheck_canaries": false,
+          "vulncheck_reported_exploitation": [
+            {
+              "url": "https://www.pwndefend.com/2026/06/09/cve-2026-34910-exploitation-itw-building-a-botnet-mirai/",
+              "date_added": "2026-06-09T00:00:00Z"
+            }
+          ],
+          "vulncheck_xdb": [],
+          "date_added": "2026-06-09T00:00:00Z",
+          "cisa_date_added": null,
+          "dueDate": null
+        },
+        "not_supported": [
+          {
+            "claim": "Official CISA KEV membership based solely on VulnCheck",
+            "reason": "CISA remains the authority for official CISA KEV status."
+          },
+          {
+            "claim": "Article-ready source sufficiency",
+            "reason": "This prefill contains VulnCheck supporting evidence only and must be joined with CISA, CVE/NVD, vendor, or other primary sources before drafting."
+          }
+        ]
+      },
+      "drafting_allowed": false,
+      "production_artifact": ".github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-34910-2026-06-09.json"
+    },
+    {
+      "candidate_key": "vulncheck-kev:CVE-2026-39808:2026-06-09",
+      "cves": [
+        "CVE-2026-39808"
+      ],
+      "cwes": [],
+      "vendorProject": "Fortinet",
+      "product": "fortisandbox",
+      "vulnerabilityName": "Fortinet fortisandbox Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')",
+      "shortDescription": "A improper neutralization of special elements used in an os command ('os command injection') vulnerability in Fortinet FortiSandbox 4.4.0 through 4.4.8 may allow attacker to execute unauthorized code or commands via",
+      "vulncheck_date_added": "2026-06-09",
+      "recency_bucket": "recent",
+      "already_seen": false,
+      "seen_cves": [],
+      "priority_score": 64,
+      "priority_reasons": [
+        "recent VulnCheck date_added",
+        "VulnCheck canary exploitation signal",
+        "3 VulnCheck reported exploitation reference(s)",
+        "2 VulnCheck XDB reference(s)"
+      ],
+      "official_cisa_kev": {
+        "status_source": "cisa_date_added field from VulnCheck record; verify against CISA before official labeling",
+        "listed": false,
+        "date_added": null,
+        "due_date": null
+      },
+      "vulncheck_exploitation_signal": {
+        "source": "VulnCheck KEV",
+        "non_authoritative": true,
+        "date_added": "2026-06-09",
+        "known_ransomware_campaign_use": "Unknown",
+        "reported_exploited_by_vulncheck_canaries": true,
+        "reported_exploitation_count": 3,
+        "xdb_count": 2,
+        "xdb_exploit_types": [
+          "initial-access"
+        ],
+        "evidence_urls": [
+          "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-39808&date=2026-06-09",
+          "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-39808&date=2026-06-10",
+          "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-39808&date=2026-06-11",
+          "https://vulncheck.com/xdb/baecd56da872",
+          "https://vulncheck.com/xdb/50e019aa766f"
+        ]
+      },
+      "source_packet_prefill": {
+        "status": "prefill_only",
+        "drafting_allowed": false,
+        "authority_boundary": {
+          "cve_identity_authority": "CVE.org / MITRE CVE Program",
+          "official_cisa_kev_authority": "CISA",
+          "vulncheck_role": "non-authoritative exploitation signal and supporting source",
+          "instruction": "Do not draft or apply official KEV labeling from VulnCheck alone; verify CISA KEV membership against CISA before publication."
+        },
+        "supporting_sources": [
+          {
+            "id": "src-vulncheck-kev",
+            "publisher": "VulnCheck",
+            "url": "https://api.vulncheck.com/v3/backup/vulncheck-kev",
+            "published_at": "2026-06-09",
+            "source_type": "vendor",
+            "role": "supporting",
+            "notes": "VulnCheck KEV community backup record; prominent VulnCheck KEV attribution required when data is surfaced."
+          }
+        ],
+        "source_quality": {
+          "has_government_source": false,
+          "has_vendor_source": true,
+          "has_primary_source": false,
+          "source_sufficiency": "needs_human_review"
+        },
+        "key_dates": {
+          "vulncheck_date_added": "2026-06-09",
+          "cisa_kev_added_at_from_vulncheck_record": null,
+          "cisa_due_date_from_vulncheck_record": null
+        },
+        "affected_products": [
+          {
+            "vendor": "Fortinet",
+            "product": "fortisandbox",
+            "versions": "unknown",
+            "source_refs": [
+              "src-vulncheck-kev"
+            ]
+          }
+        ],
+        "cves": [
+          {
+            "id": "CVE-2026-39808",
+            "source_refs": [
+              "src-vulncheck-kev"
+            ]
+          }
+        ],
+        "cwes": [],
+        "preserved_vulncheck_fields": {
+          "vendorProject": "Fortinet",
+          "product": "fortisandbox",
+          "vulnerabilityName": "Fortinet fortisandbox Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')",
+          "shortDescription": "A improper neutralization of special elements used in an os command ('os command injection') vulnerability in Fortinet FortiSandbox 4.4.0 through 4.4.8 may allow attacker to execute unauthorized code or commands via",
+          "required_action": "Apply remediations or mitigations per vendor instructions or discontinue use of the product if remediation or mitigations are unavailable.",
+          "knownRansomwareCampaignUse": "Unknown",
+          "reported_exploited_by_vulncheck_canaries": true,
+          "vulncheck_reported_exploitation": [
+            {
+              "url": "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-39808&date=2026-06-09",
+              "date_added": "2026-06-09T00:00:00Z"
+            },
+            {
+              "url": "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-39808&date=2026-06-10",
+              "date_added": "2026-06-10T00:00:00Z"
+            },
+            {
+              "url": "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-39808&date=2026-06-11",
+              "date_added": "2026-06-11T00:00:00Z"
+            }
+          ],
+          "vulncheck_xdb": [
+            {
+              "xdb_id": "baecd56da872",
+              "xdb_url": "https://vulncheck.com/xdb/baecd56da872",
+              "date_added": "2026-04-15T14:10:25Z",
+              "exploit_type": "initial-access",
+              "clone_ssh_url": "git@github.com:samu-delucas/CVE-2026-39808.git"
+            },
+            {
+              "xdb_id": "50e019aa766f",
+              "xdb_url": "https://vulncheck.com/xdb/50e019aa766f",
+              "date_added": "2026-04-18T09:15:36Z",
+              "exploit_type": "initial-access",
+              "clone_ssh_url": "git@github.com:0xBlackash/CVE-2026-39808.git"
+            }
+          ],
+          "date_added": "2026-06-09T00:00:00Z",
+          "cisa_date_added": null,
+          "dueDate": null
+        },
+        "not_supported": [
+          {
+            "claim": "Official CISA KEV membership based solely on VulnCheck",
+            "reason": "CISA remains the authority for official CISA KEV status."
+          },
+          {
+            "claim": "Article-ready source sufficiency",
+            "reason": "This prefill contains VulnCheck supporting evidence only and must be joined with CISA, CVE/NVD, vendor, or other primary sources before drafting."
+          }
+        ]
+      },
+      "drafting_allowed": false,
+      "production_artifact": ".github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-39808-2026-06-09.json"
+    },
+    {
+      "candidate_key": "vulncheck-kev:CVE-2026-49060:2026-06-08",
+      "cves": [
+        "CVE-2026-49060"
+      ],
+      "cwes": [],
+      "vendorProject": "hippooo",
+      "product": "Hippoo Mobile App for WooCommerce",
+      "vulnerabilityName": "WordPress Hippoo Mobile App for WooCommerce Privilege Escalation",
+      "shortDescription": "Incorrect Privilege Assignment vulnerability in Hippoo Mobile App for WooCommerce allows Privilege Escalation.\n\nThis issue affects Hippoo Mobile App for WooCommerce: from n/a through 1.9.4.",
+      "vulncheck_date_added": "2026-06-08",
+      "recency_bucket": "recent",
+      "already_seen": false,
+      "seen_cves": [],
+      "priority_score": 34,
+      "priority_reasons": [
+        "recent VulnCheck date_added",
+        "1 VulnCheck reported exploitation reference(s)"
+      ],
+      "official_cisa_kev": {
+        "status_source": "cisa_date_added field from VulnCheck record; verify against CISA before official labeling",
+        "listed": false,
+        "date_added": null,
+        "due_date": null
+      },
+      "vulncheck_exploitation_signal": {
+        "source": "VulnCheck KEV",
+        "non_authoritative": true,
+        "date_added": "2026-06-08",
+        "known_ransomware_campaign_use": "Unknown",
+        "reported_exploited_by_vulncheck_canaries": false,
+        "reported_exploitation_count": 1,
+        "xdb_count": 0,
+        "xdb_exploit_types": [],
+        "evidence_urls": [
+          "https://patchstack.com/database/wordpress/plugin/hippoo/vulnerability/wordpress-hippoo-mobile-app-for-woocommerce-plugin-1-9-4-privilege-escalation-vulnerability"
+        ]
+      },
+      "source_packet_prefill": {
+        "status": "prefill_only",
+        "drafting_allowed": false,
+        "authority_boundary": {
+          "cve_identity_authority": "CVE.org / MITRE CVE Program",
+          "official_cisa_kev_authority": "CISA",
+          "vulncheck_role": "non-authoritative exploitation signal and supporting source",
+          "instruction": "Do not draft or apply official KEV labeling from VulnCheck alone; verify CISA KEV membership against CISA before publication."
+        },
+        "supporting_sources": [
+          {
+            "id": "src-vulncheck-kev",
+            "publisher": "VulnCheck",
+            "url": "https://api.vulncheck.com/v3/backup/vulncheck-kev",
+            "published_at": "2026-06-08",
+            "source_type": "vendor",
+            "role": "supporting",
+            "notes": "VulnCheck KEV community backup record; prominent VulnCheck KEV attribution required when data is surfaced."
+          }
+        ],
+        "source_quality": {
+          "has_government_source": false,
+          "has_vendor_source": true,
+          "has_primary_source": false,
+          "source_sufficiency": "needs_human_review"
+        },
+        "key_dates": {
+          "vulncheck_date_added": "2026-06-08",
+          "cisa_kev_added_at_from_vulncheck_record": null,
+          "cisa_due_date_from_vulncheck_record": null
+        },
+        "affected_products": [
+          {
+            "vendor": "hippooo",
+            "product": "Hippoo Mobile App for WooCommerce",
+            "versions": "unknown",
+            "source_refs": [
+              "src-vulncheck-kev"
+            ]
+          }
+        ],
+        "cves": [
+          {
+            "id": "CVE-2026-49060",
+            "source_refs": [
+              "src-vulncheck-kev"
+            ]
+          }
+        ],
+        "cwes": [],
+        "preserved_vulncheck_fields": {
+          "vendorProject": "hippooo",
+          "product": "Hippoo Mobile App for WooCommerce",
+          "vulnerabilityName": "WordPress Hippoo Mobile App for WooCommerce Privilege Escalation",
+          "shortDescription": "Incorrect Privilege Assignment vulnerability in Hippoo Mobile App for WooCommerce allows Privilege Escalation.\n\nThis issue affects Hippoo Mobile App for WooCommerce: from n/a through 1.9.4.",
+          "required_action": "Apply remediations or mitigations per vendor instructions or discontinue use of the product if remediation or mitigations are unavailable.",
+          "knownRansomwareCampaignUse": "Unknown",
+          "reported_exploited_by_vulncheck_canaries": false,
+          "vulncheck_reported_exploitation": [
+            {
+              "url": "https://patchstack.com/database/wordpress/plugin/hippoo/vulnerability/wordpress-hippoo-mobile-app-for-woocommerce-plugin-1-9-4-privilege-escalation-vulnerability",
+              "date_added": "2026-06-08T00:00:00Z"
+            }
+          ],
+          "vulncheck_xdb": [],
+          "date_added": "2026-06-08T00:00:00Z",
+          "cisa_date_added": null,
+          "dueDate": null
+        },
+        "not_supported": [
+          {
+            "claim": "Official CISA KEV membership based solely on VulnCheck",
+            "reason": "CISA remains the authority for official CISA KEV status."
+          },
+          {
+            "claim": "Article-ready source sufficiency",
+            "reason": "This prefill contains VulnCheck supporting evidence only and must be joined with CISA, CVE/NVD, vendor, or other primary sources before drafting."
+          }
+        ]
+      },
+      "drafting_allowed": false,
+      "production_artifact": ".github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-49060-2026-06-08.json"
+    },
+    {
+      "candidate_key": "vulncheck-kev:CVE-2026-5027:2026-06-08",
+      "cves": [
+        "CVE-2026-5027"
+      ],
+      "cwes": [],
+      "vendorProject": "langflow",
+      "product": "langflow",
+      "vulnerabilityName": "langflow langflow Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')",
+      "shortDescription": "The 'POST /api/v2/files' endpoint does not sanitize the 'filename' parameter from the multipart form data, allowing an attacker to write files to arbitrary locations on the filesystem using path traversal sequences ('../').",
+      "vulncheck_date_added": "2026-06-08",
+      "recency_bucket": "recent",
+      "already_seen": false,
+      "seen_cves": [],
+      "priority_score": 74,
+      "priority_reasons": [
+        "recent VulnCheck date_added",
+        "VulnCheck canary exploitation signal",
+        "7 VulnCheck reported exploitation reference(s)",
+        "3 VulnCheck XDB reference(s)"
+      ],
+      "official_cisa_kev": {
+        "status_source": "cisa_date_added field from VulnCheck record; verify against CISA before official labeling",
+        "listed": false,
+        "date_added": null,
+        "due_date": null
+      },
+      "vulncheck_exploitation_signal": {
+        "source": "VulnCheck KEV",
+        "non_authoritative": true,
+        "date_added": "2026-06-08",
+        "known_ransomware_campaign_use": "Unknown",
+        "reported_exploited_by_vulncheck_canaries": true,
+        "reported_exploitation_count": 7,
+        "xdb_count": 3,
+        "xdb_exploit_types": [
+          "remote-with-credentials",
+          "initial-access"
+        ],
+        "evidence_urls": [
+          "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-5027&date=2026-06-08",
+          "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-5027&date=2026-06-09",
+          "https://www.linkedin.com/posts/ccondon_kevs-share-7470128376624783361-Ot2c/",
+          "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-5027&date=2026-06-10",
+          "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-5027&date=2026-06-11",
+          "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-5027&date=2026-06-12",
+          "https://www.techgines.com/post/langflow-cve-2026-5027-path-traversal-rce",
+          "https://vulncheck.com/xdb/29b343b4afaf",
+          "https://vulncheck.com/xdb/812e19ecfa4f",
+          "https://vulncheck.com/xdb/98045a28f25c"
+        ]
+      },
+      "source_packet_prefill": {
+        "status": "prefill_only",
+        "drafting_allowed": false,
+        "authority_boundary": {
+          "cve_identity_authority": "CVE.org / MITRE CVE Program",
+          "official_cisa_kev_authority": "CISA",
+          "vulncheck_role": "non-authoritative exploitation signal and supporting source",
+          "instruction": "Do not draft or apply official KEV labeling from VulnCheck alone; verify CISA KEV membership against CISA before publication."
+        },
+        "supporting_sources": [
+          {
+            "id": "src-vulncheck-kev",
+            "publisher": "VulnCheck",
+            "url": "https://api.vulncheck.com/v3/backup/vulncheck-kev",
+            "published_at": "2026-06-08",
+            "source_type": "vendor",
+            "role": "supporting",
+            "notes": "VulnCheck KEV community backup record; prominent VulnCheck KEV attribution required when data is surfaced."
+          }
+        ],
+        "source_quality": {
+          "has_government_source": false,
+          "has_vendor_source": true,
+          "has_primary_source": false,
+          "source_sufficiency": "needs_human_review"
+        },
+        "key_dates": {
+          "vulncheck_date_added": "2026-06-08",
+          "cisa_kev_added_at_from_vulncheck_record": null,
+          "cisa_due_date_from_vulncheck_record": null
+        },
+        "affected_products": [
+          {
+            "vendor": "langflow",
+            "product": "langflow",
+            "versions": "unknown",
+            "source_refs": [
+              "src-vulncheck-kev"
+            ]
+          }
+        ],
+        "cves": [
+          {
+            "id": "CVE-2026-5027",
+            "source_refs": [
+              "src-vulncheck-kev"
+            ]
+          }
+        ],
+        "cwes": [],
+        "preserved_vulncheck_fields": {
+          "vendorProject": "langflow",
+          "product": "langflow",
+          "vulnerabilityName": "langflow langflow Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')",
+          "shortDescription": "The 'POST /api/v2/files' endpoint does not sanitize the 'filename' parameter from the multipart form data, allowing an attacker to write files to arbitrary locations on the filesystem using path traversal sequences ('../').",
+          "required_action": "Apply remediations or mitigations per vendor instructions or discontinue use of the product if remediation or mitigations are unavailable.",
+          "knownRansomwareCampaignUse": "Unknown",
+          "reported_exploited_by_vulncheck_canaries": true,
+          "vulncheck_reported_exploitation": [
+            {
+              "url": "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-5027&date=2026-06-08",
+              "date_added": "2026-06-08T00:00:00Z"
+            },
+            {
+              "url": "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-5027&date=2026-06-09",
+              "date_added": "2026-06-09T00:00:00Z"
+            },
+            {
+              "url": "https://www.linkedin.com/posts/ccondon_kevs-share-7470128376624783361-Ot2c/",
+              "date_added": "2026-06-09T00:00:00Z"
+            },
+            {
+              "url": "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-5027&date=2026-06-10",
+              "date_added": "2026-06-10T00:00:00Z"
+            },
+            {
+              "url": "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-5027&date=2026-06-11",
+              "date_added": "2026-06-11T00:00:00Z"
+            },
+            {
+              "url": "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-5027&date=2026-06-12",
+              "date_added": "2026-06-12T00:00:00Z"
+            },
+            {
+              "url": "https://www.techgines.com/post/langflow-cve-2026-5027-path-traversal-rce",
+              "date_added": "2026-06-12T00:00:00Z"
+            }
+          ],
+          "vulncheck_xdb": [
+            {
+              "xdb_id": "29b343b4afaf",
+              "xdb_url": "https://vulncheck.com/xdb/29b343b4afaf",
+              "date_added": "2026-04-02T10:46:45Z",
+              "exploit_type": "remote-with-credentials",
+              "clone_ssh_url": "git@github.com:yahiahamza/CVE-2026-5027.git"
+            },
+            {
+              "xdb_id": "812e19ecfa4f",
+              "xdb_url": "https://vulncheck.com/xdb/812e19ecfa4f",
+              "date_added": "2026-04-03T10:34:51Z",
+              "exploit_type": "remote-with-credentials",
+              "clone_ssh_url": "git@github.com:EQSTLab/CVE-2026-5027.git"
+            },
+            {
+              "xdb_id": "98045a28f25c",
+              "xdb_url": "https://vulncheck.com/xdb/98045a28f25c",
+              "date_added": "2026-04-03T16:56:21Z",
+              "exploit_type": "initial-access",
+              "clone_ssh_url": "git@github.com:0xBlackash/CVE-2026-5027.git"
+            }
+          ],
+          "date_added": "2026-06-08T00:00:00Z",
+          "cisa_date_added": null,
+          "dueDate": null
+        },
+        "not_supported": [
+          {
+            "claim": "Official CISA KEV membership based solely on VulnCheck",
+            "reason": "CISA remains the authority for official CISA KEV status."
+          },
+          {
+            "claim": "Article-ready source sufficiency",
+            "reason": "This prefill contains VulnCheck supporting evidence only and must be joined with CISA, CVE/NVD, vendor, or other primary sources before drafting."
+          }
+        ]
+      },
+      "drafting_allowed": false,
+      "production_artifact": ".github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-5027-2026-06-08.json"
+    },
+    {
+      "candidate_key": "vulncheck-kev:CVE-2026-31816:2026-06-05",
+      "cves": [
+        "CVE-2026-31816"
+      ],
+      "cwes": [],
+      "vendorProject": "budibase",
+      "product": "budibase",
+      "vulnerabilityName": "budibase budibase Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')",
+      "shortDescription": "Budibase is a low code platform for creating internal tools, workflows, and admin panels. In 3.31.4 and earlier, the Budibase server's authorized() middleware that protects every server-side API endpoint can be completely bypassed by appending a webhook path pattern to the query string of any request. The isWebhookEndpoint() function uses an unanchored regex that tests against ctx.request.url, which in Koa includes the full URL with query parameters. When the regex matches, the authorized() middleware immediately calls return next(), skipping all authentication, authorization, role checks, and CSRF protection. This means a completely unauthenticated, remote attacker can access any server-side API endpoint by simply appending ?/webhooks/trigger (or any webhook pattern variant) to the URL.",
+      "vulncheck_date_added": "2026-06-05",
+      "recency_bucket": "recent",
+      "already_seen": false,
+      "seen_cves": [],
+      "priority_score": 54,
+      "priority_reasons": [
+        "recent VulnCheck date_added",
+        "VulnCheck canary exploitation signal",
+        "1 VulnCheck reported exploitation reference(s)",
+        "1 VulnCheck XDB reference(s)"
+      ],
+      "official_cisa_kev": {
+        "status_source": "cisa_date_added field from VulnCheck record; verify against CISA before official labeling",
+        "listed": false,
+        "date_added": null,
+        "due_date": null
+      },
+      "vulncheck_exploitation_signal": {
+        "source": "VulnCheck KEV",
+        "non_authoritative": true,
+        "date_added": "2026-06-05",
+        "known_ransomware_campaign_use": "Unknown",
+        "reported_exploited_by_vulncheck_canaries": true,
+        "reported_exploitation_count": 1,
+        "xdb_count": 1,
+        "xdb_exploit_types": [
+          "initial-access"
+        ],
+        "evidence_urls": [
+          "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-31816&date=2026-06-05",
+          "https://vulncheck.com/xdb/3ee67248358b"
+        ]
+      },
+      "source_packet_prefill": {
+        "status": "prefill_only",
+        "drafting_allowed": false,
+        "authority_boundary": {
+          "cve_identity_authority": "CVE.org / MITRE CVE Program",
+          "official_cisa_kev_authority": "CISA",
+          "vulncheck_role": "non-authoritative exploitation signal and supporting source",
+          "instruction": "Do not draft or apply official KEV labeling from VulnCheck alone; verify CISA KEV membership against CISA before publication."
+        },
+        "supporting_sources": [
+          {
+            "id": "src-vulncheck-kev",
+            "publisher": "VulnCheck",
+            "url": "https://api.vulncheck.com/v3/backup/vulncheck-kev",
+            "published_at": "2026-06-05",
+            "source_type": "vendor",
+            "role": "supporting",
+            "notes": "VulnCheck KEV community backup record; prominent VulnCheck KEV attribution required when data is surfaced."
+          }
+        ],
+        "source_quality": {
+          "has_government_source": false,
+          "has_vendor_source": true,
+          "has_primary_source": false,
+          "source_sufficiency": "needs_human_review"
+        },
+        "key_dates": {
+          "vulncheck_date_added": "2026-06-05",
+          "cisa_kev_added_at_from_vulncheck_record": null,
+          "cisa_due_date_from_vulncheck_record": null
+        },
+        "affected_products": [
+          {
+            "vendor": "budibase",
+            "product": "budibase",
+            "versions": "unknown",
+            "source_refs": [
+              "src-vulncheck-kev"
+            ]
+          }
+        ],
+        "cves": [
+          {
+            "id": "CVE-2026-31816",
+            "source_refs": [
+              "src-vulncheck-kev"
+            ]
+          }
+        ],
+        "cwes": [],
+        "preserved_vulncheck_fields": {
+          "vendorProject": "budibase",
+          "product": "budibase",
+          "vulnerabilityName": "budibase budibase Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')",
+          "shortDescription": "Budibase is a low code platform for creating internal tools, workflows, and admin panels. In 3.31.4 and earlier, the Budibase server's authorized() middleware that protects every server-side API endpoint can be completely bypassed by appending a webhook path pattern to the query string of any request. The isWebhookEndpoint() function uses an unanchored regex that tests against ctx.request.url, which in Koa includes the full URL with query parameters. When the regex matches, the authorized() middleware immediately calls return next(), skipping all authentication, authorization, role checks, and CSRF protection. This means a completely unauthenticated, remote attacker can access any server-side API endpoint by simply appending ?/webhooks/trigger (or any webhook pattern variant) to the URL.",
+          "required_action": "Apply remediations or mitigations per vendor instructions or discontinue use of the product if remediation or mitigations are unavailable.",
+          "knownRansomwareCampaignUse": "Unknown",
+          "reported_exploited_by_vulncheck_canaries": true,
+          "vulncheck_reported_exploitation": [
+            {
+              "url": "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-31816&date=2026-06-05",
+              "date_added": "2026-06-05T00:00:00Z"
+            }
+          ],
+          "vulncheck_xdb": [
+            {
+              "xdb_id": "3ee67248358b",
+              "xdb_url": "https://vulncheck.com/xdb/3ee67248358b",
+              "date_added": "2026-03-12T12:44:53Z",
+              "exploit_type": "initial-access",
+              "clone_ssh_url": "git@github.com:imjdl/CVE-2026-31816-rshell.git"
+            }
+          ],
+          "date_added": "2026-06-05T00:00:00Z",
+          "cisa_date_added": null,
+          "dueDate": null
+        },
+        "not_supported": [
+          {
+            "claim": "Official CISA KEV membership based solely on VulnCheck",
+            "reason": "CISA remains the authority for official CISA KEV status."
+          },
+          {
+            "claim": "Article-ready source sufficiency",
+            "reason": "This prefill contains VulnCheck supporting evidence only and must be joined with CISA, CVE/NVD, vendor, or other primary sources before drafting."
+          }
+        ]
+      },
+      "drafting_allowed": false,
+      "production_artifact": ".github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-31816-2026-06-05.json"
+    },
+    {
+      "candidate_key": "vulncheck-kev:CVE-2026-49777:2026-06-05",
+      "cves": [
+        "CVE-2026-49777"
+      ],
+      "cwes": [],
+      "vendorProject": "NetAlertX",
+      "product": "NetAlertX",
+      "vulnerabilityName": "  Improper Validation of Specified Quantity in Input",
+      "shortDescription": "Improper Validation of Specified Quantity in Input vulnerability in ShapedPlugin, LLC Product Slider Pro for WooCommerce allows Malicious Software Implanted.\n\nThis issue affects Product Slider Pro for WooCommerce: from n/a before 3.5.4.",
+      "vulncheck_date_added": "2026-06-05",
+      "recency_bucket": "recent",
+      "already_seen": false,
+      "seen_cves": [],
+      "priority_score": 34,
+      "priority_reasons": [
+        "recent VulnCheck date_added",
+        "1 VulnCheck reported exploitation reference(s)"
+      ],
+      "official_cisa_kev": {
+        "status_source": "cisa_date_added field from VulnCheck record; verify against CISA before official labeling",
+        "listed": false,
+        "date_added": null,
+        "due_date": null
+      },
+      "vulncheck_exploitation_signal": {
+        "source": "VulnCheck KEV",
+        "non_authoritative": true,
+        "date_added": "2026-06-05",
+        "known_ransomware_campaign_use": "Unknown",
+        "reported_exploited_by_vulncheck_canaries": false,
+        "reported_exploitation_count": 1,
+        "xdb_count": 0,
+        "xdb_exploit_types": [],
+        "evidence_urls": [
+          "https://patchstack.com/database/wordpress/plugin/woo-product-slider-pro/vulnerability/wordpress-product-slider-pro-for-woocommerce-plugin-3-5-2-backdoor-vulnerability"
+        ]
+      },
+      "source_packet_prefill": {
+        "status": "prefill_only",
+        "drafting_allowed": false,
+        "authority_boundary": {
+          "cve_identity_authority": "CVE.org / MITRE CVE Program",
+          "official_cisa_kev_authority": "CISA",
+          "vulncheck_role": "non-authoritative exploitation signal and supporting source",
+          "instruction": "Do not draft or apply official KEV labeling from VulnCheck alone; verify CISA KEV membership against CISA before publication."
+        },
+        "supporting_sources": [
+          {
+            "id": "src-vulncheck-kev",
+            "publisher": "VulnCheck",
+            "url": "https://api.vulncheck.com/v3/backup/vulncheck-kev",
+            "published_at": "2026-06-05",
+            "source_type": "vendor",
+            "role": "supporting",
+            "notes": "VulnCheck KEV community backup record; prominent VulnCheck KEV attribution required when data is surfaced."
+          }
+        ],
+        "source_quality": {
+          "has_government_source": false,
+          "has_vendor_source": true,
+          "has_primary_source": false,
+          "source_sufficiency": "needs_human_review"
+        },
+        "key_dates": {
+          "vulncheck_date_added": "2026-06-05",
+          "cisa_kev_added_at_from_vulncheck_record": null,
+          "cisa_due_date_from_vulncheck_record": null
+        },
+        "affected_products": [
+          {
+            "vendor": "NetAlertX",
+            "product": "NetAlertX",
+            "versions": "unknown",
+            "source_refs": [
+              "src-vulncheck-kev"
+            ]
+          }
+        ],
+        "cves": [
+          {
+            "id": "CVE-2026-49777",
+            "source_refs": [
+              "src-vulncheck-kev"
+            ]
+          }
+        ],
+        "cwes": [],
+        "preserved_vulncheck_fields": {
+          "vendorProject": "NetAlertX",
+          "product": "NetAlertX",
+          "vulnerabilityName": "  Improper Validation of Specified Quantity in Input",
+          "shortDescription": "Improper Validation of Specified Quantity in Input vulnerability in ShapedPlugin, LLC Product Slider Pro for WooCommerce allows Malicious Software Implanted.\n\nThis issue affects Product Slider Pro for WooCommerce: from n/a before 3.5.4.",
+          "required_action": "Apply remediations or mitigations per vendor instructions or discontinue use of the product if remediation or mitigations are unavailable.",
+          "knownRansomwareCampaignUse": "Unknown",
+          "reported_exploited_by_vulncheck_canaries": false,
+          "vulncheck_reported_exploitation": [
+            {
+              "url": "https://patchstack.com/database/wordpress/plugin/woo-product-slider-pro/vulnerability/wordpress-product-slider-pro-for-woocommerce-plugin-3-5-2-backdoor-vulnerability",
+              "date_added": "2026-06-05T00:00:00Z"
+            }
+          ],
+          "vulncheck_xdb": [],
+          "date_added": "2026-06-05T00:00:00Z",
+          "cisa_date_added": null,
+          "dueDate": null
+        },
+        "not_supported": [
+          {
+            "claim": "Official CISA KEV membership based solely on VulnCheck",
+            "reason": "CISA remains the authority for official CISA KEV status."
+          },
+          {
+            "claim": "Article-ready source sufficiency",
+            "reason": "This prefill contains VulnCheck supporting evidence only and must be joined with CISA, CVE/NVD, vendor, or other primary sources before drafting."
+          }
+        ]
+      },
+      "drafting_allowed": false,
+      "production_artifact": ".github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-49777-2026-06-05.json"
+    },
+    {
+      "candidate_key": "vulncheck-kev:CVE-2018-25270:2026-06-04",
+      "cves": [
+        "CVE-2018-25270"
+      ],
+      "cwes": [],
+      "vendorProject": "thinkphp",
+      "product": "ThinkPHP",
+      "vulnerabilityName": "thinkphp ThinkPHP Authorization Bypass Through User-Controlled Key",
+      "shortDescription": "ThinkPHP 5.0.23 contains a remote code execution vulnerability that allows unauthenticated attackers to execute arbitrary PHP code by invoking functions through the routing parameter. Attackers can craft requests to the index.php endpoint with malicious function parameters to execute system commands with application privileges.",
+      "vulncheck_date_added": "2026-06-04",
+      "recency_bucket": "recent",
+      "already_seen": false,
+      "seen_cves": [],
+      "priority_score": 34,
+      "priority_reasons": [
+        "recent VulnCheck date_added",
+        "1 VulnCheck reported exploitation reference(s)"
+      ],
+      "official_cisa_kev": {
+        "status_source": "cisa_date_added field from VulnCheck record; verify against CISA before official labeling",
+        "listed": false,
+        "date_added": null,
+        "due_date": null
+      },
+      "vulncheck_exploitation_signal": {
+        "source": "VulnCheck KEV",
+        "non_authoritative": true,
+        "date_added": "2026-06-04",
+        "known_ransomware_campaign_use": "Unknown",
+        "reported_exploited_by_vulncheck_canaries": false,
+        "reported_exploitation_count": 1,
+        "xdb_count": 0,
+        "xdb_exploit_types": [],
+        "evidence_urls": [
+          "https://www.stormshield.com/news/current-cyberattack-trends-variations-honeypots/"
+        ]
+      },
+      "source_packet_prefill": {
+        "status": "prefill_only",
+        "drafting_allowed": false,
+        "authority_boundary": {
+          "cve_identity_authority": "CVE.org / MITRE CVE Program",
+          "official_cisa_kev_authority": "CISA",
+          "vulncheck_role": "non-authoritative exploitation signal and supporting source",
+          "instruction": "Do not draft or apply official KEV labeling from VulnCheck alone; verify CISA KEV membership against CISA before publication."
+        },
+        "supporting_sources": [
+          {
+            "id": "src-vulncheck-kev",
+            "publisher": "VulnCheck",
+            "url": "https://api.vulncheck.com/v3/backup/vulncheck-kev",
+            "published_at": "2026-06-04",
+            "source_type": "vendor",
+            "role": "supporting",
+            "notes": "VulnCheck KEV community backup record; prominent VulnCheck KEV attribution required when data is surfaced."
+          }
+        ],
+        "source_quality": {
+          "has_government_source": false,
+          "has_vendor_source": true,
+          "has_primary_source": false,
+          "source_sufficiency": "needs_human_review"
+        },
+        "key_dates": {
+          "vulncheck_date_added": "2026-06-04",
+          "cisa_kev_added_at_from_vulncheck_record": null,
+          "cisa_due_date_from_vulncheck_record": null
+        },
+        "affected_products": [
+          {
+            "vendor": "thinkphp",
+            "product": "ThinkPHP",
+            "versions": "unknown",
+            "source_refs": [
+              "src-vulncheck-kev"
+            ]
+          }
+        ],
+        "cves": [
+          {
+            "id": "CVE-2018-25270",
+            "source_refs": [
+              "src-vulncheck-kev"
+            ]
+          }
+        ],
+        "cwes": [],
+        "preserved_vulncheck_fields": {
+          "vendorProject": "thinkphp",
+          "product": "ThinkPHP",
+          "vulnerabilityName": "thinkphp ThinkPHP Authorization Bypass Through User-Controlled Key",
+          "shortDescription": "ThinkPHP 5.0.23 contains a remote code execution vulnerability that allows unauthenticated attackers to execute arbitrary PHP code by invoking functions through the routing parameter. Attackers can craft requests to the index.php endpoint with malicious function parameters to execute system commands with application privileges.",
+          "required_action": "Apply remediations or mitigations per vendor instructions or discontinue use of the product if remediation or mitigations are unavailable.",
+          "knownRansomwareCampaignUse": "Unknown",
+          "reported_exploited_by_vulncheck_canaries": false,
+          "vulncheck_reported_exploitation": [
+            {
+              "url": "https://www.stormshield.com/news/current-cyberattack-trends-variations-honeypots/",
+              "date_added": "2026-06-04T00:00:00Z"
+            }
+          ],
+          "vulncheck_xdb": [],
+          "date_added": "2026-06-04T00:00:00Z",
+          "cisa_date_added": null,
+          "dueDate": null
+        },
+        "not_supported": [
+          {
+            "claim": "Official CISA KEV membership based solely on VulnCheck",
+            "reason": "CISA remains the authority for official CISA KEV status."
+          },
+          {
+            "claim": "Article-ready source sufficiency",
+            "reason": "This prefill contains VulnCheck supporting evidence only and must be joined with CISA, CVE/NVD, vendor, or other primary sources before drafting."
+          }
+        ]
+      },
+      "drafting_allowed": false,
+      "production_artifact": ".github/pipeline/source-packets/vulncheck-kev/prefill-cve-2018-25270-2026-06-04.json"
+    }
+  ],
+  "input_source": "live",
+  "production": {
+    "artifact_type": "source-packet-prefill",
+    "candidate_index_path": ".github/pipeline/source-packets/vulncheck-kev/latest.json",
+    "source_packet_dir": ".github/pipeline/source-packets/vulncheck-kev",
+    "artifacts_written": [
+      ".github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-35273-2026-06-11.json",
+      ".github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-10795-2026-06-10.json",
+      ".github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-34908-2026-06-09.json",
+      ".github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-34910-2026-06-09.json",
+      ".github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-39808-2026-06-09.json",
+      ".github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-49060-2026-06-08.json",
+      ".github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-5027-2026-06-08.json",
+      ".github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-31816-2026-06-05.json",
+      ".github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-49777-2026-06-05.json",
+      ".github/pipeline/source-packets/vulncheck-kev/prefill-cve-2018-25270-2026-06-04.json"
+    ],
+    "article_tasks_created": 0,
+    "drafting_enabled": false
+  }
+}

--- a/.github/pipeline/source-packets/vulncheck-kev/prefill-cve-2018-25270-2026-06-04.json
+++ b/.github/pipeline/source-packets/vulncheck-kev/prefill-cve-2018-25270-2026-06-04.json
@@ -1,0 +1,122 @@
+{
+  "schema_version": "vulncheck-kev-prefill/1",
+  "generated_at": "2026-06-12T18:51:24.461Z",
+  "source": {
+    "publisher": "VulnCheck",
+    "dataset": "VulnCheck KEV",
+    "attribution_required": true,
+    "attribution_label": "VulnCheck KEV"
+  },
+  "candidate": {
+    "candidate_key": "vulncheck-kev:CVE-2018-25270:2026-06-04",
+    "cves": [
+      "CVE-2018-25270"
+    ],
+    "recency_bucket": "recent",
+    "priority_score": 34,
+    "priority_reasons": [
+      "recent VulnCheck date_added",
+      "1 VulnCheck reported exploitation reference(s)"
+    ],
+    "official_cisa_kev": {
+      "status_source": "cisa_date_added field from VulnCheck record; verify against CISA before official labeling",
+      "listed": false,
+      "date_added": null,
+      "due_date": null
+    },
+    "vulncheck_exploitation_signal": {
+      "source": "VulnCheck KEV",
+      "non_authoritative": true,
+      "date_added": "2026-06-04",
+      "known_ransomware_campaign_use": "Unknown",
+      "reported_exploited_by_vulncheck_canaries": false,
+      "reported_exploitation_count": 1,
+      "xdb_count": 0,
+      "xdb_exploit_types": [],
+      "evidence_urls": [
+        "https://www.stormshield.com/news/current-cyberattack-trends-variations-honeypots/"
+      ]
+    },
+    "drafting_allowed": false
+  },
+  "source_packet_prefill": {
+    "status": "prefill_only",
+    "drafting_allowed": false,
+    "authority_boundary": {
+      "cve_identity_authority": "CVE.org / MITRE CVE Program",
+      "official_cisa_kev_authority": "CISA",
+      "vulncheck_role": "non-authoritative exploitation signal and supporting source",
+      "instruction": "Do not draft or apply official KEV labeling from VulnCheck alone; verify CISA KEV membership against CISA before publication."
+    },
+    "supporting_sources": [
+      {
+        "id": "src-vulncheck-kev",
+        "publisher": "VulnCheck",
+        "url": "https://api.vulncheck.com/v3/backup/vulncheck-kev",
+        "published_at": "2026-06-04",
+        "source_type": "vendor",
+        "role": "supporting",
+        "notes": "VulnCheck KEV community backup record; prominent VulnCheck KEV attribution required when data is surfaced."
+      }
+    ],
+    "source_quality": {
+      "has_government_source": false,
+      "has_vendor_source": true,
+      "has_primary_source": false,
+      "source_sufficiency": "needs_human_review"
+    },
+    "key_dates": {
+      "vulncheck_date_added": "2026-06-04",
+      "cisa_kev_added_at_from_vulncheck_record": null,
+      "cisa_due_date_from_vulncheck_record": null
+    },
+    "affected_products": [
+      {
+        "vendor": "thinkphp",
+        "product": "ThinkPHP",
+        "versions": "unknown",
+        "source_refs": [
+          "src-vulncheck-kev"
+        ]
+      }
+    ],
+    "cves": [
+      {
+        "id": "CVE-2018-25270",
+        "source_refs": [
+          "src-vulncheck-kev"
+        ]
+      }
+    ],
+    "cwes": [],
+    "preserved_vulncheck_fields": {
+      "vendorProject": "thinkphp",
+      "product": "ThinkPHP",
+      "vulnerabilityName": "thinkphp ThinkPHP Authorization Bypass Through User-Controlled Key",
+      "shortDescription": "ThinkPHP 5.0.23 contains a remote code execution vulnerability that allows unauthenticated attackers to execute arbitrary PHP code by invoking functions through the routing parameter. Attackers can craft requests to the index.php endpoint with malicious function parameters to execute system commands with application privileges.",
+      "required_action": "Apply remediations or mitigations per vendor instructions or discontinue use of the product if remediation or mitigations are unavailable.",
+      "knownRansomwareCampaignUse": "Unknown",
+      "reported_exploited_by_vulncheck_canaries": false,
+      "vulncheck_reported_exploitation": [
+        {
+          "url": "https://www.stormshield.com/news/current-cyberattack-trends-variations-honeypots/",
+          "date_added": "2026-06-04T00:00:00Z"
+        }
+      ],
+      "vulncheck_xdb": [],
+      "date_added": "2026-06-04T00:00:00Z",
+      "cisa_date_added": null,
+      "dueDate": null
+    },
+    "not_supported": [
+      {
+        "claim": "Official CISA KEV membership based solely on VulnCheck",
+        "reason": "CISA remains the authority for official CISA KEV status."
+      },
+      {
+        "claim": "Article-ready source sufficiency",
+        "reason": "This prefill contains VulnCheck supporting evidence only and must be joined with CISA, CVE/NVD, vendor, or other primary sources before drafting."
+      }
+    ]
+  }
+}

--- a/.github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-10795-2026-06-10.json
+++ b/.github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-10795-2026-06-10.json
@@ -1,0 +1,139 @@
+{
+  "schema_version": "vulncheck-kev-prefill/1",
+  "generated_at": "2026-06-12T18:51:24.460Z",
+  "source": {
+    "publisher": "VulnCheck",
+    "dataset": "VulnCheck KEV",
+    "attribution_required": true,
+    "attribution_label": "VulnCheck KEV"
+  },
+  "candidate": {
+    "candidate_key": "vulncheck-kev:CVE-2026-10795:2026-06-10",
+    "cves": [
+      "CVE-2026-10795"
+    ],
+    "recency_bucket": "recent",
+    "priority_score": 40,
+    "priority_reasons": [
+      "recent VulnCheck date_added",
+      "2 VulnCheck reported exploitation reference(s)",
+      "1 VulnCheck XDB reference(s)"
+    ],
+    "official_cisa_kev": {
+      "status_source": "cisa_date_added field from VulnCheck record; verify against CISA before official labeling",
+      "listed": false,
+      "date_added": null,
+      "due_date": null
+    },
+    "vulncheck_exploitation_signal": {
+      "source": "VulnCheck KEV",
+      "non_authoritative": true,
+      "date_added": "2026-06-10",
+      "known_ransomware_campaign_use": "Unknown",
+      "reported_exploited_by_vulncheck_canaries": false,
+      "reported_exploitation_count": 2,
+      "xdb_count": 1,
+      "xdb_exploit_types": [
+        "initial-access"
+      ],
+      "evidence_urls": [
+        "https://patchstack.com/database/wordpress/plugin/updraftplus/vulnerability/wordpress-updraftplus-wp-backup-migration-plugin-1-26-4-unauthenticated-authentication-bypass-via-updraftcentral-udrpc-vulnerability",
+        "https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/updraftplus/updraftplus-wp-backup-migration-plugin-1264-unauthenticated-authentication-bypass-via-updraftcentral-udrpc",
+        "https://vulncheck.com/xdb/8e9fd2ad3560"
+      ]
+    },
+    "drafting_allowed": false
+  },
+  "source_packet_prefill": {
+    "status": "prefill_only",
+    "drafting_allowed": false,
+    "authority_boundary": {
+      "cve_identity_authority": "CVE.org / MITRE CVE Program",
+      "official_cisa_kev_authority": "CISA",
+      "vulncheck_role": "non-authoritative exploitation signal and supporting source",
+      "instruction": "Do not draft or apply official KEV labeling from VulnCheck alone; verify CISA KEV membership against CISA before publication."
+    },
+    "supporting_sources": [
+      {
+        "id": "src-vulncheck-kev",
+        "publisher": "VulnCheck",
+        "url": "https://api.vulncheck.com/v3/backup/vulncheck-kev",
+        "published_at": "2026-06-10",
+        "source_type": "vendor",
+        "role": "supporting",
+        "notes": "VulnCheck KEV community backup record; prominent VulnCheck KEV attribution required when data is surfaced."
+      }
+    ],
+    "source_quality": {
+      "has_government_source": false,
+      "has_vendor_source": true,
+      "has_primary_source": false,
+      "source_sufficiency": "needs_human_review"
+    },
+    "key_dates": {
+      "vulncheck_date_added": "2026-06-10",
+      "cisa_kev_added_at_from_vulncheck_record": null,
+      "cisa_due_date_from_vulncheck_record": null
+    },
+    "affected_products": [
+      {
+        "vendor": "updraftplus",
+        "product": "updraftplus",
+        "versions": "unknown",
+        "source_refs": [
+          "src-vulncheck-kev"
+        ]
+      }
+    ],
+    "cves": [
+      {
+        "id": "CVE-2026-10795",
+        "source_refs": [
+          "src-vulncheck-kev"
+        ]
+      }
+    ],
+    "cwes": [],
+    "preserved_vulncheck_fields": {
+      "vendorProject": "updraftplus",
+      "product": "updraftplus",
+      "vulnerabilityName": "updraftplus updraftplus Improper Verification of Cryptographic Signature",
+      "shortDescription": "The UpdraftPlus: WP Backup & Migration Plugin plugin for WordPress is vulnerable to Authentication Bypass in all versions up to, and including, 1.26.4 via the UpdraftPlus_Remote_Communications_V2::wp_loaded function. This is due to insufficient validation of the remote communications message format, where signature verification can be bypassed and unchecked decryption return values collapse to a predictable all-zero encryption key. This makes it possible for unauthenticated attackers to forge arbitrary RPC commands and run them as the connected administrator, such as uploading and activating a malicious plugin, which ultimately leads to remote code execution.",
+      "required_action": "Apply remediations or mitigations per vendor instructions or discontinue use of the product if remediation or mitigations are unavailable.",
+      "knownRansomwareCampaignUse": "Unknown",
+      "reported_exploited_by_vulncheck_canaries": false,
+      "vulncheck_reported_exploitation": [
+        {
+          "url": "https://patchstack.com/database/wordpress/plugin/updraftplus/vulnerability/wordpress-updraftplus-wp-backup-migration-plugin-1-26-4-unauthenticated-authentication-bypass-via-updraftcentral-udrpc-vulnerability",
+          "date_added": "2026-06-10T00:00:00Z"
+        },
+        {
+          "url": "https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/updraftplus/updraftplus-wp-backup-migration-plugin-1264-unauthenticated-authentication-bypass-via-updraftcentral-udrpc",
+          "date_added": "2026-06-11T00:00:00Z"
+        }
+      ],
+      "vulncheck_xdb": [
+        {
+          "xdb_id": "8e9fd2ad3560",
+          "xdb_url": "https://vulncheck.com/xdb/8e9fd2ad3560",
+          "date_added": "2026-06-11T10:06:29Z",
+          "exploit_type": "initial-access",
+          "clone_ssh_url": "git@github.com:izxci/CVE-2026-10795.git"
+        }
+      ],
+      "date_added": "2026-06-10T00:00:00Z",
+      "cisa_date_added": null,
+      "dueDate": null
+    },
+    "not_supported": [
+      {
+        "claim": "Official CISA KEV membership based solely on VulnCheck",
+        "reason": "CISA remains the authority for official CISA KEV status."
+      },
+      {
+        "claim": "Article-ready source sufficiency",
+        "reason": "This prefill contains VulnCheck supporting evidence only and must be joined with CISA, CVE/NVD, vendor, or other primary sources before drafting."
+      }
+    ]
+  }
+}

--- a/.github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-31816-2026-06-05.json
+++ b/.github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-31816-2026-06-05.json
@@ -1,0 +1,135 @@
+{
+  "schema_version": "vulncheck-kev-prefill/1",
+  "generated_at": "2026-06-12T18:51:24.461Z",
+  "source": {
+    "publisher": "VulnCheck",
+    "dataset": "VulnCheck KEV",
+    "attribution_required": true,
+    "attribution_label": "VulnCheck KEV"
+  },
+  "candidate": {
+    "candidate_key": "vulncheck-kev:CVE-2026-31816:2026-06-05",
+    "cves": [
+      "CVE-2026-31816"
+    ],
+    "recency_bucket": "recent",
+    "priority_score": 54,
+    "priority_reasons": [
+      "recent VulnCheck date_added",
+      "VulnCheck canary exploitation signal",
+      "1 VulnCheck reported exploitation reference(s)",
+      "1 VulnCheck XDB reference(s)"
+    ],
+    "official_cisa_kev": {
+      "status_source": "cisa_date_added field from VulnCheck record; verify against CISA before official labeling",
+      "listed": false,
+      "date_added": null,
+      "due_date": null
+    },
+    "vulncheck_exploitation_signal": {
+      "source": "VulnCheck KEV",
+      "non_authoritative": true,
+      "date_added": "2026-06-05",
+      "known_ransomware_campaign_use": "Unknown",
+      "reported_exploited_by_vulncheck_canaries": true,
+      "reported_exploitation_count": 1,
+      "xdb_count": 1,
+      "xdb_exploit_types": [
+        "initial-access"
+      ],
+      "evidence_urls": [
+        "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-31816&date=2026-06-05",
+        "https://vulncheck.com/xdb/3ee67248358b"
+      ]
+    },
+    "drafting_allowed": false
+  },
+  "source_packet_prefill": {
+    "status": "prefill_only",
+    "drafting_allowed": false,
+    "authority_boundary": {
+      "cve_identity_authority": "CVE.org / MITRE CVE Program",
+      "official_cisa_kev_authority": "CISA",
+      "vulncheck_role": "non-authoritative exploitation signal and supporting source",
+      "instruction": "Do not draft or apply official KEV labeling from VulnCheck alone; verify CISA KEV membership against CISA before publication."
+    },
+    "supporting_sources": [
+      {
+        "id": "src-vulncheck-kev",
+        "publisher": "VulnCheck",
+        "url": "https://api.vulncheck.com/v3/backup/vulncheck-kev",
+        "published_at": "2026-06-05",
+        "source_type": "vendor",
+        "role": "supporting",
+        "notes": "VulnCheck KEV community backup record; prominent VulnCheck KEV attribution required when data is surfaced."
+      }
+    ],
+    "source_quality": {
+      "has_government_source": false,
+      "has_vendor_source": true,
+      "has_primary_source": false,
+      "source_sufficiency": "needs_human_review"
+    },
+    "key_dates": {
+      "vulncheck_date_added": "2026-06-05",
+      "cisa_kev_added_at_from_vulncheck_record": null,
+      "cisa_due_date_from_vulncheck_record": null
+    },
+    "affected_products": [
+      {
+        "vendor": "budibase",
+        "product": "budibase",
+        "versions": "unknown",
+        "source_refs": [
+          "src-vulncheck-kev"
+        ]
+      }
+    ],
+    "cves": [
+      {
+        "id": "CVE-2026-31816",
+        "source_refs": [
+          "src-vulncheck-kev"
+        ]
+      }
+    ],
+    "cwes": [],
+    "preserved_vulncheck_fields": {
+      "vendorProject": "budibase",
+      "product": "budibase",
+      "vulnerabilityName": "budibase budibase Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')",
+      "shortDescription": "Budibase is a low code platform for creating internal tools, workflows, and admin panels. In 3.31.4 and earlier, the Budibase server's authorized() middleware that protects every server-side API endpoint can be completely bypassed by appending a webhook path pattern to the query string of any request. The isWebhookEndpoint() function uses an unanchored regex that tests against ctx.request.url, which in Koa includes the full URL with query parameters. When the regex matches, the authorized() middleware immediately calls return next(), skipping all authentication, authorization, role checks, and CSRF protection. This means a completely unauthenticated, remote attacker can access any server-side API endpoint by simply appending ?/webhooks/trigger (or any webhook pattern variant) to the URL.",
+      "required_action": "Apply remediations or mitigations per vendor instructions or discontinue use of the product if remediation or mitigations are unavailable.",
+      "knownRansomwareCampaignUse": "Unknown",
+      "reported_exploited_by_vulncheck_canaries": true,
+      "vulncheck_reported_exploitation": [
+        {
+          "url": "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-31816&date=2026-06-05",
+          "date_added": "2026-06-05T00:00:00Z"
+        }
+      ],
+      "vulncheck_xdb": [
+        {
+          "xdb_id": "3ee67248358b",
+          "xdb_url": "https://vulncheck.com/xdb/3ee67248358b",
+          "date_added": "2026-03-12T12:44:53Z",
+          "exploit_type": "initial-access",
+          "clone_ssh_url": "git@github.com:imjdl/CVE-2026-31816-rshell.git"
+        }
+      ],
+      "date_added": "2026-06-05T00:00:00Z",
+      "cisa_date_added": null,
+      "dueDate": null
+    },
+    "not_supported": [
+      {
+        "claim": "Official CISA KEV membership based solely on VulnCheck",
+        "reason": "CISA remains the authority for official CISA KEV status."
+      },
+      {
+        "claim": "Article-ready source sufficiency",
+        "reason": "This prefill contains VulnCheck supporting evidence only and must be joined with CISA, CVE/NVD, vendor, or other primary sources before drafting."
+      }
+    ]
+  }
+}

--- a/.github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-34908-2026-06-09.json
+++ b/.github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-34908-2026-06-09.json
@@ -1,0 +1,122 @@
+{
+  "schema_version": "vulncheck-kev-prefill/1",
+  "generated_at": "2026-06-12T18:51:24.460Z",
+  "source": {
+    "publisher": "VulnCheck",
+    "dataset": "VulnCheck KEV",
+    "attribution_required": true,
+    "attribution_label": "VulnCheck KEV"
+  },
+  "candidate": {
+    "candidate_key": "vulncheck-kev:CVE-2026-34908:2026-06-09",
+    "cves": [
+      "CVE-2026-34908"
+    ],
+    "recency_bucket": "recent",
+    "priority_score": 34,
+    "priority_reasons": [
+      "recent VulnCheck date_added",
+      "1 VulnCheck reported exploitation reference(s)"
+    ],
+    "official_cisa_kev": {
+      "status_source": "cisa_date_added field from VulnCheck record; verify against CISA before official labeling",
+      "listed": false,
+      "date_added": null,
+      "due_date": null
+    },
+    "vulncheck_exploitation_signal": {
+      "source": "VulnCheck KEV",
+      "non_authoritative": true,
+      "date_added": "2026-06-09",
+      "known_ransomware_campaign_use": "Unknown",
+      "reported_exploited_by_vulncheck_canaries": false,
+      "reported_exploitation_count": 1,
+      "xdb_count": 0,
+      "xdb_exploit_types": [],
+      "evidence_urls": [
+        "https://www.pwndefend.com/2026/06/09/cve-2026-34910-exploitation-itw-building-a-botnet-mirai/"
+      ]
+    },
+    "drafting_allowed": false
+  },
+  "source_packet_prefill": {
+    "status": "prefill_only",
+    "drafting_allowed": false,
+    "authority_boundary": {
+      "cve_identity_authority": "CVE.org / MITRE CVE Program",
+      "official_cisa_kev_authority": "CISA",
+      "vulncheck_role": "non-authoritative exploitation signal and supporting source",
+      "instruction": "Do not draft or apply official KEV labeling from VulnCheck alone; verify CISA KEV membership against CISA before publication."
+    },
+    "supporting_sources": [
+      {
+        "id": "src-vulncheck-kev",
+        "publisher": "VulnCheck",
+        "url": "https://api.vulncheck.com/v3/backup/vulncheck-kev",
+        "published_at": "2026-06-09",
+        "source_type": "vendor",
+        "role": "supporting",
+        "notes": "VulnCheck KEV community backup record; prominent VulnCheck KEV attribution required when data is surfaced."
+      }
+    ],
+    "source_quality": {
+      "has_government_source": false,
+      "has_vendor_source": true,
+      "has_primary_source": false,
+      "source_sufficiency": "needs_human_review"
+    },
+    "key_dates": {
+      "vulncheck_date_added": "2026-06-09",
+      "cisa_kev_added_at_from_vulncheck_record": null,
+      "cisa_due_date_from_vulncheck_record": null
+    },
+    "affected_products": [
+      {
+        "vendor": "Ubiquiti Inc",
+        "product": "UniFi OS Server",
+        "versions": "unknown",
+        "source_refs": [
+          "src-vulncheck-kev"
+        ]
+      }
+    ],
+    "cves": [
+      {
+        "id": "CVE-2026-34908",
+        "source_refs": [
+          "src-vulncheck-kev"
+        ]
+      }
+    ],
+    "cwes": [],
+    "preserved_vulncheck_fields": {
+      "vendorProject": "Ubiquiti Inc",
+      "product": "UniFi OS Server",
+      "vulnerabilityName": "  Improper Access Control",
+      "shortDescription": "A malicious actor with access to the network could exploit an Improper Access Control vulnerability found in UniFi OS devices to make unauthorized changes to the system.",
+      "required_action": "Apply remediations or mitigations per vendor instructions or discontinue use of the product if remediation or mitigations are unavailable.",
+      "knownRansomwareCampaignUse": "Unknown",
+      "reported_exploited_by_vulncheck_canaries": false,
+      "vulncheck_reported_exploitation": [
+        {
+          "url": "https://www.pwndefend.com/2026/06/09/cve-2026-34910-exploitation-itw-building-a-botnet-mirai/",
+          "date_added": "2026-06-09T00:00:00Z"
+        }
+      ],
+      "vulncheck_xdb": [],
+      "date_added": "2026-06-09T00:00:00Z",
+      "cisa_date_added": null,
+      "dueDate": null
+    },
+    "not_supported": [
+      {
+        "claim": "Official CISA KEV membership based solely on VulnCheck",
+        "reason": "CISA remains the authority for official CISA KEV status."
+      },
+      {
+        "claim": "Article-ready source sufficiency",
+        "reason": "This prefill contains VulnCheck supporting evidence only and must be joined with CISA, CVE/NVD, vendor, or other primary sources before drafting."
+      }
+    ]
+  }
+}

--- a/.github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-34910-2026-06-09.json
+++ b/.github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-34910-2026-06-09.json
@@ -1,0 +1,122 @@
+{
+  "schema_version": "vulncheck-kev-prefill/1",
+  "generated_at": "2026-06-12T18:51:24.461Z",
+  "source": {
+    "publisher": "VulnCheck",
+    "dataset": "VulnCheck KEV",
+    "attribution_required": true,
+    "attribution_label": "VulnCheck KEV"
+  },
+  "candidate": {
+    "candidate_key": "vulncheck-kev:CVE-2026-34910:2026-06-09",
+    "cves": [
+      "CVE-2026-34910"
+    ],
+    "recency_bucket": "recent",
+    "priority_score": 34,
+    "priority_reasons": [
+      "recent VulnCheck date_added",
+      "1 VulnCheck reported exploitation reference(s)"
+    ],
+    "official_cisa_kev": {
+      "status_source": "cisa_date_added field from VulnCheck record; verify against CISA before official labeling",
+      "listed": false,
+      "date_added": null,
+      "due_date": null
+    },
+    "vulncheck_exploitation_signal": {
+      "source": "VulnCheck KEV",
+      "non_authoritative": true,
+      "date_added": "2026-06-09",
+      "known_ransomware_campaign_use": "Unknown",
+      "reported_exploited_by_vulncheck_canaries": false,
+      "reported_exploitation_count": 1,
+      "xdb_count": 0,
+      "xdb_exploit_types": [],
+      "evidence_urls": [
+        "https://www.pwndefend.com/2026/06/09/cve-2026-34910-exploitation-itw-building-a-botnet-mirai/"
+      ]
+    },
+    "drafting_allowed": false
+  },
+  "source_packet_prefill": {
+    "status": "prefill_only",
+    "drafting_allowed": false,
+    "authority_boundary": {
+      "cve_identity_authority": "CVE.org / MITRE CVE Program",
+      "official_cisa_kev_authority": "CISA",
+      "vulncheck_role": "non-authoritative exploitation signal and supporting source",
+      "instruction": "Do not draft or apply official KEV labeling from VulnCheck alone; verify CISA KEV membership against CISA before publication."
+    },
+    "supporting_sources": [
+      {
+        "id": "src-vulncheck-kev",
+        "publisher": "VulnCheck",
+        "url": "https://api.vulncheck.com/v3/backup/vulncheck-kev",
+        "published_at": "2026-06-09",
+        "source_type": "vendor",
+        "role": "supporting",
+        "notes": "VulnCheck KEV community backup record; prominent VulnCheck KEV attribution required when data is surfaced."
+      }
+    ],
+    "source_quality": {
+      "has_government_source": false,
+      "has_vendor_source": true,
+      "has_primary_source": false,
+      "source_sufficiency": "needs_human_review"
+    },
+    "key_dates": {
+      "vulncheck_date_added": "2026-06-09",
+      "cisa_kev_added_at_from_vulncheck_record": null,
+      "cisa_due_date_from_vulncheck_record": null
+    },
+    "affected_products": [
+      {
+        "vendor": "Ubiquiti Inc",
+        "product": "UniFi OS Server",
+        "versions": "unknown",
+        "source_refs": [
+          "src-vulncheck-kev"
+        ]
+      }
+    ],
+    "cves": [
+      {
+        "id": "CVE-2026-34910",
+        "source_refs": [
+          "src-vulncheck-kev"
+        ]
+      }
+    ],
+    "cwes": [],
+    "preserved_vulncheck_fields": {
+      "vendorProject": "Ubiquiti Inc",
+      "product": "UniFi OS Server",
+      "vulnerabilityName": "  Improper Input Validation",
+      "shortDescription": "A malicious actor with access to the network could exploit an Improper Input Validation vulnerability found in UniFi OS devices to execute a Command Injection.",
+      "required_action": "Apply remediations or mitigations per vendor instructions or discontinue use of the product if remediation or mitigations are unavailable.",
+      "knownRansomwareCampaignUse": "Unknown",
+      "reported_exploited_by_vulncheck_canaries": false,
+      "vulncheck_reported_exploitation": [
+        {
+          "url": "https://www.pwndefend.com/2026/06/09/cve-2026-34910-exploitation-itw-building-a-botnet-mirai/",
+          "date_added": "2026-06-09T00:00:00Z"
+        }
+      ],
+      "vulncheck_xdb": [],
+      "date_added": "2026-06-09T00:00:00Z",
+      "cisa_date_added": null,
+      "dueDate": null
+    },
+    "not_supported": [
+      {
+        "claim": "Official CISA KEV membership based solely on VulnCheck",
+        "reason": "CISA remains the authority for official CISA KEV status."
+      },
+      {
+        "claim": "Article-ready source sufficiency",
+        "reason": "This prefill contains VulnCheck supporting evidence only and must be joined with CISA, CVE/NVD, vendor, or other primary sources before drafting."
+      }
+    ]
+  }
+}

--- a/.github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-35273-2026-06-11.json
+++ b/.github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-35273-2026-06-11.json
@@ -1,0 +1,147 @@
+{
+  "schema_version": "vulncheck-kev-prefill/1",
+  "generated_at": "2026-06-12T18:51:24.460Z",
+  "source": {
+    "publisher": "VulnCheck",
+    "dataset": "VulnCheck KEV",
+    "attribution_required": true,
+    "attribution_label": "VulnCheck KEV"
+  },
+  "candidate": {
+    "candidate_key": "vulncheck-kev:CVE-2026-35273:2026-06-11",
+    "cves": [
+      "CVE-2026-35273"
+    ],
+    "recency_bucket": "recent",
+    "priority_score": 78,
+    "priority_reasons": [
+      "recent VulnCheck date_added",
+      "CISA date present in VulnCheck record; verify against CISA before official labeling",
+      "4 VulnCheck reported exploitation reference(s)",
+      "known ransomware campaign use field"
+    ],
+    "official_cisa_kev": {
+      "status_source": "cisa_date_added field from VulnCheck record; verify against CISA before official labeling",
+      "listed": true,
+      "date_added": "2026-06-12",
+      "due_date": "2026-06-15"
+    },
+    "vulncheck_exploitation_signal": {
+      "source": "VulnCheck KEV",
+      "non_authoritative": true,
+      "date_added": "2026-06-11",
+      "known_ransomware_campaign_use": "Known",
+      "reported_exploited_by_vulncheck_canaries": false,
+      "reported_exploitation_count": 4,
+      "xdb_count": 0,
+      "xdb_exploit_types": [],
+      "evidence_urls": [
+        "https://cloud.google.com/blog/topics/threat-intelligence/shinyhunters-targets-education-sector-oracle-exploit",
+        "https://www.linkedin.com/posts/charlescarmakal_urgent-multiple-0-day-vulnerabilities-share-7470696836803117057-mf6m/",
+        "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json",
+        "https://www.rapid7.com/blog/post/etr-active-exploitation-of-oracle-peoplesoft-zero-day-cve-2026-35273/"
+      ]
+    },
+    "drafting_allowed": false
+  },
+  "source_packet_prefill": {
+    "status": "prefill_only",
+    "drafting_allowed": false,
+    "authority_boundary": {
+      "cve_identity_authority": "CVE.org / MITRE CVE Program",
+      "official_cisa_kev_authority": "CISA",
+      "vulncheck_role": "non-authoritative exploitation signal and supporting source",
+      "instruction": "Do not draft or apply official KEV labeling from VulnCheck alone; verify CISA KEV membership against CISA before publication."
+    },
+    "supporting_sources": [
+      {
+        "id": "src-vulncheck-kev",
+        "publisher": "VulnCheck",
+        "url": "https://api.vulncheck.com/v3/backup/vulncheck-kev",
+        "published_at": "2026-06-11",
+        "source_type": "vendor",
+        "role": "supporting",
+        "notes": "VulnCheck KEV community backup record; prominent VulnCheck KEV attribution required when data is surfaced."
+      }
+    ],
+    "source_quality": {
+      "has_government_source": false,
+      "has_vendor_source": true,
+      "has_primary_source": false,
+      "source_sufficiency": "needs_human_review"
+    },
+    "key_dates": {
+      "vulncheck_date_added": "2026-06-11",
+      "cisa_kev_added_at_from_vulncheck_record": "2026-06-12",
+      "cisa_due_date_from_vulncheck_record": "2026-06-15"
+    },
+    "affected_products": [
+      {
+        "vendor": "Oracle",
+        "product": " PeopleSoft Enterprise PeopleTools",
+        "versions": "unknown",
+        "source_refs": [
+          "src-vulncheck-kev"
+        ]
+      }
+    ],
+    "cves": [
+      {
+        "id": "CVE-2026-35273",
+        "source_refs": [
+          "src-vulncheck-kev"
+        ]
+      }
+    ],
+    "cwes": [
+      {
+        "id": "CWE-306",
+        "name": "Unknown",
+        "source_refs": [
+          "src-vulncheck-kev"
+        ]
+      }
+    ],
+    "preserved_vulncheck_fields": {
+      "vendorProject": "Oracle",
+      "product": " PeopleSoft Enterprise PeopleTools",
+      "vulnerabilityName": "Oracle PeopleSoft Enterprise PeopleTools Missing Authentication for Critical Function Vulnerability",
+      "shortDescription": "Oracle PeopleSoft Enterprise PeopleTools contains a missing authentication for critical function vulnerability which could allow an unauthenticated attacker to obtain takeover of PeopleSoft Enterprise PeopleTools.",
+      "required_action": "Apply mitigations in accordance with vendor instructions, ensuring compliance with CISA’s BOD 26-04 Prioritizing Security Updates Based on Risk (see URL in Notes) guidance and CISA’s “Forensics Triage Requirements” (see URL in Notes). Follow applicable BOD 26-04 guidance for cloud services or discontinue use of the product if mitigations are unavailable. Stakeholders are responsible for evaluating each asset's internet exposure and ensuring adherence to BOD 26-04 patching guidelines.",
+      "knownRansomwareCampaignUse": "Known",
+      "reported_exploited_by_vulncheck_canaries": false,
+      "vulncheck_reported_exploitation": [
+        {
+          "url": "https://cloud.google.com/blog/topics/threat-intelligence/shinyhunters-targets-education-sector-oracle-exploit",
+          "date_added": "2026-06-11T00:00:00Z"
+        },
+        {
+          "url": "https://www.linkedin.com/posts/charlescarmakal_urgent-multiple-0-day-vulnerabilities-share-7470696836803117057-mf6m/",
+          "date_added": "2026-06-11T00:00:00Z"
+        },
+        {
+          "url": "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json",
+          "date_added": "2026-06-12T00:00:00Z"
+        },
+        {
+          "url": "https://www.rapid7.com/blog/post/etr-active-exploitation-of-oracle-peoplesoft-zero-day-cve-2026-35273/",
+          "date_added": "2026-06-12T00:00:00Z"
+        }
+      ],
+      "vulncheck_xdb": [],
+      "date_added": "2026-06-11T00:00:00Z",
+      "cisa_date_added": "2026-06-12T00:00:00Z",
+      "dueDate": "2026-06-15T00:00:00Z"
+    },
+    "not_supported": [
+      {
+        "claim": "Official CISA KEV membership based solely on VulnCheck",
+        "reason": "CISA remains the authority for official CISA KEV status."
+      },
+      {
+        "claim": "Article-ready source sufficiency",
+        "reason": "This prefill contains VulnCheck supporting evidence only and must be joined with CISA, CVE/NVD, vendor, or other primary sources before drafting."
+      }
+    ]
+  }
+}

--- a/.github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-39808-2026-06-09.json
+++ b/.github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-39808-2026-06-09.json
@@ -1,0 +1,153 @@
+{
+  "schema_version": "vulncheck-kev-prefill/1",
+  "generated_at": "2026-06-12T18:51:24.461Z",
+  "source": {
+    "publisher": "VulnCheck",
+    "dataset": "VulnCheck KEV",
+    "attribution_required": true,
+    "attribution_label": "VulnCheck KEV"
+  },
+  "candidate": {
+    "candidate_key": "vulncheck-kev:CVE-2026-39808:2026-06-09",
+    "cves": [
+      "CVE-2026-39808"
+    ],
+    "recency_bucket": "recent",
+    "priority_score": 64,
+    "priority_reasons": [
+      "recent VulnCheck date_added",
+      "VulnCheck canary exploitation signal",
+      "3 VulnCheck reported exploitation reference(s)",
+      "2 VulnCheck XDB reference(s)"
+    ],
+    "official_cisa_kev": {
+      "status_source": "cisa_date_added field from VulnCheck record; verify against CISA before official labeling",
+      "listed": false,
+      "date_added": null,
+      "due_date": null
+    },
+    "vulncheck_exploitation_signal": {
+      "source": "VulnCheck KEV",
+      "non_authoritative": true,
+      "date_added": "2026-06-09",
+      "known_ransomware_campaign_use": "Unknown",
+      "reported_exploited_by_vulncheck_canaries": true,
+      "reported_exploitation_count": 3,
+      "xdb_count": 2,
+      "xdb_exploit_types": [
+        "initial-access"
+      ],
+      "evidence_urls": [
+        "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-39808&date=2026-06-09",
+        "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-39808&date=2026-06-10",
+        "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-39808&date=2026-06-11",
+        "https://vulncheck.com/xdb/baecd56da872",
+        "https://vulncheck.com/xdb/50e019aa766f"
+      ]
+    },
+    "drafting_allowed": false
+  },
+  "source_packet_prefill": {
+    "status": "prefill_only",
+    "drafting_allowed": false,
+    "authority_boundary": {
+      "cve_identity_authority": "CVE.org / MITRE CVE Program",
+      "official_cisa_kev_authority": "CISA",
+      "vulncheck_role": "non-authoritative exploitation signal and supporting source",
+      "instruction": "Do not draft or apply official KEV labeling from VulnCheck alone; verify CISA KEV membership against CISA before publication."
+    },
+    "supporting_sources": [
+      {
+        "id": "src-vulncheck-kev",
+        "publisher": "VulnCheck",
+        "url": "https://api.vulncheck.com/v3/backup/vulncheck-kev",
+        "published_at": "2026-06-09",
+        "source_type": "vendor",
+        "role": "supporting",
+        "notes": "VulnCheck KEV community backup record; prominent VulnCheck KEV attribution required when data is surfaced."
+      }
+    ],
+    "source_quality": {
+      "has_government_source": false,
+      "has_vendor_source": true,
+      "has_primary_source": false,
+      "source_sufficiency": "needs_human_review"
+    },
+    "key_dates": {
+      "vulncheck_date_added": "2026-06-09",
+      "cisa_kev_added_at_from_vulncheck_record": null,
+      "cisa_due_date_from_vulncheck_record": null
+    },
+    "affected_products": [
+      {
+        "vendor": "Fortinet",
+        "product": "fortisandbox",
+        "versions": "unknown",
+        "source_refs": [
+          "src-vulncheck-kev"
+        ]
+      }
+    ],
+    "cves": [
+      {
+        "id": "CVE-2026-39808",
+        "source_refs": [
+          "src-vulncheck-kev"
+        ]
+      }
+    ],
+    "cwes": [],
+    "preserved_vulncheck_fields": {
+      "vendorProject": "Fortinet",
+      "product": "fortisandbox",
+      "vulnerabilityName": "Fortinet fortisandbox Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')",
+      "shortDescription": "A improper neutralization of special elements used in an os command ('os command injection') vulnerability in Fortinet FortiSandbox 4.4.0 through 4.4.8 may allow attacker to execute unauthorized code or commands via",
+      "required_action": "Apply remediations or mitigations per vendor instructions or discontinue use of the product if remediation or mitigations are unavailable.",
+      "knownRansomwareCampaignUse": "Unknown",
+      "reported_exploited_by_vulncheck_canaries": true,
+      "vulncheck_reported_exploitation": [
+        {
+          "url": "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-39808&date=2026-06-09",
+          "date_added": "2026-06-09T00:00:00Z"
+        },
+        {
+          "url": "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-39808&date=2026-06-10",
+          "date_added": "2026-06-10T00:00:00Z"
+        },
+        {
+          "url": "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-39808&date=2026-06-11",
+          "date_added": "2026-06-11T00:00:00Z"
+        }
+      ],
+      "vulncheck_xdb": [
+        {
+          "xdb_id": "baecd56da872",
+          "xdb_url": "https://vulncheck.com/xdb/baecd56da872",
+          "date_added": "2026-04-15T14:10:25Z",
+          "exploit_type": "initial-access",
+          "clone_ssh_url": "git@github.com:samu-delucas/CVE-2026-39808.git"
+        },
+        {
+          "xdb_id": "50e019aa766f",
+          "xdb_url": "https://vulncheck.com/xdb/50e019aa766f",
+          "date_added": "2026-04-18T09:15:36Z",
+          "exploit_type": "initial-access",
+          "clone_ssh_url": "git@github.com:0xBlackash/CVE-2026-39808.git"
+        }
+      ],
+      "date_added": "2026-06-09T00:00:00Z",
+      "cisa_date_added": null,
+      "dueDate": null
+    },
+    "not_supported": [
+      {
+        "claim": "Official CISA KEV membership based solely on VulnCheck",
+        "reason": "CISA remains the authority for official CISA KEV status."
+      },
+      {
+        "claim": "Article-ready source sufficiency",
+        "reason": "This prefill contains VulnCheck supporting evidence only and must be joined with CISA, CVE/NVD, vendor, or other primary sources before drafting."
+      }
+    ]
+  }
+}

--- a/.github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-49060-2026-06-08.json
+++ b/.github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-49060-2026-06-08.json
@@ -1,0 +1,122 @@
+{
+  "schema_version": "vulncheck-kev-prefill/1",
+  "generated_at": "2026-06-12T18:51:24.461Z",
+  "source": {
+    "publisher": "VulnCheck",
+    "dataset": "VulnCheck KEV",
+    "attribution_required": true,
+    "attribution_label": "VulnCheck KEV"
+  },
+  "candidate": {
+    "candidate_key": "vulncheck-kev:CVE-2026-49060:2026-06-08",
+    "cves": [
+      "CVE-2026-49060"
+    ],
+    "recency_bucket": "recent",
+    "priority_score": 34,
+    "priority_reasons": [
+      "recent VulnCheck date_added",
+      "1 VulnCheck reported exploitation reference(s)"
+    ],
+    "official_cisa_kev": {
+      "status_source": "cisa_date_added field from VulnCheck record; verify against CISA before official labeling",
+      "listed": false,
+      "date_added": null,
+      "due_date": null
+    },
+    "vulncheck_exploitation_signal": {
+      "source": "VulnCheck KEV",
+      "non_authoritative": true,
+      "date_added": "2026-06-08",
+      "known_ransomware_campaign_use": "Unknown",
+      "reported_exploited_by_vulncheck_canaries": false,
+      "reported_exploitation_count": 1,
+      "xdb_count": 0,
+      "xdb_exploit_types": [],
+      "evidence_urls": [
+        "https://patchstack.com/database/wordpress/plugin/hippoo/vulnerability/wordpress-hippoo-mobile-app-for-woocommerce-plugin-1-9-4-privilege-escalation-vulnerability"
+      ]
+    },
+    "drafting_allowed": false
+  },
+  "source_packet_prefill": {
+    "status": "prefill_only",
+    "drafting_allowed": false,
+    "authority_boundary": {
+      "cve_identity_authority": "CVE.org / MITRE CVE Program",
+      "official_cisa_kev_authority": "CISA",
+      "vulncheck_role": "non-authoritative exploitation signal and supporting source",
+      "instruction": "Do not draft or apply official KEV labeling from VulnCheck alone; verify CISA KEV membership against CISA before publication."
+    },
+    "supporting_sources": [
+      {
+        "id": "src-vulncheck-kev",
+        "publisher": "VulnCheck",
+        "url": "https://api.vulncheck.com/v3/backup/vulncheck-kev",
+        "published_at": "2026-06-08",
+        "source_type": "vendor",
+        "role": "supporting",
+        "notes": "VulnCheck KEV community backup record; prominent VulnCheck KEV attribution required when data is surfaced."
+      }
+    ],
+    "source_quality": {
+      "has_government_source": false,
+      "has_vendor_source": true,
+      "has_primary_source": false,
+      "source_sufficiency": "needs_human_review"
+    },
+    "key_dates": {
+      "vulncheck_date_added": "2026-06-08",
+      "cisa_kev_added_at_from_vulncheck_record": null,
+      "cisa_due_date_from_vulncheck_record": null
+    },
+    "affected_products": [
+      {
+        "vendor": "hippooo",
+        "product": "Hippoo Mobile App for WooCommerce",
+        "versions": "unknown",
+        "source_refs": [
+          "src-vulncheck-kev"
+        ]
+      }
+    ],
+    "cves": [
+      {
+        "id": "CVE-2026-49060",
+        "source_refs": [
+          "src-vulncheck-kev"
+        ]
+      }
+    ],
+    "cwes": [],
+    "preserved_vulncheck_fields": {
+      "vendorProject": "hippooo",
+      "product": "Hippoo Mobile App for WooCommerce",
+      "vulnerabilityName": "WordPress Hippoo Mobile App for WooCommerce Privilege Escalation",
+      "shortDescription": "Incorrect Privilege Assignment vulnerability in Hippoo Mobile App for WooCommerce allows Privilege Escalation.\n\nThis issue affects Hippoo Mobile App for WooCommerce: from n/a through 1.9.4.",
+      "required_action": "Apply remediations or mitigations per vendor instructions or discontinue use of the product if remediation or mitigations are unavailable.",
+      "knownRansomwareCampaignUse": "Unknown",
+      "reported_exploited_by_vulncheck_canaries": false,
+      "vulncheck_reported_exploitation": [
+        {
+          "url": "https://patchstack.com/database/wordpress/plugin/hippoo/vulnerability/wordpress-hippoo-mobile-app-for-woocommerce-plugin-1-9-4-privilege-escalation-vulnerability",
+          "date_added": "2026-06-08T00:00:00Z"
+        }
+      ],
+      "vulncheck_xdb": [],
+      "date_added": "2026-06-08T00:00:00Z",
+      "cisa_date_added": null,
+      "dueDate": null
+    },
+    "not_supported": [
+      {
+        "claim": "Official CISA KEV membership based solely on VulnCheck",
+        "reason": "CISA remains the authority for official CISA KEV status."
+      },
+      {
+        "claim": "Article-ready source sufficiency",
+        "reason": "This prefill contains VulnCheck supporting evidence only and must be joined with CISA, CVE/NVD, vendor, or other primary sources before drafting."
+      }
+    ]
+  }
+}

--- a/.github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-49777-2026-06-05.json
+++ b/.github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-49777-2026-06-05.json
@@ -1,0 +1,122 @@
+{
+  "schema_version": "vulncheck-kev-prefill/1",
+  "generated_at": "2026-06-12T18:51:24.461Z",
+  "source": {
+    "publisher": "VulnCheck",
+    "dataset": "VulnCheck KEV",
+    "attribution_required": true,
+    "attribution_label": "VulnCheck KEV"
+  },
+  "candidate": {
+    "candidate_key": "vulncheck-kev:CVE-2026-49777:2026-06-05",
+    "cves": [
+      "CVE-2026-49777"
+    ],
+    "recency_bucket": "recent",
+    "priority_score": 34,
+    "priority_reasons": [
+      "recent VulnCheck date_added",
+      "1 VulnCheck reported exploitation reference(s)"
+    ],
+    "official_cisa_kev": {
+      "status_source": "cisa_date_added field from VulnCheck record; verify against CISA before official labeling",
+      "listed": false,
+      "date_added": null,
+      "due_date": null
+    },
+    "vulncheck_exploitation_signal": {
+      "source": "VulnCheck KEV",
+      "non_authoritative": true,
+      "date_added": "2026-06-05",
+      "known_ransomware_campaign_use": "Unknown",
+      "reported_exploited_by_vulncheck_canaries": false,
+      "reported_exploitation_count": 1,
+      "xdb_count": 0,
+      "xdb_exploit_types": [],
+      "evidence_urls": [
+        "https://patchstack.com/database/wordpress/plugin/woo-product-slider-pro/vulnerability/wordpress-product-slider-pro-for-woocommerce-plugin-3-5-2-backdoor-vulnerability"
+      ]
+    },
+    "drafting_allowed": false
+  },
+  "source_packet_prefill": {
+    "status": "prefill_only",
+    "drafting_allowed": false,
+    "authority_boundary": {
+      "cve_identity_authority": "CVE.org / MITRE CVE Program",
+      "official_cisa_kev_authority": "CISA",
+      "vulncheck_role": "non-authoritative exploitation signal and supporting source",
+      "instruction": "Do not draft or apply official KEV labeling from VulnCheck alone; verify CISA KEV membership against CISA before publication."
+    },
+    "supporting_sources": [
+      {
+        "id": "src-vulncheck-kev",
+        "publisher": "VulnCheck",
+        "url": "https://api.vulncheck.com/v3/backup/vulncheck-kev",
+        "published_at": "2026-06-05",
+        "source_type": "vendor",
+        "role": "supporting",
+        "notes": "VulnCheck KEV community backup record; prominent VulnCheck KEV attribution required when data is surfaced."
+      }
+    ],
+    "source_quality": {
+      "has_government_source": false,
+      "has_vendor_source": true,
+      "has_primary_source": false,
+      "source_sufficiency": "needs_human_review"
+    },
+    "key_dates": {
+      "vulncheck_date_added": "2026-06-05",
+      "cisa_kev_added_at_from_vulncheck_record": null,
+      "cisa_due_date_from_vulncheck_record": null
+    },
+    "affected_products": [
+      {
+        "vendor": "NetAlertX",
+        "product": "NetAlertX",
+        "versions": "unknown",
+        "source_refs": [
+          "src-vulncheck-kev"
+        ]
+      }
+    ],
+    "cves": [
+      {
+        "id": "CVE-2026-49777",
+        "source_refs": [
+          "src-vulncheck-kev"
+        ]
+      }
+    ],
+    "cwes": [],
+    "preserved_vulncheck_fields": {
+      "vendorProject": "NetAlertX",
+      "product": "NetAlertX",
+      "vulnerabilityName": "  Improper Validation of Specified Quantity in Input",
+      "shortDescription": "Improper Validation of Specified Quantity in Input vulnerability in ShapedPlugin, LLC Product Slider Pro for WooCommerce allows Malicious Software Implanted.\n\nThis issue affects Product Slider Pro for WooCommerce: from n/a before 3.5.4.",
+      "required_action": "Apply remediations or mitigations per vendor instructions or discontinue use of the product if remediation or mitigations are unavailable.",
+      "knownRansomwareCampaignUse": "Unknown",
+      "reported_exploited_by_vulncheck_canaries": false,
+      "vulncheck_reported_exploitation": [
+        {
+          "url": "https://patchstack.com/database/wordpress/plugin/woo-product-slider-pro/vulnerability/wordpress-product-slider-pro-for-woocommerce-plugin-3-5-2-backdoor-vulnerability",
+          "date_added": "2026-06-05T00:00:00Z"
+        }
+      ],
+      "vulncheck_xdb": [],
+      "date_added": "2026-06-05T00:00:00Z",
+      "cisa_date_added": null,
+      "dueDate": null
+    },
+    "not_supported": [
+      {
+        "claim": "Official CISA KEV membership based solely on VulnCheck",
+        "reason": "CISA remains the authority for official CISA KEV status."
+      },
+      {
+        "claim": "Article-ready source sufficiency",
+        "reason": "This prefill contains VulnCheck supporting evidence only and must be joined with CISA, CVE/NVD, vendor, or other primary sources before drafting."
+      }
+    ]
+  }
+}

--- a/.github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-5027-2026-06-08.json
+++ b/.github/pipeline/source-packets/vulncheck-kev/prefill-cve-2026-5027-2026-06-08.json
@@ -1,0 +1,182 @@
+{
+  "schema_version": "vulncheck-kev-prefill/1",
+  "generated_at": "2026-06-12T18:51:24.461Z",
+  "source": {
+    "publisher": "VulnCheck",
+    "dataset": "VulnCheck KEV",
+    "attribution_required": true,
+    "attribution_label": "VulnCheck KEV"
+  },
+  "candidate": {
+    "candidate_key": "vulncheck-kev:CVE-2026-5027:2026-06-08",
+    "cves": [
+      "CVE-2026-5027"
+    ],
+    "recency_bucket": "recent",
+    "priority_score": 74,
+    "priority_reasons": [
+      "recent VulnCheck date_added",
+      "VulnCheck canary exploitation signal",
+      "7 VulnCheck reported exploitation reference(s)",
+      "3 VulnCheck XDB reference(s)"
+    ],
+    "official_cisa_kev": {
+      "status_source": "cisa_date_added field from VulnCheck record; verify against CISA before official labeling",
+      "listed": false,
+      "date_added": null,
+      "due_date": null
+    },
+    "vulncheck_exploitation_signal": {
+      "source": "VulnCheck KEV",
+      "non_authoritative": true,
+      "date_added": "2026-06-08",
+      "known_ransomware_campaign_use": "Unknown",
+      "reported_exploited_by_vulncheck_canaries": true,
+      "reported_exploitation_count": 7,
+      "xdb_count": 3,
+      "xdb_exploit_types": [
+        "remote-with-credentials",
+        "initial-access"
+      ],
+      "evidence_urls": [
+        "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-5027&date=2026-06-08",
+        "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-5027&date=2026-06-09",
+        "https://www.linkedin.com/posts/ccondon_kevs-share-7470128376624783361-Ot2c/",
+        "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-5027&date=2026-06-10",
+        "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-5027&date=2026-06-11",
+        "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-5027&date=2026-06-12",
+        "https://www.techgines.com/post/langflow-cve-2026-5027-path-traversal-rce",
+        "https://vulncheck.com/xdb/29b343b4afaf",
+        "https://vulncheck.com/xdb/812e19ecfa4f",
+        "https://vulncheck.com/xdb/98045a28f25c"
+      ]
+    },
+    "drafting_allowed": false
+  },
+  "source_packet_prefill": {
+    "status": "prefill_only",
+    "drafting_allowed": false,
+    "authority_boundary": {
+      "cve_identity_authority": "CVE.org / MITRE CVE Program",
+      "official_cisa_kev_authority": "CISA",
+      "vulncheck_role": "non-authoritative exploitation signal and supporting source",
+      "instruction": "Do not draft or apply official KEV labeling from VulnCheck alone; verify CISA KEV membership against CISA before publication."
+    },
+    "supporting_sources": [
+      {
+        "id": "src-vulncheck-kev",
+        "publisher": "VulnCheck",
+        "url": "https://api.vulncheck.com/v3/backup/vulncheck-kev",
+        "published_at": "2026-06-08",
+        "source_type": "vendor",
+        "role": "supporting",
+        "notes": "VulnCheck KEV community backup record; prominent VulnCheck KEV attribution required when data is surfaced."
+      }
+    ],
+    "source_quality": {
+      "has_government_source": false,
+      "has_vendor_source": true,
+      "has_primary_source": false,
+      "source_sufficiency": "needs_human_review"
+    },
+    "key_dates": {
+      "vulncheck_date_added": "2026-06-08",
+      "cisa_kev_added_at_from_vulncheck_record": null,
+      "cisa_due_date_from_vulncheck_record": null
+    },
+    "affected_products": [
+      {
+        "vendor": "langflow",
+        "product": "langflow",
+        "versions": "unknown",
+        "source_refs": [
+          "src-vulncheck-kev"
+        ]
+      }
+    ],
+    "cves": [
+      {
+        "id": "CVE-2026-5027",
+        "source_refs": [
+          "src-vulncheck-kev"
+        ]
+      }
+    ],
+    "cwes": [],
+    "preserved_vulncheck_fields": {
+      "vendorProject": "langflow",
+      "product": "langflow",
+      "vulnerabilityName": "langflow langflow Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')",
+      "shortDescription": "The 'POST /api/v2/files' endpoint does not sanitize the 'filename' parameter from the multipart form data, allowing an attacker to write files to arbitrary locations on the filesystem using path traversal sequences ('../').",
+      "required_action": "Apply remediations or mitigations per vendor instructions or discontinue use of the product if remediation or mitigations are unavailable.",
+      "knownRansomwareCampaignUse": "Unknown",
+      "reported_exploited_by_vulncheck_canaries": true,
+      "vulncheck_reported_exploitation": [
+        {
+          "url": "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-5027&date=2026-06-08",
+          "date_added": "2026-06-08T00:00:00Z"
+        },
+        {
+          "url": "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-5027&date=2026-06-09",
+          "date_added": "2026-06-09T00:00:00Z"
+        },
+        {
+          "url": "https://www.linkedin.com/posts/ccondon_kevs-share-7470128376624783361-Ot2c/",
+          "date_added": "2026-06-09T00:00:00Z"
+        },
+        {
+          "url": "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-5027&date=2026-06-10",
+          "date_added": "2026-06-10T00:00:00Z"
+        },
+        {
+          "url": "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-5027&date=2026-06-11",
+          "date_added": "2026-06-11T00:00:00Z"
+        },
+        {
+          "url": "https://api.vulncheck.com/v3/index/vulncheck-canaries?cve=CVE-2026-5027&date=2026-06-12",
+          "date_added": "2026-06-12T00:00:00Z"
+        },
+        {
+          "url": "https://www.techgines.com/post/langflow-cve-2026-5027-path-traversal-rce",
+          "date_added": "2026-06-12T00:00:00Z"
+        }
+      ],
+      "vulncheck_xdb": [
+        {
+          "xdb_id": "29b343b4afaf",
+          "xdb_url": "https://vulncheck.com/xdb/29b343b4afaf",
+          "date_added": "2026-04-02T10:46:45Z",
+          "exploit_type": "remote-with-credentials",
+          "clone_ssh_url": "git@github.com:yahiahamza/CVE-2026-5027.git"
+        },
+        {
+          "xdb_id": "812e19ecfa4f",
+          "xdb_url": "https://vulncheck.com/xdb/812e19ecfa4f",
+          "date_added": "2026-04-03T10:34:51Z",
+          "exploit_type": "remote-with-credentials",
+          "clone_ssh_url": "git@github.com:EQSTLab/CVE-2026-5027.git"
+        },
+        {
+          "xdb_id": "98045a28f25c",
+          "xdb_url": "https://vulncheck.com/xdb/98045a28f25c",
+          "date_added": "2026-04-03T16:56:21Z",
+          "exploit_type": "initial-access",
+          "clone_ssh_url": "git@github.com:0xBlackash/CVE-2026-5027.git"
+        }
+      ],
+      "date_added": "2026-06-08T00:00:00Z",
+      "cisa_date_added": null,
+      "dueDate": null
+    },
+    "not_supported": [
+      {
+        "claim": "Official CISA KEV membership based solely on VulnCheck",
+        "reason": "CISA remains the authority for official CISA KEV status."
+      },
+      {
+        "claim": "Article-ready source sufficiency",
+        "reason": "This prefill contains VulnCheck supporting evidence only and must be joined with CISA, CVE/NVD, vendor, or other primary sources before drafting."
+      }
+    ]
+  }
+}

--- a/.github/workflows/pipeline-discovery.yml
+++ b/.github/workflows/pipeline-discovery.yml
@@ -49,9 +49,9 @@ on:
         required: false
         default: "14"
       limit:
-        description: "Max tasks to create per run (default: 8)"
+        description: "Max tasks to create per run (default: 10)"
         required: false
-        default: "8"
+        default: "10"
       execute:
         description: "Write task files (true) or dry-run (false)"
         required: false
@@ -148,7 +148,7 @@ jobs:
         env:
           MODE: ${{ inputs.mode || 'all' }}
           DAYS: ${{ inputs.days || '14' }}
-          LIMIT: ${{ inputs.limit || '8' }}
+          LIMIT: ${{ inputs.limit || '10' }}
           EXECUTE: ${{ inputs.execute || 'true' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -162,12 +162,28 @@ jobs:
 
           node scripts/pipeline-discover.mjs ${ARGS}
 
-      - name: Commit new tasks to branch
+      - name: Run VulnCheck KEV source-packet intake
+        id: vulncheck
+        if: ${{ inputs.execute != 'false' && (inputs.mode == '' || inputs.mode == 'all' || inputs.mode == 'zero-day') }}
+        env:
+          VULNCHECKAPI: ${{ secrets.VULNCHECKAPI }}
+        run: |
+          set -euo pipefail
+          if [ -z "${VULNCHECKAPI:-}" ]; then
+            echo "::error::VULNCHECKAPI secret is not configured; VulnCheck production intake cannot run safely."
+            exit 1
+          fi
+          node scripts/vulncheck-kev-intake.mjs \
+            --execute \
+            --cache "$RUNNER_TEMP/vulncheck-kev-backup.json" \
+            --out "$RUNNER_TEMP/vulncheck-kev-intake-result.json"
+
+      - name: Commit new tasks and source-packet prefills to branch
         id: commit
         if: ${{ inputs.execute != 'false' }}
         run: |
           set -euo pipefail
-          git add .github/pipeline/tasks/
+          git add .github/pipeline/tasks/ .github/pipeline/source-packets/vulncheck-kev/
           if git diff --cached --quiet; then
             echo "No new discoveries this run — branch unchanged."
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
@@ -189,22 +205,29 @@ jobs:
             const LABEL = process.env.DISCOVERY_LABEL;
             const { owner, repo } = context.repo;
 
-            // ── Enumerate task files currently on the branch but not on main
-            //    These are the tasks pending human review in this PR.
+            // ── Enumerate task and source-packet prefill files currently on
+            //    the branch but not on main. These are pending human review in
+            //    this PR before landing on main.
             let taskPaths = [];
+            let packetPaths = [];
             try {
-              const diffOut = execSync(
+              const taskDiffOut = execSync(
                 `git diff --name-only origin/main...HEAD -- '.github/pipeline/tasks/*.json'`,
                 { encoding: 'utf8' },
               );
-              taskPaths = diffOut.split('\n').map(s => s.trim()).filter(Boolean);
+              taskPaths = taskDiffOut.split('\n').map(s => s.trim()).filter(Boolean);
+              const packetDiffOut = execSync(
+                `git diff --name-only origin/main...HEAD -- '.github/pipeline/source-packets/vulncheck-kev/*.json'`,
+                { encoding: 'utf8' },
+              );
+              packetPaths = packetDiffOut.split('\n').map(s => s.trim()).filter(Boolean);
             } catch (e) {
-              console.log(`Failed to enumerate branch-only task files: ${e.message}`);
+              console.log(`Failed to enumerate branch-only discovery files: ${e.message}`);
               return;
             }
 
-            if (taskPaths.length === 0) {
-              console.log('No branch-only task files detected. Skipping PR update.');
+            if (taskPaths.length === 0 && packetPaths.length === 0) {
+              console.log('No branch-only task or source-packet files detected. Skipping PR update.');
               return;
             }
 
@@ -231,12 +254,35 @@ jobs:
               }
             }
 
-            if (tasks.length === 0) {
-              console.log('No parseable tasks found on branch. Skipping PR update.');
-              return;
+            const packets = [];
+            for (const p of packetPaths) {
+              if (p.endsWith('/latest.json')) continue;
+              try {
+                const packet = JSON.parse(fs.readFileSync(p, 'utf8'));
+                const candidate = packet.candidate || {};
+                const prefill = packet.source_packet_prefill || {};
+                const product = (prefill.affected_products && prefill.affected_products[0]) || {};
+                packets.push({
+                  path: p,
+                  cves: Array.isArray(candidate.cves) ? candidate.cves : [],
+                  bucket: candidate.recency_bucket || '—',
+                  date: candidate.vulncheck_exploitation_signal?.date_added || '—',
+                  score: candidate.priority_score ?? null,
+                  officialCisa: !!candidate.official_cisa_kev?.listed,
+                  canary: !!candidate.vulncheck_exploitation_signal?.reported_exploited_by_vulncheck_canaries,
+                  vendor: product.vendor || '—',
+                  product: product.product || '—',
+                });
+              } catch (e) {
+                console.log(`Failed to parse ${p}: ${e.message}`);
+              }
             }
 
             tasks.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+            packets.sort((a, b) => {
+              if (a.date !== b.date) return String(b.date).localeCompare(String(a.date));
+              return (b.score ?? 0) - (a.score ?? 0);
+            });
 
             // ── Ensure the label exists (best-effort)
             try {
@@ -259,27 +305,45 @@ jobs:
 
             // ── Format PR body
             const nowIso = new Date().toISOString();
-            const title = `Pipeline discovery — ${tasks.length} task${tasks.length === 1 ? '' : 's'} pending`;
+            const titleParts = [];
+            if (tasks.length > 0) titleParts.push(`${tasks.length} task${tasks.length === 1 ? '' : 's'}`);
+            if (packets.length > 0) titleParts.push(`${packets.length} VulnCheck prefill${packets.length === 1 ? '' : 's'}`);
+            const title = `Pipeline discovery — ${titleParts.join(' + ')} pending`;
 
             let body = `## Automated Discovery — pending queue\n\n`;
             body += `This PR accumulates task candidates produced by the scheduled discovery workflow `;
-            body += `(\`.github/workflows/pipeline-discovery.yml\`). Tasks here are staged for your review `;
+            body += `(\`.github/workflows/pipeline-discovery.yml\`). Tasks and source-packet prefills here are staged for your review `;
             body += `on the \`${BRANCH}\` branch before landing on \`main\`.\n\n`;
             body += `**Merge** to accept the whole batch. **Close** (without merging) to discard this staged batch.\n`;
             body += `For a durable veto across future discovery runs, use the rejection-memory workflow and merge its PR.\n`;
             body += `Nothing auto-merges from this PR.\n\n`;
             body += `---\n\n`;
-            body += `**${tasks.length} task${tasks.length === 1 ? '' : 's'}** currently pending review.\n\n`;
-            body += `| Task | Type | Pri | Score | Auto-cert | Reference | Topic |\n`;
-            body += `|---|---|---|---:|:-:|---|---|\n`;
-            for (const t of tasks) {
-              const scoreCell = t.score == null ? '—' : String(t.score);
-              const certCell = t.auto_certify ? '✓' : '—';
-              const topicCell = t.topic.length > 80 ? t.topic.slice(0, 77) + '…' : t.topic;
-              const refCell = t.cve !== '—'
-                ? `\`${t.cve}\``
-                : (t.source !== '—' ? `[source](${t.source})` : '—');
-              body += `| \`${t.task_id}\` | ${t.type} | ${t.priority} | ${scoreCell} | ${certCell} | ${refCell} | ${topicCell.replace(/\|/g, '\\|')} |\n`;
+            if (tasks.length > 0) {
+              body += `**${tasks.length} task${tasks.length === 1 ? '' : 's'}** currently pending review.\n\n`;
+              body += `| Task | Type | Pri | Score | Auto-cert | Reference | Topic |\n`;
+              body += `|---|---|---|---:|:-:|---|---|\n`;
+              for (const t of tasks) {
+                const scoreCell = t.score == null ? '—' : String(t.score);
+                const certCell = t.auto_certify ? '✓' : '—';
+                const topicCell = t.topic.length > 80 ? t.topic.slice(0, 77) + '…' : t.topic;
+                const refCell = t.cve !== '—'
+                  ? `\`${t.cve}\``
+                  : (t.source !== '—' ? `[source](${t.source})` : '—');
+                body += `| \`${t.task_id}\` | ${t.type} | ${t.priority} | ${scoreCell} | ${certCell} | ${refCell} | ${topicCell.replace(/\|/g, '\\|')} |\n`;
+              }
+              body += `\n`;
+            }
+            if (packets.length > 0) {
+              body += `**${packets.length} VulnCheck KEV source-packet prefill${packets.length === 1 ? '' : 's'}** currently pending review.\n\n`;
+              body += `These are prioritization/source-packet artifacts only. They do not create article drafts, do not mark official CISA KEV membership, and require prominent VulnCheck KEV attribution if surfaced.\n\n`;
+              body += `| CVE | Date added | Bucket | Score | CISA date present | Canary signal | Vendor / product | Artifact |\n`;
+              body += `|---|---|---|---:|:-:|:-:|---|---|\n`;
+              for (const packet of packets) {
+                const cveCell = packet.cves.length > 0 ? packet.cves.map(cve => `\`${cve}\``).join(', ') : '—';
+                const artifact = packet.path.replace(/^\.\//, '');
+                body += `| ${cveCell} | ${packet.date} | ${packet.bucket} | ${packet.score == null ? '—' : packet.score} | ${packet.officialCisa ? '✓' : '—'} | ${packet.canary ? '✓' : '—'} | ${`${packet.vendor} / ${packet.product}`.replace(/\|/g, '\\|')} | \`${artifact}\` |\n`;
+              }
+              body += `\n`;
             }
             body += `\n---\n\n`;
             body += `_Last updated: ${nowIso} · Run [${context.runId}](${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}) · See [docs/PIPELINE.md](${context.serverUrl}/${owner}/${repo}/blob/main/docs/PIPELINE.md) for the end-to-end flow._\n`;

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -79,19 +79,21 @@ discovery queues are open, validated, and stable.
        cases collapse to: **reset the branch to `origin/main`** so discarded
        branch-only tasks do not linger on the long-lived discovery branch, and
        merged tasks aren't counted as new. Force-push the reset.
-   - Calls `node scripts/pipeline-discover.mjs --mode all --days 14 --limit 8 --execute`
+   - Calls `node scripts/pipeline-discover.mjs --mode all --days 14 --limit 10 --execute`
    - Script loads `.github/pipeline/config.yml`, installs lane-specific
      headroom limits, then runs the currently supported discovery lanes:
      - **zero-day:** CISA KEV + NVD CVSS enrichment
-       - **VulnCheck KEV recent intake (ROAD-014 Slice 1):** manual/dry-run
-         helper only. `node scripts/vulncheck-kev-intake.mjs --dry-run`
-         requests the VulnCheck KEV backup descriptor, follows the published
-         backup payload URL, selects recent records by top-level `date_added`,
-         and emits source-packet-prefill /
-         prioritization artifacts. It does not create tasks or draft articles.
-         CISA remains authoritative for official CISA KEV membership; VulnCheck
-         fields are non-authoritative exploitation signals and supporting
-         evidence with required VulnCheck KEV attribution.
+      - **VulnCheck KEV recent intake (ROAD-014):** live source-packet/candidate
+        prefill only. `node scripts/vulncheck-kev-intake.mjs --execute`
+        requests the VulnCheck KEV backup descriptor, follows the published
+        backup payload URL, selects records by top-level `date_added`
+        newest-first, emits up to 10 source-packet prefill artifacts per run,
+        and stages them in the discovery PR. It fills from the recent window
+        first, then older unhandled records newest-to-oldest. It does not
+        create draft tasks or article drafts. CISA remains authoritative for
+        official CISA KEV membership; VulnCheck fields are non-authoritative
+        exploitation signals and supporting evidence with required VulnCheck
+        KEV attribution.
      - **incident:** CISA alerts/advisories RSS + NCSC News RSS + Microsoft Security Blog RSS
      - **threat-actor promotion:** scans the recent incident corpus within the requested lookback window, skips actors already present in the corpus or pending threat-actor tasks (including known aliases), and promotes only evidence-backed names into new threat-actor tasks
      - **campaign promotion:** scans the recent incident corpus for named campaign-shaped incidents and strong same-actor clusters, then promotes only conservative, non-duplicate campaign candidates into new campaign tasks
@@ -176,11 +178,13 @@ discovery queues are open, validated, and stable.
      the packet is updated and preflight is rerun.
    - **VulnCheck KEV prefill:** operators may run
      `node scripts/vulncheck-kev-intake.mjs --dry-run --out <artifact.json>`
-     to inspect recent VulnCheck KEV candidates before selecting or enriching
-     zero-day source packets. The output preserves CVEs, CWEs, vendor/product,
-     ransomware-use field, canary signal, exploitation URLs, XDB references,
-     `date_added`, `cisa_date_added`, and `dueDate`. The output is
-     `prefill_only` and marks `drafting_allowed: false`.
+     to inspect VulnCheck KEV candidates before selecting or enriching zero-day
+     source packets. Scheduled production discovery runs `--execute`, writes
+     artifacts under `.github/pipeline/source-packets/vulncheck-kev/`, and
+     opens/updates the discovery PR for review. The output preserves CVEs,
+     CWEs, vendor/product, ransomware-use field, canary signal, exploitation
+     URLs, XDB references, `date_added`, `cisa_date_added`, and `dueDate`. The
+     output is `prefill_only` and marks `drafting_allowed: false`.
 
 8. **Validation gate**
    - `--validate` enforces `.github/pipeline/config.yml` `validation.*`

--- a/scripts/pipeline-config.mjs
+++ b/scripts/pipeline-config.mjs
@@ -75,12 +75,16 @@ export const DEFAULTS = Object.freeze({
   discovery_sources: {
     cisa_kev: { enabled: true },
     vulncheck_kev: {
-      enabled: false,
+      enabled: true,
       backup_url: 'https://api.vulncheck.com/v3/backup/vulncheck-kev',
       lookback_days: 30,
-      max_candidates: 25,
+      max_candidates: 10,
+      backlog_fill: true,
+      sibling_limit_per_vendor_product_day: 4,
       local_throttle_ms: 250,
       cache_ttl_minutes: 60,
+      source_packet_dir: '.github/pipeline/source-packets/vulncheck-kev',
+      candidate_index_path: '.github/pipeline/source-packets/vulncheck-kev/latest.json',
     },
     nvd: { enabled: true, lookback_days: 7, min_cvss: 7.0 },
     cisa_alerts: {

--- a/scripts/test-vulncheck-kev-intake.mjs
+++ b/scripts/test-vulncheck-kev-intake.mjs
@@ -65,9 +65,15 @@ assert.equal(result.mode, 'dry-run');
 assert.equal(result.drafting_enabled, false);
 assert.equal(result.summary.records_loaded, 3);
 assert.equal(result.summary.candidates_in_lookback, 2);
+assert.equal(result.summary.backlog_candidates_considered, 1);
 assert.equal(result.summary.already_seen_filtered, 1);
-assert.equal(result.summary.candidates_emitted, 1);
+assert.equal(result.summary.candidates_emitted, 2);
+assert.equal(result.summary.recent_emitted, 1);
+assert.equal(result.summary.backlog_emitted, 1);
 assert.equal(result.candidates[0].cves[0], 'CVE-2026-0003');
+assert.equal(result.candidates[0].recency_bucket, 'recent');
+assert.equal(result.candidates[1].cves[0], 'CVE-2026-0001');
+assert.equal(result.candidates[1].recency_bucket, 'backlog');
 assert.equal(result.candidates[0].drafting_allowed, false);
 assert.equal(result.candidates[0].official_cisa_kev.listed, true);
 assert.equal(result.candidates[0].official_cisa_kev.date_added, '2026-06-11');
@@ -76,6 +82,29 @@ assert.equal(result.candidates[0].vulncheck_exploitation_signal.xdb_exploit_type
 assert.equal(result.candidates[0].source_packet_prefill.status, 'prefill_only');
 assert.equal(result.candidates[0].source_packet_prefill.source_quality.source_sufficiency, 'needs_human_review');
 assert.match(result.candidates[0].source_packet_prefill.authority_boundary.instruction, /verify CISA KEV membership/);
+
+const noBacklog = buildRecentIntake(fixture, {
+  lookbackDays: 30,
+  maxCandidates: 25,
+  asOf: '2026-06-11',
+  seenCves: new Set(['CVE-2026-0002']),
+  backlogFill: false,
+});
+
+assert.equal(noBacklog.summary.backlog_candidates_considered, 0);
+assert.deepEqual(noBacklog.candidates.map(candidate => candidate.cves[0]), ['CVE-2026-0003']);
+
+const liveMode = buildRecentIntake(fixture, {
+  lookbackDays: 30,
+  maxCandidates: 1,
+  asOf: '2026-06-11',
+  seenCves: new Set(),
+  execute: true,
+});
+
+assert.equal(liveMode.mode, 'live');
+assert.equal(liveMode.drafting_enabled, false);
+assert.equal(liveMode.candidates[0].drafting_allowed, false);
 
 const includeSeen = buildRecentIntake(fixture, {
   lookbackDays: 30,

--- a/scripts/vulncheck-kev-intake.mjs
+++ b/scripts/vulncheck-kev-intake.mjs
@@ -2,11 +2,12 @@
 /**
  * ROAD-014 Slice 1: bounded recent-first VulnCheck KEV intake.
  *
- * This helper is intentionally dry-run/source-packet-prefill only. It fetches
- * the VulnCheck KEV backup once per run, selects recent entries by top-level
+ * This helper is intentionally source-packet-prefill only. It fetches the
+ * VulnCheck KEV backup once per run, selects recent entries by top-level
  * date_added, filters already-seen CVEs, and emits prioritization artifacts.
- * It does not create tasks, draft articles, or treat VulnCheck as official
- * CISA KEV authority.
+ * Production mode writes source-packet prefill artifacts only; it does not
+ * create article tasks, draft articles, or treat VulnCheck as official CISA
+ * KEV authority.
  */
 
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
@@ -24,6 +25,9 @@ const DEFAULT_LOOKBACK_DAYS = 30;
 const DEFAULT_MAX_CANDIDATES = 25;
 const DEFAULT_LOCAL_THROTTLE_MS = 250;
 const DEFAULT_CACHE_TTL_MINUTES = 60;
+const DEFAULT_SOURCE_PACKET_DIR = '.github/pipeline/source-packets/vulncheck-kev';
+const DEFAULT_CANDIDATE_INDEX_PATH = '.github/pipeline/source-packets/vulncheck-kev/latest.json';
+const DEFAULT_SIBLING_LIMIT = 4;
 const CVE_RE = /\bCVE-\d{4}-\d{4,}\b/gi;
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -31,13 +35,19 @@ export function usage() {
   console.log([
     'Usage:',
     '  node scripts/vulncheck-kev-intake.mjs --dry-run [options]',
+    '  node scripts/vulncheck-kev-intake.mjs --execute [options]',
     '',
     'Options:',
+    '  --execute                       Write production source-packet prefill artifacts',
     '  --input <backup.json>            Read a saved VulnCheck KEV backup JSON instead of fetching',
     '  --out <path>                     Write dry-run artifact JSON to this path',
+    '  --source-packet-dir <path>       Production prefill artifact directory',
+    '  --candidate-index <path>         Production latest candidate index path',
     '  --env-file <path>                Explicit key=value env file for VULNCHECKAPI or VULNCHECK_API_TOKEN',
     '  --lookback-days <n>              Recent window, default from config or 30',
     '  --max-candidates <n>             Maximum emitted candidates, default from config or 25',
+    '  --disable-backlog-fill           Do not fill from older unhandled candidates after recent window',
+    '  --sibling-limit <n>              Max emitted sibling CVEs per vendor/product/date, default 4',
     '  --as-of <YYYY-MM-DD>             Deterministic date for lookback cutoff, default today UTC',
     '  --cache <path>                   Optional backup cache path',
     '  --cache-ttl-minutes <n>          Cache TTL, default from config or 60',
@@ -52,11 +62,16 @@ export function usage() {
 export function parseArgs(argv) {
   const args = {
     dryRun: true,
+    execute: false,
     input: null,
     out: null,
+    sourcePacketDir: null,
+    candidateIndex: null,
     envFile: null,
     lookbackDays: null,
     maxCandidates: null,
+    backlogFill: null,
+    siblingLimit: null,
     asOf: null,
     cache: null,
     cacheTtlMinutes: null,
@@ -72,6 +87,11 @@ export function parseArgs(argv) {
     switch (token) {
       case '--dry-run':
         args.dryRun = true;
+        args.execute = false;
+        break;
+      case '--execute':
+        args.execute = true;
+        args.dryRun = false;
         break;
       case '--input':
         if (!next) throw new Error('Missing value for --input');
@@ -81,6 +101,16 @@ export function parseArgs(argv) {
       case '--out':
         if (!next) throw new Error('Missing value for --out');
         args.out = next;
+        i += 1;
+        break;
+      case '--source-packet-dir':
+        if (!next) throw new Error('Missing value for --source-packet-dir');
+        args.sourcePacketDir = next;
+        i += 1;
+        break;
+      case '--candidate-index':
+        if (!next) throw new Error('Missing value for --candidate-index');
+        args.candidateIndex = next;
         i += 1;
         break;
       case '--env-file':
@@ -96,6 +126,14 @@ export function parseArgs(argv) {
       case '--max-candidates':
         if (!next) throw new Error('Missing value for --max-candidates');
         args.maxCandidates = positiveInteger(next, '--max-candidates');
+        i += 1;
+        break;
+      case '--disable-backlog-fill':
+        args.backlogFill = false;
+        break;
+      case '--sibling-limit':
+        if (!next) throw new Error('Missing value for --sibling-limit');
+        args.siblingLimit = positiveInteger(next, '--sibling-limit');
         i += 1;
         break;
       case '--as-of':
@@ -192,11 +230,16 @@ function loadConfigDefaults(args) {
   const config = loadPipelineConfig();
   const vc = config.discovery_sources?.vulncheck_kev || {};
   return {
+    enabled: vc.enabled === true,
     endpoint: args.endpoint || vc.backup_url || DEFAULT_ENDPOINT,
     lookbackDays: args.lookbackDays || vc.lookback_days || DEFAULT_LOOKBACK_DAYS,
     maxCandidates: args.maxCandidates || vc.max_candidates || DEFAULT_MAX_CANDIDATES,
     localThrottleMs: args.localThrottleMs || vc.local_throttle_ms || DEFAULT_LOCAL_THROTTLE_MS,
     cacheTtlMinutes: args.cacheTtlMinutes || vc.cache_ttl_minutes || DEFAULT_CACHE_TTL_MINUTES,
+    backlogFill: args.backlogFill ?? (vc.backlog_fill !== false),
+    siblingLimit: args.siblingLimit || vc.sibling_limit_per_vendor_product_day || DEFAULT_SIBLING_LIMIT,
+    sourcePacketDir: args.sourcePacketDir || vc.source_packet_dir || DEFAULT_SOURCE_PACKET_DIR,
+    candidateIndex: args.candidateIndex || vc.candidate_index_path || DEFAULT_CANDIDATE_INDEX_PATH,
   };
 }
 
@@ -406,6 +449,20 @@ function candidateKey(record) {
   return `vulncheck-kev:${cves}:${normalizeDate(record.date_added) || 'unknown-date'}`;
 }
 
+function candidateFileStem(candidate) {
+  const cve = candidate.cves[0] || 'unknown-cve';
+  const date = candidate.vulncheck_date_added || 'unknown-date';
+  return `prefill-${cve.toLowerCase()}-${date}`;
+}
+
+function siblingKey(candidate) {
+  return [
+    String(candidate.vendorProject || 'unknown').toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+    String(candidate.product || 'unknown').toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+    candidate.vulncheck_date_added || 'unknown-date',
+  ].join(':');
+}
+
 function sourceRefsFor(record) {
   const urls = [];
   for (const item of Array.isArray(record.vulncheck_reported_exploitation) ? record.vulncheck_reported_exploitation : []) {
@@ -533,7 +590,7 @@ function makePrefill(record) {
   };
 }
 
-function toCandidate(record, seenCves) {
+function toCandidate(record, seenCves, recencyBucket = 'recent') {
   const cves = uniqueStrings(record.cve);
   const addedDate = normalizeDate(record.date_added);
   const seenMatches = cves.filter(cve => seenCves.has(cve));
@@ -548,6 +605,7 @@ function toCandidate(record, seenCves) {
     vulnerabilityName: record.vulnerabilityName || null,
     shortDescription: record.shortDescription || null,
     vulncheck_date_added: addedDate,
+    recency_bucket: recencyBucket,
     already_seen: cves.length > 0 && seenMatches.length === cves.length,
     seen_cves: seenMatches,
     priority_score: priority.score,
@@ -583,6 +641,8 @@ export function buildRecentIntake(payload, options = {}) {
   const cutoffMs = asOfMs - (lookbackDays * 24 * 60 * 60 * 1000);
   const cutoffDate = new Date(cutoffMs).toISOString().slice(0, 10);
   const seenCves = options.seenCves instanceof Set ? options.seenCves : new Set(options.seenCves || []);
+  const backlogFill = options.backlogFill !== false;
+  const siblingLimit = options.siblingLimit || DEFAULT_SIBLING_LIMIT;
 
   const records = asRecords(payload);
   const withDates = records
@@ -590,14 +650,30 @@ export function buildRecentIntake(payload, options = {}) {
     .filter(item => item.timestamp !== null)
     .sort((a, b) => b.timestamp - a.timestamp);
   const recent = withDates.filter(item => item.timestamp >= cutoffMs && item.timestamp <= asOfMs);
-  const mapped = recent.map(item => toCandidate(item.record, seenCves));
+  const backlog = withDates.filter(item => item.timestamp < cutoffMs);
+  const mappedRecent = recent.map(item => toCandidate(item.record, seenCves, 'recent'));
+  const mappedBacklog = backlogFill ? backlog.map(item => toCandidate(item.record, seenCves, 'backlog')) : [];
+  const mapped = [...mappedRecent, ...mappedBacklog];
   const filtered = options.includeSeen ? mapped : mapped.filter(candidate => !candidate.already_seen);
-  const candidates = filtered.slice(0, maxCandidates);
+  const siblingCounts = new Map();
+  const candidates = [];
+  let siblingDampened = 0;
+  for (const candidate of filtered) {
+    const key = siblingKey(candidate);
+    const count = siblingCounts.get(key) || 0;
+    if (count >= siblingLimit) {
+      siblingDampened += 1;
+      continue;
+    }
+    siblingCounts.set(key, count + 1);
+    candidates.push(candidate);
+    if (candidates.length >= maxCandidates) break;
+  }
 
   return {
     schema_version: 'vulncheck-kev-recent-intake/1',
     generated_at: new Date().toISOString(),
-    mode: 'dry-run',
+    mode: options.execute ? 'live' : 'dry-run',
     drafting_enabled: false,
     source: {
       publisher: 'VulnCheck',
@@ -614,16 +690,75 @@ export function buildRecentIntake(payload, options = {}) {
       cutoff_date: cutoffDate,
       sort: 'date_added desc',
       seen_filter_enabled: !options.includeSeen,
+      backlog_fill_enabled: backlogFill,
+      sibling_limit_per_vendor_product_day: siblingLimit,
     },
     summary: {
       records_loaded: records.length,
       records_with_date_added: withDates.length,
-      candidates_in_lookback: mapped.length,
+      candidates_in_lookback: mappedRecent.length,
+      backlog_candidates_considered: mappedBacklog.length,
       already_seen_filtered: options.includeSeen ? 0 : mapped.filter(candidate => candidate.already_seen).length,
+      sibling_dampened: siblingDampened,
       candidates_emitted: candidates.length,
+      recent_emitted: candidates.filter(candidate => candidate.recency_bucket === 'recent').length,
+      backlog_emitted: candidates.filter(candidate => candidate.recency_bucket === 'backlog').length,
     },
     candidates,
   };
+}
+
+function productionPacketFor(candidate) {
+  return {
+    schema_version: 'vulncheck-kev-prefill/1',
+    generated_at: new Date().toISOString(),
+    source: {
+      publisher: 'VulnCheck',
+      dataset: 'VulnCheck KEV',
+      attribution_required: true,
+      attribution_label: 'VulnCheck KEV',
+    },
+    candidate: {
+      candidate_key: candidate.candidate_key,
+      cves: candidate.cves,
+      recency_bucket: candidate.recency_bucket,
+      priority_score: candidate.priority_score,
+      priority_reasons: candidate.priority_reasons,
+      official_cisa_kev: candidate.official_cisa_kev,
+      vulncheck_exploitation_signal: candidate.vulncheck_exploitation_signal,
+      drafting_allowed: false,
+    },
+    source_packet_prefill: candidate.source_packet_prefill,
+  };
+}
+
+function writeProductionArtifacts(result, defaults) {
+  if (!defaults.enabled) {
+    throw new Error('VulnCheck KEV production intake is disabled in config (discovery_sources.vulncheck_kev.enabled=false)');
+  }
+  if (result.candidates.length === 0) {
+    return { index: null, packets: [] };
+  }
+  const packetDir = defaults.sourcePacketDir;
+  const written = [];
+  for (const candidate of result.candidates) {
+    const packetPath = join(packetDir, `${candidateFileStem(candidate)}.json`);
+    writeJson(packetPath, productionPacketFor(candidate));
+    candidate.production_artifact = packetPath;
+    written.push(packetPath);
+  }
+  writeJson(defaults.candidateIndex, {
+    ...result,
+    production: {
+      artifact_type: 'source-packet-prefill',
+      candidate_index_path: defaults.candidateIndex,
+      source_packet_dir: packetDir,
+      artifacts_written: written,
+      article_tasks_created: 0,
+      drafting_enabled: false,
+    },
+  });
+  return { index: defaults.candidateIndex, packets: written };
 }
 
 async function run() {
@@ -633,6 +768,7 @@ async function run() {
   const seenCves = collectSeenCves(args.seenCves);
   const result = buildRecentIntake(payload, {
     ...defaults,
+    execute: args.execute,
     asOf: args.asOf,
     endpoint: defaults.endpoint,
     seenCves,
@@ -640,6 +776,9 @@ async function run() {
   });
   result.input_source = source;
 
+  if (args.execute) {
+    result.production = writeProductionArtifacts(result, defaults);
+  }
   if (args.out) writeJson(args.out, result);
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 }


### PR DESCRIPTION
## Summary
- enables VulnCheck KEV as live source-packet/candidate prefill intake, not article drafting
- writes newest-first VulnCheck KEV prefill artifacts and latest candidate index under .github/pipeline/source-packets/vulncheck-kev/
- keeps CISA KEV, CVE identity, and VulnCheck exploitation signal fields separate
- updates discovery workflow so scheduled runs stage prefill artifacts in the normal discovery PR
- tunes discovery default to 10 candidates per 6-hour run for a 40/day candidate supply ceiling

## Guardrails
- no article content changes
- no VulnCheck-only drafting path
- no task files generated by VulnCheck lane
- no credential files committed
- rollback: set discovery_sources.vulncheck_kev.enabled=false

## Validation
- cd scripts && npm ci --no-audit --no-fund
- node --check scripts/vulncheck-kev-intake.mjs
- node --check scripts/test-vulncheck-kev-intake.mjs
- node --check scripts/pipeline-config.mjs
- node scripts/test-vulncheck-kev-intake.mjs
- node scripts/pipeline-config.mjs --section discovery_sources
- YAML/JSON guard for discovery workflow, config, generated prefill artifacts
- git diff --check
- live canary dry-run with root .env token
- live production execute run with root .env token

## Live run summary
- records loaded: 4952
- records with date_added: 4952
- candidates in 30-day lookback: 62
- backlog candidates considered: 4890
- already-seen filtered: 113
- sibling dampened: 0
- emitted: 10 all recent, newest-first
- article tasks created: 0