### PR TITLE
Add feature-flagged supply chain pages phase 1D

### DIFF
--- a/docs/supply-chain-pages.md
+++ b/docs/supply-chain-pages.md
@@ -1,0 +1,174 @@
+# Supply Chain Pages
+
+Threatpedia Supply Chain pages render the curated supply-chain incident corpus
+and graph primitives as static pages. The public label is **Supply Chain**.
+
+## Feature Flag
+
+Pages are disabled by default.
+
+```bash
+ENABLE_SUPPLY_CHAIN_PAGES=true
+```
+
+When the flag is not set to `true`, the static route generator emits no Supply
+Chain routes and the public navigation does not include a Supply Chain link.
+This is the default behavior and prevents disabled pages from being indexed.
+
+## Routes
+
+When enabled, the static site generates:
+
+```text
+/supply-chain/
+/supply-chain/incidents/[id]/
+/supply-chain/packages/[id]/
+/supply-chain/repositories/[id]/
+/supply-chain/organizations/[id]/
+/supply-chain/maintainers/[id]/
+```
+
+The pages are generated from checked-in JSON only:
+
+```text
+data/supply-chain-incidents/incidents.json
+data/supply-chain-entities/*.json
+data/supply-chain-relationships/relationships.json
+```
+
+## Local Build
+
+Disabled/default build:
+
+```bash
+cd site
+npm run build
+```
+
+Enabled build:
+
+```bash
+cd site
+ENABLE_SUPPLY_CHAIN_PAGES=true npm run build
+```
+
+Focused page tests:
+
+```bash
+node scripts/test-supply-chain-pages.mjs
+```
+
+Run graph validation before page generation:
+
+```bash
+python3 scripts/validate_supply_chain_incidents.py
+python3 scripts/validate_supply_chain_graph.py
+```
+
+## Page Content
+
+The index page uses public-facing Supply Chain copy and explains:
+
+- what Threatpedia tracks
+- why supply chain incidents matter
+- how entities connect
+- the evidence and confidence model
+
+It also shows five curated featured incident cards:
+
+- XZ Utils backdoor attempt
+- 3CX desktop application software supply-chain compromise
+- SolarWinds Orion software build compromise
+- event-stream malicious dependency insertion
+- ua-parser-js npm package account compromise
+
+The index page shows counts for:
+
+- incidents
+- packages
+- repositories
+- organizations
+- maintainers
+- build systems
+- distribution channels
+- compromised accounts
+- relationships
+
+Incident pages show corpus fields only: summary, confidence, evidence level,
+attack stage, source-artifact divergence, affected entities, structured supply-
+chain primitives, compromised accounts, connected entities, and references.
+
+Entity pages show the entity name, entity type, connected incidents, and
+connected entities when relationships support those links.
+
+## SEO Metadata
+
+Supply Chain pages use the shared site layout metadata path for:
+
+- page title
+- meta description
+- canonical URL
+- Open Graph title and description
+- JSON-LD where a static corpus object maps cleanly to a generic web object
+
+When `ENABLE_SUPPLY_CHAIN_PAGES` is not `true`, no Supply Chain static routes
+are emitted. If a disabled page path is rendered in a nonstandard local context,
+the page path also supports a noindex robots value.
+
+## Public Enablement Checklist
+
+Before enabling the section publicly:
+
+1. Run the corpus validators:
+
+   ```bash
+   python3 scripts/validate_supply_chain_incidents.py
+   python3 scripts/validate_supply_chain_graph.py
+   ```
+
+2. Run the page contract test:
+
+   ```bash
+   node scripts/test-supply-chain-pages.mjs
+   ```
+
+3. Confirm the disabled build emits no Supply Chain output:
+
+   ```bash
+   cd site
+   rm -rf dist
+   npm run build
+   test ! -e dist/supply-chain
+   ```
+
+4. Confirm the enabled build emits representative pages:
+
+   ```bash
+   cd site
+   rm -rf dist
+   ENABLE_SUPPLY_CHAIN_PAGES=true npm run build
+   test -f dist/supply-chain/index.html
+   test -f dist/supply-chain/incidents/SC-2024-XZ-UTILS/index.html
+   test -f dist/supply-chain/packages/pkg-npm-event-stream/index.html
+   ```
+
+5. Spot-check the generated pages for:
+
+   - no public use of internal codenames
+   - working featured incident links
+   - working related incident links
+   - confidence and evidence fields visible on incident pages
+   - no scoring, recommendations, live-feed copy, or generated conclusions
+
+## Non-Goals
+
+These pages do not implement:
+
+- scoring
+- soak windows
+- public UI conclusions beyond corpus fields
+- graph databases
+- live ingestion
+- automated attribution
+- AI-generated content
+- generated recommendations

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import {
+  SUPPLY_CHAIN_FEATURED_INCIDENT_IDS,
+  getSupplyChainEntityPage,
+  getSupplyChainIncidentPage,
+  getSupplyChainIndexModel,
+  getSupplyChainRoutes,
+  loadSupplyChainData,
+  validateSupplyChainPageData,
+} from '../site/src/lib/supplyChainPages.mjs';
+
+const data = loadSupplyChainData();
+
+function routeUrl(route) {
+  return route.slug ? `/supply-chain/${route.slug}/` : '/supply-chain/';
+}
+
+function collectSupplyChainHrefs(value, hrefs = []) {
+  if (!value || typeof value !== 'object') return hrefs;
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectSupplyChainHrefs(item, hrefs));
+    return hrefs;
+  }
+  if (typeof value.href === 'string' && value.href.startsWith('/supply-chain/')) {
+    hrefs.push(value.href);
+  }
+  Object.values(value).forEach((item) => collectSupplyChainHrefs(item, hrefs));
+  return hrefs;
+}
+
+const disabledRoutes = getSupplyChainRoutes({ enabled: false, data });
+assert.equal(disabledRoutes.length, 0, 'feature flag disabled should generate no routes');
+
+const routes = getSupplyChainRoutes({ enabled: true, data });
+const routeUrls = new Set(routes.map(routeUrl));
+assert.ok(routeUrls.has('/supply-chain/'), 'index route should be generated');
+assert.ok(routeUrls.has('/supply-chain/incidents/SC-2021-CODECOV-BASH-UPLOADER/'), 'incident route should be generated');
+assert.ok(routeUrls.has('/supply-chain/packages/pkg-npm-event-stream/'), 'package route should be generated');
+assert.ok(routeUrls.has('/supply-chain/repositories/repo-github-com-codecov-codecov-bash/'), 'repository route should be generated');
+assert.ok(routeUrls.has('/supply-chain/organizations/org-codecov/'), 'organization route should be generated');
+assert.ok(routeUrls.has('/supply-chain/maintainers/maintainer-jia-tan/'), 'maintainer route should be generated');
+
+const expectedRouteCount =
+  1 +
+  data.incidents.length +
+  data.entities.packages.length +
+  data.entities.repositories.length +
+  data.entities.organizations.length +
+  data.entities.maintainers.length;
+assert.equal(routes.length, expectedRouteCount, 'enabled route count should match routed page types');
+
+const index = getSupplyChainIndexModel(data);
+assert.equal(index.counts.incidents, data.incidents.length, 'index should expose incident count');
+assert.equal(index.counts.relationships, data.relationships.length, 'index should expose relationship count');
+assert.equal(index.counts.buildSystems, data.entities.build_systems.length, 'index should expose build system count');
+assert.equal(index.counts.distributionChannels, data.entities.distribution_channels.length, 'index should expose distribution channel count');
+assert.ok(/supply chain/i.test(index.lede), 'index should include polished public copy');
+assert.ok(!JSON.stringify(index).includes('Canary'), 'public page model should not expose the internal codename');
+assert.equal(index.explanatorySections.length, 4, 'index should include explanatory sections');
+assert.equal(index.featuredIncidents.length, 5, 'index should include five featured incidents');
+assert.deepEqual(
+  index.featuredIncidents.map((incident) => incident.id),
+  SUPPLY_CHAIN_FEATURED_INCIDENT_IDS,
+  'featured incident order should be curated and stable'
+);
+index.featuredIncidents.forEach((incident) => {
+  assert.ok(routeUrls.has(incident.href), `featured incident route should resolve: ${incident.href}`);
+});
+assert.equal(index.entitySummaries.length, 7, 'index should include seven entity summary cards');
+assert.ok(index.seo.title, 'index should include SEO title');
+assert.ok(index.seo.description, 'index should include SEO description');
+assert.equal(index.seo.canonicalPath, '/supply-chain/', 'index should include canonical path');
+assert.ok(index.seo.ogTitle, 'index should include Open Graph title');
+assert.ok(index.seo.ogDescription, 'index should include Open Graph description');
+assert.ok(index.seo.jsonLd, 'index should include JSON-LD');
+
+const codecov = getSupplyChainIncidentPage('SC-2021-CODECOV-BASH-UPLOADER', data);
+assert.ok(codecov.incident.summary, 'incident page should include summary');
+assert.equal(codecov.incident.confidence, 'high', 'incident page should include confidence');
+assert.equal(codecov.incident.evidence_level, 'vendor', 'incident page should include evidence level');
+assert.equal(codecov.incident.attack_stage, 'ci_cd_compromise', 'incident page should include attack stage');
+assert.equal(codecov.incident.source_artifact_divergence, true, 'incident page should include source-artifact divergence');
+assert.ok(codecov.sections.repositories.length > 0, 'incident page should include repositories');
+assert.ok(codecov.sections.organizations.length > 0, 'incident page should include organizations');
+assert.ok(codecov.sections.buildSystems.length > 0, 'incident page should include build systems');
+assert.ok(codecov.sections.distributionChannels.length > 0, 'incident page should include distribution channels');
+assert.ok(codecov.incident.references.length > 0, 'incident page should include references');
+assert.ok(codecov.connectedEntities.length > 0, 'incident page should include relationship-aware connected entities');
+assert.equal(
+  new Set(codecov.connectedEntities.map((entity) => entity.href || entity.id)).size,
+  codecov.connectedEntities.length,
+  'incident connected entities should be deduplicated by entity'
+);
+codecov.connectedEntities.forEach((entity) => {
+  assert.ok(
+    ![
+      'accounts',
+      'build_systems',
+      'distribution_channels',
+      'maintainers',
+      'organizations',
+      'packages',
+      'repositories',
+    ].includes(entity.entityType),
+    'connected entity labels should use singular display names'
+  );
+});
+assert.ok(codecov.seo.title.includes('Supply Chain'), 'incident page should include SEO title');
+assert.ok(codecov.seo.description, 'incident page should include SEO description');
+assert.equal(
+  codecov.seo.canonicalPath,
+  '/supply-chain/incidents/SC-2021-CODECOV-BASH-UPLOADER/',
+  'incident page should include canonical path'
+);
+assert.ok(codecov.seo.ogTitle, 'incident page should include Open Graph title');
+assert.ok(codecov.seo.jsonLd, 'incident page should include JSON-LD');
+assert.deepEqual(
+  codecov.seo.jsonLd.about,
+  codecov.incident.supply_chain_vectors.map((vector) => ({ '@type': 'Thing', name: vector })),
+  'incident JSON-LD should expose supply-chain vectors as Thing objects'
+);
+
+const eventStreamPackage = getSupplyChainEntityPage('packages', 'pkg-npm-event-stream', data);
+assert.ok(eventStreamPackage.relatedIncidents.length > 0, 'entity page should include related incidents');
+eventStreamPackage.relatedIncidents.forEach((incident) => {
+  assert.ok(routeUrls.has(incident.href), `related incident route should resolve: ${incident.href}`);
+});
+assert.ok(eventStreamPackage.connectedEntities.length > 0, 'entity page should include connected entities');
+eventStreamPackage.connectedEntities.forEach((entity) => {
+  assert.ok(
+    ![
+      'accounts',
+      'build_systems',
+      'distribution_channels',
+      'maintainers',
+      'organizations',
+      'packages',
+      'repositories',
+    ].includes(entity.entityType),
+    'entity labels should use singular display names'
+  );
+});
+assert.ok(eventStreamPackage.seo.title.includes('Package'), 'entity page should include SEO title');
+assert.ok(eventStreamPackage.seo.description, 'entity page should include SEO description');
+assert.equal(
+  eventStreamPackage.seo.canonicalPath,
+  '/supply-chain/packages/pkg-npm-event-stream/',
+  'entity page should include canonical path'
+);
+assert.ok(eventStreamPackage.seo.ogTitle, 'entity page should include Open Graph title');
+assert.ok(eventStreamPackage.seo.jsonLd, 'entity page should include JSON-LD');
+
+const brokenData = {
+  ...data,
+  relationships: data.relationships.map((relationship, index) =>
+    index === 0 ? { ...relationship, target: 'pkg-missing' } : relationship
+  ),
+};
+assert.ok(validateSupplyChainPageData(brokenData).some((error) => error.includes('target unknown')));
+assert.throws(
+  () => getSupplyChainRoutes({ enabled: true, data: brokenData }),
+  /Supply Chain page data is invalid/,
+  'broken relationship targets should block route generation'
+);
+assert.throws(
+  () => getSupplyChainIndexModel(null),
+  /getSupplyChainIndexModel: invalid Supply Chain page data/,
+  'index model should reject non-object page data'
+);
+assert.throws(
+  () => getSupplyChainIncidentPage('SC-2021-CODECOV-BASH-UPLOADER', { ...data, entities: null }),
+  /data.entities: expected object/,
+  'incident model should reject missing entity collections before nested access'
+);
+assert.throws(
+  () => getSupplyChainEntityPage('packages', 'pkg-npm-event-stream', { ...data, incidents: null }),
+  /data.incidents: expected array/,
+  'entity model should reject missing incidents before relationship traversal'
+);
+assert.throws(
+  () => getSupplyChainRoutes({ enabled: true, data: { ...data, entities: { packages: [] } } }),
+  /data.entities.repositories: expected array/,
+  'route generation should reject incomplete entity collections'
+);
+
+routes.forEach((route) => {
+  collectSupplyChainHrefs(route.page).forEach((href) => {
+    assert.ok(routeUrls.has(href), `orphan internal supply-chain link: ${href}`);
+  });
+});
+
+console.log(`Supply Chain page tests passed: routes=${routes.length}`);

