### PR TITLE
Deepen supply chain incident graph corpus phase 1C

### DIFF
--- a/data/supply-chain-entities/accounts.json
+++ b/data/supply-chain-entities/accounts.json
@@ -1,0 +1,106 @@
+[
+  {
+    "account_type": "source_control_account",
+    "aliases": [
+      "tj-actions GitHub Action release path"
+    ],
+    "id": "account-github-tj-actions-github-action-release-path",
+    "name": "tj-actions GitHub Action release path",
+    "provider": "GitHub",
+    "role": "action_release",
+    "source_incident_ids": [
+      "SC-2025-TJ-ACTIONS-CHANGED-FILES"
+    ]
+  },
+  {
+    "account_type": "package_registry_account",
+    "aliases": [
+      "eslint-scope npm maintainer account"
+    ],
+    "id": "account-npm-eslint-scope-npm-maintainer-account",
+    "name": "eslint-scope npm maintainer account",
+    "provider": "npm",
+    "role": "maintainer_publish",
+    "source_incident_ids": [
+      "SC-2018-ESLINT-SCOPE"
+    ]
+  },
+  {
+    "account_type": "package_registry_account",
+    "aliases": [
+      "@ledgerhq/connect-kit npm publish account"
+    ],
+    "id": "account-npm-ledgerhq-connect-kit-npm-publish-account",
+    "name": "@ledgerhq/connect-kit npm publish account",
+    "provider": "npm",
+    "role": "maintainer_publish",
+    "source_incident_ids": [
+      "SC-2023-LEDGER-CONNECT-KIT"
+    ]
+  },
+  {
+    "account_type": "package_registry_account",
+    "aliases": [
+      "@lottiefiles/lottie-player npm publish account"
+    ],
+    "id": "account-npm-lottiefiles-lottie-player-npm-publish-account",
+    "name": "@lottiefiles/lottie-player npm publish account",
+    "provider": "npm",
+    "role": "maintainer_publish",
+    "source_incident_ids": [
+      "SC-2024-LOTTIE-PLAYER"
+    ]
+  },
+  {
+    "account_type": "package_registry_account",
+    "aliases": [
+      "ua-parser-js npm maintainer account"
+    ],
+    "id": "account-npm-ua-parser-js-npm-maintainer-account",
+    "name": "ua-parser-js npm maintainer account",
+    "provider": "npm",
+    "role": "maintainer_publish",
+    "source_incident_ids": [
+      "SC-2021-UA-PARSER-JS"
+    ]
+  },
+  {
+    "account_type": "source_control_account",
+    "aliases": [
+      "PHP git server commit identity"
+    ],
+    "id": "account-php-git-php-git-server-commit-identity",
+    "name": "PHP git server commit identity",
+    "provider": "PHP Git",
+    "role": "source_commit",
+    "source_incident_ids": [
+      "SC-2021-PHP-GIT-SERVER"
+    ]
+  },
+  {
+    "account_type": "package_registry_account",
+    "aliases": [
+      "ctx PyPI project account"
+    ],
+    "id": "account-pypi-ctx-pypi-project-account",
+    "name": "ctx PyPI project account",
+    "provider": "PyPI",
+    "role": "maintainer_publish",
+    "source_incident_ids": [
+      "SC-2022-PYPI-CTX"
+    ]
+  },
+  {
+    "account_type": "package_registry_token",
+    "aliases": [
+      "Ultralytics PyPI publishing token"
+    ],
+    "id": "account-pypi-ultralytics-pypi-publishing-token",
+    "name": "Ultralytics PyPI publishing token",
+    "provider": "PyPI",
+    "role": "package_publish",
+    "source_incident_ids": [
+      "SC-2024-ULTRALYTICS-PYPI"
+    ]
+  }
+]

--- a/data/supply-chain-entities/build_systems.json
+++ b/data/supply-chain-entities/build_systems.json
@@ -1,0 +1,75 @@
+[
+  {
+    "aliases": [
+      "3CX DesktopApp build pipeline"
+    ],
+    "category": "vendor-build",
+    "id": "build-3cx-3cx-desktopapp-build-pipeline",
+    "name": "3CX DesktopApp build pipeline",
+    "provider": "3CX",
+    "source_incident_ids": [
+      "SC-2023-THREE-CX-DESKTOP"
+    ]
+  },
+  {
+    "aliases": [
+      "Codecov Bash Uploader distribution pipeline"
+    ],
+    "category": "ci-cd",
+    "id": "build-codecov-codecov-bash-uploader-distribution-pipeline",
+    "name": "Codecov Bash Uploader distribution pipeline",
+    "provider": "Codecov",
+    "source_incident_ids": [
+      "SC-2021-CODECOV-BASH-UPLOADER"
+    ]
+  },
+  {
+    "aliases": [
+      "GitHub Actions"
+    ],
+    "category": "ci-cd",
+    "id": "build-github-github-actions",
+    "name": "GitHub Actions",
+    "provider": "GitHub",
+    "source_incident_ids": [
+      "SC-2024-ULTRALYTICS-PYPI",
+      "SC-2025-TJ-ACTIONS-CHANGED-FILES"
+    ]
+  },
+  {
+    "aliases": [
+      "NetBeans project build process"
+    ],
+    "category": "developer-build",
+    "id": "build-netbeans-netbeans-project-build-process",
+    "name": "NetBeans project build process",
+    "provider": "NetBeans",
+    "source_incident_ids": [
+      "SC-2020-OCTOPUS-SCANNER"
+    ]
+  },
+  {
+    "aliases": [
+      "PyTorch nightly build pipeline"
+    ],
+    "category": "project-build",
+    "id": "build-pytorch-pytorch-nightly-build-pipeline",
+    "name": "PyTorch nightly build pipeline",
+    "provider": "PyTorch",
+    "source_incident_ids": [
+      "SC-2022-PYTORCH-NIGHTLY"
+    ]
+  },
+  {
+    "aliases": [
+      "SolarWinds Orion build system"
+    ],
+    "category": "vendor-build",
+    "id": "build-solarwinds-solarwinds-orion-build-system",
+    "name": "SolarWinds Orion build system",
+    "provider": "SolarWinds",
+    "source_incident_ids": [
+      "SC-2020-SOLARWINDS-ORION"
+    ]
+  }
+]

--- a/data/supply-chain-entities/distribution_channels.json
+++ b/data/supply-chain-entities/distribution_channels.json
@@ -1,0 +1,150 @@
+[
+  {
+    "aliases": [
+      "Codecov Bash Uploader download path"
+    ],
+    "channel_type": "script_download",
+    "ecosystem": "ci-cd",
+    "id": "channel-ci-cd-script-download-codecov-bash-uploader-download-path",
+    "name": "Codecov Bash Uploader download path",
+    "source_incident_ids": [
+      "SC-2021-CODECOV-BASH-UPLOADER"
+    ]
+  },
+  {
+    "aliases": [
+      "GitHub Actions Marketplace"
+    ],
+    "channel_type": "ci_cd_marketplace",
+    "ecosystem": "github-actions",
+    "id": "channel-github-actions-ci-cd-marketplace-github-actions-marketplace",
+    "name": "GitHub Actions Marketplace",
+    "source_incident_ids": [
+      "SC-2025-TJ-ACTIONS-CHANGED-FILES"
+    ]
+  },
+  {
+    "aliases": [
+      "Upstream source release tarball"
+    ],
+    "channel_type": "source_release",
+    "ecosystem": "linux",
+    "id": "channel-linux-source-release-upstream-source-release-tarball",
+    "name": "Upstream source release tarball",
+    "source_incident_ids": [
+      "SC-2024-XZ-UTILS"
+    ]
+  },
+  {
+    "aliases": [
+      "Linux Mint download site"
+    ],
+    "channel_type": "website_download",
+    "ecosystem": "linux",
+    "id": "channel-linux-website-download-linux-mint-download-site",
+    "name": "Linux Mint download site",
+    "source_incident_ids": [
+      "SC-2016-LINUX-MINT-ISO"
+    ]
+  },
+  {
+    "aliases": [
+      "npm registry"
+    ],
+    "channel_type": "package_registry",
+    "ecosystem": "npm",
+    "id": "channel-npm-package-registry-npm-registry",
+    "name": "npm registry",
+    "source_incident_ids": [
+      "SC-2018-ESLINT-SCOPE",
+      "SC-2018-NPM-EVENT-STREAM",
+      "SC-2021-DEPENDENCY-CONFUSION",
+      "SC-2021-NPM-RC",
+      "SC-2021-UA-PARSER-JS",
+      "SC-2022-COLORS-FAKER",
+      "SC-2022-NODE-IPC",
+      "SC-2023-LEDGER-CONNECT-KIT",
+      "SC-2024-LOTTIE-PLAYER"
+    ]
+  },
+  {
+    "aliases": [
+      "PyPI"
+    ],
+    "channel_type": "package_registry",
+    "ecosystem": "pypi",
+    "id": "channel-pypi-package-registry-pypi",
+    "name": "PyPI",
+    "source_incident_ids": [
+      "SC-2021-DEPENDENCY-CONFUSION",
+      "SC-2022-PYPI-CTX",
+      "SC-2022-PYTORCH-NIGHTLY",
+      "SC-2024-ULTRALYTICS-PYPI"
+    ]
+  },
+  {
+    "aliases": [
+      "RubyGems"
+    ],
+    "channel_type": "package_registry",
+    "ecosystem": "rubygems",
+    "id": "channel-rubygems-package-registry-rubygems",
+    "name": "RubyGems",
+    "source_incident_ids": [
+      "SC-2021-DEPENDENCY-CONFUSION"
+    ]
+  },
+  {
+    "aliases": [
+      "Source repository"
+    ],
+    "channel_type": "source_repository",
+    "ecosystem": "source-control",
+    "id": "channel-source-control-source-repository-source-repository",
+    "name": "Source repository",
+    "source_incident_ids": [
+      "SC-2020-OCTOPUS-SCANNER",
+      "SC-2021-PHP-GIT-SERVER"
+    ]
+  },
+  {
+    "aliases": [
+      "Signed software installer/update channel"
+    ],
+    "channel_type": "signed_update",
+    "ecosystem": "vendor-update",
+    "id": "channel-vendor-update-signed-update-signed-software-installer-update-channel",
+    "name": "Signed software installer/update channel",
+    "source_incident_ids": [
+      "SC-2017-CCLEANER",
+      "SC-2019-ASUS-SHADOWHAMMER",
+      "SC-2020-SOLARWINDS-ORION",
+      "SC-2023-THREE-CX-DESKTOP"
+    ]
+  },
+  {
+    "aliases": [
+      "Vendor software update channel"
+    ],
+    "channel_type": "software_update",
+    "ecosystem": "vendor-update",
+    "id": "channel-vendor-update-software-update-vendor-software-update-channel",
+    "name": "Vendor software update channel",
+    "source_incident_ids": [
+      "SC-2017-NOTPETYA-MEDOC",
+      "SC-2021-KASEYA-VSA"
+    ]
+  },
+  {
+    "aliases": [
+      "Third-party CDN script"
+    ],
+    "channel_type": "cdn_script",
+    "ecosystem": "web",
+    "id": "channel-web-cdn-script-third-party-cdn-script",
+    "name": "Third-party CDN script",
+    "source_incident_ids": [
+      "SC-2024-POLYFILL-IO"
+    ]
+  }
+]

--- a/data/supply-chain-entities/maintainers.json
+++ b/data/supply-chain-entities/maintainers.json
@@ -42,5 +42,15 @@
     "source_incident_ids": [
       "SC-2022-NODE-IPC"
     ]
+  },
+  {
+    "aliases": [
+      "right9ctrl"
+    ],
+    "id": "maintainer-right9ctrl",
+    "name": "right9ctrl",
+    "source_incident_ids": [
+      "SC-2018-NPM-EVENT-STREAM"
+    ]
   }
 ]

--- a/data/supply-chain-entities/packages.json
+++ b/data/supply-chain-entities/packages.json
@@ -25,6 +25,18 @@
   },
   {
     "aliases": [
+      "eslint-config-eslint"
+    ],
+    "ecosystem": "npm",
+    "id": "pkg-npm-eslint-config-eslint",
+    "name": "eslint-config-eslint",
+    "package_url": "pkg:npm/eslint-config-eslint",
+    "source_incident_ids": [
+      "SC-2018-ESLINT-SCOPE"
+    ]
+  },
+  {
+    "aliases": [
       "eslint-scope"
     ],
     "ecosystem": "npm",
@@ -61,6 +73,18 @@
   },
   {
     "aliases": [
+      "flatmap-stream"
+    ],
+    "ecosystem": "npm",
+    "id": "pkg-npm-flatmap-stream",
+    "name": "flatmap-stream",
+    "package_url": "pkg:npm/flatmap-stream",
+    "source_incident_ids": [
+      "SC-2018-NPM-EVENT-STREAM"
+    ]
+  },
+  {
+    "aliases": [
       "@ledgerhq/connect-kit"
     ],
     "ecosystem": "npm",
@@ -91,6 +115,18 @@
     "id": "pkg-npm-node-ipc",
     "name": "node-ipc",
     "package_url": "pkg:npm/node-ipc",
+    "source_incident_ids": [
+      "SC-2022-NODE-IPC"
+    ]
+  },
+  {
+    "aliases": [
+      "peacenotwar"
+    ],
+    "ecosystem": "npm",
+    "id": "pkg-npm-peacenotwar",
+    "name": "peacenotwar",
+    "package_url": "pkg:npm/peacenotwar",
     "source_incident_ids": [
       "SC-2022-NODE-IPC"
     ]

--- a/data/supply-chain-entities/repositories.json
+++ b/data/supply-chain-entities/repositories.json
@@ -1,6 +1,19 @@
 [
   {
     "aliases": [
+      "codecov/codecov-bash"
+    ],
+    "host": "github.com",
+    "id": "repo-github-com-codecov-codecov-bash",
+    "name": "codecov/codecov-bash",
+    "owner": "codecov",
+    "source_incident_ids": [
+      "SC-2021-CODECOV-BASH-UPLOADER"
+    ],
+    "url": "https://github.com/codecov/codecov-bash"
+  },
+  {
+    "aliases": [
       "dominictarr/event-stream"
     ],
     "host": "github.com",
@@ -11,6 +24,19 @@
       "SC-2018-NPM-EVENT-STREAM"
     ],
     "url": "https://github.com/dominictarr/event-stream"
+  },
+  {
+    "aliases": [
+      "eslint/eslint-scope"
+    ],
+    "host": "github.com",
+    "id": "repo-github-com-eslint-eslint-scope",
+    "name": "eslint/eslint-scope",
+    "owner": "eslint",
+    "source_incident_ids": [
+      "SC-2018-ESLINT-SCOPE"
+    ],
+    "url": "https://github.com/eslint/eslint-scope"
   },
   {
     "aliases": [
@@ -27,6 +53,58 @@
   },
   {
     "aliases": [
+      "php/php-src"
+    ],
+    "host": "github.com",
+    "id": "repo-github-com-php-php-src",
+    "name": "php/php-src",
+    "owner": "php",
+    "source_incident_ids": [
+      "SC-2021-PHP-GIT-SERVER"
+    ],
+    "url": "https://github.com/php/php-src"
+  },
+  {
+    "aliases": [
+      "pytorch/pytorch"
+    ],
+    "host": "github.com",
+    "id": "repo-github-com-pytorch-pytorch",
+    "name": "pytorch/pytorch",
+    "owner": "pytorch",
+    "source_incident_ids": [
+      "SC-2022-PYTORCH-NIGHTLY"
+    ],
+    "url": "https://github.com/pytorch/pytorch"
+  },
+  {
+    "aliases": [
+      "RIAEvangelist/node-ipc"
+    ],
+    "host": "github.com",
+    "id": "repo-github-com-riaevangelist-node-ipc",
+    "name": "RIAEvangelist/node-ipc",
+    "owner": "RIAEvangelist",
+    "source_incident_ids": [
+      "SC-2022-NODE-IPC"
+    ],
+    "url": "https://github.com/RIAEvangelist/node-ipc"
+  },
+  {
+    "aliases": [
+      "tj-actions/changed-files"
+    ],
+    "host": "github.com",
+    "id": "repo-github-com-tj-actions-changed-files",
+    "name": "tj-actions/changed-files",
+    "owner": "tj-actions",
+    "source_incident_ids": [
+      "SC-2025-TJ-ACTIONS-CHANGED-FILES"
+    ],
+    "url": "https://github.com/tj-actions/changed-files"
+  },
+  {
+    "aliases": [
       "tukaani-project/xz"
     ],
     "host": "github.com",
@@ -37,5 +115,18 @@
       "SC-2024-XZ-UTILS"
     ],
     "url": "https://github.com/tukaani-project/xz"
+  },
+  {
+    "aliases": [
+      "ultralytics/ultralytics"
+    ],
+    "host": "github.com",
+    "id": "repo-github-com-ultralytics-ultralytics",
+    "name": "ultralytics/ultralytics",
+    "owner": "ultralytics",
+    "source_incident_ids": [
+      "SC-2024-ULTRALYTICS-PYPI"
+    ],
+    "url": "https://github.com/ultralytics/ultralytics"
   }
 ]

