### PR TITLE
[codex] document lane provenance metadata

### DIFF
--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -34,9 +34,9 @@ bulk-support lanes are out of scope here (see ADR 0009).
 ```
 
 No API key is required on the scheduled path. Article generation happens
-**inside an agent's own subscription** (Claude Code, Gemini, or a human typing)
-when the dispatcher hands off the task. This keeps the pipeline
-agent-agnostic and lets it scale without centralizing model spend.
+**inside an approved agent/model lane or a human-operated session** when the
+dispatcher hands off the task. This keeps the pipeline agent-agnostic and lets
+it scale without centralizing model spend.
 
 `scripts/generate-article.mjs` is **legacy / manual only** — it calls the
 Claude API directly and is not used by any scheduled workflow. Retain for
@@ -200,8 +200,8 @@ discovery queues are open, validated, and stable.
      non-media sources unless one government source is present.
    - Article frontmatter may include an optional `generation` object for
      internal auditability. When present, it must include non-empty `provider`
-     and `model` fields and may include `tool`, `agent`, and `promptProfile`.
-     This metadata is not rendered in the public article UI.
+     and `model` fields and may include `tool`, `agent`, `lane`, `surface`, and
+     `promptProfile`. This metadata is not rendered in the public article UI.
    - Framework mappings are validated against the public schema mirror and
      pinned framework data where available. New ATT&CK mappings should declare
      `attack-version: "v19"` or `attack-version: "v19.0"` unless the task is
@@ -324,8 +324,10 @@ workflow language such as "this article," "this report," `reviewStatus`,
 `draft_ai`, "attribution confidence," or "confidence grade." Those values can
 exist in frontmatter or operator notes where appropriate. Optional `generation`
 model provenance metadata can also exist in frontmatter for auditability, but
-must not be narrated in public prose. Public article prose should describe the
-evidence basis directly rather than narrating
+must not be narrated in public prose. Optional `generation.lane` and
+`generation.surface` fields identify the producer lane and execution surface
+for review/audit only. Public article prose should describe the evidence basis
+directly rather than narrating
 Threatpedia's internal scoring or editorial process.
 
 **Config authority:** `pipeline-dispatcher.yml` now reads thresholds from

--- a/docs/bot-automation-processes.md
+++ b/docs/bot-automation-processes.md
@@ -1,5 +1,12 @@
 # Threatpedia Bot Automation Processes
 
+> **Status note (2026-06-12):** This is a legacy automation-process reference.
+> Current fresh-content pipeline behavior, review-gate semantics, and
+> provenance rules are governed by [`docs/PIPELINE.md`](PIPELINE.md). Any
+> Gemini-specific "must pass Gemini Code Assist" language below should be read
+> as legacy guidance superseded by the configured current-head AI reviewer model
+> in the pipeline docs.
+
 ## Overview
 
 Threatpedia automation is coordinated through scheduled agent tasks that execute on defined schedules across 11 active pipelines: new threat intelligence discovery, incident enrichment, gap-fill reporting, glossary term management, threat actor linking, zero-day tracking, source research, scraper development, data ingestion, and bot-assisted code review. All tasks follow a standardized workflow that includes:
@@ -63,7 +70,7 @@ Security is non-negotiable in all automation processes. The following rules prot
 - **Never commit unvalidated data** — failed validation should cause task to abort and report
 
 ### PR Review and Merging
-- **All PRs must pass Gemini Code Assist review** before owner account merges
+- **All PRs must satisfy the current configured review-gate model** before owner account merges
 - **Critical and high-priority findings** must be fixed before merge
 - **Medium and low findings** should also be reviewed before merge; if one is deferred, the deferment must be explicit and owned by the merger
 - **Reply to actionable Gemini comments** with the fix or disposition before resolving the thread

--- a/scripts/pipeline-run-task.mjs
+++ b/scripts/pipeline-run-task.mjs
@@ -170,6 +170,8 @@ const GENERATION_METADATA_SCHEMA = `  generation: object (optional; non-rendered
     model: string (required when generation is present; exact model identifier used for drafting)
     tool: string (optional; e.g., "claude-cli", "codex", "gemini-cli")
     agent: string (optional; must be a canonical generatedBy identity)
+    lane: string (optional; drafting lane or worker lane)
+    surface: string (optional; execution surface or wrapper)
     promptProfile: string (optional; worker or prompt profile name)`;
 
 // ── Schemas per content type ────────────────────────────────────────────────
@@ -363,7 +365,7 @@ function buildRules(task) {
   11. MITRE tactic casing must use the canonical ATT&CK vocabulary; new mappings should declare attack-version "v19" or "v19.0" unless preserving a legacy article version; optional metadata must use confidence ${SCHEMA_MAPPING_CONFIDENCE_VALUES.join(' | ')} and non-empty evidence when present
   12. Do not bulk-assign or preserve Defense Evasion for ATT&CK v19 split cases without article-supported review; use the pinned v19 data and omit uncertain mappings rather than guessing
   13. framework-mappings are optional and currently only allowed for source-supported adversarial AI/ML behavior; MITRE ATLAS entries require framework: mitre-atlas and mapping-id AML.T####[.###]
-  14. Optional generation metadata is allowed only in frontmatter, not public prose; if present it must include non-empty provider and model fields
+  14. Optional generation metadata is allowed only in frontmatter, not public prose; if present it must include non-empty provider and model fields and may include lane/surface for provenance
   15. Do not add ATLAS because a topic is broadly AI-adjacent; require article evidence that an AI/ML system was targeted, abused as tooling, bypassed as a control, or compromised in the ML supply chain
   16. Canonical publisher aliases must be normalized in frontmatter and body
   17. The Astro build must pass: cd site && npm run build`;

--- a/scripts/pipeline-schema.mjs
+++ b/scripts/pipeline-schema.mjs
@@ -104,6 +104,8 @@ export const SCHEMA_GENERATION_METADATA_REQUIRED_FIELDS = Object.freeze([
 export const SCHEMA_GENERATION_METADATA_OPTIONAL_FIELDS = Object.freeze([
   'tool',
   'agent',
+  'lane',
+  'surface',
   'promptProfile',
 ]);
 

--- a/scripts/public-prose-guardrails.mjs
+++ b/scripts/public-prose-guardrails.mjs
@@ -17,7 +17,7 @@ const PUBLIC_PROSE_GUARDRAILS = [
   },
   {
     label: 'internal generation-metadata leakage',
-    regex: /\b(?:generation[-\s\u2013\u2014]*metadata|model[-\s\u2013\u2014]*provenance[-\s\u2013\u2014]*metadata|generated(?:By|Date)|generation\.(?:provider|model|tool|agent|promptProfile)|prompt[-\s\u2013\u2014]*profile|model\s+used\s+to\s+generate\s+this\s+(?:article|report|assessment|write[- \u2013\u2014]?ups?))\b/i,
+    regex: /\b(?:generation[-\s\u2013\u2014]*metadata|model[-\s\u2013\u2014]*provenance[-\s\u2013\u2014]*metadata|generated(?:By|Date)|generation\.(?:provider|model|tool|agent|lane|surface|promptProfile)|prompt[-\s\u2013\u2014]*profile|model\s+used\s+to\s+generate\s+this\s+(?:article|report|assessment|write[- \u2013\u2014]?ups?))\b/i,
   },
 ];
 

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -42,6 +42,8 @@ const generationMetadata = z.object({
   model: z.string().min(1),
   tool: z.string().min(1).optional(),
   agent: generatedBy.optional(),
+  lane: z.string().min(1).optional(),
+  surface: z.string().min(1).optional(),
   promptProfile: z.string().min(1).optional(),
 }).strict();
 


### PR DESCRIPTION
## What changed

- Adds optional `generation.lane` and `generation.surface` provenance fields to the public Astro schema and validator mirror.
- Updates pipeline docs to describe approved agent/model lanes instead of naming specific subscriptions.
- Marks the old bot automation runbook as legacy where it conflicts with current review-gate semantics.

## Validation

- `git diff --check`
- `node scripts/pipeline-schema.mjs`
- `node -e "import('./scripts/public-prose-guardrails.mjs')..."`
- `cd scripts && npm ci --no-audit --no-fund`
- `node scripts/validate-content-corpus.mjs --files-file <empty>`
- `node scripts/pipeline-run-task.mjs --list`
- `cd site && npm ci`
- `cd site && npm run build`

## Notes

- This does not render provenance metadata publicly.
- Build passed with existing campaign related-incident warnings.