### PR TITLE
docs: align dispatcher guardrail diagram caps

### DIFF
--- a/.github/pipeline/diagrams/dispatcher-guardrails.md
+++ b/.github/pipeline/diagrams/dispatcher-guardrails.md
@@ -112,6 +112,7 @@ flowchart TB
   Unblocked work still flows around a blocked task — the
   dispatcher doesn't serialize the whole queue on one dependency.
 
-- **Per-run ceiling is intentional.** Up to 3 tasks dispatched per
-  run, hardcoded. Tunable to a config knob in a later slice if the
-  pattern changes; today it's a deliberate cap, not a knob.
+- **Per-run ceiling is intentional.** The dispatcher reads
+  `queues.dispatcher.tasks_per_run`, defaults to 3 tasks per run,
+  and refuses values above 12. The knob is deliberate and bounded,
+  not an unbounded throughput bypass.

--- a/.github/pipeline/diagrams/dispatcher-guardrails.md
+++ b/.github/pipeline/diagrams/dispatcher-guardrails.md
@@ -39,9 +39,9 @@ flowchart TB
     end
 
     subgraph BP["backpressure (hysteresis)"]
-      BPQ{"drafts pending<br/>≥ max_pending (50)?"}
+      BPQ{"drafts pending<br/>≥ max_pending (100)?"}
       BPI["open pipeline/backpressure Issue"]
-      BPW["pause · wait until<br/>queue < backpressure_resume (40)"]
+      BPW["pause · wait until<br/>queue < backpressure_resume (80)"]
       BPC["auto-close Issue on resume"]
     end
 
@@ -56,7 +56,7 @@ flowchart TB
     end
   end
 
-  DISPATCH["select top pending (P0..P3)<br/>dispatch up to 3 per run"]
+  DISPATCH["select top pending (P0..P3)<br/>dispatch up to 12 per run"]
   PRIV["pipeline/ready Issue<br/>+ labels"]
 
   CRON --> INSTALL --> READ --> CFG


### PR DESCRIPTION
Follow-up for late review feedback on #1132 after that PR had already merged.\n\nChanges:\n- update dispatcher guardrail diagram max_pending label from 50 to 100\n- update backpressure_resume label from 40 to 80\n- update dispatch label from 3 to 12 tasks/run\n\nValidation:\n- rg "max_pending \(|backpressure_resume \(|dispatch up to" .github/pipeline/diagrams/dispatcher-guardrails.md\n- git diff --check\n\nRequesting non-author review:\n/gemini review\n@codex review\n@ernestpenfold-bot review