--- a/data/supply-chain-incidents/incidents.json
+++ b/data/supply-chain-incidents/incidents.json
@@ -7,7 +7,10 @@
     "status": "confirmed",
     "first_observed_at": "2016-02-20",
     "disclosed_at": "2016-02-21",
-    "affected_ecosystems": ["linux", "distribution-website"],
+    "affected_ecosystems": [
+      "linux",
+      "distribution-website"
+    ],
     "affected_components": [
       {
         "component_type": "website",
@@ -17,8 +20,13 @@
         "package_url": null
       }
     ],
-    "supply_chain_vectors": ["distribution_site_compromise"],
-    "impact_categories": ["malware_distribution", "backdoor"],
+    "supply_chain_vectors": [
+      "distribution_site_compromise"
+    ],
+    "impact_categories": [
+      "malware_distribution",
+      "backdoor"
+    ],
     "references": [
       {
         "title": "Beware of hacked ISOs if you downloaded Linux Mint on February 20th",
@@ -27,7 +35,26 @@
         "published_at": "2016-02-21"
       }
     ],
-    "tags": ["iso", "distribution"]
+    "tags": [
+      "iso",
+      "distribution"
+    ],
+    "confidence": "high",
+    "evidence_level": "vendor",
+    "attack_stage": "distribution_compromise",
+    "source_artifact_divergence": true,
+    "notes": "Backdoored ISO was distributed through the public Linux Mint download site.",
+    "maintainers": [],
+    "repositories": [],
+    "build_systems": [],
+    "distribution_channels": [
+      {
+        "name": "Linux Mint download site",
+        "channel_type": "website_download",
+        "ecosystem": "linux"
+      }
+    ],
+    "compromised_accounts": []
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -37,7 +64,10 @@
     "status": "confirmed",
     "first_observed_at": "2017-06-27",
     "disclosed_at": "2017-07-01",
-    "affected_ecosystems": ["windows", "vendor-update"],
+    "affected_ecosystems": [
+      "windows",
+      "vendor-update"
+    ],
     "affected_components": [
       {
         "component_type": "software",
@@ -47,8 +77,14 @@
         "package_url": null
       }
     ],
-    "supply_chain_vectors": ["vendor_update_compromise"],
-    "impact_categories": ["destructive_payload", "ransomware_delivery", "downstream_customer_compromise"],
+    "supply_chain_vectors": [
+      "vendor_update_compromise"
+    ],
+    "impact_categories": [
+      "destructive_payload",
+      "ransomware_delivery",
+      "downstream_customer_compromise"
+    ],
     "references": [
       {
         "title": "Petya Ransomware",
@@ -57,7 +93,26 @@
         "published_at": "2017-07-01"
       }
     ],
-    "tags": ["notpetya", "software-update"]
+    "tags": [
+      "notpetya",
+      "software-update"
+    ],
+    "confidence": "high",
+    "evidence_level": "vendor",
+    "attack_stage": "distribution_compromise",
+    "source_artifact_divergence": null,
+    "notes": "Compromise centered on a vendor software update channel used by downstream customers.",
+    "maintainers": [],
+    "repositories": [],
+    "build_systems": [],
+    "distribution_channels": [
+      {
+        "name": "Vendor software update channel",
+        "channel_type": "software_update",
+        "ecosystem": "vendor-update"
+      }
+    ],
+    "compromised_accounts": []
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -67,7 +122,10 @@
     "status": "confirmed",
     "first_observed_at": "2017-08-15",
     "disclosed_at": "2017-09-18",
-    "affected_ecosystems": ["windows", "vendor-update"],
+    "affected_ecosystems": [
+      "windows",
+      "vendor-update"
+    ],
     "affected_components": [
       {
         "component_type": "software",
@@ -77,8 +135,13 @@
         "package_url": null
       }
     ],
-    "supply_chain_vectors": ["signed_update_compromise"],
-    "impact_categories": ["malware_distribution", "backdoor"],
+    "supply_chain_vectors": [
+      "signed_update_compromise"
+    ],
+    "impact_categories": [
+      "malware_distribution",
+      "backdoor"
+    ],
     "references": [
       {
         "title": "CCleaner Command and Control Causes Concern",
@@ -87,7 +150,26 @@
         "published_at": "2017-09-18"
       }
     ],
-    "tags": ["signed-update", "windows"]
+    "tags": [
+      "signed-update",
+      "windows"
+    ],
+    "confidence": "high",
+    "evidence_level": "researcher",
+    "attack_stage": "distribution_compromise",
+    "source_artifact_divergence": null,
+    "notes": "Signed CCleaner installer/update artifacts carried malicious code.",
+    "maintainers": [],
+    "repositories": [],
+    "build_systems": [],
+    "distribution_channels": [
+      {
+        "name": "Signed software installer/update channel",
+        "channel_type": "signed_update",
+        "ecosystem": "vendor-update"
+      }
+    ],
+    "compromised_accounts": []
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -97,7 +179,9 @@
     "status": "confirmed",
     "first_observed_at": "2018-07-12",
     "disclosed_at": "2018-07-12",
-    "affected_ecosystems": ["npm"],
+    "affected_ecosystems": [
+      "npm"
+    ],
     "affected_components": [
       {
         "component_type": "package",
@@ -105,10 +189,23 @@
         "name": "eslint-scope",
         "vendor": "ESLint",
         "package_url": "pkg:npm/eslint-scope"
+      },
+      {
+        "component_type": "package",
+        "ecosystem": "npm",
+        "name": "eslint-config-eslint",
+        "vendor": "ESLint",
+        "package_url": "pkg:npm/eslint-config-eslint"
       }
     ],
-    "supply_chain_vectors": ["maintainer_account_compromise", "package_repository_compromise"],
-    "impact_categories": ["credential_theft", "developer_workstation_compromise"],
+    "supply_chain_vectors": [
+      "maintainer_account_compromise",
+      "package_repository_compromise"
+    ],
+    "impact_categories": [
+      "credential_theft",
+      "developer_workstation_compromise"
+    ],
     "references": [
       {
         "title": "Postmortem for Malicious Package Publishes",
@@ -117,7 +214,40 @@
         "published_at": "2018-07-12"
       }
     ],
-    "tags": ["npm", "maintainer-account"]
+    "tags": [
+      "npm",
+      "maintainer-account"
+    ],
+    "confidence": "high",
+    "evidence_level": "vendor",
+    "attack_stage": "account_compromise",
+    "source_artifact_divergence": false,
+    "notes": "Malicious npm publishes followed maintainer account compromise.",
+    "maintainers": [],
+    "repositories": [
+      {
+        "name": "eslint/eslint-scope",
+        "host": "github.com",
+        "owner": "eslint",
+        "url": "https://github.com/eslint/eslint-scope"
+      }
+    ],
+    "build_systems": [],
+    "distribution_channels": [
+      {
+        "name": "npm registry",
+        "channel_type": "package_registry",
+        "ecosystem": "npm"
+      }
+    ],
+    "compromised_accounts": [
+      {
+        "name": "eslint-scope npm maintainer account",
+        "provider": "npm",
+        "account_type": "package_registry_account",
+        "role": "maintainer_publish"
+      }
+    ]
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -127,7 +257,9 @@
     "status": "confirmed",
     "first_observed_at": "2018-09-09",
     "disclosed_at": "2018-11-26",
-    "affected_ecosystems": ["npm"],
+    "affected_ecosystems": [
+      "npm"
+    ],
     "affected_components": [
       {
         "component_type": "package",
@@ -135,10 +267,22 @@
         "name": "event-stream",
         "vendor": "open source maintainers",
         "package_url": "pkg:npm/event-stream"
+      },
+      {
+        "component_type": "package",
+        "ecosystem": "npm",
+        "name": "flatmap-stream",
+        "vendor": "right9ctrl",
+        "package_url": "pkg:npm/flatmap-stream"
       }
     ],
-    "supply_chain_vectors": ["malicious_dependency"],
-    "impact_categories": ["credential_theft", "crypto_theft"],
+    "supply_chain_vectors": [
+      "malicious_dependency"
+    ],
+    "impact_categories": [
+      "credential_theft",
+      "crypto_theft"
+    ],
     "references": [
       {
         "title": "I don't have time to maintain this package",
@@ -147,7 +291,46 @@
         "published_at": "2018-11-26"
       }
     ],
-    "tags": ["npm", "dependency"]
+    "tags": [
+      "npm",
+      "dependency"
+    ],
+    "confidence": "high",
+    "evidence_level": "primary",
+    "attack_stage": "package_publish",
+    "source_artifact_divergence": false,
+    "notes": "Maintainer transfer introduced flatmap-stream into the event-stream dependency path.",
+    "maintainers": [
+      {
+        "name": "Dominic Tarr",
+        "aliases": [
+          "dominictarr"
+        ],
+        "id_slug": "dominictarr"
+      },
+      {
+        "name": "right9ctrl",
+        "aliases": [],
+        "id_slug": "right9ctrl"
+      }
+    ],
+    "repositories": [
+      {
+        "name": "dominictarr/event-stream",
+        "host": "github.com",
+        "owner": "dominictarr",
+        "url": "https://github.com/dominictarr/event-stream"
+      }
+    ],
+    "build_systems": [],
+    "distribution_channels": [
+      {
+        "name": "npm registry",
+        "channel_type": "package_registry",
+        "ecosystem": "npm"
+      }
+    ],
+    "compromised_accounts": []
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -157,7 +340,10 @@
     "status": "confirmed",
     "first_observed_at": "2018-06-01",
     "disclosed_at": "2019-03-25",
-    "affected_ecosystems": ["windows", "vendor-update"],
+    "affected_ecosystems": [
+      "windows",
+      "vendor-update"
+    ],
     "affected_components": [
       {
         "component_type": "update_channel",
@@ -167,8 +353,13 @@
         "package_url": null
       }
     ],
-    "supply_chain_vectors": ["signed_update_compromise"],
-    "impact_categories": ["malware_distribution", "backdoor"],
+    "supply_chain_vectors": [
+      "signed_update_compromise"
+    ],
+    "impact_categories": [
+      "malware_distribution",
+      "backdoor"
+    ],
     "references": [
       {
         "title": "Operation ShadowHammer",
@@ -177,7 +368,26 @@
         "published_at": "2019-03-25"
       }
     ],
-    "tags": ["signed-update", "targeted"]
+    "tags": [
+      "signed-update",
+      "targeted"
+    ],
+    "confidence": "high",
+    "evidence_level": "researcher",
+    "attack_stage": "distribution_compromise",
+    "source_artifact_divergence": null,
+    "notes": "Signed ASUS Live Update channel distributed targeted malicious updates.",
+    "maintainers": [],
+    "repositories": [],
+    "build_systems": [],
+    "distribution_channels": [
+      {
+        "name": "Signed software installer/update channel",
+        "channel_type": "signed_update",
+        "ecosystem": "vendor-update"
+      }
+    ],
+    "compromised_accounts": []
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -187,7 +397,10 @@
     "status": "confirmed",
     "first_observed_at": "2020-03-01",
     "disclosed_at": "2020-03-09",
-    "affected_ecosystems": ["java", "source-repository"],
+    "affected_ecosystems": [
+      "java",
+      "source-repository"
+    ],
     "affected_components": [
       {
         "component_type": "project",
@@ -197,8 +410,14 @@
         "package_url": null
       }
     ],
-    "supply_chain_vectors": ["source_repository_compromise", "build_system_compromise"],
-    "impact_categories": ["developer_workstation_compromise", "malware_distribution"],
+    "supply_chain_vectors": [
+      "source_repository_compromise",
+      "build_system_compromise"
+    ],
+    "impact_categories": [
+      "developer_workstation_compromise",
+      "malware_distribution"
+    ],
     "references": [
       {
         "title": "Octopus Scanner Malware: Open Source Supply Chain",
@@ -207,7 +426,32 @@
         "published_at": "2020-03-09"
       }
     ],
-    "tags": ["github", "java"]
+    "tags": [
+      "github",
+      "java"
+    ],
+    "confidence": "high",
+    "evidence_level": "researcher",
+    "attack_stage": "source_compromise",
+    "source_artifact_divergence": null,
+    "notes": "Malicious NetBeans projects used developer build workflows to propagate.",
+    "maintainers": [],
+    "repositories": [],
+    "build_systems": [
+      {
+        "name": "NetBeans project build process",
+        "provider": "NetBeans",
+        "category": "developer-build"
+      }
+    ],
+    "distribution_channels": [
+      {
+        "name": "Source repository",
+        "channel_type": "source_repository",
+        "ecosystem": "source-control"
+      }
+    ],
+    "compromised_accounts": []
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -217,7 +461,10 @@
     "status": "confirmed",
     "first_observed_at": "2020-03-01",
     "disclosed_at": "2020-12-13",
-    "affected_ecosystems": ["windows", "vendor-update"],
+    "affected_ecosystems": [
+      "windows",
+      "vendor-update"
+    ],
     "affected_components": [
       {
         "component_type": "software",
@@ -227,8 +474,14 @@
         "package_url": null
       }
     ],