--- a/site/src/components/SupplyChainEntityList.astro
+++ b/site/src/components/SupplyChainEntityList.astro
@@ -1,0 +1,95 @@
+---
+interface Item {
+  href?: string | null;
+  label: string;
+  type?: string;
+  entityType?: string;
+  context?: string;
+}
+
+interface Props {
+  title: string;
+  items: Item[];
+}
+
+const { title, items } = Astro.props;
+
+function titleCase(value?: string) {
+  return String(value || '').toLowerCase().replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
+}
+---
+
+<section class="sc-section">
+  <h2>{title}</h2>
+  {items.length > 0 ? (
+    <ul class="entity-list">
+      {items.map((item) => (
+        <li>
+          <span class="entity-main">
+            {item.href ? <a href={item.href}>{item.label}</a> : <span>{item.label}</span>}
+            {item.context && <small>{item.context}</small>}
+          </span>
+          {(item.entityType || item.type) && <em>{titleCase(item.entityType || item.type)}</em>}
+        </li>
+      ))}
+    </ul>
+  ) : (
+    <p class="empty">No structured records.</p>
+  )}
+</section>
+
+<style>
+  .sc-section {
+    margin: 30px 0;
+  }
+
+  .sc-section h2 {
+    font-size: 1rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .entity-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    border-top: 1px solid var(--border);
+  }
+
+  .entity-list li {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    border-bottom: 1px solid var(--border);
+    padding: 12px 0;
+  }
+
+  .entity-list em,
+  .entity-list small,
+  .empty {
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    font-style: normal;
+  }
+
+  .entity-main {
+    min-width: 0;
+  }
+
+  .entity-list small {
+    display: block;
+    margin-top: 4px;
+  }
+
+  @media (max-width: 720px) {
+    .entity-list li {
+      display: block;
+    }
+
+    .entity-list em {
+      display: block;
+      margin-top: 4px;
+    }
+  }
+</style>

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -4,11 +4,35 @@ import { getCollection } from 'astro:content';
 interface Props {
   title: string;
   description?: string;
+  canonicalPath?: string;
+  ogTitle?: string;
+  ogDescription?: string;
+  robots?: string;
+  jsonLd?: Record<string, unknown> | Record<string, unknown>[];
 }
 
