### PR TITLE
fix(pipeline): gate source-packet review batches

### DIFF
--- a/.github/workflows/pipeline-review-gate.yml
+++ b/.github/workflows/pipeline-review-gate.yml
@@ -32,7 +32,7 @@ jobs:
       (
         github.event_name == 'pull_request_review' &&
         contains(
-          fromJSON('["gemini-code-assist", "gemini-code-assist[bot]", "dangermouse-bot", "ernestpenfold-bot"]'),
+          fromJSON('["chatgpt-codex-connector", "chatgpt-codex-connector[bot]", "gemini-code-assist", "gemini-code-assist[bot]", "dangermouse-bot", "ernestpenfold-bot"]'),
           github.event.review.user.login
         )
       ) ||

--- a/scripts/pipeline-review-gate.mjs
+++ b/scripts/pipeline-review-gate.mjs
@@ -11,6 +11,8 @@
 import { PIPELINE_TASK_FILE_PATH_RE } from './pipeline-task-patterns.mjs';
 
 const DEFAULT_AI_REVIEW_LOGINS = [
+  'chatgpt-codex-connector',
+  'chatgpt-codex-connector[bot]',
   'gemini-code-assist',
   'gemini-code-assist[bot]',
   'dangermouse-bot',
@@ -18,6 +20,7 @@ const DEFAULT_AI_REVIEW_LOGINS = [
 ];
 const CONTENT_FILE_RE = /^site\/src\/content\/(?:incidents|campaigns|threat-actors|zero-days)\/.+\.mdx?$/;
 const PUBLIC_SITE_FILE_RE = /^site\/(?:src\/|package(?:-lock)?\.json$|astro\.config\.)/;
+const SOURCE_PACKET_FILE_RE = /^\.github\/pipeline\/source-packets\/.+\.json$/;
 const PIPELINE_FILE_RE = /^(?:scripts\/|\.github\/workflows\/|\.github\/pipeline\/config\.yml$|docs\/PIPELINE\.md$|site\/src\/content\.config\.ts$)/;
 
 function parseArgs(argv) {
@@ -90,6 +93,7 @@ function isAiLogin(login, aiLogins) {
 function isRelevantFile(path) {
   return CONTENT_FILE_RE.test(path)
     || PUBLIC_SITE_FILE_RE.test(path)
+    || SOURCE_PACKET_FILE_RE.test(path)
     || PIPELINE_FILE_RE.test(path)
     || PIPELINE_TASK_FILE_PATH_RE.test(path);
 }


### PR DESCRIPTION
## Summary
- include .github/pipeline/source-packets/*.json changes in pipeline-review-gate relevance
- recognize chatgpt-codex-connector and chatgpt-codex-connector[bot] as AI reviewers in the default gate login list

## Verification
- node --check scripts/pipeline-review-gate.mjs
- GITHUB_TOKEN=... node scripts/pipeline-review-gate.mjs --repo MahdiHedhli/threatpedia --pr 1125 --json -> still fails for missing current-head AI review object
- GITHUB_TOKEN=... node scripts/pipeline-review-gate.mjs --repo MahdiHedhli/threatpedia --pr 1126 --json -> applicable=true, recognizes Codex AI review, fails on 1 unresolved current AI thread

## Notes
This is a review-gate logic change and needs non-author review before merge.