-    "supply_chain_vectors": ["build_system_compromise", "signed_update_compromise"],
-    "impact_categories": ["backdoor", "downstream_customer_compromise"],
+    "supply_chain_vectors": [
+      "build_system_compromise",
+      "signed_update_compromise"
+    ],
+    "impact_categories": [
+      "backdoor",
+      "downstream_customer_compromise"
+    ],
     "references": [
       {
         "title": "Advanced Persistent Threat Compromise of Government Agencies, Critical Infrastructure, and Private Sector Organizations",
@@ -237,7 +490,32 @@
         "published_at": "2020-12-17"
       }
     ],
-    "tags": ["build-system", "sunburst"]
+    "tags": [
+      "build-system",
+      "sunburst"
+    ],
+    "confidence": "high",
+    "evidence_level": "vendor",
+    "attack_stage": "build_compromise",
+    "source_artifact_divergence": null,
+    "notes": "Compromise affected the Orion build and signed update pipeline.",
+    "maintainers": [],
+    "repositories": [],
+    "build_systems": [
+      {
+        "name": "SolarWinds Orion build system",
+        "provider": "SolarWinds",
+        "category": "vendor-build"
+      }
+    ],
+    "distribution_channels": [
+      {
+        "name": "Signed software installer/update channel",
+        "channel_type": "signed_update",
+        "ecosystem": "vendor-update"
+      }
+    ],
+    "compromised_accounts": []
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -247,7 +525,11 @@
     "status": "confirmed",
     "first_observed_at": "2021-02-09",
     "disclosed_at": "2021-02-09",
-    "affected_ecosystems": ["npm", "pypi", "rubygems"],
+    "affected_ecosystems": [
+      "npm",
+      "pypi",
+      "rubygems"
+    ],
     "affected_components": [
       {
         "component_type": "package",
@@ -257,8 +539,13 @@
         "package_url": null
       }
     ],
-    "supply_chain_vectors": ["dependency_confusion"],
-    "impact_categories": ["developer_workstation_compromise", "data_exfiltration"],
+    "supply_chain_vectors": [
+      "dependency_confusion"
+    ],
+    "impact_categories": [
+      "developer_workstation_compromise",
+      "data_exfiltration"
+    ],
     "references": [
       {
         "title": "Dependency Confusion: How I Hacked Into Apple, Microsoft and Dozens of Other Companies",
@@ -267,7 +554,36 @@
         "published_at": "2021-02-09"
       }
     ],
-    "tags": ["dependency-confusion", "research"]
+    "tags": [
+      "dependency-confusion",
+      "research"
+    ],
+    "confidence": "high",
+    "evidence_level": "researcher",
+    "attack_stage": "dependency_resolution",
+    "source_artifact_divergence": false,
+    "notes": "Research demonstrated dependency resolver behavior across public registries.",
+    "maintainers": [],
+    "repositories": [],
+    "build_systems": [],
+    "distribution_channels": [
+      {
+        "name": "npm registry",
+        "channel_type": "package_registry",
+        "ecosystem": "npm"
+      },
+      {
+        "name": "PyPI",
+        "channel_type": "package_registry",
+        "ecosystem": "pypi"
+      },
+      {
+        "name": "RubyGems",
+        "channel_type": "package_registry",
+        "ecosystem": "rubygems"
+      }
+    ],
+    "compromised_accounts": []
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -277,7 +593,10 @@
     "status": "confirmed",
     "first_observed_at": "2021-03-28",
     "disclosed_at": "2021-03-28",
-    "affected_ecosystems": ["php", "source-repository"],
+    "affected_ecosystems": [
+      "php",
+      "source-repository"
+    ],
     "affected_components": [
       {
         "component_type": "project",
@@ -287,8 +606,12 @@
         "package_url": null
       }
     ],
-    "supply_chain_vectors": ["source_repository_compromise"],
-    "impact_categories": ["backdoor"],
+    "supply_chain_vectors": [
+      "source_repository_compromise"
+    ],
+    "impact_categories": [
+      "backdoor"
+    ],
     "references": [
       {
         "title": "PHP Git server compromise notice",
@@ -297,7 +620,40 @@
         "published_at": "2021-03-28"
       }
     ],
-    "tags": ["source-control", "php"]
+    "tags": [
+      "source-control",
+      "php"
+    ],
+    "confidence": "high",
+    "evidence_level": "vendor",
+    "attack_stage": "source_compromise",
+    "source_artifact_divergence": false,
+    "notes": "Malicious commits were pushed to the PHP source repository before release.",
+    "maintainers": [],
+    "repositories": [
+      {
+        "name": "php/php-src",
+        "host": "github.com",
+        "owner": "php",
+        "url": "https://github.com/php/php-src"
+      }
+    ],
+    "build_systems": [],
+    "distribution_channels": [
+      {
+        "name": "Source repository",
+        "channel_type": "source_repository",
+        "ecosystem": "source-control"
+      }
+    ],
+    "compromised_accounts": [
+      {
+        "name": "PHP git server commit identity",
+        "provider": "PHP Git",
+        "account_type": "source_control_account",
+        "role": "source_commit"
+      }
+    ]
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -307,7 +663,9 @@
     "status": "confirmed",
     "first_observed_at": "2021-01-31",
     "disclosed_at": "2021-04-15",
-    "affected_ecosystems": ["ci-cd"],
+    "affected_ecosystems": [
+      "ci-cd"
+    ],
     "affected_components": [
       {
         "component_type": "service",
@@ -317,8 +675,13 @@
         "package_url": null
       }
     ],
-    "supply_chain_vectors": ["build_system_compromise"],
-    "impact_categories": ["credential_theft", "data_exfiltration"],
+    "supply_chain_vectors": [
+      "build_system_compromise"
+    ],
+    "impact_categories": [
+      "credential_theft",
+      "data_exfiltration"
+    ],
     "references": [
       {
         "title": "Bash Uploader Security Update",
@@ -327,7 +690,39 @@
         "published_at": "2021-04-15"
       }
     ],
-    "tags": ["ci-cd", "credentials"]
+    "tags": [
+      "ci-cd",
+      "credentials"
+    ],
+    "confidence": "high",
+    "evidence_level": "vendor",
+    "attack_stage": "ci_cd_compromise",
+    "source_artifact_divergence": true,
+    "notes": "Uploader script compromise affected CI environments and exposed environment variables.",
+    "maintainers": [],
+    "repositories": [
+      {
+        "name": "codecov/codecov-bash",
+        "host": "github.com",
+        "owner": "codecov",
+        "url": "https://github.com/codecov/codecov-bash"
+      }
+    ],
+    "build_systems": [
+      {
+        "name": "Codecov Bash Uploader distribution pipeline",
+        "provider": "Codecov",
+        "category": "ci-cd"
+      }
+    ],
+    "distribution_channels": [
+      {
+        "name": "Codecov Bash Uploader download path",
+        "channel_type": "script_download",
+        "ecosystem": "ci-cd"
+      }
+    ],
+    "compromised_accounts": []
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -337,7 +732,10 @@
     "status": "confirmed",
     "first_observed_at": "2021-07-02",
     "disclosed_at": "2021-07-02",
-    "affected_ecosystems": ["managed-service", "windows"],
+    "affected_ecosystems": [
+      "managed-service",
+      "windows"
+    ],
     "affected_components": [
       {
         "component_type": "software",
@@ -347,8 +745,13 @@
         "package_url": null
       }
     ],
-    "supply_chain_vectors": ["vendor_update_compromise"],
-    "impact_categories": ["ransomware_delivery", "downstream_customer_compromise"],
+    "supply_chain_vectors": [
+      "vendor_update_compromise"
+    ],
+    "impact_categories": [
+      "ransomware_delivery",
+      "downstream_customer_compromise"
+    ],
     "references": [
       {
         "title": "Kaseya VSA Supply-Chain Ransomware Attack",
@@ -357,7 +760,26 @@
         "published_at": "2021-07-02"
       }
     ],
-    "tags": ["ransomware", "msp"]
+    "tags": [
+      "ransomware",
+      "msp"
+    ],
+    "confidence": "high",
+    "evidence_level": "vendor",
+    "attack_stage": "distribution_compromise",
+    "source_artifact_divergence": null,
+    "notes": "Managed service provider update path distributed ransomware to downstream customers.",
+    "maintainers": [],
+    "repositories": [],
+    "build_systems": [],
+    "distribution_channels": [
+      {
+        "name": "Vendor software update channel",
+        "channel_type": "software_update",
+        "ecosystem": "vendor-update"
+      }
+    ],
+    "compromised_accounts": []
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -367,7 +789,9 @@
     "status": "confirmed",
     "first_observed_at": "2021-10-22",
     "disclosed_at": "2021-10-22",
-    "affected_ecosystems": ["npm"],
+    "affected_ecosystems": [
+      "npm"
+    ],
     "affected_components": [
       {
         "component_type": "package",
@@ -377,8 +801,14 @@
         "package_url": "pkg:npm/ua-parser-js"
       }
     ],
-    "supply_chain_vectors": ["maintainer_account_compromise", "package_repository_compromise"],
-    "impact_categories": ["credential_theft", "cryptomining"],
+    "supply_chain_vectors": [
+      "maintainer_account_compromise",
+      "package_repository_compromise"
+    ],
+    "impact_categories": [
+      "credential_theft",
+      "cryptomining"
+    ],
     "references": [
       {
         "title": "Malware in ua-parser-js",
@@ -387,7 +817,33 @@
         "published_at": "2021-10-22"
       }
     ],
-    "tags": ["npm", "account-compromise"]
+    "tags": [
+      "npm",
+      "account-compromise"
+    ],
+    "confidence": "high",
+    "evidence_level": "vendor",
+    "attack_stage": "account_compromise",
+    "source_artifact_divergence": false,
+    "notes": "Malicious npm versions were published after package account compromise.",
+    "maintainers": [],
+    "repositories": [],
+    "build_systems": [],
+    "distribution_channels": [
+      {
+        "name": "npm registry",
+        "channel_type": "package_registry",
+        "ecosystem": "npm"
+      }
+    ],
+    "compromised_accounts": [
+      {
+        "name": "ua-parser-js npm maintainer account",
+        "provider": "npm",
+        "account_type": "package_registry_account",
+        "role": "maintainer_publish"
+      }
+    ]
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -397,7 +853,9 @@
     "status": "confirmed",
     "first_observed_at": "2021-11-04",
     "disclosed_at": "2021-11-04",
-    "affected_ecosystems": ["npm"],
+    "affected_ecosystems": [
+      "npm"
+    ],
     "affected_components": [
       {
         "component_type": "package",
@@ -407,8 +865,12 @@
         "package_url": "pkg:npm/rc"
       }
     ],
-    "supply_chain_vectors": ["package_repository_compromise"],
-    "impact_categories": ["malware_distribution"],
+    "supply_chain_vectors": [
+      "package_repository_compromise"
+    ],
+    "impact_categories": [
+      "malware_distribution"
+    ],
     "references": [
       {
         "title": "Embedded malware in rc",
@@ -417,7 +879,26 @@
         "published_at": "2021-11-04"
       }
     ],
-    "tags": ["npm", "malicious-package"]
+    "tags": [
+      "npm",
+      "malicious-package"
+    ],
+    "confidence": "high",
+    "evidence_level": "vendor",
+    "attack_stage": "package_publish",
+    "source_artifact_divergence": false,
+    "notes": "Malicious npm package versions were published through the registry.",
+    "maintainers": [],
+    "repositories": [],
+    "build_systems": [],
+    "distribution_channels": [
+      {
+        "name": "npm registry",
+        "channel_type": "package_registry",
+        "ecosystem": "npm"
+      }
+    ],
+    "compromised_accounts": []
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -427,7 +908,9 @@
     "status": "confirmed",
     "first_observed_at": "2022-01-08",
     "disclosed_at": "2022-01-09",
-    "affected_ecosystems": ["npm"],
+    "affected_ecosystems": [
+      "npm"
+    ],
     "affected_components": [
       {
         "component_type": "package",
@@ -444,8 +927,13 @@
         "package_url": "pkg:npm/faker"
       }
     ],
-    "supply_chain_vectors": ["protestware"],
-    "impact_categories": ["destructive_payload", "protest_payload"],
+    "supply_chain_vectors": [
+      "protestware"
+    ],
+    "impact_categories": [
+      "destructive_payload",
+      "protest_payload"
+    ],
     "references": [
       {
         "title": "colors.js issue discussion after disruptive release",
@@ -454,7 +942,41 @@
         "published_at": "2022-01-09"
       }
     ],
-    "tags": ["npm", "protestware"]
+    "tags": [
+      "npm",
+      "protestware"
+    ],
+    "confidence": "high",
+    "evidence_level": "primary",
+    "attack_stage": "package_publish",
+    "source_artifact_divergence": false,
+    "notes": "Maintainer-published protestware releases affected downstream npm consumers.",
+    "maintainers": [
+      {
+        "name": "Marak Squires",
+        "aliases": [
+          "Marak"
+        ],
+        "id_slug": "marak-squires"
+      }
+    ],
+    "repositories": [
+      {
+        "name": "Marak/colors.js",
+        "host": "github.com",
+        "owner": "Marak",
+        "url": "https://github.com/Marak/colors.js"
+      }
+    ],
+    "build_systems": [],
+    "distribution_channels": [
+      {
+        "name": "npm registry",
+        "channel_type": "package_registry",
+        "ecosystem": "npm"
+      }
+    ],
+    "compromised_accounts": []
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -464,7 +986,9 @@
     "status": "confirmed",
     "first_observed_at": "2022-03-08",
     "disclosed_at": "2022-03-16",
-    "affected_ecosystems": ["npm"],
+    "affected_ecosystems": [
+      "npm"
+    ],
     "affected_components": [
       {
         "component_type": "package",
@@ -472,10 +996,22 @@
         "name": "node-ipc",
         "vendor": "open source maintainer",
         "package_url": "pkg:npm/node-ipc"
+      },
+      {
+        "component_type": "package",
+        "ecosystem": "npm",
+        "name": "peacenotwar",
+        "vendor": "RIAEvangelist",
+        "package_url": "pkg:npm/peacenotwar"
       }
     ],
-    "supply_chain_vectors": ["protestware"],
-    "impact_categories": ["destructive_payload", "protest_payload"],
+    "supply_chain_vectors": [
+      "protestware"
+    ],
+    "impact_categories": [
+      "destructive_payload",
+      "protest_payload"
+    ],
     "references": [
       {
         "title": "Peacenotwar malicious npm node-ipc package vulnerability",
@@ -484,7 +1020,41 @@
         "published_at": "2022-03-16"
       }
     ],
-    "tags": ["npm", "protestware"]
+    "tags": [
+      "npm",
+      "protestware"
+    ],
+    "confidence": "high",
+    "evidence_level": "researcher",
+    "attack_stage": "package_publish",
+    "source_artifact_divergence": false,
+    "notes": "Protestware behavior was distributed through npm package releases and dependencies.",
+    "maintainers": [
+      {
+        "name": "RIAEvangelist",
+        "aliases": [
+          "Brandon Nozaki Miller"
+        ],
+        "id_slug": "riaevangelist"
+      }
+    ],
+    "repositories": [
+      {
+        "name": "RIAEvangelist/node-ipc",
+        "host": "github.com",
+        "owner": "RIAEvangelist",
+        "url": "https://github.com/RIAEvangelist/node-ipc"
+      }
+    ],
+    "build_systems": [],
+    "distribution_channels": [
+      {
+        "name": "npm registry",
+        "channel_type": "package_registry",
+        "ecosystem": "npm"
+      }
+    ],
+    "compromised_accounts": []
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -494,7 +1064,9 @@
     "status": "confirmed",
     "first_observed_at": "2022-05-21",
     "disclosed_at": "2022-05-24",
