### PR TITLE
Polish feature-flagged Supply Chain pages

### DIFF
--- a/docs/supply-chain-pages.md
+++ b/docs/supply-chain-pages.md
@@ -1,8 +1,7 @@
 # Supply Chain Pages
 
 Threatpedia Supply Chain pages render the curated supply-chain incident corpus
-and graph primitives as static pages. The public label is **Supply Chain**. The
-internal implementation may still use the supply-chain-canary codename.
+and graph primitives as static pages. The public label is **Supply Chain**.
 
 ## Feature Flag
 
@@ -14,6 +13,7 @@ ENABLE_SUPPLY_CHAIN_PAGES=true
 
 When the flag is not set to `true`, the static route generator emits no Supply
 Chain routes and the public navigation does not include a Supply Chain link.
+This is the default behavior and prevents disabled pages from being indexed.
 
 ## Routes
 
@@ -67,6 +67,21 @@ python3 scripts/validate_supply_chain_graph.py
 
 ## Page Content
 
+The index page uses public-facing Supply Chain copy and explains:
+
+- what Threatpedia tracks
+- why supply chain incidents matter
+- how entities connect
+- the evidence and confidence model
+
+It also shows five curated featured incident cards:
+
+- XZ Utils backdoor attempt
+- 3CX desktop application software supply-chain compromise
+- SolarWinds Orion software build compromise
+- event-stream malicious dependency insertion
+- ua-parser-js npm package account compromise
+
 The index page shows counts for:
 
 - incidents
@@ -76,14 +91,74 @@ The index page shows counts for:
 - maintainers
 - build systems
 - distribution channels
+- compromised accounts
 - relationships
 
 Incident pages show corpus fields only: summary, confidence, evidence level,
 attack stage, source-artifact divergence, affected entities, structured supply-
-chain primitives, compromised accounts, and references.
+chain primitives, compromised accounts, connected entities, and references.
 
 Entity pages show the entity name, entity type, connected incidents, and
 connected entities when relationships support those links.
