### PR TITLE
Add supply chain incident corpus phase 1A

### DIFF
--- a/data/supply-chain-incidents/incidents.json
+++ b/data/supply-chain-incidents/incidents.json
@@ -155,7 +155,7 @@
     "title": "ASUS Live Update Operation ShadowHammer",
     "summary": "Attackers compromised the ASUS Live Update utility and distributed signed malicious updates to selected downstream systems.",
     "status": "confirmed",
-    "first_observed_at": "2019-01-01",
+    "first_observed_at": "2018-06-01",
     "disclosed_at": "2019-03-25",
     "affected_ecosystems": ["windows", "vendor-update"],
     "affected_components": [

--- a/data/supply-chain-incidents/incidents.json
+++ b/data/supply-chain-incidents/incidents.json
@@ -1,0 +1,766 @@
+[
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2016-LINUX-MINT-ISO",
+    "title": "Linux Mint ISO distribution site compromise",
+    "summary": "Attackers modified Linux Mint download infrastructure so some users received a backdoored ISO image instead of the legitimate distribution image.",
+    "status": "confirmed",
+    "first_observed_at": "2016-02-20",
+    "disclosed_at": "2016-02-21",
+    "affected_ecosystems": ["linux", "distribution-website"],
+    "affected_components": [
+      {
+        "component_type": "website",
+        "ecosystem": "linux",
+        "name": "Linux Mint ISO downloads",
+        "vendor": "Linux Mint",
+        "package_url": null
+      }
+    ],
+    "supply_chain_vectors": ["distribution_site_compromise"],
+    "impact_categories": ["malware_distribution", "backdoor"],
+    "references": [
+      {
+        "title": "Beware of hacked ISOs if you downloaded Linux Mint on February 20th",
+        "publisher": "Linux Mint",
+        "url": "https://blog.linuxmint.com/?p=2994",
+        "published_at": "2016-02-21"
+      }
+    ],
+    "tags": ["iso", "distribution"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2017-NOTPETYA-MEDOC",
+    "title": "NotPetya distributed through M.E.Doc update channel",
+    "summary": "The NotPetya destructive malware outbreak was seeded through a compromised Ukrainian accounting software update mechanism used by M.E.Doc customers.",
+    "status": "confirmed",
+    "first_observed_at": "2017-06-27",
+    "disclosed_at": "2017-07-01",
+    "affected_ecosystems": ["windows", "vendor-update"],
+    "affected_components": [
+      {
+        "component_type": "software",
+        "ecosystem": "windows",
+        "name": "M.E.Doc",
+        "vendor": "Intellect Service",
+        "package_url": null
+      }
+    ],
+    "supply_chain_vectors": ["vendor_update_compromise"],
+    "impact_categories": ["destructive_payload", "ransomware_delivery", "downstream_customer_compromise"],
+    "references": [
+      {
+        "title": "Petya Ransomware",
+        "publisher": "CISA",
+        "url": "https://www.cisa.gov/news-events/alerts/2017/07/01/petya-ransomware",
+        "published_at": "2017-07-01"
+      }
+    ],
+    "tags": ["notpetya", "software-update"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2017-CCLEANER",
+    "title": "CCleaner signed installer compromise",
+    "summary": "A legitimate CCleaner release was modified and signed, distributing malware to downstream users through the normal software update and download path.",
+    "status": "confirmed",
+    "first_observed_at": "2017-08-15",
+    "disclosed_at": "2017-09-18",
+    "affected_ecosystems": ["windows", "vendor-update"],
+    "affected_components": [
+      {
+        "component_type": "software",
+        "ecosystem": "windows",
+        "name": "CCleaner",
+        "vendor": "Piriform",
+        "package_url": null
+      }
+    ],
+    "supply_chain_vectors": ["signed_update_compromise"],
+    "impact_categories": ["malware_distribution", "backdoor"],
+    "references": [
+      {
+        "title": "CCleaner Command and Control Causes Concern",
+        "publisher": "Cisco Talos",
+        "url": "https://blog.talosintelligence.com/ccleaner-c2-concern/",
+        "published_at": "2017-09-18"
+      }
+    ],
+    "tags": ["signed-update", "windows"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2018-ESLINT-SCOPE",
+    "title": "eslint-scope npm package credential-stealing release",
+    "summary": "An attacker used compromised npm maintainer credentials to publish malicious eslint-scope and eslint-config-eslint releases that attempted to steal npm tokens.",
+    "status": "confirmed",
+    "first_observed_at": "2018-07-12",
+    "disclosed_at": "2018-07-12",
+    "affected_ecosystems": ["npm"],
+    "affected_components": [
+      {
+        "component_type": "package",
+        "ecosystem": "npm",
+        "name": "eslint-scope",
+        "vendor": "ESLint",
+        "package_url": "pkg:npm/eslint-scope"
+      }
+    ],
+    "supply_chain_vectors": ["maintainer_account_compromise", "package_repository_compromise"],
+    "impact_categories": ["credential_theft", "developer_workstation_compromise"],
+    "references": [
+      {
+        "title": "Postmortem for Malicious Package Publishes",
+        "publisher": "ESLint",
+        "url": "https://eslint.org/blog/2018/07/postmortem-for-malicious-package-publishes/",
+        "published_at": "2018-07-12"
+      }
+    ],
+    "tags": ["npm", "maintainer-account"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2018-NPM-EVENT-STREAM",
+    "title": "event-stream malicious dependency insertion",
+    "summary": "A maintainer transfer enabled a malicious dependency to be added to the event-stream npm package dependency tree, targeting downstream cryptocurrency wallet software.",
+    "status": "confirmed",
+    "first_observed_at": "2018-09-09",
+    "disclosed_at": "2018-11-26",
+    "affected_ecosystems": ["npm"],
+    "affected_components": [
+      {
+        "component_type": "package",
+        "ecosystem": "npm",
+        "name": "event-stream",
+        "vendor": "open source maintainers",
+        "package_url": "pkg:npm/event-stream"
+      }
+    ],
+    "supply_chain_vectors": ["malicious_dependency"],
+    "impact_categories": ["credential_theft", "crypto_theft"],
+    "references": [
+      {
+        "title": "I don't have time to maintain this package",
+        "publisher": "GitHub",
+        "url": "https://github.com/dominictarr/event-stream/issues/116",
+        "published_at": "2018-11-26"
+      }
+    ],
+    "tags": ["npm", "dependency"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2019-ASUS-SHADOWHAMMER",
+    "title": "ASUS Live Update Operation ShadowHammer",
+    "summary": "Attackers compromised the ASUS Live Update utility and distributed signed malicious updates to selected downstream systems.",
+    "status": "confirmed",
+    "first_observed_at": "2019-01-01",
+    "disclosed_at": "2019-03-25",
+    "affected_ecosystems": ["windows", "vendor-update"],
+    "affected_components": [
+      {
+        "component_type": "update_channel",
+        "ecosystem": "windows",
+        "name": "ASUS Live Update",
+        "vendor": "ASUS",
+        "package_url": null
+      }
+    ],
+    "supply_chain_vectors": ["signed_update_compromise"],
+    "impact_categories": ["malware_distribution", "backdoor"],
+    "references": [
+      {
+        "title": "Operation ShadowHammer",
+        "publisher": "Kaspersky Securelist",
+        "url": "https://securelist.com/operation-shadowhammer/89992/",
+        "published_at": "2019-03-25"
+      }
+    ],
+    "tags": ["signed-update", "targeted"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2020-OCTOPUS-SCANNER",
+    "title": "Octopus Scanner malicious NetBeans project campaign",
+    "summary": "Malicious code planted in open source NetBeans projects propagated through developer builds and attempted to infect additional projects.",
+    "status": "confirmed",
+    "first_observed_at": "2020-03-01",
+    "disclosed_at": "2020-03-09",
+    "affected_ecosystems": ["java", "source-repository"],
+    "affected_components": [
+      {
+        "component_type": "project",
+        "ecosystem": "java",
+        "name": "NetBeans projects",
+        "vendor": "multiple open source maintainers",
+        "package_url": null
+      }
+    ],
+    "supply_chain_vectors": ["source_repository_compromise", "build_system_compromise"],
+    "impact_categories": ["developer_workstation_compromise", "malware_distribution"],
+    "references": [
+      {
+        "title": "Octopus Scanner Malware: Open Source Supply Chain",
+        "publisher": "GitHub Security Lab",
+        "url": "https://github.blog/security/vulnerability-research/octopus-scanner-malware-open-source-supply-chain/",
+        "published_at": "2020-03-09"
+      }
+    ],
+    "tags": ["github", "java"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2020-SOLARWINDS-ORION",
+    "title": "SolarWinds Orion software build compromise",
+    "summary": "Attackers compromised the SolarWinds Orion build process and inserted the SUNBURST backdoor into signed software updates delivered to customers.",
+    "status": "confirmed",
+    "first_observed_at": "2020-03-01",
+    "disclosed_at": "2020-12-13",
+    "affected_ecosystems": ["windows", "vendor-update"],
+    "affected_components": [
+      {
+        "component_type": "software",
+        "ecosystem": "windows",
+        "name": "SolarWinds Orion",
+        "vendor": "SolarWinds",
+        "package_url": null
+      }
+    ],
+    "supply_chain_vectors": ["build_system_compromise", "signed_update_compromise"],
+    "impact_categories": ["backdoor", "downstream_customer_compromise"],
+    "references": [
+      {
+        "title": "Advanced Persistent Threat Compromise of Government Agencies, Critical Infrastructure, and Private Sector Organizations",
+        "publisher": "CISA",
+        "url": "https://www.cisa.gov/news-events/cybersecurity-advisories/aa20-352a",
+        "published_at": "2020-12-17"
+      }
+    ],
+    "tags": ["build-system", "sunburst"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2021-DEPENDENCY-CONFUSION",
+    "title": "Dependency confusion proof-of-concept campaign",
+    "summary": "Researchers demonstrated that public package registries could be abused to satisfy internal dependency names and execute code in downstream build environments.",
+    "status": "confirmed",
+    "first_observed_at": "2021-02-09",
+    "disclosed_at": "2021-02-09",
+    "affected_ecosystems": ["npm", "pypi", "rubygems"],
+    "affected_components": [
+      {
+        "component_type": "package",
+        "ecosystem": "multiple",
+        "name": "internal dependency names",
+        "vendor": "multiple organizations",
+        "package_url": null
+      }
+    ],
+    "supply_chain_vectors": ["dependency_confusion"],
+    "impact_categories": ["developer_workstation_compromise", "data_exfiltration"],
+    "references": [
+      {
+        "title": "Dependency Confusion: How I Hacked Into Apple, Microsoft and Dozens of Other Companies",
+        "publisher": "Alex Birsan",
+        "url": "https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610",
+        "published_at": "2021-02-09"
+      }
+    ],
+    "tags": ["dependency-confusion", "research"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2021-PHP-GIT-SERVER",
+    "title": "PHP source repository backdoor attempt",
+    "summary": "Attackers pushed malicious commits to the PHP source repository that would have introduced a backdoor if accepted into releases.",
+    "status": "confirmed",
+    "first_observed_at": "2021-03-28",
+    "disclosed_at": "2021-03-28",
+    "affected_ecosystems": ["php", "source-repository"],
+    "affected_components": [
+      {
+        "component_type": "project",
+        "ecosystem": "php",
+        "name": "php-src",
+        "vendor": "PHP project",
+        "package_url": null
+      }
+    ],
+    "supply_chain_vectors": ["source_repository_compromise"],
+    "impact_categories": ["backdoor"],
+    "references": [
+      {
+        "title": "PHP Git server compromise notice",
+        "publisher": "PHP.net",
+        "url": "https://www.php.net/archive/2021.php#2021-03-28-1",
+        "published_at": "2021-03-28"
+      }
+    ],
+    "tags": ["source-control", "php"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2021-CODECOV-BASH-UPLOADER",
+    "title": "Codecov Bash Uploader credential exfiltration",
+    "summary": "The Codecov Bash Uploader was modified by an attacker, enabling environment variable and credential exfiltration from affected CI environments.",
+    "status": "confirmed",
+    "first_observed_at": "2021-01-31",
+    "disclosed_at": "2021-04-15",
+    "affected_ecosystems": ["ci-cd"],
+    "affected_components": [
+      {
+        "component_type": "service",
+        "ecosystem": "ci-cd",
+        "name": "Codecov Bash Uploader",
+        "vendor": "Codecov",
+        "package_url": null
+      }
+    ],
+    "supply_chain_vectors": ["build_system_compromise"],
+    "impact_categories": ["credential_theft", "data_exfiltration"],
+    "references": [
+      {
+        "title": "Bash Uploader Security Update",
+        "publisher": "Codecov",
+        "url": "https://about.codecov.io/security-update/",
+        "published_at": "2021-04-15"
+      }
+    ],
+    "tags": ["ci-cd", "credentials"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2021-KASEYA-VSA",
+    "title": "Kaseya VSA ransomware supply-chain attack",
+    "summary": "Attackers abused Kaseya VSA management software to distribute ransomware through managed service provider environments to downstream customers.",
+    "status": "confirmed",
+    "first_observed_at": "2021-07-02",
+    "disclosed_at": "2021-07-02",
+    "affected_ecosystems": ["managed-service", "windows"],
+    "affected_components": [
+      {
+        "component_type": "software",
+        "ecosystem": "windows",
+        "name": "Kaseya VSA",
+        "vendor": "Kaseya",
+        "package_url": null
+      }
+    ],
+    "supply_chain_vectors": ["vendor_update_compromise"],
+    "impact_categories": ["ransomware_delivery", "downstream_customer_compromise"],
+    "references": [
+      {
+        "title": "Kaseya VSA Supply-Chain Ransomware Attack",
+        "publisher": "CISA",
+        "url": "https://www.cisa.gov/news-events/alerts/2021/07/02/kaseya-vsa-supply-chain-ransomware-attack",
+        "published_at": "2021-07-02"
+      }
+    ],
+    "tags": ["ransomware", "msp"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2021-UA-PARSER-JS",
+    "title": "ua-parser-js npm package account compromise",
+    "summary": "Malicious versions of ua-parser-js were published to npm after maintainer account compromise, delivering credential-stealing and cryptomining payloads.",
+    "status": "confirmed",
+    "first_observed_at": "2021-10-22",
+    "disclosed_at": "2021-10-22",
+    "affected_ecosystems": ["npm"],
+    "affected_components": [
+      {
+        "component_type": "package",
+        "ecosystem": "npm",
+        "name": "ua-parser-js",
+        "vendor": "open source maintainers",
+        "package_url": "pkg:npm/ua-parser-js"
+      }
+    ],
+    "supply_chain_vectors": ["maintainer_account_compromise", "package_repository_compromise"],
+    "impact_categories": ["credential_theft", "cryptomining"],
+    "references": [
+      {
+        "title": "Malware in ua-parser-js",
+        "publisher": "GitHub Advisory Database",
+        "url": "https://github.com/advisories/GHSA-pjwm-rvh2-c87w",
+        "published_at": "2021-10-22"
+      }
+    ],
+    "tags": ["npm", "account-compromise"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2021-NPM-RC",
+    "title": "rc npm package malicious release",
+    "summary": "The rc npm package had malicious versions published that required users to downgrade and inspect systems for suspicious activity.",
+    "status": "confirmed",
+    "first_observed_at": "2021-11-04",
+    "disclosed_at": "2021-11-04",
+    "affected_ecosystems": ["npm"],
+    "affected_components": [
+      {
+        "component_type": "package",
+        "ecosystem": "npm",
+        "name": "rc",
+        "vendor": "open source maintainers",
+        "package_url": "pkg:npm/rc"
+      }
+    ],
+    "supply_chain_vectors": ["package_repository_compromise"],
+    "impact_categories": ["malware_distribution"],
+    "references": [
+      {
+        "title": "Embedded malware in rc",
+        "publisher": "GitHub Advisory Database",
+        "url": "https://github.com/advisories/GHSA-g2q5-5433-rhrf",
+        "published_at": "2021-11-04"
+      }
+    ],
+    "tags": ["npm", "malicious-package"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2022-COLORS-FAKER",
+    "title": "colors and faker npm protestware releases",
+    "summary": "The maintainer of colors and faker published intentionally disruptive releases that broke downstream consumers and demonstrated maintainer-driven supply-chain risk.",
+    "status": "confirmed",
+    "first_observed_at": "2022-01-08",
+    "disclosed_at": "2022-01-09",
+    "affected_ecosystems": ["npm"],
+    "affected_components": [
+      {
+        "component_type": "package",
+        "ecosystem": "npm",
+        "name": "colors",
+        "vendor": "open source maintainer",
+        "package_url": "pkg:npm/colors"
+      },
+      {
+        "component_type": "package",
+        "ecosystem": "npm",
+        "name": "faker",
+        "vendor": "open source maintainer",
+        "package_url": "pkg:npm/faker"
+      }
+    ],
+    "supply_chain_vectors": ["protestware"],
+    "impact_categories": ["destructive_payload", "protest_payload"],
+    "references": [
+      {
+        "title": "colors.js issue discussion after disruptive release",
+        "publisher": "GitHub",
+        "url": "https://github.com/Marak/colors.js/issues/285",
+        "published_at": "2022-01-09"
+      }
+    ],
+    "tags": ["npm", "protestware"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2022-NODE-IPC",
+    "title": "node-ipc peacenotwar protestware release",
+    "summary": "The node-ipc npm package included protestware behavior that modified files for users in certain geographies, creating downstream integrity and availability risk.",
+    "status": "confirmed",
+    "first_observed_at": "2022-03-08",
+    "disclosed_at": "2022-03-16",
+    "affected_ecosystems": ["npm"],
+    "affected_components": [
+      {
+        "component_type": "package",
+        "ecosystem": "npm",
+        "name": "node-ipc",
+        "vendor": "open source maintainer",
+        "package_url": "pkg:npm/node-ipc"
+      }
+    ],
+    "supply_chain_vectors": ["protestware"],
+    "impact_categories": ["destructive_payload", "protest_payload"],
+    "references": [
+      {
+        "title": "Peacenotwar malicious npm node-ipc package vulnerability",
+        "publisher": "Snyk",
+        "url": "https://snyk.io/blog/peacenotwar-malicious-npm-node-ipc-package-vulnerability/",
+        "published_at": "2022-03-16"
+      }
+    ],
+    "tags": ["npm", "protestware"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2022-PYPI-CTX",
+    "title": "ctx PyPI project account takeover",
+    "summary": "The ctx project on PyPI was taken over and replaced with malicious code that collected environment variables from affected users.",
+    "status": "confirmed",
+    "first_observed_at": "2022-05-21",
+    "disclosed_at": "2022-05-24",
+    "affected_ecosystems": ["pypi"],
+    "affected_components": [
+      {
+        "component_type": "package",
+        "ecosystem": "pypi",
+        "name": "ctx",
+        "vendor": "open source maintainer",
+        "package_url": "pkg:pypi/ctx"
+      }
+    ],
+    "supply_chain_vectors": ["maintainer_account_compromise", "package_repository_compromise"],
+    "impact_categories": ["credential_theft", "data_exfiltration"],
+    "references": [
+      {
+        "title": "Account Takeover and Malicious Replacement of ctx Project",
+        "publisher": "Python Security",
+        "url": "https://python-security.readthedocs.io/pypi-vuln/index-2022-05-24-ctx-domain-takeover.html",
+        "published_at": "2022-05-24"
+      }
+    ],
+    "tags": ["pypi", "account-takeover"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2022-PYTORCH-NIGHTLY",
+    "title": "PyTorch nightly dependency confusion compromise",
+    "summary": "A malicious torchtriton package on PyPI was installed by some PyTorch nightly users because it shadowed an expected dependency name.",
+    "status": "confirmed",
+    "first_observed_at": "2022-12-25",
+    "disclosed_at": "2022-12-31",
+    "affected_ecosystems": ["pypi", "python"],
+    "affected_components": [
+      {
+        "component_type": "package",
+        "ecosystem": "pypi",
+        "name": "torchtriton",
+        "vendor": "malicious publisher",
+        "package_url": "pkg:pypi/torchtriton"
+      },
+      {
+        "component_type": "project",
+        "ecosystem": "python",
+        "name": "PyTorch nightly",
+        "vendor": "PyTorch",
+        "package_url": null
+      }
+    ],
+    "supply_chain_vectors": ["dependency_confusion"],
+    "impact_categories": ["credential_theft", "developer_workstation_compromise"],
+    "references": [
+      {
+        "title": "Compromised PyTorch-nightly dependency chain between December 25th and December 30th, 2022",
+        "publisher": "PyTorch",
+        "url": "https://pytorch.org/blog/compromised-nightly-dependency/",
+        "published_at": "2022-12-31"
+      }
+    ],
+    "tags": ["pypi", "dependency-confusion"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2023-THREE-CX-DESKTOP",
+    "title": "3CX desktop application software supply-chain compromise",
+    "summary": "Attackers compromised 3CX desktop application builds, causing trojanized installers and updates to reach downstream customers.",
+    "status": "confirmed",
+    "first_observed_at": "2023-03-22",
+    "disclosed_at": "2023-03-29",
+    "affected_ecosystems": ["windows", "macos", "vendor-update"],
+    "affected_components": [
+      {
+        "component_type": "software",
+        "ecosystem": "desktop",
+        "name": "3CX DesktopApp",
+        "vendor": "3CX",
+        "package_url": null
+      }
+    ],
+    "supply_chain_vectors": ["build_system_compromise", "signed_update_compromise"],
+    "impact_categories": ["malware_distribution", "backdoor", "downstream_customer_compromise"],
+    "references": [
+      {
+        "title": "3CX Software Supply Chain Compromise",
+        "publisher": "Mandiant",
+        "url": "https://cloud.google.com/blog/topics/threat-intelligence/3cx-software-supply-chain-compromise",
+        "published_at": "2023-04-20"
+      }
+    ],
+    "tags": ["desktop", "signed-update"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2023-LEDGER-CONNECT-KIT",
+    "title": "Ledger Connect Kit npm package compromise",
+    "summary": "A compromised Ledger Connect Kit npm release injected malicious code into downstream web applications and targeted cryptocurrency wallet transactions.",
+    "status": "confirmed",
+    "first_observed_at": "2023-12-14",
+    "disclosed_at": "2023-12-14",
+    "affected_ecosystems": ["npm", "web3"],
+    "affected_components": [
+      {
+        "component_type": "package",
+        "ecosystem": "npm",
+        "name": "@ledgerhq/connect-kit",
+        "vendor": "Ledger",
+        "package_url": "pkg:npm/%40ledgerhq/connect-kit"
+      }
+    ],
+    "supply_chain_vectors": ["maintainer_account_compromise", "package_repository_compromise"],
+    "impact_categories": ["crypto_theft", "downstream_customer_compromise"],
+    "references": [
+      {
+        "title": "Security Incident Report",
+        "publisher": "Ledger",
+        "url": "https://www.ledger.com/blog/security-incident-report",
+        "published_at": "2023-12-14"
+      }
+    ],
+    "tags": ["npm", "web3"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2024-XZ-UTILS",
+    "title": "XZ Utils backdoor attempt",
+    "summary": "A backdoor was inserted into upstream XZ Utils release tarballs, affecting some downstream Linux distribution packaging before broad removal.",
+    "status": "confirmed",
+    "first_observed_at": "2024-02-24",
+    "disclosed_at": "2024-03-29",
+    "affected_ecosystems": ["linux", "source-release"],
+    "affected_components": [
+      {
+        "component_type": "project",
+        "ecosystem": "linux",
+        "name": "xz-utils",
+        "vendor": "Tukaani Project",
+        "package_url": null
+      }
+    ],
+    "supply_chain_vectors": ["source_repository_compromise", "malicious_dependency"],
+    "impact_categories": ["backdoor"],
+    "references": [
+      {
+        "title": "Backdoor in upstream xz/liblzma leading to SSH server compromise",
+        "publisher": "Openwall oss-security",
+        "url": "https://www.openwall.com/lists/oss-security/2024/03/29/4",
+        "published_at": "2024-03-29"
+      }
+    ],
+    "tags": ["linux", "backdoor"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2024-POLYFILL-IO",
+    "title": "Polyfill.io CDN script supply-chain compromise",
+    "summary": "The Polyfill.io service began serving malicious JavaScript to downstream websites that embedded the third-party CDN script.",
+    "status": "confirmed",
+    "first_observed_at": "2024-06-25",
+    "disclosed_at": "2024-06-25",
+    "affected_ecosystems": ["web", "cdn"],
+    "affected_components": [
+      {
+        "component_type": "service",
+        "ecosystem": "web",
+        "name": "Polyfill.io",
+        "vendor": "Polyfill.io",
+        "package_url": null
+      }
+    ],
+    "supply_chain_vectors": ["cdn_script_compromise"],
+    "impact_categories": ["malware_distribution", "downstream_customer_compromise"],
+    "references": [
+      {
+        "title": "Polyfill supply chain attack hits 100K+ sites",
+        "publisher": "Sansec",
+        "url": "https://sansec.io/research/polyfill-supply-chain-attack",
+        "published_at": "2024-06-25"
+      }
+    ],
+    "tags": ["cdn", "javascript"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2024-ULTRALYTICS-PYPI",
+    "title": "Ultralytics PyPI package compromise",
+    "summary": "The ultralytics Python project suffered a supply-chain attack through compromised GitHub Actions workflows and PyPI publishing, resulting in malicious package releases.",
+    "status": "confirmed",
+    "first_observed_at": "2024-12-04",
+    "disclosed_at": "2024-12-11",
+    "affected_ecosystems": ["pypi", "github-actions"],
+    "affected_components": [
+      {
+        "component_type": "package",
+        "ecosystem": "pypi",
+        "name": "ultralytics",
+        "vendor": "Ultralytics",
+        "package_url": "pkg:pypi/ultralytics"
+      }
+    ],
+    "supply_chain_vectors": ["build_system_compromise", "package_repository_compromise"],
+    "impact_categories": ["cryptomining", "developer_workstation_compromise"],
+    "references": [
+      {
+        "title": "Supply-chain attack analysis: Ultralytics",
+        "publisher": "PyPI Blog",
+        "url": "https://blog.pypi.org/posts/2024-12-11-ultralytics-attack-analysis/",
+        "published_at": "2024-12-11"
+      }
+    ],
+    "tags": ["pypi", "github-actions"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2024-LOTTIE-PLAYER",
+    "title": "LottieFiles lottie-player npm package compromise",
+    "summary": "Compromised releases of the @lottiefiles/lottie-player npm package injected malicious wallet-draining code into downstream web applications.",
+    "status": "confirmed",
+    "first_observed_at": "2024-10-30",
+    "disclosed_at": "2024-10-31",
+    "affected_ecosystems": ["npm", "web"],
+    "affected_components": [
+      {
+        "component_type": "package",
+        "ecosystem": "npm",
+        "name": "@lottiefiles/lottie-player",
+        "vendor": "LottieFiles",
+        "package_url": "pkg:npm/%40lottiefiles/lottie-player"
+      }
+    ],
+    "supply_chain_vectors": ["maintainer_account_compromise", "package_repository_compromise"],
+    "impact_categories": ["crypto_theft", "downstream_customer_compromise"],
+    "references": [
+      {
+        "title": "Resolution of Security Incident with @lottiefiles/lottie-player Package",
+        "publisher": "LottieFiles",
+        "url": "https://lottiefiles.com/blog/inside-lottiefiles/resolution-of-security-incident-with-lottiefiles-lottie-player-package",
+        "published_at": "2024-10-31"
+      }
+    ],
+    "tags": ["npm", "web3"]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2025-TJ-ACTIONS-CHANGED-FILES",
+    "title": "tj-actions changed-files GitHub Action compromise",
+    "summary": "The tj-actions/changed-files GitHub Action was compromised, exposing secrets from affected workflow runs through malicious action behavior.",
+    "status": "confirmed",
+    "first_observed_at": "2025-03-14",
+    "disclosed_at": "2025-03-15",
+    "affected_ecosystems": ["github-actions", "ci-cd"],
+    "affected_components": [
+      {
+        "component_type": "service",
+        "ecosystem": "github-actions",
+        "name": "tj-actions/changed-files",
+        "vendor": "tj-actions",
+        "package_url": null
+      }
+    ],
+    "supply_chain_vectors": ["ci_cd_action_compromise"],
+    "impact_categories": ["credential_theft", "developer_workstation_compromise"],
+    "references": [
+      {
+        "title": "Harden-Runner detection: tj-actions/changed-files action is compromised",
+        "publisher": "StepSecurity",
+        "url": "https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised",
+        "published_at": "2025-03-15"
+      }
+    ],
+    "tags": ["github-actions", "ci-cd"]
+  }
+]

--- a/data/supply-chain-incidents/incidents.json
+++ b/data/supply-chain-incidents/incidents.json
@@ -52,7 +52,7 @@
     "references": [
       {
         "title": "Petya Ransomware",
-        "publisher": "CISA",
+        "publisher": "Cybersecurity and Infrastructure Security Agency",
         "url": "https://www.cisa.gov/news-events/alerts/2017/07/01/petya-ransomware",
         "published_at": "2017-07-01"
       }
@@ -232,7 +232,7 @@
     "references": [
       {
         "title": "Advanced Persistent Threat Compromise of Government Agencies, Critical Infrastructure, and Private Sector Organizations",
-        "publisher": "CISA",
+        "publisher": "Cybersecurity and Infrastructure Security Agency",
         "url": "https://www.cisa.gov/news-events/cybersecurity-advisories/aa20-352a",
         "published_at": "2020-12-17"
       }
@@ -352,7 +352,7 @@
     "references": [
       {
         "title": "Kaseya VSA Supply-Chain Ransomware Attack",
-        "publisher": "CISA",
+        "publisher": "Cybersecurity and Infrastructure Security Agency",
         "url": "https://www.cisa.gov/news-events/alerts/2021/07/02/kaseya-vsa-supply-chain-ransomware-attack",
         "published_at": "2021-07-02"
       }

--- a/data/supply-chain-incidents/schema.json
+++ b/data/supply-chain-incidents/schema.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://threatpedia.wiki/schemas/supply-chain-incident-1.json",
+  "title": "Threatpedia Supply Chain Incident",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "id",
+    "title",
+    "summary",
+    "status",
+    "first_observed_at",
+    "disclosed_at",
+    "affected_ecosystems",
+    "affected_components",
+    "supply_chain_vectors",
+    "impact_categories",
+    "references",
+    "tags"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "supply-chain-incident/1"
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^SC-[0-9]{4}-[A-Z0-9-]+$"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 8
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 40
+    },
+    "status": {
+      "enum": ["confirmed"]
+    },
+    "first_observed_at": {
+      "type": "string",
+      "format": "date"
+    },
+    "disclosed_at": {
+      "type": "string",
+      "format": "date"
+    },
+    "affected_ecosystems": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    },
+    "affected_components": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/affected_component"
+      }
+    },
+    "supply_chain_vectors": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "enum": [
+          "build_system_compromise",
+          "cdn_script_compromise",
+          "ci_cd_action_compromise",
+          "dependency_confusion",
+          "distribution_site_compromise",
+          "maintainer_account_compromise",
+          "malicious_dependency",
+          "package_repository_compromise",
+          "protestware",
+          "signed_update_compromise",
+          "source_repository_compromise",
+          "vendor_update_compromise"
+        ]
+      }
+    },
+    "impact_categories": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "enum": [
+          "backdoor",
+          "credential_theft",
+          "crypto_theft",
+          "cryptomining",
+          "data_exfiltration",
+          "destructive_payload",
+          "developer_workstation_compromise",
+          "downstream_customer_compromise",
+          "malware_distribution",
+          "protest_payload",
+          "ransomware_delivery"
+        ]
+      }
+    },
+    "references": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/reference"
+      }
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "$defs": {
+    "affected_component": {
+      "type": "object",
+      "required": ["component_type", "ecosystem", "name", "vendor"],
+      "properties": {
+        "component_type": {
+          "enum": ["package", "project", "software", "service", "update_channel", "website"]
+        },
+        "ecosystem": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "package_url": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "reference": {
+      "type": "object",
+      "required": ["title", "publisher", "url", "published_at"],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "publisher": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "published_at": {
+          "type": "string",
+          "format": "date"
+        }
+      }
+    }
+  }
+}

--- a/data/supply-chain-incidents/schema.json
+++ b/data/supply-chain-incidents/schema.json
@@ -130,7 +130,8 @@
           "type": "string"
         },
         "package_url": {
-          "type": ["string", "null"]
+          "type": ["string", "null"],
+          "pattern": "^pkg:[a-z0-9.+-]+/[^\\s]+$"
         }
       }
     },

--- a/docs/supply-chain-incident-schema.md
+++ b/docs/supply-chain-incident-schema.md
@@ -1,0 +1,132 @@
+# Supply-Chain Incident Corpus Schema
+
+Threatpedia maintains a structured supply-chain incident corpus so historical
+incidents can inform later graph-schema design, attribution modeling, and
+release-event enrichment without mixing those later decisions into the raw
+corpus.
+
+Phase 1A is intentionally narrow. The corpus is machine-readable evidence
+inventory, not a risk engine.
+
+## Corpus Location
+
+```text
+data/supply-chain-incidents/
+```
+
+The current corpus is:
+
+```text
+data/supply-chain-incidents/incidents.json
+```
+
+The schema primitive is:
+
+```text
+data/supply-chain-incidents/schema.json
+```
+
+## What the Corpus Models
+
+Each incident records a public, documented supply-chain compromise or abuse
+pattern using `schema_version: "supply-chain-incident/1"`.
+
+The core fields are:
+
+- `id`: stable identifier using `SC-YYYY-SLUG`
+- `title`: short human-readable name
+- `summary`: bounded factual summary
+- `status`: currently `confirmed`
+- `first_observed_at`: earliest known activity date in `YYYY-MM-DD`
+- `disclosed_at`: public disclosure date in `YYYY-MM-DD`
+- `affected_ecosystems`: ecosystem labels such as `npm`, `pypi`, `windows`,
+  `github-actions`, or `vendor-update`
+- `affected_components`: structured impacted packages, projects, services, or
+  update channels
+- `supply_chain_vectors`: normalized vector labels
+- `impact_categories`: normalized impact labels
+- `references`: public documentation for the incident
+- `tags`: additional non-authoritative grouping tags
+
+Package components may include `package_url` when a PURL is available. Non-
+package software, services, websites, and update channels should use `null`.
+
+## Vector Labels
+
+Current `supply_chain_vectors` values are:
+
+- `build_system_compromise`
+- `cdn_script_compromise`
+- `ci_cd_action_compromise`
+- `dependency_confusion`
+- `distribution_site_compromise`
+- `maintainer_account_compromise`
+- `malicious_dependency`
+- `package_repository_compromise`
+- `protestware`
+- `signed_update_compromise`
+- `source_repository_compromise`
+- `vendor_update_compromise`
+
+These are modeling primitives. They are not actor attribution and do not imply
+severity.
+
+## Impact Labels
+
+Current `impact_categories` values are:
+
+- `backdoor`
+- `credential_theft`
+- `crypto_theft`
+- `cryptomining`
+- `data_exfiltration`
+- `destructive_payload`
+- `developer_workstation_compromise`
+- `downstream_customer_compromise`
+- `malware_distribution`
+- `protest_payload`
+- `ransomware_delivery`
+
+These describe observed incident effects. They are not scoring labels.
+
+## References
+
+Every incident must have at least one public reference with:
+
+- `title`
+- `publisher`
+- `url`
+- `published_at`
+
+The validator checks URL shape and date format. It does not fetch references or
+make external network calls.
+
+## Adding Future Incidents
+
+1. Add a new object to `data/supply-chain-incidents/incidents.json`.
+2. Use a stable ID in the form `SC-YYYY-SLUG`.
+3. Keep `summary` factual and bounded.
+4. Use existing vector and impact labels when possible.
+5. Add a new label only when the existing schema cannot represent the incident.
+6. Include at least one public reference.
+7. Run validation:
+
+```bash
+python3 scripts/validate_supply_chain_incidents.py
+python3 -m unittest discover -s tests
+git diff --check
+```
+
+## Non-Goals
+
+This corpus does not implement:
+
+- scoring
+- risk engines
+- graph databases
+- attribution automation
+- dashboards
+- UI
+- live feeds
+- malware detection
+- policy recommendations

--- a/scripts/validate_supply_chain_incidents.py
+++ b/scripts/validate_supply_chain_incidents.py
@@ -238,7 +238,7 @@ def validate_schema_file(schema: Any) -> list[str]:
     if schema_version.get("const") != SCHEMA_VERSION:
         errors.append("schema.schema_version.const: does not match validator schema version")
     required = schema.get("required")
-    if required != REQUIRED_FIELDS:
+    if not isinstance(required, list) or set(required) != set(REQUIRED_FIELDS):
         errors.append("schema.required: does not match validator required fields")
     return errors
 

--- a/scripts/validate_supply_chain_incidents.py
+++ b/scripts/validate_supply_chain_incidents.py
@@ -87,8 +87,12 @@ def parse_date(value: Any) -> date | None:
 def is_valid_url(value: Any) -> bool:
     if not isinstance(value, str) or any(char.isspace() for char in value):
         return False
-    parsed = urlparse(value)
-    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+    try:
+        parsed = urlparse(value)
+        parsed.port
+        return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+    except ValueError:
+        return False
 
 
 def require_string(errors: list[str], path: str, value: Any, *, min_length: int = 1) -> None:
@@ -153,14 +157,15 @@ def validate_incident(incident: Any) -> list[str]:
     if not isinstance(incident, dict):
         return ["incident: expected object"]
 
-    incident_id = incident.get("id", "<missing-id>")
+    raw_id = incident.get("id")
+    incident_id = raw_id if isinstance(raw_id, str) else "<missing-id>"
     for field in REQUIRED_FIELDS:
         if field not in incident:
             errors.append(f"{incident_id}.{field}: missing required field")
 
     if incident.get("schema_version") != SCHEMA_VERSION:
         errors.append(f"{incident_id}.schema_version: expected {SCHEMA_VERSION!r}")
-    if not isinstance(incident.get("id"), str) or not ID_PATTERN.match(incident["id"]):
+    if not isinstance(raw_id, str) or not ID_PATTERN.match(raw_id):
         errors.append(f"{incident_id}.id: expected SC-YYYY-SLUG identifier")
     require_string(errors, f"{incident_id}.title", incident.get("title"), min_length=8)
     require_string(errors, f"{incident_id}.summary", incident.get("summary"), min_length=40)
@@ -224,7 +229,13 @@ def validate_schema_file(schema: Any) -> list[str]:
     errors: list[str] = []
     if not isinstance(schema, dict):
         return ["schema: expected object"]
-    if schema.get("properties", {}).get("schema_version", {}).get("const") != SCHEMA_VERSION:
+    properties = schema.get("properties", {})
+    if not isinstance(properties, dict):
+        return ["schema.properties: expected object"]
+    schema_version = properties.get("schema_version", {})
+    if not isinstance(schema_version, dict):
+        return ["schema.properties.schema_version: expected object"]
+    if schema_version.get("const") != SCHEMA_VERSION:
         errors.append("schema.schema_version.const: does not match validator schema version")
     required = schema.get("required")
     if required != REQUIRED_FIELDS:

--- a/scripts/validate_supply_chain_incidents.py
+++ b/scripts/validate_supply_chain_incidents.py
@@ -114,7 +114,7 @@ def require_enum_list(errors: list[str], path: str, value: Any, allowed: set[str
     if not isinstance(value, list):
         return
     for index, item in enumerate(value):
-        if item not in allowed:
+        if isinstance(item, str) and item not in allowed:
             errors.append(f"{path}[{index}]: invalid value {item!r}")
 
 
@@ -163,42 +163,55 @@ def validate_incident(incident: Any) -> list[str]:
         if field not in incident:
             errors.append(f"{incident_id}.{field}: missing required field")
 
-    if incident.get("schema_version") != SCHEMA_VERSION:
+    if "schema_version" in incident and incident.get("schema_version") != SCHEMA_VERSION:
         errors.append(f"{incident_id}.schema_version: expected {SCHEMA_VERSION!r}")
-    if not isinstance(raw_id, str) or not ID_PATTERN.match(raw_id):
-        errors.append(f"{incident_id}.id: expected SC-YYYY-SLUG identifier")
-    require_string(errors, f"{incident_id}.title", incident.get("title"), min_length=8)
-    require_string(errors, f"{incident_id}.summary", incident.get("summary"), min_length=40)
-    if incident.get("status") not in VALID_STATUS:
+    if "id" in incident:
+        if not isinstance(raw_id, str) or not ID_PATTERN.match(raw_id):
+            errors.append(f"{incident_id}.id: expected SC-YYYY-SLUG identifier")
+    if "title" in incident:
+        require_string(errors, f"{incident_id}.title", incident.get("title"), min_length=8)
+    if "summary" in incident:
+        require_string(errors, f"{incident_id}.summary", incident.get("summary"), min_length=40)
+    if "status" in incident and incident.get("status") not in VALID_STATUS:
         errors.append(f"{incident_id}.status: invalid value {incident.get('status')!r}")
 
-    first_observed_at = parse_date(incident.get("first_observed_at"))
-    disclosed_at = parse_date(incident.get("disclosed_at"))
-    if first_observed_at is None:
-        errors.append(f"{incident_id}.first_observed_at: expected YYYY-MM-DD date")
-    if disclosed_at is None:
-        errors.append(f"{incident_id}.disclosed_at: expected YYYY-MM-DD date")
+    first_observed_at = None
+    if "first_observed_at" in incident:
+        first_observed_at = parse_date(incident.get("first_observed_at"))
+        if first_observed_at is None:
+            errors.append(f"{incident_id}.first_observed_at: expected YYYY-MM-DD date")
+    disclosed_at = None
+    if "disclosed_at" in incident:
+        disclosed_at = parse_date(incident.get("disclosed_at"))
+        if disclosed_at is None:
+            errors.append(f"{incident_id}.disclosed_at: expected YYYY-MM-DD date")
     if first_observed_at and disclosed_at and disclosed_at < first_observed_at:
         errors.append(f"{incident_id}.disclosed_at: cannot be before first_observed_at")
 
-    require_string_list(errors, f"{incident_id}.affected_ecosystems", incident.get("affected_ecosystems"))
-    require_enum_list(errors, f"{incident_id}.supply_chain_vectors", incident.get("supply_chain_vectors"), VALID_VECTORS)
-    require_enum_list(errors, f"{incident_id}.impact_categories", incident.get("impact_categories"), VALID_IMPACTS)
-    require_string_list(errors, f"{incident_id}.tags", incident.get("tags"))
+    if "affected_ecosystems" in incident:
+        require_string_list(errors, f"{incident_id}.affected_ecosystems", incident.get("affected_ecosystems"))
+    if "supply_chain_vectors" in incident:
+        require_enum_list(errors, f"{incident_id}.supply_chain_vectors", incident.get("supply_chain_vectors"), VALID_VECTORS)
+    if "impact_categories" in incident:
+        require_enum_list(errors, f"{incident_id}.impact_categories", incident.get("impact_categories"), VALID_IMPACTS)
+    if "tags" in incident:
+        require_string_list(errors, f"{incident_id}.tags", incident.get("tags"))
 
-    components = incident.get("affected_components")
-    if not isinstance(components, list) or not components:
-        errors.append(f"{incident_id}.affected_components: expected non-empty list")
-    else:
-        for index, component in enumerate(components):
-            validate_component(errors, incident_id, index, component)
+    if "affected_components" in incident:
+        components = incident.get("affected_components")
+        if not isinstance(components, list) or not components:
+            errors.append(f"{incident_id}.affected_components: expected non-empty list")
+        else:
+            for index, component in enumerate(components):
+                validate_component(errors, incident_id, index, component)
 
-    references = incident.get("references")
-    if not isinstance(references, list) or not references:
-        errors.append(f"{incident_id}.references: expected non-empty list")
-    else:
-        for index, reference in enumerate(references):
-            validate_reference(errors, incident_id, index, reference)
+    if "references" in incident:
+        references = incident.get("references")
+        if not isinstance(references, list) or not references:
+            errors.append(f"{incident_id}.references: expected non-empty list")
+        else:
+            for index, reference in enumerate(references):
+                validate_reference(errors, incident_id, index, reference)
 
     return errors
 

--- a/scripts/validate_supply_chain_incidents.py
+++ b/scripts/validate_supply_chain_incidents.py
@@ -18,7 +18,8 @@ DEFAULT_CORPUS_PATH = REPO_ROOT / "data" / "supply-chain-incidents" / "incidents
 DEFAULT_SCHEMA_PATH = REPO_ROOT / "data" / "supply-chain-incidents" / "schema.json"
 SCHEMA_VERSION = "supply-chain-incident/1"
 ID_PATTERN = re.compile(r"^SC-[0-9]{4}-[A-Z0-9-]+$")
-PURL_PATTERN = re.compile(r"^pkg:[a-z0-9.+-]+/.+")
+FULL_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+PURL_PATTERN = re.compile(r"^pkg:[a-z0-9.+-]+/[^\s]+$")
 
 REQUIRED_FIELDS = [
     "schema_version",
@@ -75,7 +76,7 @@ def load_json(path: Path) -> Any:
 
 
 def parse_date(value: Any) -> date | None:
-    if not isinstance(value, str):
+    if not isinstance(value, str) or not FULL_DATE_PATTERN.fullmatch(value):
         return None
     try:
         return date.fromisoformat(value)
@@ -127,7 +128,7 @@ def validate_component(errors: list[str], incident_id: str, index: int, componen
     if component.get("component_type") not in VALID_COMPONENT_TYPES:
         errors.append(f"{path}.component_type: invalid value {component.get('component_type')!r}")
     package_url = component.get("package_url")
-    if package_url is not None and not (isinstance(package_url, str) and PURL_PATTERN.match(package_url)):
+    if package_url is not None and not (isinstance(package_url, str) and PURL_PATTERN.fullmatch(package_url)):
         errors.append(f"{path}.package_url: expected null or package URL")
 
 

--- a/scripts/validate_supply_chain_incidents.py
+++ b/scripts/validate_supply_chain_incidents.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Validate the Threatpedia supply-chain incident corpus."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+from urllib.parse import urlparse
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CORPUS_PATH = REPO_ROOT / "data" / "supply-chain-incidents" / "incidents.json"
+DEFAULT_SCHEMA_PATH = REPO_ROOT / "data" / "supply-chain-incidents" / "schema.json"
+SCHEMA_VERSION = "supply-chain-incident/1"
+ID_PATTERN = re.compile(r"^SC-[0-9]{4}-[A-Z0-9-]+$")
+PURL_PATTERN = re.compile(r"^pkg:[a-z0-9.+-]+/.+")
+
+REQUIRED_FIELDS = [
+    "schema_version",
+    "id",
+    "title",
+    "summary",
+    "status",
+    "first_observed_at",
+    "disclosed_at",
+    "affected_ecosystems",
+    "affected_components",
+    "supply_chain_vectors",
+    "impact_categories",
+    "references",
+    "tags",
+]
+
+REQUIRED_COMPONENT_FIELDS = ["component_type", "ecosystem", "name", "vendor"]
+REQUIRED_REFERENCE_FIELDS = ["title", "publisher", "url", "published_at"]
+VALID_STATUS = {"confirmed"}
+VALID_COMPONENT_TYPES = {"package", "project", "software", "service", "update_channel", "website"}
+VALID_VECTORS = {
+    "build_system_compromise",
+    "cdn_script_compromise",
+    "ci_cd_action_compromise",
+    "dependency_confusion",
+    "distribution_site_compromise",
+    "maintainer_account_compromise",
+    "malicious_dependency",
+    "package_repository_compromise",
+    "protestware",
+    "signed_update_compromise",
+    "source_repository_compromise",
+    "vendor_update_compromise",
+}
+VALID_IMPACTS = {
+    "backdoor",
+    "credential_theft",
+    "crypto_theft",
+    "cryptomining",
+    "data_exfiltration",
+    "destructive_payload",
+    "developer_workstation_compromise",
+    "downstream_customer_compromise",
+    "malware_distribution",
+    "protest_payload",
+    "ransomware_delivery",
+}
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def parse_date(value: Any) -> date | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def is_valid_url(value: Any) -> bool:
+    if not isinstance(value, str) or any(char.isspace() for char in value):
+        return False
+    parsed = urlparse(value)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def require_string(errors: list[str], path: str, value: Any, *, min_length: int = 1) -> None:
+    if not isinstance(value, str) or len(value.strip()) < min_length:
+        errors.append(f"{path}: expected non-empty string")
+
+
+def require_string_list(errors: list[str], path: str, value: Any) -> None:
+    if not isinstance(value, list) or not value:
+        errors.append(f"{path}: expected non-empty list")
+        return
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            errors.append(f"{path}[{index}]: expected non-empty string")
+
+
+def require_enum_list(errors: list[str], path: str, value: Any, allowed: set[str]) -> None:
+    require_string_list(errors, path, value)
+    if not isinstance(value, list):
+        return
+    for index, item in enumerate(value):
+        if item not in allowed:
+            errors.append(f"{path}[{index}]: invalid value {item!r}")
+
+
+def validate_component(errors: list[str], incident_id: str, index: int, component: Any) -> None:
+    path = f"{incident_id}.affected_components[{index}]"
+    if not isinstance(component, dict):
+        errors.append(f"{path}: expected object")
+        return
+    for field in REQUIRED_COMPONENT_FIELDS:
+        if field not in component:
+            errors.append(f"{path}.{field}: missing required field")
+    require_string(errors, f"{path}.ecosystem", component.get("ecosystem"))
+    require_string(errors, f"{path}.name", component.get("name"))
+    require_string(errors, f"{path}.vendor", component.get("vendor"))
+    if component.get("component_type") not in VALID_COMPONENT_TYPES:
+        errors.append(f"{path}.component_type: invalid value {component.get('component_type')!r}")
+    package_url = component.get("package_url")
+    if package_url is not None and not (isinstance(package_url, str) and PURL_PATTERN.match(package_url)):
+        errors.append(f"{path}.package_url: expected null or package URL")
+
+
+def validate_reference(errors: list[str], incident_id: str, index: int, reference: Any) -> None:
+    path = f"{incident_id}.references[{index}]"
+    if not isinstance(reference, dict):
+        errors.append(f"{path}: expected object")
+        return
+    for field in REQUIRED_REFERENCE_FIELDS:
+        if field not in reference:
+            errors.append(f"{path}.{field}: missing required field")
+    require_string(errors, f"{path}.title", reference.get("title"))
+    require_string(errors, f"{path}.publisher", reference.get("publisher"))
+    if not is_valid_url(reference.get("url")):
+        errors.append(f"{path}.url: expected http(s) URL")
+    if parse_date(reference.get("published_at")) is None:
+        errors.append(f"{path}.published_at: expected YYYY-MM-DD date")
+
+
+def validate_incident(incident: Any) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(incident, dict):
+        return ["incident: expected object"]
+
+    incident_id = incident.get("id", "<missing-id>")
+    for field in REQUIRED_FIELDS:
+        if field not in incident:
+            errors.append(f"{incident_id}.{field}: missing required field")
+
+    if incident.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"{incident_id}.schema_version: expected {SCHEMA_VERSION!r}")
+    if not isinstance(incident.get("id"), str) or not ID_PATTERN.match(incident["id"]):
+        errors.append(f"{incident_id}.id: expected SC-YYYY-SLUG identifier")
+    require_string(errors, f"{incident_id}.title", incident.get("title"), min_length=8)
+    require_string(errors, f"{incident_id}.summary", incident.get("summary"), min_length=40)
+    if incident.get("status") not in VALID_STATUS:
+        errors.append(f"{incident_id}.status: invalid value {incident.get('status')!r}")
+
+    first_observed_at = parse_date(incident.get("first_observed_at"))
+    disclosed_at = parse_date(incident.get("disclosed_at"))
+    if first_observed_at is None:
+        errors.append(f"{incident_id}.first_observed_at: expected YYYY-MM-DD date")
+    if disclosed_at is None:
+        errors.append(f"{incident_id}.disclosed_at: expected YYYY-MM-DD date")
+    if first_observed_at and disclosed_at and disclosed_at < first_observed_at:
+        errors.append(f"{incident_id}.disclosed_at: cannot be before first_observed_at")
+
+    require_string_list(errors, f"{incident_id}.affected_ecosystems", incident.get("affected_ecosystems"))
+    require_enum_list(errors, f"{incident_id}.supply_chain_vectors", incident.get("supply_chain_vectors"), VALID_VECTORS)
+    require_enum_list(errors, f"{incident_id}.impact_categories", incident.get("impact_categories"), VALID_IMPACTS)
+    require_string_list(errors, f"{incident_id}.tags", incident.get("tags"))
+
+    components = incident.get("affected_components")
+    if not isinstance(components, list) or not components:
+        errors.append(f"{incident_id}.affected_components: expected non-empty list")
+    else:
+        for index, component in enumerate(components):
+            validate_component(errors, incident_id, index, component)
+
+    references = incident.get("references")
+    if not isinstance(references, list) or not references:
+        errors.append(f"{incident_id}.references: expected non-empty list")
+    else:
+        for index, reference in enumerate(references):
+            validate_reference(errors, incident_id, index, reference)
+
+    return errors
+
+
+def validate_corpus(corpus: Any) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(corpus, list):
+        return ["corpus: expected top-level array"]
+    if len(corpus) < 25:
+        errors.append(f"corpus: expected at least 25 incidents, found {len(corpus)}")
+
+    seen_ids: set[str] = set()
+    for index, incident in enumerate(corpus):
+        incident_errors = validate_incident(incident)
+        errors.extend(incident_errors)
+        if isinstance(incident, dict):
+            incident_id = incident.get("id")
+            if isinstance(incident_id, str):
+                if incident_id in seen_ids:
+                    errors.append(f"{incident_id}: duplicate id")
+                seen_ids.add(incident_id)
+            else:
+                errors.append(f"corpus[{index}].id: missing valid id")
+    return errors
+
+
+def validate_schema_file(schema: Any) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(schema, dict):
+        return ["schema: expected object"]
+    if schema.get("properties", {}).get("schema_version", {}).get("const") != SCHEMA_VERSION:
+        errors.append("schema.schema_version.const: does not match validator schema version")
+    required = schema.get("required")
+    if required != REQUIRED_FIELDS:
+        errors.append("schema.required: does not match validator required fields")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS_PATH)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA_PATH)
+    args = parser.parse_args(argv)
+
+    errors: list[str] = []
+    try:
+        corpus = load_json(args.corpus)
+        schema = load_json(args.schema)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"failed to load supply-chain incident inputs: {exc}", file=sys.stderr)
+        return 2
+
+    errors.extend(validate_schema_file(schema))
+    errors.extend(validate_corpus(corpus))
+
+    if errors:
+        print("Supply-chain incident validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(f"Validated {len(corpus)} supply-chain incidents from {args.corpus}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_supply_chain_incidents.py
+++ b/scripts/validate_supply_chain_incidents.py
@@ -100,8 +100,11 @@ def require_string(errors: list[str], path: str, value: Any, *, min_length: int 
         errors.append(f"{path}: expected non-empty string")
 
 
-def require_string_list(errors: list[str], path: str, value: Any) -> None:
-    if not isinstance(value, list) or not value:
+def require_string_list(errors: list[str], path: str, value: Any, *, allow_empty: bool = False) -> None:
+    if not isinstance(value, list):
+        errors.append(f"{path}: expected list")
+        return
+    if not value and not allow_empty:
         errors.append(f"{path}: expected non-empty list")
         return
     for index, item in enumerate(value):
@@ -126,10 +129,13 @@ def validate_component(errors: list[str], incident_id: str, index: int, componen
     for field in REQUIRED_COMPONENT_FIELDS:
         if field not in component:
             errors.append(f"{path}.{field}: missing required field")
-    require_string(errors, f"{path}.ecosystem", component.get("ecosystem"))
-    require_string(errors, f"{path}.name", component.get("name"))
-    require_string(errors, f"{path}.vendor", component.get("vendor"))
-    if component.get("component_type") not in VALID_COMPONENT_TYPES:
+    if "ecosystem" in component:
+        require_string(errors, f"{path}.ecosystem", component.get("ecosystem"))
+    if "name" in component:
+        require_string(errors, f"{path}.name", component.get("name"))
+    if "vendor" in component:
+        require_string(errors, f"{path}.vendor", component.get("vendor"))
+    if "component_type" in component and component.get("component_type") not in VALID_COMPONENT_TYPES:
         errors.append(f"{path}.component_type: invalid value {component.get('component_type')!r}")
     package_url = component.get("package_url")
     if package_url is not None and not (isinstance(package_url, str) and PURL_PATTERN.fullmatch(package_url)):
@@ -144,11 +150,13 @@ def validate_reference(errors: list[str], incident_id: str, index: int, referenc
     for field in REQUIRED_REFERENCE_FIELDS:
         if field not in reference:
             errors.append(f"{path}.{field}: missing required field")
-    require_string(errors, f"{path}.title", reference.get("title"))
-    require_string(errors, f"{path}.publisher", reference.get("publisher"))
-    if not is_valid_url(reference.get("url")):
+    if "title" in reference:
+        require_string(errors, f"{path}.title", reference.get("title"))
+    if "publisher" in reference:
+        require_string(errors, f"{path}.publisher", reference.get("publisher"))
+    if "url" in reference and not is_valid_url(reference.get("url")):
         errors.append(f"{path}.url: expected http(s) URL")
-    if parse_date(reference.get("published_at")) is None:
+    if "published_at" in reference and parse_date(reference.get("published_at")) is None:
         errors.append(f"{path}.published_at: expected YYYY-MM-DD date")
 
 
@@ -195,7 +203,7 @@ def validate_incident(incident: Any) -> list[str]:
     if "impact_categories" in incident:
         require_enum_list(errors, f"{incident_id}.impact_categories", incident.get("impact_categories"), VALID_IMPACTS)
     if "tags" in incident:
-        require_string_list(errors, f"{incident_id}.tags", incident.get("tags"))
+        require_string_list(errors, f"{incident_id}.tags", incident.get("tags"), allow_empty=True)
 
     if "affected_components" in incident:
         components = incident.get("affected_components")

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -112,6 +112,15 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
             ["schema.properties.schema_version: expected object"],
         )
 
+    def test_schema_required_fields_are_order_insensitive(self) -> None:
+        schema = load_json(SCHEMA_PATH)
+        schema["required"] = list(reversed(schema["required"]))
+
+        self.assertEqual(validator.validate_schema_file(schema), [])
+
+        schema["required"].pop()
+        self.assertEqual(validator.validate_schema_file(schema), ["schema.required: does not match validator required fields"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR_PATH = REPO_ROOT / "scripts" / "validate_supply_chain_incidents.py"
+CORPUS_PATH = REPO_ROOT / "data" / "supply-chain-incidents" / "incidents.json"
+SCHEMA_PATH = REPO_ROOT / "data" / "supply-chain-incidents" / "schema.json"
+
+
+def load_validator():
+    spec = importlib.util.spec_from_file_location("validate_supply_chain_incidents", VALIDATOR_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load supply-chain incident validator")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+validator = load_validator()
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class SupplyChainIncidentValidationTests(unittest.TestCase):
+    def test_current_corpus_validates(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        schema = load_json(SCHEMA_PATH)
+
+        self.assertGreaterEqual(len(corpus), 25)
+        self.assertEqual(validator.validate_schema_file(schema), [])
+        self.assertEqual(validator.validate_corpus(corpus), [])
+
+    def test_duplicate_ids_fail_validation(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        duplicate = copy.deepcopy(corpus[:2])
+        duplicate[1]["id"] = duplicate[0]["id"]
+
+        errors = validator.validate_corpus(duplicate)
+
+        self.assertTrue(any("duplicate id" in error for error in errors))
+
+    def test_required_fields_dates_and_references_are_enforced(self) -> None:
+        incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
+        del incident["title"]
+        incident["disclosed_at"] = "not-a-date"
+        incident["references"][0]["url"] = "not a url"
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any(".title: missing required field" in error for error in errors))
+        self.assertTrue(any(".disclosed_at: expected YYYY-MM-DD date" in error for error in errors))
+        self.assertTrue(any(".references[0].url: expected http(s) URL" in error for error in errors))
+
+    def test_schema_enums_are_enforced(self) -> None:
+        incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
+        incident["supply_chain_vectors"] = ["scoring"]
+        incident["impact_categories"] = ["risk_engine"]
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any(".supply_chain_vectors[0]: invalid value" in error for error in errors))
+        self.assertTrue(any(".impact_categories[0]: invalid value" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -59,6 +59,26 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
         self.assertTrue(any(".disclosed_at: expected YYYY-MM-DD date" in error for error in errors))
         self.assertTrue(any(".references[0].url: expected http(s) URL" in error for error in errors))
 
+    def test_dates_must_use_hyphenated_full_date_format(self) -> None:
+        incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
+        incident["first_observed_at"] = "2024-W13-5"
+        incident["disclosed_at"] = "20240329"
+        incident["references"][0]["published_at"] = "20240329"
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any(".first_observed_at: expected YYYY-MM-DD date" in error for error in errors))
+        self.assertTrue(any(".disclosed_at: expected YYYY-MM-DD date" in error for error in errors))
+        self.assertTrue(any(".references[0].published_at: expected YYYY-MM-DD date" in error for error in errors))
+
+    def test_package_url_rejects_whitespace_and_partial_matches(self) -> None:
+        incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
+        incident["affected_components"][0]["package_url"] = "pkg:npm/example package"
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any(".affected_components[0].package_url: expected null or package URL" in error for error in errors))
+
     def test_schema_enums_are_enforced(self) -> None:
         incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
         incident["supply_chain_vectors"] = ["scoring"]

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -67,6 +67,30 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
 
         self.assertEqual([error for error in errors if ".title" in error], [f"{incident['id']}.title: missing required field"])
 
+    def test_missing_nested_required_fields_report_once(self) -> None:
+        incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
+        del incident["affected_components"][0]["ecosystem"]
+        del incident["references"][0]["url"]
+
+        errors = validator.validate_incident(incident)
+
+        self.assertEqual(
+            [error for error in errors if ".affected_components[0].ecosystem" in error],
+            [f"{incident['id']}.affected_components[0].ecosystem: missing required field"],
+        )
+        self.assertEqual(
+            [error for error in errors if ".references[0].url" in error],
+            [f"{incident['id']}.references[0].url: missing required field"],
+        )
+
+    def test_empty_tags_are_allowed_by_schema_and_validator(self) -> None:
+        incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
+        incident["tags"] = []
+
+        errors = validator.validate_incident(incident)
+
+        self.assertEqual([error for error in errors if ".tags" in error], [])
+
     def test_non_string_id_is_reported_without_crashing(self) -> None:
         incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
         incident["id"] = None

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -59,6 +59,14 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
         self.assertTrue(any(".disclosed_at: expected YYYY-MM-DD date" in error for error in errors))
         self.assertTrue(any(".references[0].url: expected http(s) URL" in error for error in errors))
 
+    def test_non_string_id_is_reported_without_crashing(self) -> None:
+        incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
+        incident["id"] = None
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any("<missing-id>.id: expected SC-YYYY-SLUG identifier" in error for error in errors))
+
     def test_dates_must_use_hyphenated_full_date_format(self) -> None:
         incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
         incident["first_observed_at"] = "2024-W13-5"
@@ -79,6 +87,14 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
 
         self.assertTrue(any(".affected_components[0].package_url: expected null or package URL" in error for error in errors))
 
+    def test_malformed_url_is_rejected_without_crashing(self) -> None:
+        incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
+        incident["references"][0]["url"] = "https://example.com:bad-port"
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any(".references[0].url: expected http(s) URL" in error for error in errors))
+
     def test_schema_enums_are_enforced(self) -> None:
         incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
         incident["supply_chain_vectors"] = ["scoring"]
@@ -88,6 +104,13 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
 
         self.assertTrue(any(".supply_chain_vectors[0]: invalid value" in error for error in errors))
         self.assertTrue(any(".impact_categories[0]: invalid value" in error for error in errors))
+
+    def test_schema_shape_errors_are_reported_without_crashing(self) -> None:
+        self.assertEqual(validator.validate_schema_file({"properties": []}), ["schema.properties: expected object"])
+        self.assertEqual(
+            validator.validate_schema_file({"properties": {"schema_version": []}}),
+            ["schema.properties.schema_version: expected object"],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -59,6 +59,14 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
         self.assertTrue(any(".disclosed_at: expected YYYY-MM-DD date" in error for error in errors))
         self.assertTrue(any(".references[0].url: expected http(s) URL" in error for error in errors))
 
+    def test_missing_required_field_reports_once(self) -> None:
+        incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
+        del incident["title"]
+
+        errors = validator.validate_incident(incident)
+
+        self.assertEqual([error for error in errors if ".title" in error], [f"{incident['id']}.title: missing required field"])
+
     def test_non_string_id_is_reported_without_crashing(self) -> None:
         incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
         incident["id"] = None
@@ -104,6 +112,14 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
 
         self.assertTrue(any(".supply_chain_vectors[0]: invalid value" in error for error in errors))
         self.assertTrue(any(".impact_categories[0]: invalid value" in error for error in errors))
+
+    def test_unhashable_enum_items_do_not_crash_validation(self) -> None:
+        incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
+        incident["supply_chain_vectors"] = [{}]
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any(".supply_chain_vectors[0]: expected non-empty string" in error for error in errors))
 
     def test_schema_shape_errors_are_reported_without_crashing(self) -> None:
         self.assertEqual(validator.validate_schema_file({"properties": []}), ["schema.properties: expected object"])


### PR DESCRIPTION
## Summary
- add a structured supply-chain incident corpus with 25 documented historical incidents
- add a common `supply-chain-incident/1` schema primitive
- add dependency-free validation tooling for IDs, required fields, dates, references, enums, and PURL shape
- add unit tests and documentation for future corpus additions

## Non-goals preserved
- no scoring
- no risk engine
- no graph database
- no attribution automation
- no dashboards or UI
- no live feeds

## Validation
- python3 scripts/validate_supply_chain_incidents.py
- python3 -m unittest discover -s tests
- python3 -m compileall scripts/validate_supply_chain_incidents.py tests
- git diff --check