-    "affected_ecosystems": ["pypi"],
+    "affected_ecosystems": [
+      "pypi"
+    ],
     "affected_components": [
       {
         "component_type": "package",
@@ -504,8 +1076,14 @@
         "package_url": "pkg:pypi/ctx"
       }
     ],
-    "supply_chain_vectors": ["maintainer_account_compromise", "package_repository_compromise"],
-    "impact_categories": ["credential_theft", "data_exfiltration"],
+    "supply_chain_vectors": [
+      "maintainer_account_compromise",
+      "package_repository_compromise"
+    ],
+    "impact_categories": [
+      "credential_theft",
+      "data_exfiltration"
+    ],
     "references": [
       {
         "title": "Account Takeover and Malicious Replacement of ctx Project",
@@ -514,7 +1092,33 @@
         "published_at": "2022-05-24"
       }
     ],
-    "tags": ["pypi", "account-takeover"]
+    "tags": [
+      "pypi",
+      "account-takeover"
+    ],
+    "confidence": "high",
+    "evidence_level": "researcher",
+    "attack_stage": "account_compromise",
+    "source_artifact_divergence": false,
+    "notes": "PyPI project takeover replaced a package with credential-harvesting behavior.",
+    "maintainers": [],
+    "repositories": [],
+    "build_systems": [],
+    "distribution_channels": [
+      {
+        "name": "PyPI",
+        "channel_type": "package_registry",
+        "ecosystem": "pypi"
+      }
+    ],
+    "compromised_accounts": [
+      {
+        "name": "ctx PyPI project account",
+        "provider": "PyPI",
+        "account_type": "package_registry_account",
+        "role": "maintainer_publish"
+      }
+    ]
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -524,7 +1128,10 @@
     "status": "confirmed",
     "first_observed_at": "2022-12-25",
     "disclosed_at": "2022-12-31",
-    "affected_ecosystems": ["pypi", "python"],
+    "affected_ecosystems": [
+      "pypi",
+      "python"
+    ],
     "affected_components": [
       {
         "component_type": "package",
@@ -541,8 +1148,13 @@
         "package_url": null
       }
     ],
-    "supply_chain_vectors": ["dependency_confusion"],
-    "impact_categories": ["credential_theft", "developer_workstation_compromise"],
+    "supply_chain_vectors": [
+      "dependency_confusion"
+    ],
+    "impact_categories": [
+      "credential_theft",
+      "developer_workstation_compromise"
+    ],
     "references": [
       {
         "title": "Compromised PyTorch-nightly dependency chain between December 25th and December 30th, 2022",
@@ -551,7 +1163,39 @@
         "published_at": "2022-12-31"
       }
     ],
-    "tags": ["pypi", "dependency-confusion"]
+    "tags": [
+      "pypi",
+      "dependency-confusion"
+    ],
+    "confidence": "high",
+    "evidence_level": "vendor",
+    "attack_stage": "dependency_resolution",
+    "source_artifact_divergence": false,
+    "notes": "Dependency confusion affected PyTorch nightly dependency resolution.",
+    "maintainers": [],
+    "repositories": [
+      {
+        "name": "pytorch/pytorch",
+        "host": "github.com",
+        "owner": "pytorch",
+        "url": "https://github.com/pytorch/pytorch"
+      }
+    ],
+    "build_systems": [
+      {
+        "name": "PyTorch nightly build pipeline",
+        "provider": "PyTorch",
+        "category": "project-build"
+      }
+    ],
+    "distribution_channels": [
+      {
+        "name": "PyPI",
+        "channel_type": "package_registry",
+        "ecosystem": "pypi"
+      }
+    ],
+    "compromised_accounts": []
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -561,7 +1205,11 @@
     "status": "confirmed",
     "first_observed_at": "2023-03-22",
     "disclosed_at": "2023-03-29",
-    "affected_ecosystems": ["windows", "macos", "vendor-update"],
+    "affected_ecosystems": [
+      "windows",
+      "macos",
+      "vendor-update"
+    ],
     "affected_components": [
       {
         "component_type": "software",
@@ -571,8 +1219,15 @@
         "package_url": null
       }
     ],
-    "supply_chain_vectors": ["build_system_compromise", "signed_update_compromise"],
-    "impact_categories": ["malware_distribution", "backdoor", "downstream_customer_compromise"],
+    "supply_chain_vectors": [
+      "build_system_compromise",
+      "signed_update_compromise"
+    ],
+    "impact_categories": [
+      "malware_distribution",
+      "backdoor",
+      "downstream_customer_compromise"
+    ],
     "references": [
       {
         "title": "3CX Software Supply Chain Compromise",
@@ -581,7 +1236,32 @@
         "published_at": "2023-04-20"
       }
     ],
-    "tags": ["desktop", "signed-update"]
+    "tags": [
+      "desktop",
+      "signed-update"
+    ],
+    "confidence": "high",
+    "evidence_level": "researcher",
+    "attack_stage": "build_compromise",
+    "source_artifact_divergence": null,
+    "notes": "Compromise affected desktop application build/distribution for downstream customers.",
+    "maintainers": [],
+    "repositories": [],
+    "build_systems": [
+      {
+        "name": "3CX DesktopApp build pipeline",
+        "provider": "3CX",
+        "category": "vendor-build"
+      }
+    ],
+    "distribution_channels": [
+      {
+        "name": "Signed software installer/update channel",
+        "channel_type": "signed_update",
+        "ecosystem": "vendor-update"
+      }
+    ],
+    "compromised_accounts": []
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -591,7 +1271,10 @@
     "status": "confirmed",
     "first_observed_at": "2023-12-14",
     "disclosed_at": "2023-12-14",
-    "affected_ecosystems": ["npm", "web3"],
+    "affected_ecosystems": [
+      "npm",
+      "web3"
+    ],
     "affected_components": [
       {
         "component_type": "package",
@@ -601,8 +1284,14 @@
         "package_url": "pkg:npm/%40ledgerhq/connect-kit"
       }
     ],
-    "supply_chain_vectors": ["maintainer_account_compromise", "package_repository_compromise"],
-    "impact_categories": ["crypto_theft", "downstream_customer_compromise"],
+    "supply_chain_vectors": [
+      "maintainer_account_compromise",
+      "package_repository_compromise"
+    ],
+    "impact_categories": [
+      "crypto_theft",
+      "downstream_customer_compromise"
+    ],
     "references": [
       {
         "title": "Security Incident Report",
@@ -611,7 +1300,33 @@
         "published_at": "2023-12-14"
       }
     ],
-    "tags": ["npm", "web3"]
+    "tags": [
+      "npm",
+      "web3"
+    ],
+    "confidence": "high",
+    "evidence_level": "vendor",
+    "attack_stage": "account_compromise",
+    "source_artifact_divergence": false,
+    "notes": "Compromised npm publish path for Ledger Connect Kit affected downstream dapps.",
+    "maintainers": [],
+    "repositories": [],
+    "build_systems": [],
+    "distribution_channels": [
+      {
+        "name": "npm registry",
+        "channel_type": "package_registry",
+        "ecosystem": "npm"
+      }
+    ],
+    "compromised_accounts": [
+      {
+        "name": "@ledgerhq/connect-kit npm publish account",
+        "provider": "npm",
+        "account_type": "package_registry_account",
+        "role": "maintainer_publish"
+      }
+    ]
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -621,7 +1336,10 @@
     "status": "confirmed",
     "first_observed_at": "2024-02-24",
     "disclosed_at": "2024-03-29",
-    "affected_ecosystems": ["linux", "source-release"],
+    "affected_ecosystems": [
+      "linux",
+      "source-release"
+    ],
     "affected_components": [
       {
         "component_type": "project",
@@ -631,8 +1349,13 @@
         "package_url": null
       }
     ],
-    "supply_chain_vectors": ["source_repository_compromise", "malicious_dependency"],
-    "impact_categories": ["backdoor"],
+    "supply_chain_vectors": [
+      "source_repository_compromise",
+      "malicious_dependency"
+    ],
+    "impact_categories": [
+      "backdoor"
+    ],
     "references": [
       {
         "title": "Backdoor in upstream xz/liblzma leading to SSH server compromise",
@@ -641,7 +1364,41 @@
         "published_at": "2024-03-29"
       }
     ],
-    "tags": ["linux", "backdoor"]
+    "tags": [
+      "linux",
+      "backdoor"
+    ],
+    "confidence": "high",
+    "evidence_level": "primary",
+    "attack_stage": "source_compromise",
+    "source_artifact_divergence": true,
+    "notes": "Backdoor was present in upstream release artifacts, making source-artifact divergence a key modeling primitive.",
+    "maintainers": [
+      {
+        "name": "Jia Tan",
+        "aliases": [
+          "JiaT75"
+        ],
+        "id_slug": "jia-tan"
+      }
+    ],
+    "repositories": [
+      {
+        "name": "tukaani-project/xz",
+        "host": "github.com",
+        "owner": "tukaani-project",
+        "url": "https://github.com/tukaani-project/xz"
+      }
+    ],
+    "build_systems": [],
+    "distribution_channels": [
+      {
+        "name": "Upstream source release tarball",
+        "channel_type": "source_release",
+        "ecosystem": "linux"
+      }
+    ],
+    "compromised_accounts": []
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -651,7 +1408,10 @@
     "status": "confirmed",
     "first_observed_at": "2024-06-25",
     "disclosed_at": "2024-06-25",
-    "affected_ecosystems": ["web", "cdn"],
+    "affected_ecosystems": [
+      "web",
+      "cdn"
+    ],
     "affected_components": [
       {
         "component_type": "service",
@@ -661,8 +1421,13 @@
         "package_url": null
       }
     ],
-    "supply_chain_vectors": ["cdn_script_compromise"],
-    "impact_categories": ["malware_distribution", "downstream_customer_compromise"],
+    "supply_chain_vectors": [
+      "cdn_script_compromise"
+    ],
+    "impact_categories": [
+      "malware_distribution",
+      "downstream_customer_compromise"
+    ],
     "references": [
       {
         "title": "Polyfill supply chain attack hits 100K+ sites",
@@ -671,7 +1436,26 @@
         "published_at": "2024-06-25"
       }
     ],
-    "tags": ["cdn", "javascript"]
+    "tags": [
+      "cdn",
+      "javascript"
+    ],
+    "confidence": "high",
+    "evidence_level": "researcher",
+    "attack_stage": "distribution_compromise",
+    "source_artifact_divergence": null,
+    "notes": "Third-party CDN script delivery path served malicious JavaScript to downstream sites.",
+    "maintainers": [],
+    "repositories": [],
+    "build_systems": [],
+    "distribution_channels": [
+      {
+        "name": "Third-party CDN script",
+        "channel_type": "cdn_script",
+        "ecosystem": "web"
+      }
+    ],
+    "compromised_accounts": []
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -681,7 +1465,10 @@
     "status": "confirmed",
     "first_observed_at": "2024-12-04",
     "disclosed_at": "2024-12-11",
-    "affected_ecosystems": ["pypi", "github-actions"],
+    "affected_ecosystems": [
+      "pypi",
+      "github-actions"
+    ],
     "affected_components": [
       {
         "component_type": "package",
@@ -691,8 +1478,14 @@
         "package_url": "pkg:pypi/ultralytics"
       }
     ],
-    "supply_chain_vectors": ["build_system_compromise", "package_repository_compromise"],
-    "impact_categories": ["cryptomining", "developer_workstation_compromise"],
+    "supply_chain_vectors": [
+      "build_system_compromise",
+      "package_repository_compromise"
+    ],
+    "impact_categories": [
+      "cryptomining",
+      "developer_workstation_compromise"
+    ],
     "references": [
       {
         "title": "Supply-chain attack analysis: Ultralytics",
@@ -701,7 +1494,46 @@
         "published_at": "2024-12-11"
       }
     ],
-    "tags": ["pypi", "github-actions"]
+    "tags": [
+      "pypi",
+      "github-actions"
+    ],
+    "confidence": "high",
+    "evidence_level": "vendor",
+    "attack_stage": "ci_cd_compromise",
+    "source_artifact_divergence": false,
+    "notes": "Compromised GitHub Actions/PyPI publishing flow produced malicious package releases.",
+    "maintainers": [],
+    "repositories": [
+      {
+        "name": "ultralytics/ultralytics",
+        "host": "github.com",
+        "owner": "ultralytics",
+        "url": "https://github.com/ultralytics/ultralytics"
+      }
+    ],
+    "build_systems": [
+      {
+        "name": "GitHub Actions",
+        "provider": "GitHub",
+        "category": "ci-cd"
+      }
+    ],
+    "distribution_channels": [
+      {
+        "name": "PyPI",
+        "channel_type": "package_registry",
+        "ecosystem": "pypi"
+      }
+    ],
+    "compromised_accounts": [
+      {
+        "name": "Ultralytics PyPI publishing token",
+        "provider": "PyPI",
+        "account_type": "package_registry_token",
+        "role": "package_publish"
+      }
+    ]
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -711,7 +1543,10 @@
     "status": "confirmed",
     "first_observed_at": "2024-10-30",
     "disclosed_at": "2024-10-31",
-    "affected_ecosystems": ["npm", "web"],
+    "affected_ecosystems": [
+      "npm",
+      "web"
+    ],
     "affected_components": [
       {
         "component_type": "package",
@@ -721,8 +1556,14 @@
         "package_url": "pkg:npm/%40lottiefiles/lottie-player"
       }
     ],
-    "supply_chain_vectors": ["maintainer_account_compromise", "package_repository_compromise"],
-    "impact_categories": ["crypto_theft", "downstream_customer_compromise"],
+    "supply_chain_vectors": [
+      "maintainer_account_compromise",
+      "package_repository_compromise"
+    ],
+    "impact_categories": [
+      "crypto_theft",
+      "downstream_customer_compromise"
+    ],
     "references": [
       {
         "title": "Resolution of Security Incident with @lottiefiles/lottie-player Package",
@@ -731,7 +1572,33 @@
         "published_at": "2024-10-31"
       }
     ],