+
+## SEO Metadata
+
+Supply Chain pages use the shared site layout metadata path for:
+
+- page title
+- meta description
+- canonical URL
+- Open Graph title and description
+- JSON-LD where a static corpus object maps cleanly to a generic web object
+
+When `ENABLE_SUPPLY_CHAIN_PAGES` is not `true`, no Supply Chain static routes
+are emitted. If a disabled page path is rendered in a nonstandard local context,
+the page path also supports a noindex robots value.
+
+## Public Enablement Checklist
+
+Before enabling the section publicly:
+
+1. Run the corpus validators:
+
+   ```bash
+   python3 scripts/validate_supply_chain_incidents.py
+   python3 scripts/validate_supply_chain_graph.py
+   ```
+
+2. Run the page contract test:
+
+   ```bash
+   node scripts/test-supply-chain-pages.mjs
+   ```
+
+3. Confirm the disabled build emits no Supply Chain output:
+
+   ```bash
+   cd site
+   rm -rf dist
+   npm run build
+   test ! -e dist/supply-chain
+   ```
+
+4. Confirm the enabled build emits representative pages:
+
+   ```bash
+   cd site
+   rm -rf dist
+   ENABLE_SUPPLY_CHAIN_PAGES=true npm run build
+   test -f dist/supply-chain/index.html
+   test -f dist/supply-chain/incidents/SC-2024-XZ-UTILS/index.html
+   test -f dist/supply-chain/packages/pkg-npm-event-stream/index.html
+   ```
+
+5. Spot-check the generated pages for:
+
+   - no public use of internal codenames
+   - working featured incident links
+   - working related incident links
+   - confidence and evidence fields visible on incident pages
+   - no scoring, recommendations, live-feed copy, or generated conclusions
 
 ## Non-Goals
 

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import assert from 'node:assert/strict';
 import {
+  SUPPLY_CHAIN_FEATURED_INCIDENT_IDS,
+  getSupplyChainEntityPage,
   getSupplyChainIncidentPage,
   getSupplyChainIndexModel,
   getSupplyChainRoutes,
@@ -53,6 +55,25 @@ assert.equal(index.counts.incidents, data.incidents.length, 'index should expose
 assert.equal(index.counts.relationships, data.relationships.length, 'index should expose relationship count');
 assert.equal(index.counts.buildSystems, data.entities.build_systems.length, 'index should expose build system count');
 assert.equal(index.counts.distributionChannels, data.entities.distribution_channels.length, 'index should expose distribution channel count');
+assert.ok(/supply chain/i.test(index.lede), 'index should include polished public copy');
+assert.ok(!JSON.stringify(index).includes('Canary'), 'public page model should not expose the internal codename');
+assert.equal(index.explanatorySections.length, 4, 'index should include explanatory sections');
+assert.equal(index.featuredIncidents.length, 5, 'index should include five featured incidents');
+assert.deepEqual(
+  index.featuredIncidents.map((incident) => incident.id),
+  SUPPLY_CHAIN_FEATURED_INCIDENT_IDS,
+  'featured incident order should be curated and stable'
+);
+index.featuredIncidents.forEach((incident) => {
+  assert.ok(routeUrls.has(incident.href), `featured incident route should resolve: ${incident.href}`);
+});
+assert.equal(index.entitySummaries.length, 7, 'index should include seven entity summary cards');
+assert.ok(index.seo.title, 'index should include SEO title');
+assert.ok(index.seo.description, 'index should include SEO description');
+assert.equal(index.seo.canonicalPath, '/supply-chain/', 'index should include canonical path');
+assert.ok(index.seo.ogTitle, 'index should include Open Graph title');
+assert.ok(index.seo.ogDescription, 'index should include Open Graph description');
+assert.ok(index.seo.jsonLd, 'index should include JSON-LD');
 
 const codecov = getSupplyChainIncidentPage('SC-2021-CODECOV-BASH-UPLOADER', data);
 assert.ok(codecov.incident.summary, 'incident page should include summary');
@@ -65,6 +86,65 @@ assert.ok(codecov.sections.organizations.length > 0, 'incident page should inclu
 assert.ok(codecov.sections.buildSystems.length > 0, 'incident page should include build systems');
 assert.ok(codecov.sections.distributionChannels.length > 0, 'incident page should include distribution channels');
 assert.ok(codecov.incident.references.length > 0, 'incident page should include references');
+assert.ok(codecov.connectedEntities.length > 0, 'incident page should include relationship-aware connected entities');
+assert.equal(
+  new Set(codecov.connectedEntities.map((entity) => entity.href || entity.id)).size,
+  codecov.connectedEntities.length,
+  'incident connected entities should be deduplicated by entity'
+);
+codecov.connectedEntities.forEach((entity) => {
+  assert.ok(
+    ![
+      'accounts',
+      'build_systems',
+      'distribution_channels',
+      'maintainers',
+      'organizations',
+      'packages',
+      'repositories',
+    ].includes(entity.entityType),
+    'connected entity labels should use singular display names'
+  );
+});
+assert.ok(codecov.seo.title.includes('Supply Chain'), 'incident page should include SEO title');
+assert.ok(codecov.seo.description, 'incident page should include SEO description');
+assert.equal(
+  codecov.seo.canonicalPath,
+  '/supply-chain/incidents/SC-2021-CODECOV-BASH-UPLOADER/',
+  'incident page should include canonical path'
+);
+assert.ok(codecov.seo.ogTitle, 'incident page should include Open Graph title');
+assert.ok(codecov.seo.jsonLd, 'incident page should include JSON-LD');
+
+const eventStreamPackage = getSupplyChainEntityPage('packages', 'pkg-npm-event-stream', data);
+assert.ok(eventStreamPackage.relatedIncidents.length > 0, 'entity page should include related incidents');
+eventStreamPackage.relatedIncidents.forEach((incident) => {
+  assert.ok(routeUrls.has(incident.href), `related incident route should resolve: ${incident.href}`);
+});
+assert.ok(eventStreamPackage.connectedEntities.length > 0, 'entity page should include connected entities');
+eventStreamPackage.connectedEntities.forEach((entity) => {
+  assert.ok(
+    ![
+      'accounts',
+      'build_systems',
+      'distribution_channels',
+      'maintainers',
+      'organizations',
+      'packages',
+      'repositories',
+    ].includes(entity.entityType),
+    'entity labels should use singular display names'
+  );
+});
+assert.ok(eventStreamPackage.seo.title.includes('Package'), 'entity page should include SEO title');
+assert.ok(eventStreamPackage.seo.description, 'entity page should include SEO description');
+assert.equal(
+  eventStreamPackage.seo.canonicalPath,
+  '/supply-chain/packages/pkg-npm-event-stream/',
+  'entity page should include canonical path'
+);
+assert.ok(eventStreamPackage.seo.ogTitle, 'entity page should include Open Graph title');
+assert.ok(eventStreamPackage.seo.jsonLd, 'entity page should include JSON-LD');
 
 const brokenData = {
   ...data,

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -115,6 +115,11 @@ assert.equal(
 );
 assert.ok(codecov.seo.ogTitle, 'incident page should include Open Graph title');
 assert.ok(codecov.seo.jsonLd, 'incident page should include JSON-LD');
+assert.deepEqual(
+  codecov.seo.jsonLd.about,
+  codecov.incident.supply_chain_vectors.map((vector) => ({ '@type': 'Thing', name: vector })),
+  'incident JSON-LD should expose supply-chain vectors as Thing objects'
+);
 
 const eventStreamPackage = getSupplyChainEntityPage('packages', 'pkg-npm-event-stream', data);
 assert.ok(eventStreamPackage.relatedIncidents.length > 0, 'entity page should include related incidents');

--- a/site/src/components/SupplyChainEntityList.astro
+++ b/site/src/components/SupplyChainEntityList.astro
@@ -3,6 +3,8 @@ interface Item {
   href?: string | null;
   label: string;
   type?: string;
+  entityType?: string;
+  context?: string;
 }
 
 interface Props {
@@ -23,8 +25,11 @@ function titleCase(value?: string) {
     <ul class="entity-list">
       {items.map((item) => (
         <li>
-          {item.href ? <a href={item.href}>{item.label}</a> : <span>{item.label}</span>}
-          {item.type && <em>{titleCase(item.type)}</em>}
+          <span class="entity-main">
+            {item.href ? <a href={item.href}>{item.label}</a> : <span>{item.label}</span>}
+            {item.context && <small>{item.context}</small>}
+          </span>
+          {(item.entityType || item.type) && <em>{titleCase(item.entityType || item.type)}</em>}
         </li>
       ))}
     </ul>
@@ -60,11 +65,21 @@ function titleCase(value?: string) {
   }
 
   .entity-list em,
+  .entity-list small,
   .empty {
     color: var(--muted);
     font-family: var(--font-mono);
     font-size: 0.72rem;
     font-style: normal;
+  }
+
+  .entity-main {
+    min-width: 0;
+  }
+
+  .entity-list small {
+    display: block;
+    margin-top: 4px;
   }
 
   @media (max-width: 720px) {

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -31,6 +31,7 @@ const canonicalUrl = canonicalPath ? new URL(canonicalPath, Astro.site ?? 'https
 const hasOpenGraph = Boolean(ogTitle || ogDescription || canonicalUrl);
 const openGraphTitle = ogTitle || `${title} — Threatpedia`;
 const openGraphDescription = ogDescription || description;
+const openGraphType = canonicalPath?.startsWith('/supply-chain/incidents/') ? 'article' : 'website';
 const serializedJsonLd = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : null;
 
 // Build ticker items from all collections
@@ -119,7 +120,7 @@ try {
       <>
         <meta property="og:title" content={openGraphTitle} />
         <meta property="og:description" content={openGraphDescription} />
-        <meta property="og:type" content="website" />
+        <meta property="og:type" content={openGraphType} />
         {canonicalUrl && <meta property="og:url" content={canonicalUrl} />}
       </>
     )}

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -4,9 +4,22 @@ import { getCollection } from 'astro:content';
 interface Props {
   title: string;
   description?: string;
+  canonicalPath?: string;
+  ogTitle?: string;
+  ogDescription?: string;
+  robots?: string;
+  jsonLd?: Record<string, unknown> | Record<string, unknown>[];
 }
 
-const { title, description = 'The Definitive Cyber Threat Encyclopedia' } = Astro.props;
+const {
+  title,
+  description = 'The Definitive Cyber Threat Encyclopedia',
+  canonicalPath,
+  ogTitle,
+  ogDescription,
+  robots,
+  jsonLd,
+} = Astro.props;
 const enablePlausibleAnalytics = import.meta.env.PROD;
 const supplyChainEnv =
   typeof process !== 'undefined'
@@ -14,6 +27,11 @@ const supplyChainEnv =
     : import.meta.env.ENABLE_SUPPLY_CHAIN_PAGES;
 const enableSupplyChainPages = String(supplyChainEnv || '').toLowerCase() === 'true';
 const plausibleScriptSrc = 'https://plausible.io/js/pa-JU90GDszdzYfdcQawYHNo.js';
+const canonicalUrl = canonicalPath ? new URL(canonicalPath, Astro.site ?? 'https://threatpedia.wiki').toString() : null;
+const hasOpenGraph = Boolean(ogTitle || ogDescription || canonicalUrl);
+const openGraphTitle = ogTitle || `${title} — Threatpedia`;
+const openGraphDescription = ogDescription || description;
+const serializedJsonLd = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : null;
 
 // Build ticker items from all collections
 interface TickerItem {
@@ -95,6 +113,16 @@ try {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
+    {robots && <meta name="robots" content={robots} />}
+    {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
+    {hasOpenGraph && (
+      <>
+        <meta property="og:title" content={openGraphTitle} />
+        <meta property="og:description" content={openGraphDescription} />
+        <meta property="og:type" content="website" />
+        {canonicalUrl && <meta property="og:url" content={canonicalUrl} />}
+      </>
+    )}
     <meta name="theme-color" content="#080b10" />
     <link rel="icon" type="image/svg+xml" href="/tp-favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -109,6 +137,7 @@ try {
         </script>
       </>
     )}
+    {serializedJsonLd && <script type="application/ld+json" set:html={serializedJsonLd} />}
     <title>{title} — Threatpedia</title>
   </head>
   <body>

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -389,6 +389,16 @@ export function getSupplyChainIncidentPage(id, data = loadSupplyChainData()) {
         description,
         url: `https://threatpedia.wiki/supply-chain/incidents/${incident.id}/`,
         datePublished: incident.disclosed_at || incident.first_observed_at,
+        author: {
+          '@type': 'Organization',
+          name: 'Threatpedia',
+          url: 'https://threatpedia.wiki/',
+        },
+        publisher: {
+          '@type': 'Organization',
+          name: 'Threatpedia',
+          url: 'https://threatpedia.wiki/',
+        },
         about: (Array.isArray(incident.supply_chain_vectors) ? incident.supply_chain_vectors : []).map((vector) => ({
           '@type': 'Thing',
           name: vector,

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -37,6 +37,44 @@ export const SUPPLY_CHAIN_ENTITY_TYPES = [
   { key: 'maintainers', segment: 'maintainers', label: 'Maintainer', plural: 'Maintainers' },
 ];
 
+export const SUPPLY_CHAIN_FEATURED_INCIDENT_IDS = [
+  'SC-2024-XZ-UTILS',
+  'SC-2023-THREE-CX-DESKTOP',
+  'SC-2020-SOLARWINDS-ORION',
+  'SC-2018-NPM-EVENT-STREAM',
+  'SC-2021-UA-PARSER-JS',
+];
+
+export const SUPPLY_CHAIN_INDEX_COPY = {
+  lede:
+    'Threatpedia tracks software supply chain incidents as connected facts about packages, repositories, organizations, maintainers, build systems, distribution channels, and compromised accounts.',
+  sections: [
+    {
+      title: 'What Threatpedia Tracks',
+      body:
+        'This section models confirmed supply chain incidents and the entities named by the corpus. The goal is structured recall: which packages, repositories, maintainers, and organizations appear together in public evidence.',
+    },
+    {
+      title: 'Why Supply Chain Incidents Matter',
+      body:
+        'A supply chain compromise can turn trusted update channels, build systems, or package registries into distribution paths. Tracking those links helps defenders compare incidents without inventing risk scores.',
+    },
+    {
+      title: 'How Entities Connect',
+      body:
+        'Entities are connected through explicit relationship records derived from the curated incident corpus. A package, repository, organization, or maintainer page shows the incidents that support that connection.',
+    },
+    {
+      title: 'Evidence and Confidence Model',
+      body:
+        'Each incident carries confidence and evidence-level fields from the corpus. Pages show those fields directly and avoid conclusions beyond the recorded evidence.',
+    },
+  ],
+};
+
+const indexDescription =
+  'Threatpedia Supply Chain tracks curated software supply chain incidents and the packages, repositories, organizations, maintainers, build systems, and distribution channels connected to them.';
+
 const allEntityFiles = {
   accounts: 'accounts.json',
   build_systems: 'build_systems.json',
@@ -48,6 +86,65 @@ const allEntityFiles = {
 };
 
 const routeEntityBySegment = Object.fromEntries(SUPPLY_CHAIN_ENTITY_TYPES.map((item) => [item.segment, item]));
+
+const entitySummaryDefinitions = [
+  {
+    key: 'packages',
+    title: 'Packages',
+    description: 'Named software packages affected by or involved in supply chain incidents.',
+    href: null,
+  },
+  {
+    key: 'repositories',
+    title: 'Repositories',
+    description: 'Source repositories, release repositories, and project repositories cited by incident evidence.',
+    href: null,
+  },
+  {
+    key: 'organizations',
+    title: 'Organizations',
+    description: 'Vendors, projects, companies, registries, and public organizations connected to incidents.',
+    href: null,
+  },
+  {
+    key: 'maintainers',
+    title: 'Maintainers',
+    description: 'Individual maintainers or maintainer identities named by the structured corpus.',
+    href: null,
+  },
+  {
+    key: 'build_systems',
+    title: 'Build Systems',
+    description: 'Build, CI, release, or signing systems recorded as part of the incident chain.',
+    href: null,
+  },
+  {
+    key: 'distribution_channels',
+    title: 'Distribution Channels',
+    description: 'Registries, update systems, downloads, and other channels used to distribute affected artifacts.',
+    href: null,
+  },
+  {
+    key: 'accounts',
+    title: 'Compromised Accounts',
+    description: 'Accounts or identities recorded as compromised in the incident corpus.',
+    href: null,
+  },
+];
+
+const ENTITY_COLLECTION_LABELS = {
+  packages: 'Package',
+  repositories: 'Repository',
+  organizations: 'Organization',
+  maintainers: 'Maintainer',
+  build_systems: 'Build System',
+  distribution_channels: 'Distribution Channel',
+  accounts: 'Compromised Account',
+};
+
+function entityTypeLabel(entity) {
+  return ENTITY_COLLECTION_LABELS[entity.entityCollection] || entity.entityCollection;
+}
 
 export function isSupplyChainPagesEnabled(env = typeof process !== 'undefined' ? process.env || {} : {}) {
   return String(env.ENABLE_SUPPLY_CHAIN_PAGES || '').toLowerCase() === 'true';
@@ -135,18 +232,61 @@ function incidentLinksFor(data, entityId) {
     .sort(compareLabel);
 }
 
+function dedupeRows(rows) {
+  if (!Array.isArray(rows)) return [];
+  const seen = new Set();
+  return rows.filter((row) => {
+    const key = `${row.href || row.id}:${row.context || ''}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 function entityConnectionsFor(data, entityId) {
-  return relationshipRows(data, entityId)
+  const direct = relationshipRows(data, entityId)
+    .filter((row) => row.entity && row.oppositeId !== entityId)
+    .map((row) => ({
+      href: linkForEntity(row.entity),
+      label: row.entity.name,
+      id: row.entity.id,
+      type: row.type,
+      entityType: entityTypeLabel(row.entity),
+    }))
+    .filter((item) => item.href);
+
+  const incidentNodes = relationshipRows(data, entityId)
+    .filter((row) => row.incident)
+    .map((row) => `incident-${row.incident.id}`);
+  const throughIncidents = incidentNodes.flatMap((incidentNode) =>
+    relationshipRows(data, incidentNode)
+      .filter((row) => row.entity && row.entity.id !== entityId)
+      .map((row) => ({
+        href: linkForEntity(row.entity),
+        label: row.entity.name,
+        id: row.entity.id,
+        type: row.type,
+        entityType: entityTypeLabel(row.entity),
+        context: data.incidentByNodeId.get(incidentNode)?.title,
+      }))
+      .filter((item) => item.href)
+  );
+
+  return dedupeRows([...direct, ...throughIncidents]).sort(compareLabel);
+}
+
+function incidentConnectedEntities(data, incidentId) {
+  const nodeId = `incident-${incidentId}`;
+  const rows = relationshipRows(data, nodeId)
     .filter((row) => row.entity)
     .map((row) => ({
       href: linkForEntity(row.entity),
       label: row.entity.name,
       id: row.entity.id,
       type: row.type,
-      entityType: row.entity.entityCollection,
-    }))
-    .filter((item) => item.href)
-    .sort(compareLabel);
+      entityType: entityTypeLabel(row.entity),
+    }));
+  return dedupeRows(rows).sort(compareLabel);
 }
 
 function incidentEntityLinks(data, incidentId, relationshipType) {
@@ -166,9 +306,44 @@ function incidentEntities(data, incidentId, collectionKey, relationshipType) {
 }
 
 export function getSupplyChainIndexModel(data = loadSupplyChainData()) {
+  const featuredIncidents = SUPPLY_CHAIN_FEATURED_INCIDENT_IDS.map((id) => {
+    const incident = data.incidents.find((item) => item.id === id);
+    if (!incident) throw new Error(`Featured Supply Chain incident not found: ${id}`);
+    return {
+      id: incident.id,
+      title: incident.title,
+      summary: incident.summary,
+      href: `/supply-chain/incidents/${incident.id}/`,
+      attackStage: incident.attack_stage,
+      evidenceLevel: incident.evidence_level,
+      confidence: incident.confidence,
+    };
+  });
+
   return {
     kind: 'index',
     title: 'Supply Chain',
+    lede: SUPPLY_CHAIN_INDEX_COPY.lede,
+    explanatorySections: SUPPLY_CHAIN_INDEX_COPY.sections,
+    featuredIncidents,
+    entitySummaries: entitySummaryDefinitions.map((summary) => ({
+      ...summary,
+      count: data.entities[summary.key]?.length || 0,
+    })),
+    seo: {
+      title: 'Supply Chain',
+      description: indexDescription,
+      canonicalPath: '/supply-chain/',
+      ogTitle: 'Threatpedia Supply Chain',
+      ogDescription: indexDescription,
+      jsonLd: {
+        '@context': 'https://schema.org',
+        '@type': 'CollectionPage',
+        name: 'Threatpedia Supply Chain',
+        description: indexDescription,
+        url: 'https://threatpedia.wiki/supply-chain/',
+      },
+    },
     counts: {
       incidents: data.incidents.length,
       packages: data.entities.packages.length,
@@ -195,10 +370,28 @@ export function getSupplyChainIndexModel(data = loadSupplyChainData()) {
 export function getSupplyChainIncidentPage(id, data = loadSupplyChainData()) {
   const incident = data.incidents.find((item) => item.id === id);
   if (!incident) return null;
+  const description = incident.summary;
   return {
     kind: 'incident',
     title: incident.title,
     incident,
+    connectedEntities: incidentConnectedEntities(data, id),
+    seo: {
+      title: `Supply Chain: ${incident.title}`,
+      description,
+      canonicalPath: `/supply-chain/incidents/${incident.id}/`,
+      ogTitle: `${incident.title} - Threatpedia Supply Chain`,
+      ogDescription: description,
+      jsonLd: {
+        '@context': 'https://schema.org',
+        '@type': 'Article',
+        headline: incident.title,
+        description,
+        url: `https://threatpedia.wiki/supply-chain/incidents/${incident.id}/`,
+        datePublished: incident.disclosed_at || incident.first_observed_at,
+        about: incident.supply_chain_vectors || [],
+      },
+    },
     sections: {
       packages: incidentEntityLinks(data, id, 'AFFECTED_PACKAGE'),
       repositories: incidentEntityLinks(data, id, 'AFFECTED_REPOSITORY'),
@@ -217,13 +410,31 @@ export function getSupplyChainEntityPage(collectionKey, id, data = loadSupplyCha
   if (!entity) return null;
   const type = SUPPLY_CHAIN_ENTITY_TYPES.find((item) => item.key === collectionKey);
   if (!type) return null;
+  const relatedIncidents = incidentLinksFor(data, id);
+  const description = `${type.label} entity in the Threatpedia Supply Chain corpus with ${relatedIncidents.length} connected incident${relatedIncidents.length === 1 ? '' : 's'}.`;
   return {
     kind: 'entity',
     title: entity.name,
     entity: { ...entity, entityCollection: collectionKey },
     entityType: type.label,
-    connectedIncidents: incidentLinksFor(data, id),
+    relatedIncidents,
+    connectedIncidents: relatedIncidents,
     connectedEntities: entityConnectionsFor(data, id),
+    seo: {
+      title: `Supply Chain ${type.label}: ${entity.name}`,
+      description,
+      canonicalPath: `/supply-chain/${type.segment}/${entity.id}/`,
+      ogTitle: `${entity.name} - Threatpedia Supply Chain ${type.label}`,
+      ogDescription: description,
+      jsonLd: {
+        '@context': 'https://schema.org',
+        '@type': 'Thing',
+        name: entity.name,
+        identifier: entity.id,
+        description,
+        url: `https://threatpedia.wiki/supply-chain/${type.segment}/${entity.id}/`,
+      },
+    },
   };
 }
 

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -389,7 +389,10 @@ export function getSupplyChainIncidentPage(id, data = loadSupplyChainData()) {
         description,
         url: `https://threatpedia.wiki/supply-chain/incidents/${incident.id}/`,
         datePublished: incident.disclosed_at || incident.first_observed_at,
-        about: incident.supply_chain_vectors || [],
+        about: (Array.isArray(incident.supply_chain_vectors) ? incident.supply_chain_vectors : []).map((vector) => ({
+          '@type': 'Thing',
+          name: vector,
+        })),
       },
     },
     sections: {

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -1,7 +1,7 @@
 ---
 import Base from '../../layouts/Base.astro';
 import EntityList from '../../components/SupplyChainEntityList.astro';
-import { getSupplyChainRoutes } from '../../lib/supplyChainPages.mjs';
+import { getSupplyChainRoutes, isSupplyChainPagesEnabled } from '../../lib/supplyChainPages.mjs';
 
 export function getStaticPaths() {
   return getSupplyChainRoutes().map((route) => ({
@@ -11,6 +11,7 @@ export function getStaticPaths() {
 }
 
 const { page } = Astro.props;
+const supplyChainPagesEnabled = isSupplyChainPagesEnabled();
 
 function label(value) {
   if (value === null || value === undefined) return 'unknown';
@@ -22,16 +23,30 @@ function titleCase(value) {
   return label(value).replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
-const title = page?.kind === 'index' ? 'Supply Chain' : `Supply Chain: ${page?.title}`;
+const title = page?.seo?.title || (page?.kind === 'index' ? 'Supply Chain' : `Supply Chain: ${page?.title}`);
+const description = page?.seo?.description || 'Threatpedia Supply Chain incident and entity pages.';
+const canonicalPath = page?.seo?.canonicalPath;
+const ogTitle = page?.seo?.ogTitle;
+const ogDescription = page?.seo?.ogDescription;
+const jsonLd = page?.seo?.jsonLd;
+const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
 ---
 
-<Base title={title} description="Threatpedia Supply Chain corpus and entity graph primitives">
+<Base
+  title={title}
+  description={description}
+  canonicalPath={canonicalPath}
+  ogTitle={ogTitle}
+  ogDescription={ogDescription}
+  robots={robots}
+  jsonLd={jsonLd}
+>
   {page.kind === 'index' && (
     <section class="supply-chain-page">
       <header class="sc-header">
         <p class="eyebrow">Threatpedia</p>
         <h1>Supply Chain</h1>
-        <p class="lede">Validated incident corpus and graph primitives generated from static JSON.</p>
+        <p class="lede">{page.lede}</p>
       </header>
 
       <section class="metric-grid" aria-label="Supply Chain corpus counts">
@@ -43,6 +58,45 @@ const title = page?.kind === 'index' ? 'Supply Chain' : `Supply Chain: ${page?.t
         <div><span>{page.counts.buildSystems}</span><p>Build Systems</p></div>
         <div><span>{page.counts.distributionChannels}</span><p>Distribution Channels</p></div>
         <div><span>{page.counts.relationships}</span><p>Relationships</p></div>
+      </section>
+
+      <section class="copy-grid" aria-label="Supply Chain explanation">
+        {page.explanatorySections.map((section) => (
+          <article class="info-panel">
+            <h2>{section.title}</h2>
+            <p>{section.body}</p>
+          </article>
+        ))}
+      </section>
+
+      <section class="sc-section">
+        <h2>Featured Incidents</h2>
+        <div class="featured-grid">
+          {page.featuredIncidents.map((incident) => (
+            <article class="incident-card">
+              <a href={incident.href}>{incident.title}</a>
+              <p>{incident.summary}</p>
+              <div class="card-meta">
+                <span>{titleCase(incident.attackStage)}</span>
+                <span>{titleCase(incident.evidenceLevel)}</span>
+                <span>{titleCase(incident.confidence)}</span>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section class="sc-section">
+        <h2>Entity Summary</h2>
+        <div class="entity-summary-grid">
+          {page.entitySummaries.map((entity) => (
+            <article class="entity-card">
+              <span>{entity.count}</span>
+              <h3>{entity.title}</h3>
+              <p>{entity.description}</p>
+            </article>
+          ))}
+        </div>
       </section>
 
       <section class="sc-section">
@@ -95,6 +149,7 @@ const title = page?.kind === 'index' ? 'Supply Chain' : `Supply Chain: ${page?.t
       <EntityList title="Build Systems" items={page.sections.buildSystems} />
       <EntityList title="Distribution Channels" items={page.sections.distributionChannels} />
       <EntityList title="Compromised Accounts" items={page.sections.compromisedAccounts} />
+      <EntityList title="Connected Entities" items={page.connectedEntities} />
 
       <section class="sc-section">
         <h2>References</h2>
@@ -120,10 +175,10 @@ const title = page?.kind === 'index' ? 'Supply Chain' : `Supply Chain: ${page?.t
 
       <section class="detail-grid">
         <div><span>Entity Type</span><strong>{page.entityType}</strong></div>
-        <div><span>Connected Incidents</span><strong>{page.connectedIncidents.length}</strong></div>
+        <div><span>Related Incidents</span><strong>{page.relatedIncidents.length}</strong></div>
       </section>
 
-      <EntityList title="Connected Incidents" items={page.connectedIncidents} />
+      <EntityList title="Related Incidents" items={page.relatedIncidents} />
       <EntityList title="Connected Entities" items={page.connectedEntities} />
     </article>
   )}
@@ -135,7 +190,9 @@ const title = page?.kind === 'index' ? 'Supply Chain' : `Supply Chain: ${page?.t
   }
 
   .sc-header {
-    margin-bottom: 28px;
+    margin-bottom: 30px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid var(--border);
   }
 
   .eyebrow {
@@ -157,6 +214,87 @@ const title = page?.kind === 'index' ? 'Supply Chain' : `Supply Chain: ${page?.t
     color: var(--muted);
     max-width: 820px;
     line-height: 1.65;
+  }
+
+  .copy-grid,
+  .featured-grid,
+  .entity-summary-grid {
+    display: grid;
+    gap: 16px;
+    margin: 30px 0;
+  }
+
+  .copy-grid {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  }
+
+  .featured-grid {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  }
+
+  .entity-summary-grid {
+    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  }
+
+  .info-panel,
+  .incident-card,
+  .entity-card {
+    border: 1px solid var(--border);
+    background: var(--surface);
+    border-radius: 6px;
+    padding: 16px;
+  }
+
+  .info-panel h2,
+  .entity-card h3 {
+    margin: 0 0 8px;
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+
+  .info-panel h2 {
+    font-size: 1rem;
+  }
+
+  .info-panel p,
+  .incident-card p,
+  .entity-card p {
+    color: var(--muted);
+    line-height: 1.6;
+    margin: 0;
+  }
+
+  .incident-card a {
+    display: inline-block;
+    font-family: var(--font-serif);
+    font-size: 1.05rem;
+    line-height: 1.3;
+    margin-bottom: 10px;
+  }
+
+  .card-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 14px;
+  }
+
+  .card-meta span {
+    border: 1px solid var(--border);
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.08em;
+    padding: 4px 7px;
+    text-transform: uppercase;
+  }
+
+  .entity-card span {
+    color: var(--amber);
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 1.55rem;
+    margin-bottom: 8px;
   }
 
   .metric-grid,


### PR DESCRIPTION
## Summary
- add public-facing Supply Chain index copy and explanatory sections
- add five curated featured incident cards: XZ Utils, 3CX, SolarWinds, event-stream, and ua-parser-js
- add entity summary cards for packages, repositories, organizations, maintainers, build systems, distribution channels, and compromised accounts
- add relationship-aware Connected Entities sections on incident pages and Related Incidents sections on entity pages
- add opt-in SEO metadata support for Supply Chain pages: title, description, canonical URL, Open Graph metadata, and JSON-LD
- expand focused tests and update the public enablement checklist

## Validation
- node scripts/test-supply-chain-pages.mjs
- node --check scripts/test-supply-chain-pages.mjs && node --check site/src/lib/supplyChainPages.mjs
- python3 scripts/validate_supply_chain_incidents.py && python3 scripts/validate_supply_chain_graph.py
- git diff --check
- cd site && rm -rf dist && npm run build && test ! -e dist/supply-chain
- cd site && rm -rf dist && ENABLE_SUPPLY_CHAIN_PAGES=true npm run build && test -f dist/supply-chain/index.html && test -f dist/supply-chain/incidents/SC-2024-XZ-UTILS/index.html && test -f dist/supply-chain/packages/pkg-npm-event-stream/index.html
- cd site && rg -q "Threatpedia Supply Chain" dist/supply-chain/index.html && rg -q "property=\"og:title\"" dist/supply-chain/index.html && rg -q "application/ld\+json" dist/supply-chain/index.html
- cd site && rg -q "Related Incidents" dist/supply-chain/packages/pkg-npm-event-stream/index.html && rg -q "Connected Entities" dist/supply-chain/incidents/SC-2024-XZ-UTILS/index.html && ! rg -q "Canary|canary" dist/supply-chain

## Scope boundaries
- no scoring
- no soak windows
- no live feeds
- no graph database
- no AI-generated conclusions
- no attribution automation
- no enterprise API
- no public claims beyond the curated corpus

Stacked on Phase 1D PR #1134 because this polish layer depends on the feature-flagged Supply Chain routes introduced there.