-const { title, description = 'The Definitive Cyber Threat Encyclopedia' } = Astro.props;
+const {
+  title,
+  description = 'The Definitive Cyber Threat Encyclopedia',
+  canonicalPath,
+  ogTitle,
+  ogDescription,
+  robots,
+  jsonLd,
+} = Astro.props;
 const enablePlausibleAnalytics = import.meta.env.PROD;
+const supplyChainEnv =
+  typeof process !== 'undefined'
+    ? process.env?.ENABLE_SUPPLY_CHAIN_PAGES
+    : import.meta.env.ENABLE_SUPPLY_CHAIN_PAGES;
+const enableSupplyChainPages = String(supplyChainEnv || '').toLowerCase() === 'true';
 const plausibleScriptSrc = 'https://plausible.io/js/pa-JU90GDszdzYfdcQawYHNo.js';
+const canonicalUrl = canonicalPath ? new URL(canonicalPath, Astro.site ?? 'https://threatpedia.wiki').toString() : null;
+const hasOpenGraph = Boolean(ogTitle || ogDescription || canonicalUrl);
+const openGraphTitle = ogTitle || `${title} — Threatpedia`;
+const openGraphDescription = ogDescription || description;
+const openGraphType = canonicalPath?.startsWith('/supply-chain/incidents/') ? 'article' : 'website';
+const serializedJsonLd = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : null;
 
 // Build ticker items from all collections
 interface TickerItem {
@@ -90,6 +114,16 @@ try {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
+    {robots && <meta name="robots" content={robots} />}
+    {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
+    {hasOpenGraph && (
+      <>
+        <meta property="og:title" content={openGraphTitle} />
+        <meta property="og:description" content={openGraphDescription} />
+        <meta property="og:type" content={openGraphType} />
+        {canonicalUrl && <meta property="og:url" content={canonicalUrl} />}
+      </>
+    )}
     <meta name="theme-color" content="#080b10" />
     <link rel="icon" type="image/svg+xml" href="/tp-favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -104,6 +138,7 @@ try {
         </script>
       </>
     )}
+    {serializedJsonLd && <script type="application/ld+json" set:html={serializedJsonLd} />}
     <title>{title} — Threatpedia</title>
   </head>
   <body>
@@ -155,6 +190,7 @@ try {
         <a href="/campaigns/">Campaigns</a>
         <a href="/threat-actors/">Threat Actors</a>
         <a href="/zero-days/">Zero-Days</a>
+        {enableSupplyChainPages && <a href="/supply-chain/">Supply Chain</a>}
         <a href="/glossary/">Glossary</a>
         <a href="/roadmap/">Roadmap</a>
         <a href="/privacy/">Privacy</a>

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -1,0 +1,521 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const incidentRelativePath = 'data/supply-chain-incidents/incidents.json';
+
+function findRepoRoot(startDirs) {
+  const seen = new Set();
+  for (const startDir of startDirs) {
+    let currentDir = path.resolve(startDir);
+    while (!seen.has(currentDir)) {
+      seen.add(currentDir);
+      if (existsSync(path.join(currentDir, incidentRelativePath))) {
+        return currentDir;
+      }
+      const parentDir = path.dirname(currentDir);
+      if (parentDir === currentDir) {
+        break;
+      }
+      currentDir = parentDir;
+    }
+  }
+  throw new Error(`Unable to locate Supply Chain corpus from ${startDirs.join(', ')}`);
+}
+
+const repoRoot = findRepoRoot([moduleDir, process.cwd()]);
+const incidentPath = path.join(repoRoot, 'data/supply-chain-incidents/incidents.json');
+const relationshipPath = path.join(repoRoot, 'data/supply-chain-relationships/relationships.json');
+const entityDir = path.join(repoRoot, 'data/supply-chain-entities');
+let cachedData = null;
+
+export const SUPPLY_CHAIN_ENTITY_TYPES = [
+  { key: 'packages', segment: 'packages', label: 'Package', plural: 'Packages' },
+  { key: 'repositories', segment: 'repositories', label: 'Repository', plural: 'Repositories' },
+  { key: 'organizations', segment: 'organizations', label: 'Organization', plural: 'Organizations' },
+  { key: 'maintainers', segment: 'maintainers', label: 'Maintainer', plural: 'Maintainers' },
+];
+
+export const SUPPLY_CHAIN_FEATURED_INCIDENT_IDS = [
+  'SC-2024-XZ-UTILS',
+  'SC-2023-THREE-CX-DESKTOP',
+  'SC-2020-SOLARWINDS-ORION',
+  'SC-2018-NPM-EVENT-STREAM',
+  'SC-2021-UA-PARSER-JS',
+];
+
+export const SUPPLY_CHAIN_INDEX_COPY = {
+  lede:
+    'Threatpedia tracks software supply chain incidents as connected facts about packages, repositories, organizations, maintainers, build systems, distribution channels, and compromised accounts.',
+  sections: [
+    {
+      title: 'What Threatpedia Tracks',
+      body:
+        'This section models confirmed supply chain incidents and the entities named by the corpus. The goal is structured recall: which packages, repositories, maintainers, and organizations appear together in public evidence.',
+    },
+    {
+      title: 'Why Supply Chain Incidents Matter',
+      body:
+        'A supply chain compromise can turn trusted update channels, build systems, or package registries into distribution paths. Tracking those links helps defenders compare incidents without inventing risk scores.',
+    },
+    {
+      title: 'How Entities Connect',
+      body:
+        'Entities are connected through explicit relationship records derived from the curated incident corpus. A package, repository, organization, or maintainer page shows the incidents that support that connection.',
+    },
+    {
+      title: 'Evidence and Confidence Model',
+      body:
+        'Each incident carries confidence and evidence-level fields from the corpus. Pages show those fields directly and avoid conclusions beyond the recorded evidence.',
+    },
+  ],
+};
+
+const indexDescription =
+  'Threatpedia Supply Chain tracks curated software supply chain incidents and the packages, repositories, organizations, maintainers, build systems, and distribution channels connected to them.';
+
+const allEntityFiles = {
+  accounts: 'accounts.json',
+  build_systems: 'build_systems.json',
+  distribution_channels: 'distribution_channels.json',
+  maintainers: 'maintainers.json',
+  organizations: 'organizations.json',
+  packages: 'packages.json',
+  repositories: 'repositories.json',
+};
+
+const routeEntityBySegment = Object.fromEntries(SUPPLY_CHAIN_ENTITY_TYPES.map((item) => [item.segment, item]));
+
+const entitySummaryDefinitions = [
+  {
+    key: 'packages',
+    title: 'Packages',
+    description: 'Named software packages affected by or involved in supply chain incidents.',
+    href: null,
+  },
+  {
+    key: 'repositories',
+    title: 'Repositories',
+    description: 'Source repositories, release repositories, and project repositories cited by incident evidence.',
+    href: null,
+  },
+  {
+    key: 'organizations',
+    title: 'Organizations',
+    description: 'Vendors, projects, companies, registries, and public organizations connected to incidents.',
+    href: null,
+  },
+  {
+    key: 'maintainers',
+    title: 'Maintainers',
+    description: 'Individual maintainers or maintainer identities named by the structured corpus.',
+    href: null,
+  },
+  {
+    key: 'build_systems',
+    title: 'Build Systems',
+    description: 'Build, CI, release, or signing systems recorded as part of the incident chain.',
+    href: null,
+  },
+  {
+    key: 'distribution_channels',
+    title: 'Distribution Channels',
+    description: 'Registries, update systems, downloads, and other channels used to distribute affected artifacts.',
+    href: null,
+  },
+  {
+    key: 'accounts',
+    title: 'Compromised Accounts',
+    description: 'Accounts or identities recorded as compromised in the incident corpus.',
+    href: null,
+  },
+];
+
+const ENTITY_COLLECTION_LABELS = {
+  packages: 'Package',
+  repositories: 'Repository',
+  organizations: 'Organization',
+  maintainers: 'Maintainer',
+  build_systems: 'Build System',
+  distribution_channels: 'Distribution Channel',
+  accounts: 'Compromised Account',
+};
+
+function entityTypeLabel(entity) {
+  return ENTITY_COLLECTION_LABELS[entity.entityCollection] || entity.entityCollection;
+}
+
+export function isSupplyChainPagesEnabled(env = typeof process !== 'undefined' ? process.env || {} : {}) {
+  return String(env.ENABLE_SUPPLY_CHAIN_PAGES || '').toLowerCase() === 'true';
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, 'utf-8'));
+}
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function supplyChainPageDataShapeErrors(data) {
+  const errors = [];
+  if (!isPlainObject(data)) {
+    return ['data: expected object'];
+  }
+  if (!Array.isArray(data.incidents)) errors.push('data.incidents: expected array');
+  if (!Array.isArray(data.relationships)) errors.push('data.relationships: expected array');
+  if (!isPlainObject(data.entities)) {
+    errors.push('data.entities: expected object');
+  } else {
+    Object.keys(allEntityFiles).forEach((key) => {
+      if (!Array.isArray(data.entities[key])) errors.push(`data.entities.${key}: expected array`);
+    });
+  }
+  if (!(data.entityById instanceof Map)) errors.push('data.entityById: expected Map');
+  if (!(data.incidentByNodeId instanceof Map)) errors.push('data.incidentByNodeId: expected Map');
+  return errors;
+}
+
+function assertSupplyChainPageData(data, context) {
+  const errors = supplyChainPageDataShapeErrors(data);
+  if (errors.length > 0) {
+    throw new Error(`${context}: invalid Supply Chain page data:\n${errors.join('\n')}`);
+  }
+}
+
+export function loadSupplyChainData() {
+  if (cachedData) return cachedData;
+  const incidents = readJson(incidentPath);
+  const relationships = readJson(relationshipPath);
+  const entities = Object.fromEntries(
+    Object.entries(allEntityFiles).map(([key, filename]) => [key, readJson(path.join(entityDir, filename))])
+  );
+  const entityById = new Map();
+  Object.entries(entities).forEach(([type, items]) => {
+    items.forEach((entity) => {
+      entityById.set(entity.id, { ...entity, entityCollection: type });
+    });
+  });
+  const incidentByNodeId = new Map(incidents.map((incident) => [`incident-${incident.id}`, incident]));
+  cachedData = { incidents, relationships, entities, entityById, incidentByNodeId };
+  return cachedData;
+}
+
+export function validateSupplyChainPageData(data = loadSupplyChainData()) {
+  const errors = [];
+  errors.push(...supplyChainPageDataShapeErrors(data));
+  if (errors.length > 0) return errors;
+
+  const validIncidentNodes = new Set(data.incidents.map((incident) => `incident-${incident.id}`));
+  data.relationships.forEach((relationship, index) => {
+    const sourceExists = validIncidentNodes.has(relationship.source) || data.entityById.has(relationship.source);
+    const targetExists = validIncidentNodes.has(relationship.target) || data.entityById.has(relationship.target);
+    if (!sourceExists) errors.push(`relationships[${index}].source unknown: ${relationship.source}`);
+    if (!targetExists) errors.push(`relationships[${index}].target unknown: ${relationship.target}`);
+  });
+  return errors;
+}
+
+function relationshipRows(data, nodeId) {
+  return data.relationships
+    .filter((relationship) => relationship.source === nodeId || relationship.target === nodeId)
+    .map((relationship) => {
+      const oppositeId = relationship.source === nodeId ? relationship.target : relationship.source;
+      const incident = data.incidentByNodeId.get(oppositeId);
+      const entity = data.entityById.get(oppositeId);
+      return {
+        ...relationship,
+        oppositeId,
+        incident,
+        entity,
+      };
+    });
+}
+
+function linkForEntity(entity) {
+  const type = SUPPLY_CHAIN_ENTITY_TYPES.find((item) => item.key === entity.entityCollection);
+  return type ? `/supply-chain/${type.segment}/${entity.id}/` : null;
+}
+
+function entityLink(data, entityId) {
+  const entity = data.entityById.get(entityId);
+  if (!entity) return null;
+  const href = linkForEntity(entity);
+  return { href, label: entity.name, id: entity.id };
+}
+
+function compareLabel(a, b) {
+  return (a.label || '').localeCompare(b.label || '');
+}
+
+function compareTitle(a, b) {
+  return (a.title || '').localeCompare(b.title || '');
+}
+
+function incidentLinksFor(data, entityId) {
+  return relationshipRows(data, entityId)
+    .filter((row) => row.incident)
+    .map((row) => ({
+      href: `/supply-chain/incidents/${row.incident.id}/`,
+      label: row.incident.title,
+      id: row.incident.id,
+      type: row.type,
+    }))
+    .sort(compareLabel);
+}
+
+function dedupeRows(rows) {
+  if (!Array.isArray(rows)) return [];
+  const seen = new Set();
+  return rows.filter((row) => {
+    const key = `${row.href || row.id}:${row.context || ''}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function entityConnectionsFor(data, entityId) {
+  const direct = relationshipRows(data, entityId)
+    .filter((row) => row.entity && row.oppositeId !== entityId)
+    .map((row) => ({
+      href: linkForEntity(row.entity),
+      label: row.entity.name,
+      id: row.entity.id,
+      type: row.type,
+      entityType: entityTypeLabel(row.entity),
+    }))
+    .filter((item) => item.href);
+
+  const incidentNodes = relationshipRows(data, entityId)
+    .filter((row) => row.incident)
+    .map((row) => `incident-${row.incident.id}`);
+  const throughIncidents = incidentNodes.flatMap((incidentNode) =>
+    relationshipRows(data, incidentNode)
+      .filter((row) => row.entity && row.entity.id !== entityId)
+      .map((row) => ({
+        href: linkForEntity(row.entity),
+        label: row.entity.name,
+        id: row.entity.id,
+        type: row.type,
+        entityType: entityTypeLabel(row.entity),
+        context: data.incidentByNodeId.get(incidentNode)?.title,
+      }))
+      .filter((item) => item.href)
+  );
+
+  return dedupeRows([...direct, ...throughIncidents]).sort(compareLabel);
+}
+
+function incidentConnectedEntities(data, incidentId) {
+  const nodeId = `incident-${incidentId}`;
+  const rows = relationshipRows(data, nodeId)
+    .filter((row) => row.entity)
+    .map((row) => ({
+      href: linkForEntity(row.entity),
+      label: row.entity.name,
+      id: row.entity.id,
+      type: row.type,
+      entityType: entityTypeLabel(row.entity),
+    }));
+  return dedupeRows(rows).sort(compareLabel);
+}
+
+function incidentEntityLinks(data, incidentId, relationshipType) {
+  const nodeId = `incident-${incidentId}`;
+  return data.relationships
+    .filter((relationship) => relationship.source === nodeId && relationship.type === relationshipType)
+    .map((relationship) => entityLink(data, relationship.target))
+    .filter(Boolean)
+    .sort(compareLabel);
+}
+
+function incidentEntities(data, incidentId, collectionKey, relationshipType) {
+  const links = incidentEntityLinks(data, incidentId, relationshipType);
+  if (links.length > 0) return links;
+  const incident = data.incidents.find((item) => item.id === incidentId);
+  return (incident?.[collectionKey] || []).map((item) => ({ label: item.name, id: item.name, href: null }));
+}
+
+export function getSupplyChainIndexModel(data = loadSupplyChainData()) {
+  assertSupplyChainPageData(data, 'getSupplyChainIndexModel');
+  const featuredIncidents = SUPPLY_CHAIN_FEATURED_INCIDENT_IDS.map((id) => {
+    const incident = data.incidents.find((item) => item.id === id);
+    if (!incident) throw new Error(`Featured Supply Chain incident not found: ${id}`);
+    return {
+      id: incident.id,
+      title: incident.title,
+      summary: incident.summary,
+      href: `/supply-chain/incidents/${incident.id}/`,
+      attackStage: incident.attack_stage,
+      evidenceLevel: incident.evidence_level,
+      confidence: incident.confidence,
+    };
+  });
+
+  return {
+    kind: 'index',
+    title: 'Supply Chain',
+    lede: SUPPLY_CHAIN_INDEX_COPY.lede,
+    explanatorySections: SUPPLY_CHAIN_INDEX_COPY.sections,
+    featuredIncidents,
+    entitySummaries: entitySummaryDefinitions.map((summary) => ({
+      ...summary,
+      count: data.entities[summary.key]?.length || 0,
+    })),
+    seo: {
+      title: 'Supply Chain',
+      description: indexDescription,
+      canonicalPath: '/supply-chain/',
+      ogTitle: 'Threatpedia Supply Chain',
+      ogDescription: indexDescription,
+      jsonLd: {
+        '@context': 'https://schema.org',
+        '@type': 'CollectionPage',
+        name: 'Threatpedia Supply Chain',
+        description: indexDescription,
+        url: 'https://threatpedia.wiki/supply-chain/',
+      },
+    },
+    counts: {
+      incidents: data.incidents.length,
+      packages: data.entities.packages.length,
+      repositories: data.entities.repositories.length,
+      organizations: data.entities.organizations.length,
+      maintainers: data.entities.maintainers.length,
+      buildSystems: data.entities.build_systems.length,
+      distributionChannels: data.entities.distribution_channels.length,
+      relationships: data.relationships.length,
+    },
+    incidents: data.incidents
+      .map((incident) => ({
+        id: incident.id,
+        title: incident.title,
+        summary: incident.summary,
+        href: `/supply-chain/incidents/${incident.id}/`,
+        attackStage: incident.attack_stage,
+        evidenceLevel: incident.evidence_level,
+      }))
+      .sort(compareTitle),
+  };
+}
+
+export function getSupplyChainIncidentPage(id, data = loadSupplyChainData()) {
+  assertSupplyChainPageData(data, 'getSupplyChainIncidentPage');
+  const incident = data.incidents.find((item) => item.id === id);
+  if (!incident) return null;
+  const description = incident.summary;
+  return {
+    kind: 'incident',
+    title: incident.title,
+    incident,
+    connectedEntities: incidentConnectedEntities(data, id),
+    seo: {
+      title: `Supply Chain: ${incident.title}`,
+      description,
+      canonicalPath: `/supply-chain/incidents/${incident.id}/`,
+      ogTitle: `${incident.title} - Threatpedia Supply Chain`,
+      ogDescription: description,
+      jsonLd: {
+        '@context': 'https://schema.org',
+        '@type': 'Article',
+        headline: incident.title,
+        description,
+        url: `https://threatpedia.wiki/supply-chain/incidents/${incident.id}/`,
+        datePublished: incident.disclosed_at || incident.first_observed_at,
+        author: {
+          '@type': 'Organization',
+          name: 'Threatpedia',
+          url: 'https://threatpedia.wiki/',
+        },
+        publisher: {
+          '@type': 'Organization',
+          name: 'Threatpedia',
+          url: 'https://threatpedia.wiki/',
+        },
+        about: (Array.isArray(incident.supply_chain_vectors) ? incident.supply_chain_vectors : []).map((vector) => ({
+          '@type': 'Thing',
+          name: vector,
+        })),
+      },
+    },
+    sections: {
+      packages: incidentEntityLinks(data, id, 'AFFECTED_PACKAGE'),
+      repositories: incidentEntityLinks(data, id, 'AFFECTED_REPOSITORY'),
+      organizations: incidentEntityLinks(data, id, 'AFFECTED_ORGANIZATION'),
+      maintainers: incidentEntityLinks(data, id, 'AFFECTED_MAINTAINER'),
+      buildSystems: incidentEntities(data, id, 'build_systems', 'USED_BUILD_SYSTEM'),
+      distributionChannels: incidentEntities(data, id, 'distribution_channels', 'USED_DISTRIBUTION_CHANNEL'),
+      compromisedAccounts: incidentEntities(data, id, 'compromised_accounts', 'COMPROMISED_ACCOUNT'),
+    },
+  };
+}
+
+export function getSupplyChainEntityPage(collectionKey, id, data = loadSupplyChainData()) {
+  assertSupplyChainPageData(data, 'getSupplyChainEntityPage');
+  const collection = data.entities[collectionKey] || [];
+  const entity = collection.find((item) => item.id === id);
+  if (!entity) return null;
+  const type = SUPPLY_CHAIN_ENTITY_TYPES.find((item) => item.key === collectionKey);
+  if (!type) return null;
+  const relatedIncidents = incidentLinksFor(data, id);
+  const description = `${type.label} entity in the Threatpedia Supply Chain corpus with ${relatedIncidents.length} connected incident${relatedIncidents.length === 1 ? '' : 's'}.`;
+  return {
+    kind: 'entity',
+    title: entity.name,
+    entity: { ...entity, entityCollection: collectionKey },
+    entityType: type.label,
+    relatedIncidents,
+    connectedIncidents: relatedIncidents,
+    connectedEntities: entityConnectionsFor(data, id),
+    seo: {
+      title: `Supply Chain ${type.label}: ${entity.name}`,
+      description,
+      canonicalPath: `/supply-chain/${type.segment}/${entity.id}/`,
+      ogTitle: `${entity.name} - Threatpedia Supply Chain ${type.label}`,
+      ogDescription: description,
+      jsonLd: {
+        '@context': 'https://schema.org',
+        '@type': 'Thing',
+        name: entity.name,
+        identifier: entity.id,
+        description,
+        url: `https://threatpedia.wiki/supply-chain/${type.segment}/${entity.id}/`,
+      },
+    },
+  };
+}
+
+export function getSupplyChainRoutes(options = {}) {
+  const enabled = options.enabled ?? isSupplyChainPagesEnabled(options.env);
+  if (!enabled) return [];
+  const data = options.data || loadSupplyChainData();
+  const errors = validateSupplyChainPageData(data);
+  if (errors.length > 0) {
+    throw new Error(`Supply Chain page data is invalid:\n${errors.join('\n')}`);
+  }
+
+  const routes = [{ slug: undefined, page: getSupplyChainIndexModel(data) }];
+  data.incidents.forEach((incident) => {
+    routes.push({ slug: `incidents/${incident.id}`, page: getSupplyChainIncidentPage(incident.id, data) });
+  });
+  SUPPLY_CHAIN_ENTITY_TYPES.forEach((entityType) => {
+    data.entities[entityType.key].forEach((entity) => {
+      routes.push({
+        slug: `${entityType.segment}/${entity.id}`,
+        page: getSupplyChainEntityPage(entityType.key, entity.id, data),
+      });
+    });
+  });
+  return routes;
+}
+
+export function pageFromSlug(slug, data = loadSupplyChainData()) {
+  if (!slug) return getSupplyChainIndexModel(data);
+  const [segment, id] = slug.split('/');
+  if (segment === 'incidents') return getSupplyChainIncidentPage(id, data);
+  const entityType = routeEntityBySegment[segment];
+  if (!entityType) return null;
+  return getSupplyChainEntityPage(entityType.key, id, data);
+}

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -1,0 +1,415 @@
+---
+import Base from '../../layouts/Base.astro';
+import EntityList from '../../components/SupplyChainEntityList.astro';
+import { getSupplyChainRoutes, isSupplyChainPagesEnabled } from '../../lib/supplyChainPages.mjs';
+
+export function getStaticPaths() {
+  return getSupplyChainRoutes().map((route) => ({
+    params: { slug: route.slug },
+    props: { page: route.page },
+  }));
+}
+
+const { page } = Astro.props;
+const supplyChainPagesEnabled = isSupplyChainPagesEnabled();
+
+function label(value) {
+  if (value === null || value === undefined) return 'unknown';
+  if (typeof value === 'boolean') return value ? 'yes' : 'no';
+  return String(value).replace(/_/g, ' ');
+}
+
+function titleCase(value) {
+  return label(value).replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+const title = page?.seo?.title || (page?.kind === 'index' ? 'Supply Chain' : `Supply Chain: ${page?.title}`);
+const description = page?.seo?.description || 'Threatpedia Supply Chain incident and entity pages.';
+const canonicalPath = page?.seo?.canonicalPath;
+const ogTitle = page?.seo?.ogTitle;
+const ogDescription = page?.seo?.ogDescription;
+const jsonLd = page?.seo?.jsonLd;
+const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
+---
+
+<Base
+  title={title}
+  description={description}
+  canonicalPath={canonicalPath}
+  ogTitle={ogTitle}
+  ogDescription={ogDescription}
+  robots={robots}
+  jsonLd={jsonLd}
+>
+  {page.kind === 'index' && (
+    <section class="supply-chain-page">
+      <header class="sc-header">
+        <p class="eyebrow">Threatpedia</p>
+        <h1>Supply Chain</h1>
+        <p class="lede">{page.lede}</p>
+      </header>
+
+      <section class="metric-grid" aria-label="Supply Chain corpus counts">
+        <div><span>{page.counts.incidents}</span><p>Incidents</p></div>
+        <div><span>{page.counts.packages}</span><p>Packages</p></div>
+        <div><span>{page.counts.repositories}</span><p>Repositories</p></div>
+        <div><span>{page.counts.organizations}</span><p>Organizations</p></div>
+        <div><span>{page.counts.maintainers}</span><p>Maintainers</p></div>
+        <div><span>{page.counts.buildSystems}</span><p>Build Systems</p></div>
+        <div><span>{page.counts.distributionChannels}</span><p>Distribution Channels</p></div>
+        <div><span>{page.counts.relationships}</span><p>Relationships</p></div>
+      </section>
+
+      <section class="copy-grid" aria-label="Supply Chain explanation">
+        {page.explanatorySections.map((section) => (
+          <article class="info-panel">
+            <h2>{section.title}</h2>
+            <p>{section.body}</p>
+          </article>
+        ))}
+      </section>
+
+      <section class="sc-section">
+        <h2>Featured Incidents</h2>
+        <div class="featured-grid">
+          {page.featuredIncidents.map((incident) => (
+            <article class="incident-card">
+              <a href={incident.href}>{incident.title}</a>
+              <p>{incident.summary}</p>
+              <div class="card-meta">
+                <span>{titleCase(incident.attackStage)}</span>
+                <span>{titleCase(incident.evidenceLevel)}</span>
+                <span>{titleCase(incident.confidence)}</span>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section class="sc-section">
+        <h2>Entity Summary</h2>
+        <div class="entity-summary-grid">
+          {page.entitySummaries.map((entity) => (
+            <article class="entity-card">
+              <span>{entity.count}</span>
+              <h3>{entity.title}</h3>
+              <p>{entity.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section class="sc-section">
+        <h2>Incidents</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Attack Stage</th>
+                <th>Evidence</th>
+              </tr>
+            </thead>
+            <tbody>
+              {page.incidents.map((incident) => (
+                <tr>
+                  <td><span class="mono">{incident.id}</span></td>
+                  <td><a href={incident.href}>{incident.title}</a></td>
+                  <td>{titleCase(incident.attackStage)}</td>
+                  <td>{titleCase(incident.evidenceLevel)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </section>
+  )}
+
+  {page.kind === 'incident' && (
+    <article class="supply-chain-page">
+      <header class="sc-header">
+        <p class="eyebrow">Supply Chain Incident</p>
+        <h1>{page.incident.title}</h1>
+        <p class="lede">{page.incident.summary}</p>
+      </header>
+
+      <section class="detail-grid">
+        <div><span>Confidence</span><strong>{titleCase(page.incident.confidence)}</strong></div>
+        <div><span>Evidence Level</span><strong>{titleCase(page.incident.evidence_level)}</strong></div>
+        <div><span>Attack Stage</span><strong>{titleCase(page.incident.attack_stage)}</strong></div>
+        <div><span>Source Artifact Divergence</span><strong>{titleCase(page.incident.source_artifact_divergence)}</strong></div>
+      </section>
+
+      <EntityList title="Affected Packages" items={page.sections.packages} />
+      <EntityList title="Repositories" items={page.sections.repositories} />
+      <EntityList title="Organizations" items={page.sections.organizations} />
+      <EntityList title="Maintainers" items={page.sections.maintainers} />
+      <EntityList title="Build Systems" items={page.sections.buildSystems} />
+      <EntityList title="Distribution Channels" items={page.sections.distributionChannels} />
+      <EntityList title="Compromised Accounts" items={page.sections.compromisedAccounts} />
+      <EntityList title="Connected Entities" items={page.connectedEntities} />
+
+      <section class="sc-section">
+        <h2>References</h2>
+        <ul class="reference-list">
+          {page.incident.references.map((reference) => (
+            <li>
+              <a href={reference.url} target="_blank" rel="noopener noreferrer">{reference.title}</a>
+              <span>{reference.publisher} · {reference.published_at}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </article>
+  )}
+
+  {page.kind === 'entity' && (
+    <article class="supply-chain-page">
+      <header class="sc-header">
+        <p class="eyebrow">{page.entityType}</p>
+        <h1>{page.entity.name}</h1>
+        <p class="lede"><span class="mono">{page.entity.id}</span></p>
+      </header>
+
+      <section class="detail-grid">
+        <div><span>Entity Type</span><strong>{page.entityType}</strong></div>
+        <div><span>Related Incidents</span><strong>{page.relatedIncidents.length}</strong></div>
+      </section>
+
+      <EntityList title="Related Incidents" items={page.relatedIncidents} />
+      <EntityList title="Connected Entities" items={page.connectedEntities} />
+    </article>
+  )}
+</Base>
+
+<style>
+  .supply-chain-page {
+    max-width: 1180px;
+  }
+
+  .sc-header {
+    margin-bottom: 30px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    color: var(--amber);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    margin: 0 0 10px;
+  }
+
+  .sc-header h1 {
+    margin: 0 0 10px;
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+
+  .lede {
+    color: var(--muted);
+    max-width: 820px;
+    line-height: 1.65;
+  }
+
+  .copy-grid,
+  .featured-grid,
+  .entity-summary-grid {
+    display: grid;
+    gap: 16px;
+    margin: 30px 0;
+  }
+
+  .copy-grid {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  }
+
+  .featured-grid {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  }
+
+  .entity-summary-grid {
+    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  }
+
+  .info-panel,
+  .incident-card,
+  .entity-card {
+    border: 1px solid var(--border);
+    background: var(--surface);
+    border-radius: 6px;
+    padding: 16px;
+  }
+
+  .info-panel h2,
+  .entity-card h3 {
+    margin: 0 0 8px;
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+
+  .info-panel h2 {
+    font-size: 1rem;
+  }
+
+  .info-panel p,
+  .incident-card p,
+  .entity-card p {
+    color: var(--muted);
+    line-height: 1.6;
+    margin: 0;
+  }
+
+  .incident-card a {
+    display: inline-block;
+    font-family: var(--font-serif);
+    font-size: 1.05rem;
+    line-height: 1.3;
+    margin-bottom: 10px;
+  }
+
+  .card-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 14px;
+  }
+
+  .card-meta span {
+    border: 1px solid var(--border);
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.08em;
+    padding: 4px 7px;
+    text-transform: uppercase;
+  }
+
+  .entity-card span {
+    color: var(--amber);
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 1.55rem;
+    margin-bottom: 8px;
+  }
+
+  .metric-grid,
+  .detail-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1px;
+    background: var(--border);
+    border: 1px solid var(--border);
+    margin-bottom: 28px;
+  }
+
+  .metric-grid div,
+  .detail-grid div {
+    background: var(--surface);
+    padding: 16px;
+  }
+
+  .metric-grid span,
+  .detail-grid strong {
+    display: block;
+    color: var(--white);
+    font-family: var(--font-mono);
+    font-size: 1.35rem;
+    line-height: 1.2;
+  }
+
+  .metric-grid p,
+  .detail-grid span {
+    margin: 6px 0 0;
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .sc-section {
+    margin: 30px 0;
+  }
+
+  .sc-section h2 {
+    font-size: 1rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .table-wrap {
+    overflow-x: auto;
+    border: 1px solid var(--border);
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 760px;
+  }
+
+  th,
+  td {
+    border-bottom: 1px solid var(--border);
+    padding: 12px;
+    text-align: left;
+    vertical-align: top;
+  }
+
+  th {
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .mono {
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+  }
+
+  .entity-list,
+  .reference-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    border-top: 1px solid var(--border);
+  }
+
+  .entity-list li,
+  .reference-list li {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    border-bottom: 1px solid var(--border);
+    padding: 12px 0;
+  }
+
+  .entity-list em,
+  .reference-list span,
+  .empty {
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    font-style: normal;
+  }
+
+  @media (max-width: 720px) {
+    .entity-list li,
+    .reference-list li {
+      display: block;
+    }
+
+    .entity-list em,
+    .reference-list span {
+      display: block;
+      margin-top: 4px;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- add feature-flagged static Supply Chain pages generated from the supply-chain incident/entity/relationship JSON artifacts
- add ENABLE_SUPPLY_CHAIN_PAGES gate; default false emits no /supply-chain routes and no nav link
- add /supply-chain/, incident pages, package/repository/organization/maintainer pages
- add build-time data validation for broken relationship targets and no orphan internal links
- add docs and focused page tests

## Generated routes when enabled
- /supply-chain/
- /supply-chain/incidents/[id]/
- /supply-chain/packages/[id]/
- /supply-chain/repositories/[id]/
- /supply-chain/organizations/[id]/
- /supply-chain/maintainers/[id]/

## Validation
- node scripts/test-supply-chain-pages.mjs
- python3 scripts/validate_supply_chain_incidents.py && python3 scripts/validate_supply_chain_graph.py
- node --check scripts/test-supply-chain-pages.mjs && node --check site/src/lib/supplyChainPages.mjs
- cd site && npm run build
- cd site && test ! -e dist/supply-chain
- cd site && ENABLE_SUPPLY_CHAIN_PAGES=true npm run build
- cd site && test -f dist/supply-chain/index.html && test -f dist/supply-chain/incidents/SC-2021-CODECOV-BASH-UPLOADER/index.html && test -f dist/supply-chain/packages/pkg-npm-event-stream/index.html
- git diff --check

## Scope boundaries
- no scoring
- no soak windows
- no graph DB
- no live ingestion
- no automated attribution
- no AI-generated content
- no generated conclusions beyond corpus fields

Stacked on Phase 1C PR #1133 because this page layer consumes the enriched corpus and graph primitives from that branch.