-    "tags": ["npm", "web3"]
+    "tags": [
+      "npm",
+      "web3"
+    ],
+    "confidence": "high",
+    "evidence_level": "vendor",
+    "attack_stage": "account_compromise",
+    "source_artifact_divergence": false,
+    "notes": "Compromised npm publishing account released wallet-draining package versions.",
+    "maintainers": [],
+    "repositories": [],
+    "build_systems": [],
+    "distribution_channels": [
+      {
+        "name": "npm registry",
+        "channel_type": "package_registry",
+        "ecosystem": "npm"
+      }
+    ],
+    "compromised_accounts": [
+      {
+        "name": "@lottiefiles/lottie-player npm publish account",
+        "provider": "npm",
+        "account_type": "package_registry_account",
+        "role": "maintainer_publish"
+      }
+    ]
   },
   {
     "schema_version": "supply-chain-incident/1",
@@ -741,7 +1608,10 @@
     "status": "confirmed",
     "first_observed_at": "2025-03-14",
     "disclosed_at": "2025-03-15",
-    "affected_ecosystems": ["github-actions", "ci-cd"],
+    "affected_ecosystems": [
+      "github-actions",
+      "ci-cd"
+    ],
     "affected_components": [
       {
         "component_type": "service",
@@ -751,8 +1621,13 @@
         "package_url": null
       }
     ],
-    "supply_chain_vectors": ["ci_cd_action_compromise"],
-    "impact_categories": ["credential_theft", "developer_workstation_compromise"],
+    "supply_chain_vectors": [
+      "ci_cd_action_compromise"
+    ],
+    "impact_categories": [
+      "credential_theft",
+      "developer_workstation_compromise"
+    ],
     "references": [
       {
         "title": "Harden-Runner detection: tj-actions/changed-files action is compromised",
@@ -761,6 +1636,45 @@
         "published_at": "2025-03-15"
       }
     ],
-    "tags": ["github-actions", "ci-cd"]
+    "tags": [
+      "github-actions",
+      "ci-cd"
+    ],
+    "confidence": "high",
+    "evidence_level": "researcher",
+    "attack_stage": "ci_cd_compromise",
+    "source_artifact_divergence": false,
+    "notes": "Compromised GitHub Action exposed secrets from downstream workflows.",
+    "maintainers": [],
+    "repositories": [
+      {
+        "name": "tj-actions/changed-files",
+        "host": "github.com",
+        "owner": "tj-actions",
+        "url": "https://github.com/tj-actions/changed-files"
+      }
+    ],
+    "build_systems": [
+      {
+        "name": "GitHub Actions",
+        "provider": "GitHub",
+        "category": "ci-cd"
+      }
+    ],
+    "distribution_channels": [
+      {
+        "name": "GitHub Actions Marketplace",
+        "channel_type": "ci_cd_marketplace",
+        "ecosystem": "github-actions"
+      }
+    ],
+    "compromised_accounts": [
+      {
+        "name": "tj-actions GitHub Action release path",
+        "provider": "GitHub",
+        "account_type": "source_control_account",
+        "role": "action_release"
+      }
+    ]
   }
 ]

--- a/data/supply-chain-incidents/schema.json
+++ b/data/supply-chain-incidents/schema.json
@@ -16,7 +16,16 @@
     "supply_chain_vectors",
     "impact_categories",
     "references",
-    "tags"
+    "tags",
+    "confidence",
+    "evidence_level",
+    "attack_stage",
+    "source_artifact_divergence",
+    "maintainers",
+    "repositories",
+    "build_systems",
+    "distribution_channels",
+    "compromised_accounts"
   ],
   "properties": {
     "schema_version": {
@@ -35,7 +44,9 @@
       "minLength": 40
     },
     "status": {
-      "enum": ["confirmed"]
+      "enum": [
+        "confirmed"
+      ]
     },
     "first_observed_at": {
       "type": "string",
@@ -110,15 +121,93 @@
       "items": {
         "type": "string"
       }
+    },
+    "confidence": {
+      "enum": [
+        "high",
+        "medium",
+        "low"
+      ]
+    },
+    "evidence_level": {
+      "enum": [
+        "primary",
+        "vendor",
+        "researcher",
+        "media",
+        "inferred"
+      ]
+    },
+    "attack_stage": {
+      "enum": [
+        "source_compromise",
+        "build_compromise",
+        "account_compromise",
+        "package_publish",
+        "dependency_resolution",
+        "distribution_compromise",
+        "ci_cd_compromise"
+      ]
+    },
+    "source_artifact_divergence": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "notes": {
+      "type": "string"
+    },
+    "maintainers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/maintainer"
+      }
+    },
+    "repositories": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/repository"
+      }
+    },
+    "build_systems": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/build_system"
+      }
+    },
+    "distribution_channels": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/distribution_channel"
+      }
+    },
+    "compromised_accounts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/compromised_account"
+      }
     }
   },
   "$defs": {
     "affected_component": {
       "type": "object",
-      "required": ["component_type", "ecosystem", "name", "vendor"],
+      "required": [
+        "component_type",
+        "ecosystem",
+        "name",
+        "vendor"
+      ],
       "properties": {
         "component_type": {
-          "enum": ["package", "project", "software", "service", "update_channel", "website"]
+          "enum": [
+            "package",
+            "project",
+            "software",
+            "service",
+            "update_channel",
+            "website"
+          ]
         },
         "ecosystem": {
           "type": "string"
@@ -137,7 +226,12 @@
     },
     "reference": {
       "type": "object",
-      "required": ["title", "publisher", "url", "published_at"],
+      "required": [
+        "title",
+        "publisher",
+        "url",
+        "published_at"
+      ],
       "properties": {
         "title": {
           "type": "string"
@@ -152,6 +246,113 @@
         "published_at": {
           "type": "string",
           "format": "date"
+        }
+      }
+    },
+    "maintainer": {
+      "type": "object",
+      "required": [
+        "name",
+        "aliases",
+        "id_slug"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id_slug": {
+          "type": "string"
+        }
+      }
+    },
+    "repository": {
+      "type": "object",
+      "required": [
+        "name",
+        "host",
+        "owner",
+        "url"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "build_system": {
+      "type": "object",
+      "required": [
+        "name",
+        "provider",
+        "category"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string"
+        }
+      }
+    },
+    "distribution_channel": {
+      "type": "object",
+      "required": [
+        "name",
+        "channel_type",
+        "ecosystem"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "channel_type": {
+          "type": "string"
+        },
+        "ecosystem": {
+          "type": "string"
+        }
+      }
+    },
+    "compromised_account": {
+      "type": "object",
+      "required": [
+        "name",
+        "provider",
+        "account_type",
+        "role"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "account_type": {
+          "type": "string"
+        },
+        "role": {
+          "type": "string"
         }
       }
     }

--- a/data/supply-chain-relationships/relationships.json
+++ b/data/supply-chain-relationships/relationships.json
@@ -5,14 +5,34 @@
     "type": "AFFECTED_ORGANIZATION"
   },
   {
+    "source": "incident-SC-2016-LINUX-MINT-ISO",
+    "target": "channel-linux-website-download-linux-mint-download-site",
+    "type": "SOURCE_ARTIFACT_DIVERGENCE"
+  },
+  {
+    "source": "incident-SC-2016-LINUX-MINT-ISO",
+    "target": "channel-linux-website-download-linux-mint-download-site",
+    "type": "USED_DISTRIBUTION_CHANNEL"
+  },
+  {
     "source": "incident-SC-2017-CCLEANER",
     "target": "org-piriform",
     "type": "AFFECTED_ORGANIZATION"
   },
   {
+    "source": "incident-SC-2017-CCLEANER",
+    "target": "channel-vendor-update-signed-update-signed-software-installer-update-channel",
+    "type": "USED_DISTRIBUTION_CHANNEL"
+  },
+  {
     "source": "incident-SC-2017-NOTPETYA-MEDOC",
     "target": "org-intellect-service",
     "type": "AFFECTED_ORGANIZATION"
+  },
+  {
+    "source": "incident-SC-2017-NOTPETYA-MEDOC",
+    "target": "channel-vendor-update-software-update-vendor-software-update-channel",
+    "type": "USED_DISTRIBUTION_CHANNEL"
   },
   {
     "source": "incident-SC-2018-ESLINT-SCOPE",
@@ -21,12 +41,37 @@
   },
   {
     "source": "incident-SC-2018-ESLINT-SCOPE",
+    "target": "pkg-npm-eslint-config-eslint",
+    "type": "AFFECTED_PACKAGE"
+  },
+  {
+    "source": "incident-SC-2018-ESLINT-SCOPE",
     "target": "pkg-npm-eslint-scope",
     "type": "AFFECTED_PACKAGE"
   },
   {
+    "source": "incident-SC-2018-ESLINT-SCOPE",
+    "target": "repo-github-com-eslint-eslint-scope",
+    "type": "AFFECTED_REPOSITORY"
+  },
+  {
+    "source": "incident-SC-2018-ESLINT-SCOPE",
+    "target": "account-npm-eslint-scope-npm-maintainer-account",
+    "type": "COMPROMISED_ACCOUNT"
+  },
+  {
+    "source": "incident-SC-2018-ESLINT-SCOPE",
+    "target": "channel-npm-package-registry-npm-registry",
+    "type": "USED_DISTRIBUTION_CHANNEL"
+  },
+  {
     "source": "incident-SC-2018-NPM-EVENT-STREAM",
     "target": "maintainer-dominictarr",
+    "type": "AFFECTED_MAINTAINER"
+  },
+  {
+    "source": "incident-SC-2018-NPM-EVENT-STREAM",
+    "target": "maintainer-right9ctrl",
     "type": "AFFECTED_MAINTAINER"
   },
   {
@@ -36,8 +81,18 @@
   },
   {
     "source": "incident-SC-2018-NPM-EVENT-STREAM",
+    "target": "pkg-npm-flatmap-stream",
+    "type": "AFFECTED_PACKAGE"
+  },
+  {
+    "source": "incident-SC-2018-NPM-EVENT-STREAM",
     "target": "repo-github-com-dominictarr-event-stream",
     "type": "AFFECTED_REPOSITORY"
+  },
+  {
+    "source": "incident-SC-2018-NPM-EVENT-STREAM",
+    "target": "channel-npm-package-registry-npm-registry",
+    "type": "USED_DISTRIBUTION_CHANNEL"
   },
   {
     "source": "incident-SC-2019-ASUS-SHADOWHAMMER",
@@ -45,9 +100,34 @@
     "type": "AFFECTED_ORGANIZATION"
   },
   {
+    "source": "incident-SC-2019-ASUS-SHADOWHAMMER",
+    "target": "channel-vendor-update-signed-update-signed-software-installer-update-channel",
+    "type": "USED_DISTRIBUTION_CHANNEL"
+  },
+  {
+    "source": "incident-SC-2020-OCTOPUS-SCANNER",
+    "target": "build-netbeans-netbeans-project-build-process",
+    "type": "USED_BUILD_SYSTEM"
+  },
+  {
+    "source": "incident-SC-2020-OCTOPUS-SCANNER",
+    "target": "channel-source-control-source-repository-source-repository",
+    "type": "USED_DISTRIBUTION_CHANNEL"
+  },
+  {
     "source": "incident-SC-2020-SOLARWINDS-ORION",
     "target": "org-solarwinds",
     "type": "AFFECTED_ORGANIZATION"
+  },
+  {
+    "source": "incident-SC-2020-SOLARWINDS-ORION",
+    "target": "build-solarwinds-solarwinds-orion-build-system",
+    "type": "USED_BUILD_SYSTEM"
+  },
+  {
+    "source": "incident-SC-2020-SOLARWINDS-ORION",
+    "target": "channel-vendor-update-signed-update-signed-software-installer-update-channel",
+    "type": "USED_DISTRIBUTION_CHANNEL"
   },
   {
     "source": "incident-SC-2021-CODECOV-BASH-UPLOADER",
@@ -55,9 +135,44 @@
     "type": "AFFECTED_ORGANIZATION"
   },
   {
+    "source": "incident-SC-2021-CODECOV-BASH-UPLOADER",
+    "target": "repo-github-com-codecov-codecov-bash",
+    "type": "AFFECTED_REPOSITORY"
+  },
+  {
+    "source": "incident-SC-2021-CODECOV-BASH-UPLOADER",
+    "target": "channel-ci-cd-script-download-codecov-bash-uploader-download-path",
+    "type": "SOURCE_ARTIFACT_DIVERGENCE"
+  },
+  {
+    "source": "incident-SC-2021-CODECOV-BASH-UPLOADER",
+    "target": "build-codecov-codecov-bash-uploader-distribution-pipeline",
+    "type": "USED_BUILD_SYSTEM"
+  },
+  {
+    "source": "incident-SC-2021-CODECOV-BASH-UPLOADER",
+    "target": "channel-ci-cd-script-download-codecov-bash-uploader-download-path",
+    "type": "USED_DISTRIBUTION_CHANNEL"
+  },
+  {
     "source": "incident-SC-2021-DEPENDENCY-CONFUSION",
     "target": "pkg-multiple-internal-dependency-names",
     "type": "AFFECTED_PACKAGE"
+  },
+  {
+    "source": "incident-SC-2021-DEPENDENCY-CONFUSION",
+    "target": "channel-npm-package-registry-npm-registry",
+    "type": "USED_DISTRIBUTION_CHANNEL"
+  },
+  {
+    "source": "incident-SC-2021-DEPENDENCY-CONFUSION",
+    "target": "channel-pypi-package-registry-pypi",
+    "type": "USED_DISTRIBUTION_CHANNEL"
+  },
+  {
+    "source": "incident-SC-2021-DEPENDENCY-CONFUSION",
+    "target": "channel-rubygems-package-registry-rubygems",
+    "type": "USED_DISTRIBUTION_CHANNEL"
   },
   {
     "source": "incident-SC-2021-KASEYA-VSA",
@@ -65,9 +180,19 @@
     "type": "AFFECTED_ORGANIZATION"
   },
   {
+    "source": "incident-SC-2021-KASEYA-VSA",
+    "target": "channel-vendor-update-software-update-vendor-software-update-channel",
+    "type": "USED_DISTRIBUTION_CHANNEL"
+  },
+  {
     "source": "incident-SC-2021-NPM-RC",
     "target": "pkg-npm-rc",
     "type": "AFFECTED_PACKAGE"
+  },
+  {
+    "source": "incident-SC-2021-NPM-RC",
+    "target": "channel-npm-package-registry-npm-registry",
+    "type": "USED_DISTRIBUTION_CHANNEL"
   },
   {
     "source": "incident-SC-2021-PHP-GIT-SERVER",
@@ -75,9 +200,34 @@
     "type": "AFFECTED_ORGANIZATION"
   },
   {
+    "source": "incident-SC-2021-PHP-GIT-SERVER",
+    "target": "repo-github-com-php-php-src",
+    "type": "AFFECTED_REPOSITORY"
+  },
+  {
+    "source": "incident-SC-2021-PHP-GIT-SERVER",
+    "target": "account-php-git-php-git-server-commit-identity",
+    "type": "COMPROMISED_ACCOUNT"
+  },
+  {
+    "source": "incident-SC-2021-PHP-GIT-SERVER",
+    "target": "channel-source-control-source-repository-source-repository",
+    "type": "USED_DISTRIBUTION_CHANNEL"
+  },
+  {
     "source": "incident-SC-2021-UA-PARSER-JS",
     "target": "pkg-npm-ua-parser-js",
     "type": "AFFECTED_PACKAGE"
+  },
+  {
+    "source": "incident-SC-2021-UA-PARSER-JS",
+    "target": "account-npm-ua-parser-js-npm-maintainer-account",
+    "type": "COMPROMISED_ACCOUNT"
+  },
+  {
+    "source": "incident-SC-2021-UA-PARSER-JS",
+    "target": "channel-npm-package-registry-npm-registry",
+    "type": "USED_DISTRIBUTION_CHANNEL"
   },
   {
     "source": "incident-SC-2022-COLORS-FAKER",
@@ -100,6 +250,11 @@
     "type": "AFFECTED_REPOSITORY"
   },
   {
+    "source": "incident-SC-2022-COLORS-FAKER",
+    "target": "channel-npm-package-registry-npm-registry",
+    "type": "USED_DISTRIBUTION_CHANNEL"
+  },
+  {
     "source": "incident-SC-2022-NODE-IPC",
     "target": "maintainer-riaevangelist",
     "type": "AFFECTED_MAINTAINER"
@@ -110,9 +265,34 @@
     "type": "AFFECTED_PACKAGE"
   },
   {
+    "source": "incident-SC-2022-NODE-IPC",
+    "target": "pkg-npm-peacenotwar",
+    "type": "AFFECTED_PACKAGE"
+  },
+  {
+    "source": "incident-SC-2022-NODE-IPC",
+    "target": "repo-github-com-riaevangelist-node-ipc",
+    "type": "AFFECTED_REPOSITORY"
+  },
+  {
+    "source": "incident-SC-2022-NODE-IPC",
+    "target": "channel-npm-package-registry-npm-registry",
+    "type": "USED_DISTRIBUTION_CHANNEL"
+  },
+  {
     "source": "incident-SC-2022-PYPI-CTX",
     "target": "pkg-pypi-ctx",
     "type": "AFFECTED_PACKAGE"
+  },
+  {
+    "source": "incident-SC-2022-PYPI-CTX",
+    "target": "account-pypi-ctx-pypi-project-account",
+    "type": "COMPROMISED_ACCOUNT"
+  },
+  {
+    "source": "incident-SC-2022-PYPI-CTX",
+    "target": "channel-pypi-package-registry-pypi",
+    "type": "USED_DISTRIBUTION_CHANNEL"
   },
   {
     "source": "incident-SC-2022-PYTORCH-NIGHTLY",
@@ -125,6 +305,21 @@
     "type": "AFFECTED_PACKAGE"
   },
   {
+    "source": "incident-SC-2022-PYTORCH-NIGHTLY",
+    "target": "repo-github-com-pytorch-pytorch",
+    "type": "AFFECTED_REPOSITORY"
+  },
+  {
+    "source": "incident-SC-2022-PYTORCH-NIGHTLY",
+    "target": "build-pytorch-pytorch-nightly-build-pipeline",
+    "type": "USED_BUILD_SYSTEM"
+  },
+  {
+    "source": "incident-SC-2022-PYTORCH-NIGHTLY",
+    "target": "channel-pypi-package-registry-pypi",
+    "type": "USED_DISTRIBUTION_CHANNEL"
+  },
+  {
     "source": "incident-SC-2023-LEDGER-CONNECT-KIT",
     "target": "org-ledger",
     "type": "AFFECTED_ORGANIZATION"
@@ -135,9 +330,29 @@
     "type": "AFFECTED_PACKAGE"
   },
   {
+    "source": "incident-SC-2023-LEDGER-CONNECT-KIT",
+    "target": "account-npm-ledgerhq-connect-kit-npm-publish-account",
+    "type": "COMPROMISED_ACCOUNT"
+  },
+  {
+    "source": "incident-SC-2023-LEDGER-CONNECT-KIT",
+    "target": "channel-npm-package-registry-npm-registry",
+    "type": "USED_DISTRIBUTION_CHANNEL"
+  },
+  {
     "source": "incident-SC-2023-THREE-CX-DESKTOP",
     "target": "org-3cx",
     "type": "AFFECTED_ORGANIZATION"
+  },
+  {
+    "source": "incident-SC-2023-THREE-CX-DESKTOP",
+    "target": "build-3cx-3cx-desktopapp-build-pipeline",
+    "type": "USED_BUILD_SYSTEM"
+  },
+  {
+    "source": "incident-SC-2023-THREE-CX-DESKTOP",
+    "target": "channel-vendor-update-signed-update-signed-software-installer-update-channel",
+    "type": "USED_DISTRIBUTION_CHANNEL"
   },
   {
     "source": "incident-SC-2024-LOTTIE-PLAYER",
@@ -150,9 +365,24 @@
     "type": "AFFECTED_PACKAGE"
   },
   {
+    "source": "incident-SC-2024-LOTTIE-PLAYER",
+    "target": "account-npm-lottiefiles-lottie-player-npm-publish-account",
+    "type": "COMPROMISED_ACCOUNT"
+  },
+  {
+    "source": "incident-SC-2024-LOTTIE-PLAYER",
+    "target": "channel-npm-package-registry-npm-registry",
+    "type": "USED_DISTRIBUTION_CHANNEL"
+  },
+  {
     "source": "incident-SC-2024-POLYFILL-IO",
     "target": "org-polyfill-io",
     "type": "AFFECTED_ORGANIZATION"
+  },
+  {
+    "source": "incident-SC-2024-POLYFILL-IO",
+    "target": "channel-web-cdn-script-third-party-cdn-script",
+    "type": "USED_DISTRIBUTION_CHANNEL"
   },
   {
     "source": "incident-SC-2024-ULTRALYTICS-PYPI",
@@ -163,6 +393,26 @@
     "source": "incident-SC-2024-ULTRALYTICS-PYPI",
     "target": "pkg-pypi-ultralytics",
     "type": "AFFECTED_PACKAGE"
+  },
+  {
+    "source": "incident-SC-2024-ULTRALYTICS-PYPI",
+    "target": "repo-github-com-ultralytics-ultralytics",
+    "type": "AFFECTED_REPOSITORY"
+  },
+  {
+    "source": "incident-SC-2024-ULTRALYTICS-PYPI",
+    "target": "account-pypi-ultralytics-pypi-publishing-token",
+    "type": "COMPROMISED_ACCOUNT"
+  },
+  {
+    "source": "incident-SC-2024-ULTRALYTICS-PYPI",
+    "target": "build-github-github-actions",
+    "type": "USED_BUILD_SYSTEM"
+  },
+  {
+    "source": "incident-SC-2024-ULTRALYTICS-PYPI",
+    "target": "channel-pypi-package-registry-pypi",
+    "type": "USED_DISTRIBUTION_CHANNEL"
   },
   {
     "source": "incident-SC-2024-XZ-UTILS",
@@ -180,8 +430,38 @@
     "type": "AFFECTED_REPOSITORY"
   },
   {
+    "source": "incident-SC-2024-XZ-UTILS",
+    "target": "channel-linux-source-release-upstream-source-release-tarball",
+    "type": "SOURCE_ARTIFACT_DIVERGENCE"
+  },
+  {
+    "source": "incident-SC-2024-XZ-UTILS",
+    "target": "channel-linux-source-release-upstream-source-release-tarball",
+    "type": "USED_DISTRIBUTION_CHANNEL"
+  },
+  {
     "source": "incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
     "target": "org-tj-actions",
     "type": "AFFECTED_ORGANIZATION"
+  },
+  {
+    "source": "incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
+    "target": "repo-github-com-tj-actions-changed-files",
+    "type": "AFFECTED_REPOSITORY"
+  },
+  {
+    "source": "incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
+    "target": "account-github-tj-actions-github-action-release-path",
+    "type": "COMPROMISED_ACCOUNT"
+  },
+  {
+    "source": "incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
+    "target": "build-github-github-actions",
+    "type": "USED_BUILD_SYSTEM"
+  },
+  {
+    "source": "incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
+    "target": "channel-github-actions-ci-cd-marketplace-github-actions-marketplace",
+    "type": "USED_DISTRIBUTION_CHANNEL"
   }
 ]

--- a/docs/supply-chain-graph-primitives.md
+++ b/docs/supply-chain-graph-primitives.md
@@ -1,8 +1,10 @@
 # Supply-Chain Graph Primitives
 
-Phase 1B converts the curated supply-chain incident corpus into first-class
-entity and relationship JSON files. This is a lightweight relationship layer,
-not a graph database.
+Phase 1B introduced first-class entity and relationship JSON files. Phase 1C
+deepens those primitives by extracting build systems, distribution channels,
+and compromised accounts from the curated incident corpus.
+
+This is a lightweight relationship layer, not a graph database.
 
 ## Inputs
 
@@ -17,6 +19,9 @@ data/supply-chain-entities/maintainers.json
 data/supply-chain-entities/packages.json
 data/supply-chain-entities/repositories.json
 data/supply-chain-entities/organizations.json
+data/supply-chain-entities/build_systems.json
+data/supply-chain-entities/distribution_channels.json
+data/supply-chain-entities/accounts.json
 ```
 
 Each entity has:
@@ -28,6 +33,8 @@ Each entity has:
 
 Package entities also carry `ecosystem` and `package_url` when available.
 Repository entities also carry `host`, `url`, and `owner`.
+Build-system, distribution-channel, and account entities carry type-specific
+fields copied from the incident corpus.
 
 ## Relationship Store
 
@@ -42,6 +49,10 @@ Allowed relationship types are intentionally narrow:
 - `AFFECTED_REPOSITORY`
 - `AFFECTED_ORGANIZATION`
 - `RELATED_INCIDENT`
+- `USED_BUILD_SYSTEM`
+- `USED_DISTRIBUTION_CHANNEL`
+- `COMPROMISED_ACCOUNT`
+- `SOURCE_ARTIFACT_DIVERGENCE`
 
 Relationships usually use an incident node as the source:
 
@@ -52,6 +63,19 @@ Relationships usually use an incident node as the source:
   "type": "AFFECTED_PACKAGE"
 }
 ```
+
+## Current Graph Density
+
+The Phase 1C depth pass over the same 25 incidents currently emits:
+
+- Maintainers: 5
+- Packages: 16
+- Repositories: 10
+- Organizations: 19
+- Build systems: 6
+- Distribution channels: 11
+- Compromised accounts: 8
+- Relationships: 95
 
 ## Build and Validate
 
@@ -81,6 +105,9 @@ This phase supports lookup questions such as:
 - incidents involving a maintainer
 - incidents involving a repository
 - incidents involving an organization
+- incidents involving a build system
+- incidents involving a distribution channel
+- incidents involving a compromised account
 
 It does not implement:
 

--- a/docs/supply-chain-incident-schema.md
+++ b/docs/supply-chain-incident-schema.md
@@ -5,8 +5,8 @@ incidents can inform later graph-schema design, attribution modeling, and
 release-event enrichment without mixing those later decisions into the raw
 corpus.
 
-Phase 1A is intentionally narrow. The corpus is machine-readable evidence
-inventory, not a risk engine.
+Phase 1C keeps the corpus as machine-readable evidence inventory while adding
+enough structured depth for graph primitives. It is still not a risk engine.
 
 ## Corpus Location
 
@@ -47,9 +47,49 @@ The core fields are:
 - `impact_categories`: normalized impact labels
 - `references`: public documentation for the incident
 - `tags`: additional non-authoritative grouping tags
+- `confidence`: `high`, `medium`, or `low` confidence in the structured record
+- `evidence_level`: strongest evidence class used for the record: `primary`,
+  `vendor`, `researcher`, `media`, or `inferred`
+- `attack_stage`: controlled stage label for where the supply-chain abuse
+  entered or propagated
+- `source_artifact_divergence`: `true`, `false`, or `null` when unknown
+- `maintainers`: named maintainers or maintainership handles when directly
+  supported
+- `repositories`: source repositories tied to the incident
+- `build_systems`: build or CI/CD systems tied to the incident
+- `distribution_channels`: registries, update channels, CDN scripts, source
+  releases, or download paths used by the incident
+- `compromised_accounts`: package-registry, source-control, or release-path
+  accounts/tokens tied to the incident
 
 Package components may include `package_url` when a PURL is available. Non-
 package software, services, websites, and update channels should use `null`.
+
+## Attack Stages
+
+Current `attack_stage` values are:
+
+- `source_compromise`
+- `build_compromise`
+- `account_compromise`
+- `package_publish`
+- `dependency_resolution`
+- `distribution_compromise`
+- `ci_cd_compromise`
+
+These are placement labels for relationship extraction. They are not scoring
+labels and do not attribute an actor.
+
+## Evidence Quality
+
+Every incident must carry:
+
+- `confidence`: `high`, `medium`, or `low`
+- `evidence_level`: `primary`, `vendor`, `researcher`, `media`, or `inferred`
+
+Use `inferred` only when the structured field is clearly derived from the
+documented record and no stronger class applies. Do not use evidence quality as
+a severity score.
 
 ## Vector Labels
 
@@ -109,10 +149,15 @@ make external network calls.
 4. Use existing vector and impact labels when possible.
 5. Add a new label only when the existing schema cannot represent the incident.
 6. Include at least one public reference.
-7. Run validation:
+7. Fill evidence-quality and graph-depth fields. Use empty arrays for
+   unsupported maintainers, repositories, build systems, distribution channels,
+   or compromised accounts.
+8. Regenerate graph primitives and run validation:
 
 ```bash
+python3 scripts/build_supply_chain_entities.py
 python3 scripts/validate_supply_chain_incidents.py
+python3 scripts/validate_supply_chain_graph.py
 python3 -m unittest discover -s tests
 git diff --check
 ```

--- a/scripts/build_supply_chain_entities.py
+++ b/scripts/build_supply_chain_entities.py
@@ -17,6 +17,9 @@ DEFAULT_ENTITY_DIR = REPO_ROOT / "data" / "supply-chain-entities"
 DEFAULT_RELATIONSHIP_DIR = REPO_ROOT / "data" / "supply-chain-relationships"
 
 ENTITY_FILES = {
+    "accounts": "accounts.json",
+    "build_systems": "build_systems.json",
+    "distribution_channels": "distribution_channels.json",
     "maintainers": "maintainers.json",
     "packages": "packages.json",
     "repositories": "repositories.json",
@@ -27,7 +30,11 @@ RELATIONSHIP_TYPES = {
     "AFFECTED_MAINTAINER",
     "AFFECTED_REPOSITORY",
     "AFFECTED_ORGANIZATION",
+    "COMPROMISED_ACCOUNT",
     "RELATED_INCIDENT",
+    "SOURCE_ARTIFACT_DIVERGENCE",
+    "USED_BUILD_SYSTEM",
+    "USED_DISTRIBUTION_CHANNEL",
 }
 GENERIC_VENDOR_NAMES = {
     "malicious publisher",
@@ -35,11 +42,11 @@ GENERIC_VENDOR_NAMES = {
     "multiple organizations",
     "open source maintainer",
     "open source maintainers",
+    "riaevangelist",
+    "right9ctrl",
 }
 GITHUB_SYSTEM_PATHS = {
-    "about",
     "advisories",
-    "blog",
     "collections",
     "explore",
     "features",
@@ -47,64 +54,12 @@ GITHUB_SYSTEM_PATHS = {
     "marketplace",
     "notifications",
     "orgs",
-    "pricing",
     "search",
-    "security",
     "settings",
     "sponsors",
     "topics",
     "trending",
 }
-
-# Explicit human/entity hints are used only where the Phase 1A corpus does not
-# yet carry first-class maintainer/repository fields.
-INCIDENT_ENTITY_HINTS: dict[str, dict[str, list[dict[str, Any]]]] = {
-    "SC-2018-NPM-EVENT-STREAM": {
-        "maintainers": [
-            {"name": "Dominic Tarr", "aliases": ["dominictarr"], "id_slug": "dominictarr"},
-        ],
-        "repositories": [
-            {
-                "name": "dominictarr/event-stream",
-                "host": "github.com",
-                "url": "https://github.com/dominictarr/event-stream",
-                "owner": "dominictarr",
-            }
-        ],
-    },
-    "SC-2022-COLORS-FAKER": {
-        "maintainers": [
-            {"name": "Marak Squires", "aliases": ["Marak"]},
-        ],
-        "repositories": [
-            {
-                "name": "Marak/colors.js",
-                "host": "github.com",
-                "url": "https://github.com/Marak/colors.js",
-                "owner": "Marak",
-            }
-        ],
-    },
-    "SC-2022-NODE-IPC": {
-        "maintainers": [
-            {"name": "RIAEvangelist", "aliases": ["Brandon Nozaki Miller"]},
-        ]
-    },
-    "SC-2024-XZ-UTILS": {
-        "maintainers": [
-            {"name": "Jia Tan", "aliases": ["JiaT75"]},
-        ],
-        "repositories": [
-            {
-                "name": "tukaani-project/xz",
-                "host": "github.com",
-                "url": "https://github.com/tukaani-project/xz",
-                "owner": "tukaani-project",
-            }
-        ],
-    },
-}
-
 
 def load_json(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
@@ -128,10 +83,6 @@ def incident_node_id(incident_id: str) -> str:
     return f"incident-{incident_id}"
 
 
-def is_generic_vendor(name: str) -> bool:
-    return normalize_alias(name).replace("-", " ") in GENERIC_VENDOR_NAMES
-
-
 def github_repository_from_url(url: str) -> dict[str, str] | None:
     parsed = urlparse(url)
     if parsed.netloc.lower() != "github.com":
@@ -139,9 +90,7 @@ def github_repository_from_url(url: str) -> dict[str, str] | None:
     parts = [part for part in parsed.path.split("/") if part]
     if len(parts) < 2 or parts[0].lower() in GITHUB_SYSTEM_PATHS:
         return None
-    owner, repo = parts[0], parts[1]
-    if repo.lower().endswith(".git"):
-        repo = repo[:-4]
+    owner, repo = parts[0], parts[1].removesuffix(".git")
     if not repo:
         return None
     return {
@@ -150,6 +99,10 @@ def github_repository_from_url(url: str) -> dict[str, str] | None:
         "url": f"https://github.com/{owner}/{repo}",
         "owner": owner,
     }
+
+
+def is_generic_vendor(name: str) -> bool:
+    return normalize_alias(name).replace("-", " ") in GENERIC_VENDOR_NAMES
 
 
 def add_source(entity: dict[str, Any], incident_id: str) -> None:
@@ -217,8 +170,8 @@ def upsert_repository(repositories: dict[str, dict[str, Any]], repo: dict[str, s
 
 def upsert_maintainer(maintainers: dict[str, dict[str, Any]], hint: dict[str, Any], incident_id: str) -> str:
     name = hint["name"]
-    aliases = sorted(set(hint.get("aliases", []) + [name]))
-    entity_id = stable_id("maintainer", hint.get("id_slug", name))
+    aliases = sorted(set((hint.get("aliases") or []) + [name]))
+    entity_id = stable_id("maintainer", hint["id_slug"])
     entity = maintainers.setdefault(
         entity_id,
         {
@@ -233,6 +186,58 @@ def upsert_maintainer(maintainers: dict[str, dict[str, Any]], hint: dict[str, An
     return entity_id
 
 
+def upsert_build_system(build_systems: dict[str, dict[str, Any]], item: dict[str, str], incident_id: str) -> str:
+    entity_id = stable_id("build", item["provider"], item["name"])
+    entity = build_systems.setdefault(
+        entity_id,
+        {
+            "id": entity_id,
+            "name": item["name"],
+            "provider": item["provider"],
+            "category": item["category"],
+            "aliases": sorted({item["name"]}),
+            "source_incident_ids": [],
+        },
+    )
+    add_source(entity, incident_id)
+    return entity_id
+
+
+def upsert_distribution_channel(channels: dict[str, dict[str, Any]], item: dict[str, str], incident_id: str) -> str:
+    entity_id = stable_id("channel", item["ecosystem"], item["channel_type"], item["name"])
+    entity = channels.setdefault(
+        entity_id,
+        {
+            "id": entity_id,
+            "name": item["name"],
+            "channel_type": item["channel_type"],
+            "ecosystem": item["ecosystem"],
+            "aliases": sorted({item["name"]}),
+            "source_incident_ids": [],
+        },
+    )
+    add_source(entity, incident_id)
+    return entity_id
+
+
+def upsert_account(accounts: dict[str, dict[str, Any]], item: dict[str, str], incident_id: str) -> str:
+    entity_id = stable_id("account", item["provider"], item["name"])
+    entity = accounts.setdefault(
+        entity_id,
+        {
+            "id": entity_id,
+            "name": item["name"],
+            "provider": item["provider"],
+            "account_type": item["account_type"],
+            "role": item["role"],
+            "aliases": sorted({item["name"]}),
+            "source_incident_ids": [],
+        },
+    )
+    add_source(entity, incident_id)
+    return entity_id
+
+
 def relationship(source: str, target: str, relationship_type: str) -> dict[str, str]:
     if relationship_type not in RELATIONSHIP_TYPES:
         raise ValueError(f"invalid relationship type: {relationship_type}")
@@ -240,6 +245,9 @@ def relationship(source: str, target: str, relationship_type: str) -> dict[str, 
 
 
 def build_graph(corpus: list[dict[str, Any]]) -> dict[str, Any]:
+    accounts: dict[str, dict[str, Any]] = {}
+    build_systems: dict[str, dict[str, Any]] = {}
+    distribution_channels: dict[str, dict[str, Any]] = {}
     maintainers: dict[str, dict[str, Any]] = {}
     packages: dict[str, dict[str, Any]] = {}
     repositories: dict[str, dict[str, Any]] = {}
@@ -261,21 +269,36 @@ def build_graph(corpus: list[dict[str, Any]]) -> dict[str, Any]:
             if org_id:
                 add_relationship(relationship(source, org_id, "AFFECTED_ORGANIZATION"))
 
-        for reference in incident.get("references", []):
-            repo = github_repository_from_url(reference.get("url", ""))
-            if repo:
-                repo_id = upsert_repository(repositories, repo, incident_id)
-                add_relationship(relationship(source, repo_id, "AFFECTED_REPOSITORY"))
-
-        hints = INCIDENT_ENTITY_HINTS.get(incident_id, {})
-        for hint in hints.get("maintainers", []):
-            maintainer_id = upsert_maintainer(maintainers, hint, incident_id)
+        divergence_channel_targets: list[str] = []
+        for maintainer in incident.get("maintainers") or []:
+            maintainer_id = upsert_maintainer(maintainers, maintainer, incident_id)
             add_relationship(relationship(source, maintainer_id, "AFFECTED_MAINTAINER"))
-        for hint in hints.get("repositories", []):
-            repo_id = upsert_repository(repositories, hint, incident_id)
+
+        for repo in incident.get("repositories") or []:
+            repo_id = upsert_repository(repositories, repo, incident_id)
             add_relationship(relationship(source, repo_id, "AFFECTED_REPOSITORY"))
 
+        for item in incident.get("build_systems") or []:
+            build_system_id = upsert_build_system(build_systems, item, incident_id)
+            add_relationship(relationship(source, build_system_id, "USED_BUILD_SYSTEM"))
+
+        for item in incident.get("distribution_channels") or []:
+            channel_id = upsert_distribution_channel(distribution_channels, item, incident_id)
+            divergence_channel_targets.append(channel_id)
+            add_relationship(relationship(source, channel_id, "USED_DISTRIBUTION_CHANNEL"))
+
+        for item in incident.get("compromised_accounts") or []:
+            account_id = upsert_account(accounts, item, incident_id)
+            add_relationship(relationship(source, account_id, "COMPROMISED_ACCOUNT"))
+
+        if incident.get("source_artifact_divergence") is True:
+            for channel_id in divergence_channel_targets:
+                add_relationship(relationship(source, channel_id, "SOURCE_ARTIFACT_DIVERGENCE"))
+
     return {
+        "accounts": sorted(accounts.values(), key=lambda item: item["id"]),
+        "build_systems": sorted(build_systems.values(), key=lambda item: item["id"]),
+        "distribution_channels": sorted(distribution_channels.values(), key=lambda item: item["id"]),
         "maintainers": sorted(maintainers.values(), key=lambda item: item["id"]),
         "packages": sorted(packages.values(), key=lambda item: item["id"]),
         "repositories": sorted(repositories.values(), key=lambda item: item["id"]),
@@ -306,6 +329,9 @@ def main(argv: list[str] | None = None) -> int:
         f"packages={len(graph['packages'])} "
         f"repositories={len(graph['repositories'])} "
         f"organizations={len(graph['organizations'])} "
+        f"build_systems={len(graph['build_systems'])} "
+        f"distribution_channels={len(graph['distribution_channels'])} "
+        f"accounts={len(graph['accounts'])} "
         f"relationships={len(graph['relationships'])}"
     )
     return 0

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -17,6 +17,9 @@ DEFAULT_ENTITY_DIR = REPO_ROOT / "data" / "supply-chain-entities"
 DEFAULT_RELATIONSHIP_PATH = REPO_ROOT / "data" / "supply-chain-relationships" / "relationships.json"
 
 ENTITY_FILES = {
+    "accounts": "accounts.json",
+    "build_systems": "build_systems.json",
+    "distribution_channels": "distribution_channels.json",
     "maintainers": "maintainers.json",
     "packages": "packages.json",
     "repositories": "repositories.json",
@@ -27,15 +30,32 @@ VALID_RELATIONSHIP_TYPES = {
     "AFFECTED_MAINTAINER",
     "AFFECTED_REPOSITORY",
     "AFFECTED_ORGANIZATION",
+    "COMPROMISED_ACCOUNT",
     "RELATED_INCIDENT",
+    "SOURCE_ARTIFACT_DIVERGENCE",
+    "USED_BUILD_SYSTEM",
+    "USED_DISTRIBUTION_CHANNEL",
 }
-ENTITY_ID_PATTERN = re.compile(r"^(maintainer|pkg|repo|org)-[a-z0-9][a-z0-9-]*$")
+ENTITY_ID_PATTERN = re.compile(r"^(account|build|channel|maintainer|pkg|repo|org)-[a-z0-9][a-z0-9-]*$")
 RELATIONSHIP_TARGET_PREFIXES = {
     "AFFECTED_PACKAGE": "pkg-",
     "AFFECTED_MAINTAINER": "maintainer-",
     "AFFECTED_REPOSITORY": "repo-",
     "AFFECTED_ORGANIZATION": "org-",
+    "COMPROMISED_ACCOUNT": "account-",
     "RELATED_INCIDENT": "incident-",
+    "SOURCE_ARTIFACT_DIVERGENCE": ("repo-", "channel-"),
+    "USED_BUILD_SYSTEM": "build-",
+    "USED_DISTRIBUTION_CHANNEL": "channel-",
+}
+ENTITY_TYPE_REQUIRED_FIELDS = {
+    "accounts": ["provider", "account_type", "role"],
+    "build_systems": ["provider", "category"],
+    "distribution_channels": ["channel_type", "ecosystem"],
+    "maintainers": [],
+    "organizations": [],
+    "packages": ["ecosystem"],
+    "repositories": ["host", "url", "owner"],
 }
 
 
@@ -84,6 +104,9 @@ def validate_entity_file(errors: list[str], entity_type: str, entities: Any, inc
         ids.add(entity_id)
         if not isinstance(entity.get("name"), str) or not entity["name"].strip():
             errors.append(f"{entity_id}.name: expected non-empty string")
+        for field in ENTITY_TYPE_REQUIRED_FIELDS.get(entity_type, []):
+            if not isinstance(entity.get(field), str) or not entity[field].strip():
+                errors.append(f"{entity_id}.{field}: expected non-empty string")
         source_incident_ids = entity.get("source_incident_ids")
         if not isinstance(source_incident_ids, list) or not source_incident_ids:
             errors.append(f"{entity_id}.source_incident_ids: expected non-empty list")
@@ -160,6 +183,24 @@ def validate_relationships(
     return errors
 
 
+def validate_corpus_implied_relationships(corpus: list[dict[str, Any]], relationships: Any) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(relationships, list):
+        return errors
+    relationships_by_source_type = {
+        (relationship.get("source"), relationship.get("type"))
+        for relationship in relationships
+        if isinstance(relationship, dict)
+    }
+    for incident in corpus:
+        if not isinstance(incident, dict) or not isinstance(incident.get("id"), str):
+            continue
+        source = incident_node_id(incident["id"])
+        if incident.get("source_artifact_divergence") is True and (source, "SOURCE_ARTIFACT_DIVERGENCE") not in relationships_by_source_type:
+            errors.append(f"{source}: missing SOURCE_ARTIFACT_DIVERGENCE relationship")
+    return errors
+
+
 def validate_graph(corpus: Any, entities_by_type: dict[str, Any], relationships: Any) -> list[str]:
     errors: list[str] = []
     if not isinstance(corpus, list):
@@ -183,6 +224,7 @@ def validate_graph(corpus: Any, entities_by_type: dict[str, Any], relationships:
             incident_ids=incident_ids,
         )
     )
+    errors.extend(validate_corpus_implied_relationships(corpus, relationships))
     return errors
 
 

--- a/scripts/validate_supply_chain_incidents.py
+++ b/scripts/validate_supply_chain_incidents.py
@@ -35,11 +35,36 @@ REQUIRED_FIELDS = [
     "impact_categories",
     "references",
     "tags",
+    "confidence",
+    "evidence_level",
+    "attack_stage",
+    "source_artifact_divergence",
+    "maintainers",
+    "repositories",
+    "build_systems",
+    "distribution_channels",
+    "compromised_accounts",
 ]
 
 REQUIRED_COMPONENT_FIELDS = ["component_type", "ecosystem", "name", "vendor"]
 REQUIRED_REFERENCE_FIELDS = ["title", "publisher", "url", "published_at"]
+REQUIRED_MAINTAINER_FIELDS = ["name", "aliases", "id_slug"]
+REQUIRED_REPOSITORY_FIELDS = ["name", "host", "owner", "url"]
+REQUIRED_BUILD_SYSTEM_FIELDS = ["name", "provider", "category"]
+REQUIRED_DISTRIBUTION_CHANNEL_FIELDS = ["name", "channel_type", "ecosystem"]
+REQUIRED_COMPROMISED_ACCOUNT_FIELDS = ["name", "provider", "account_type", "role"]
 VALID_STATUS = {"confirmed"}
+VALID_CONFIDENCE = {"high", "medium", "low"}
+VALID_EVIDENCE_LEVELS = {"primary", "vendor", "researcher", "media", "inferred"}
+VALID_ATTACK_STAGES = {
+    "source_compromise",
+    "build_compromise",
+    "account_compromise",
+    "package_publish",
+    "dependency_resolution",
+    "distribution_compromise",
+    "ci_cd_compromise",
+}
 VALID_COMPONENT_TYPES = {"package", "project", "software", "service", "update_channel", "website"}
 VALID_VECTORS = {
     "build_system_compromise",
@@ -160,6 +185,63 @@ def validate_reference(errors: list[str], incident_id: str, index: int, referenc
         errors.append(f"{path}.published_at: expected YYYY-MM-DD date")
 
 
+def validate_maintainer(errors: list[str], incident_id: str, index: int, maintainer: Any) -> None:
+    path = f"{incident_id}.maintainers[{index}]"
+    if not isinstance(maintainer, dict):
+        errors.append(f"{path}: expected object")
+        return
+    for field in REQUIRED_MAINTAINER_FIELDS:
+        if field not in maintainer:
+            errors.append(f"{path}.{field}: missing required field")
+    if "name" in maintainer:
+        require_string(errors, f"{path}.name", maintainer.get("name"))
+    if "id_slug" in maintainer:
+        require_string(errors, f"{path}.id_slug", maintainer.get("id_slug"))
+    if "aliases" in maintainer:
+        aliases = maintainer.get("aliases")
+        if not isinstance(aliases, list):
+            errors.append(f"{path}.aliases: expected list")
+            return
+        for alias_index, alias in enumerate(aliases):
+            if not isinstance(alias, str) or not alias.strip():
+                errors.append(f"{path}.aliases[{alias_index}]: expected non-empty string")
+
+def validate_repository(errors: list[str], incident_id: str, index: int, repository: Any) -> None:
+    path = f"{incident_id}.repositories[{index}]"
+    if not isinstance(repository, dict):
+        errors.append(f"{path}: expected object")
+        return
+    for field in REQUIRED_REPOSITORY_FIELDS:
+        if field not in repository:
+            errors.append(f"{path}.{field}: missing required field")
+        elif field != "url":
+            require_string(errors, f"{path}.{field}", repository[field])
+    if "url" in repository and not is_valid_url(repository["url"]):
+        errors.append(f"{path}.url: expected http(s) URL")
+
+
+def validate_named_fields(
+    errors: list[str],
+    incident_id: str,
+    field_name: str,
+    required_fields: list[str],
+    records: Any,
+) -> None:
+    if not isinstance(records, list):
+        errors.append(f"{incident_id}.{field_name}: expected list")
+        return
+    for index, record in enumerate(records):
+        path = f"{incident_id}.{field_name}[{index}]"
+        if not isinstance(record, dict):
+            errors.append(f"{path}: expected object")
+            continue
+        for field in required_fields:
+            if field not in record:
+                errors.append(f"{path}.{field}: missing required field")
+            else:
+                require_string(errors, f"{path}.{field}", record[field])
+
+
 def validate_incident(incident: Any) -> list[str]:
     errors: list[str] = []
     if not isinstance(incident, dict):
@@ -182,6 +264,21 @@ def validate_incident(incident: Any) -> list[str]:
         require_string(errors, f"{incident_id}.summary", incident.get("summary"), min_length=40)
     if "status" in incident and incident.get("status") not in VALID_STATUS:
         errors.append(f"{incident_id}.status: invalid value {incident.get('status')!r}")
+    if incident.get("confidence") not in VALID_CONFIDENCE:
+        errors.append(f"{incident_id}.confidence: invalid value {incident.get('confidence')!r}")
+    if incident.get("evidence_level") not in VALID_EVIDENCE_LEVELS:
+        errors.append(f"{incident_id}.evidence_level: invalid value {incident.get('evidence_level')!r}")
+    if incident.get("attack_stage") not in VALID_ATTACK_STAGES:
+        errors.append(f"{incident_id}.attack_stage: invalid value {incident.get('attack_stage')!r}")
+    if incident.get("source_artifact_divergence") is not None and not isinstance(incident.get("source_artifact_divergence"), bool):
+        errors.append(f"{incident_id}.source_artifact_divergence: expected boolean or null")
+    distribution_channels = incident.get("distribution_channels")
+    if incident.get("source_artifact_divergence") is True and (
+        not isinstance(distribution_channels, list) or not distribution_channels
+    ):
+        errors.append(f"{incident_id}.source_artifact_divergence: cannot be true when distribution_channels is empty")
+    if "notes" in incident:
+        require_string(errors, f"{incident_id}.notes", incident.get("notes"), min_length=8)
 
     first_observed_at = None
     if "first_observed_at" in incident:
@@ -220,6 +317,36 @@ def validate_incident(incident: Any) -> list[str]:
         else:
             for index, reference in enumerate(references):
                 validate_reference(errors, incident_id, index, reference)
+
+    maintainers = incident.get("maintainers")
+    if not isinstance(maintainers, list):
+        errors.append(f"{incident_id}.maintainers: expected list")
+    else:
+        for index, maintainer in enumerate(maintainers):
+            validate_maintainer(errors, incident_id, index, maintainer)
+
+    repositories = incident.get("repositories")
+    if not isinstance(repositories, list):
+        errors.append(f"{incident_id}.repositories: expected list")
+    else:
+        for index, repository in enumerate(repositories):
+            validate_repository(errors, incident_id, index, repository)
+
+    validate_named_fields(errors, incident_id, "build_systems", REQUIRED_BUILD_SYSTEM_FIELDS, incident.get("build_systems"))
+    validate_named_fields(
+        errors,
+        incident_id,
+        "distribution_channels",
+        REQUIRED_DISTRIBUTION_CHANNEL_FIELDS,
+        incident.get("distribution_channels"),
+    )
+    validate_named_fields(
+        errors,
+        incident_id,
+        "compromised_accounts",
+        REQUIRED_COMPROMISED_ACCOUNT_FIELDS,
+        incident.get("compromised_accounts"),
+    )
 
     return errors
 

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -44,12 +44,33 @@ class SupplyChainGraphTests(unittest.TestCase):
         package_ids = {entity["id"] for entity in graph["packages"]}
         maintainer_ids = {entity["id"] for entity in graph["maintainers"]}
         organization_ids = {entity["id"] for entity in graph["organizations"]}
+        repository_ids = {entity["id"] for entity in graph["repositories"]}
+        build_system_ids = {entity["id"] for entity in graph["build_systems"]}
+        channel_ids = {entity["id"] for entity in graph["distribution_channels"]}
+        account_ids = {entity["id"] for entity in graph["accounts"]}
 
+        self.assertGreaterEqual(len(graph["relationships"]), 90)
         self.assertIn("pkg-npm-event-stream", package_ids)
+        self.assertIn("pkg-npm-flatmap-stream", package_ids)
         self.assertIn("maintainer-jia-tan", maintainer_ids)
         self.assertIn("maintainer-dominictarr", maintainer_ids)
         self.assertIn("org-codecov", organization_ids)
         self.assertIn("org-polyfill-io", organization_ids)
+        self.assertIn("repo-github-com-dominictarr-event-stream", repository_ids)
+        self.assertIn("build-github-github-actions", build_system_ids)
+        self.assertIn("channel-npm-package-registry-npm-registry", channel_ids)
+        self.assertIn("account-npm-eslint-scope-npm-maintainer-account", account_ids)
+
+    def test_source_artifact_divergence_targets_distribution_channels(self) -> None:
+        graph = builder.build_graph(load_json(CORPUS_PATH))
+        relationships = [
+            item
+            for item in graph["relationships"]
+            if item["type"] == "SOURCE_ARTIFACT_DIVERGENCE"
+        ]
+
+        self.assertGreaterEqual(len(relationships), 1)
+        self.assertTrue(all(item["target"].startswith("channel-") for item in relationships))
 
     def test_invalid_relationship_target_fails(self) -> None:
         corpus = load_json(CORPUS_PATH)
@@ -125,10 +146,8 @@ class SupplyChainGraphTests(unittest.TestCase):
     def test_github_repository_parser_skips_system_paths_and_normalizes_dot_git(self) -> None:
         self.assertIsNone(builder.github_repository_from_url("https://github.com/orgs/example/packages"))
         self.assertIsNone(builder.github_repository_from_url("https://github.com/advisories/GHSA-xxxx-yyyy-zzzz"))
-        self.assertIsNone(builder.github_repository_from_url("https://github.com/blog/example"))
-        self.assertIsNone(builder.github_repository_from_url("https://github.com/security/advisories"))
         self.assertEqual(
-            builder.github_repository_from_url("https://github.com/example/project.GIT/issues/1"),
+            builder.github_repository_from_url("https://github.com/example/project.git/issues/1"),
             {
                 "name": "example/project",
                 "host": "github.com",
@@ -136,6 +155,46 @@ class SupplyChainGraphTests(unittest.TestCase):
                 "owner": "example",
             },
         )
+
+    def test_unsupported_relationship_type_fails(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        entities_by_type = validator.load_entities(ENTITY_DIR)
+        relationships = copy.deepcopy(load_json(RELATIONSHIP_PATH))
+        relationships[0]["type"] = "SCORED"
+
+        errors = validator.validate_graph(corpus, entities_by_type, relationships)
+
+        self.assertTrue(any("invalid relationship type" in error for error in errors))
+
+    def test_new_entity_type_required_fields_are_validated(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        entities_by_type = validator.load_entities(ENTITY_DIR)
+        relationships = load_json(RELATIONSHIP_PATH)
+        entities_by_type["accounts"] = copy.deepcopy(entities_by_type["accounts"])
+        entities_by_type["build_systems"] = copy.deepcopy(entities_by_type["build_systems"])
+        entities_by_type["distribution_channels"] = copy.deepcopy(entities_by_type["distribution_channels"])
+        del entities_by_type["accounts"][0]["provider"]
+        del entities_by_type["build_systems"][0]["category"]
+        del entities_by_type["distribution_channels"][0]["ecosystem"]
+
+        errors = validator.validate_graph(corpus, entities_by_type, relationships)
+
+        self.assertTrue(any(".provider: expected non-empty string" in error for error in errors))
+        self.assertTrue(any(".category: expected non-empty string" in error for error in errors))
+        self.assertTrue(any(".ecosystem: expected non-empty string" in error for error in errors))
+
+    def test_source_artifact_divergence_requires_relationship(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        entities_by_type = validator.load_entities(ENTITY_DIR)
+        relationships = [
+            relationship
+            for relationship in load_json(RELATIONSHIP_PATH)
+            if relationship["type"] != "SOURCE_ARTIFACT_DIVERGENCE"
+        ]
+
+        errors = validator.validate_graph(corpus, entities_by_type, relationships)
+
+        self.assertTrue(any("missing SOURCE_ARTIFACT_DIVERGENCE relationship" in error for error in errors))
 
 
 if __name__ == "__main__":

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -50,12 +50,14 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
     def test_required_fields_dates_and_references_are_enforced(self) -> None:
         incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
         del incident["title"]
+        del incident["confidence"]
         incident["disclosed_at"] = "not-a-date"
         incident["references"][0]["url"] = "not a url"
 
         errors = validator.validate_incident(incident)
 
         self.assertTrue(any(".title: missing required field" in error for error in errors))
+        self.assertTrue(any(".confidence: missing required field" in error for error in errors))
         self.assertTrue(any(".disclosed_at: expected YYYY-MM-DD date" in error for error in errors))
         self.assertTrue(any(".references[0].url: expected http(s) URL" in error for error in errors))
 
@@ -131,11 +133,42 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
         incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
         incident["supply_chain_vectors"] = ["scoring"]
         incident["impact_categories"] = ["risk_engine"]
+        incident["confidence"] = "score-10"
+        incident["evidence_level"] = "ai"
+        incident["attack_stage"] = "attribution"
 
         errors = validator.validate_incident(incident)
 
         self.assertTrue(any(".supply_chain_vectors[0]: invalid value" in error for error in errors))
         self.assertTrue(any(".impact_categories[0]: invalid value" in error for error in errors))
+        self.assertTrue(any(".confidence: invalid value" in error for error in errors))
+        self.assertTrue(any(".evidence_level: invalid value" in error for error in errors))
+        self.assertTrue(any(".attack_stage: invalid value" in error for error in errors))
+
+    def test_structured_depth_fields_are_enforced(self) -> None:
+        incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
+        incident["distribution_channels"] = [
+            {
+                "name": "",
+                "channel_type": "package_registry",
+                "ecosystem": "npm"
+            }
+        ]
+        incident["maintainers"] = [
+            {
+                "name": "Example Maintainer",
+                "aliases": ["example"],
+                "id_slug": "example"
+            }
+        ]
+        incident["source_artifact_divergence"] = "yes"
+        del incident["maintainers"][0]["id_slug"]
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any(".distribution_channels[0].name: expected non-empty string" in error for error in errors))
+        self.assertTrue(any(".source_artifact_divergence: expected boolean or null" in error for error in errors))
+        self.assertTrue(any(".maintainers[0].id_slug: missing required field" in error for error in errors))
 
     def test_unhashable_enum_items_do_not_crash_validation(self) -> None:
         incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
@@ -160,6 +193,17 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
 
         schema["required"].pop()
         self.assertEqual(validator.validate_schema_file(schema), ["schema.required: does not match validator required fields"])
+
+    def test_source_artifact_divergence_requires_distribution_channels(self) -> None:
+        incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
+        incident["source_artifact_divergence"] = True
+        incident["distribution_channels"] = []
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(
+            any(".source_artifact_divergence: cannot be true when distribution_channels is empty" in error for error in errors)
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- deepen the existing 25 supply-chain incidents with structured evidence-quality and graph-bearing fields
- add confidence, evidence_level, attack_stage, source_artifact_divergence, maintainers, repositories, build_systems, distribution_channels, and compromised_accounts
- update entity extraction to emit build systems, distribution channels, and compromised accounts
- add relationship extraction for USED_BUILD_SYSTEM, USED_DISTRIBUTION_CHANNEL, COMPROMISED_ACCOUNT, and SOURCE_ARTIFACT_DIVERGENCE
- update validators, docs, generated graph files, and tests

## Graph density
Before Phase 1C from Phase 1B:
- Maintainers: 4
- Packages: 13
- Repositories: 3
- Organizations: 17
- Relationships: 37

After Phase 1C:
- Maintainers: 5
- Packages: 16
- Repositories: 10
- Organizations: 19
- Build systems: 6
- Distribution channels: 11
- Compromised accounts: 8
- Relationships: 95

## Scope boundaries
- no scoring
- no soak windows
- no graph database
- no public UI
- no AI inference
- no automated attribution
- no new ingestion feeds

## Validation
- python3 scripts/build_supply_chain_entities.py && python3 scripts/validate_supply_chain_graph.py
- python3 scripts/validate_supply_chain_incidents.py
- python3 -m unittest discover -s tests
- python3 -m compileall scripts/build_supply_chain_entities.py scripts/validate_supply_chain_graph.py scripts/validate_supply_chain_incidents.py tests
- git diff --check

Stacked on Phase 1B PR #1131 because that PR introduces the graph primitive layer this depth pass expands.
