### PR TITLE
Add Supply Chain public readiness gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ desktop.ini
 /out
 /build
 *.log
+
+# ── Local Worker State ────────────────────────────────────────────────────────
+.worker-state/

--- a/docs/supply-chain-pages.md
+++ b/docs/supply-chain-pages.md
@@ -129,7 +129,19 @@ the page path also supports a noindex robots value.
 
 ## Public Enablement Checklist
 
-Before enabling the section publicly:
+Before enabling the section publicly, run the readiness gate:
+
+```bash
+node scripts/check_supply_chain_public_readiness.mjs
+```
+
+The gate writes `.worker-state/supply-chain-public-readiness.json` and returns a
+single PASS/FAIL decision. See
+[Supply Chain Public Readiness Gate](./supply-chain-public-readiness.md) for the
+full readiness contract.
+
+If the gate fails and an operator needs to inspect individual steps, the manual
+checks are:
 
 1. Run the corpus validators:
 

--- a/docs/supply-chain-public-readiness.md
+++ b/docs/supply-chain-public-readiness.md
@@ -1,0 +1,70 @@
+# Supply Chain Public Readiness Gate
+
+The Supply Chain section is feature-flagged by `ENABLE_SUPPLY_CHAIN_PAGES`.
+Before enabling it in a public deployment, run the public readiness gate from
+the repository root:
+
+```bash
+node scripts/check_supply_chain_public_readiness.mjs
+```
+
+If working from the `scripts/` package directory, the same gate is available as:
+
+```bash
+cd scripts
+npm run check:supply-chain-public-readiness
+```
+
+The gate writes a machine-readable report to:
+
+```text
+.worker-state/supply-chain-public-readiness.json
+```
+
+## PASS Criteria
+
+A `pass` result means the gate completed all required checks and found no
+public-enablement blockers. The gate verifies:
+
+- supply-chain incident validation passes
+- supply-chain graph validation passes
+- supply-chain page model tests pass
+- site dependencies install with `npm ci --no-audit --no-fund`
+- the default disabled build emits no `/supply-chain/` output
+- the enabled build emits `/supply-chain/` output
+- public copy contains no `Canary` wording
+- the Supply Chain nav link appears only when the flag is enabled
+- `/supply-chain/` exists only when the flag is enabled
+- all five featured incident pages exist when enabled
+- featured incident pages render editorial sections
+- generated Supply Chain pages have no broken internal Supply Chain links
+- SEO metadata exists on the index and featured incident pages
+- emitted JSON-LD blocks parse as valid JSON
+- enabled Supply Chain pages are not marked `noindex`
+- generated route count matches the corpus-derived route count
+
+## Report Shape
+
+The readiness report includes:
+
+- `status`: `pass` or `fail`
+- `timestamp`: ISO timestamp for the run
+- `counts`: corpus and generated-route counts used by the gate
+- `checked_routes`: index, featured incident, and sampled generated routes
+- `checks`: command-level results with exit codes and output tails
+- `failures`: operator-facing blockers
+
+The report is intended for operator handoff and audit. A failed report should
+be treated as a stop condition for public enablement until the listed blocker is
+fixed and the gate returns `pass`.
+
+## Operational Notes
+
+The readiness gate does not enable the feature flag, change deployment
+configuration, create pages when disabled, or relax validation policy. It only
+answers whether the current corpus, graph, page code, and generated static
+output are safe to deploy with `ENABLE_SUPPLY_CHAIN_PAGES=true`.
+
+Existing campaign validator warnings may appear during the Astro build because
+the site build runs campaign validation first. Those warnings are not Supply
+Chain readiness failures unless the build exits non-zero.

--- a/docs/supply-chain-stack-status.md
+++ b/docs/supply-chain-stack-status.md
@@ -1,0 +1,131 @@
+# Supply Chain Stack Status
+
+Status recorded from the rebuilt Phase 1G readiness branch on 2026-06-13.
+
+Result: PASS for the current post-squash stack. Supply Chain remains disabled
+by default unless `ENABLE_SUPPLY_CHAIN_PAGES=true` is set by an operator.
+
+## PR Chain Order
+
+| Order | Phase | PR | Branch | Head reviewed | Base | Status |
+|---:|---|---|---|---|---|---|
+| 1 | Phase 1A incident corpus | [#1130](https://github.com/MahdiHedhli/threatpedia/pull/1130) | `codex/supply-chain-phase1a` | merged before this rebuild | `main` | merged to `main` |
+| 2 | Phase 1B graph primitives | [#1131](https://github.com/MahdiHedhli/threatpedia/pull/1131) | `codex/supply-chain-phase1b` | `dca5adc2f127fa788460292b6de7938f0db82405` | `main` | merged to `main` |
+| 3 | Phase 1C corpus depth pass | [#1133](https://github.com/MahdiHedhli/threatpedia/pull/1133) | `codex/supply-chain-phase1c` | `52ba1f9fa28591bb5ae44abeba8b133375265b1e` | `main` | merged to `main` |
+| 4 | Phase 1D feature-flagged pages | [#1134](https://github.com/MahdiHedhli/threatpedia/pull/1134) | `codex/supply-chain-phase1d` | `a7dbf64842d54cad68ed2e20c01102060d4a4e16` | `main` | merged to `main` |
+| 5 | Phase 1E public polish | [#1135](https://github.com/MahdiHedhli/threatpedia/pull/1135) | `codex/supply-chain-phase1e` | folded into #1134 after stacked squash merge | `codex/supply-chain-phase1d` | no separate `main` merge needed |
+| 6 | Phase 1F featured editorial pages | [#1139](https://github.com/MahdiHedhli/threatpedia/pull/1139) | `codex/supply-chain-phase1f` | `c6f7f03de6737f4c5666357b4881c6c6e9654ecb` | `main` | merged to `main`; replaces closed #1136 |
+| 7 | Phase 1G public readiness gate | [#1138](https://github.com/MahdiHedhli/threatpedia/pull/1138) | `codex/supply-chain-phase1g` | rebuilt on current `main` | `main` | ready after current-head recheck |
+
+## Merge Notes
+
+The original stack was squash-merged in phases. Because squash merges changed
+the ancestry of the lower branches, later stacked PRs were rebuilt onto current
+`main` before merge rather than merged from stale stacked bases.
+
+- #1135 was already merged into the stacked Phase 1D branch before #1134 was
+  rebuilt; its public polish changes are included in the #1134 merge.
+- #1136 could not be reopened because its deleted stacked base blocked GitHub
+  retargeting. It was rebuilt as #1139 and merged to `main`.
+- #1138 is the remaining readiness gate branch. It should be reread against
+  live GitHub state before merge and merged only with a current head SHA guard.
+
+## Validation Commands And Results
+
+Run from the rebuilt Phase 1G branch based on `main` after #1139 merged.
+
+```bash
+python3 scripts/validate_supply_chain_incidents.py
+```
+
+Result: PASS. Validated 25 supply-chain incidents.
+
+```bash
+python3 scripts/validate_supply_chain_graph.py
+```
+
+Result: PASS. Validated graph primitives: 73 entities and 93 relationships.
+
+```bash
+node scripts/test-supply-chain-pages.mjs
+```
+
+Result: PASS. Supply Chain page tests passed with 74 routes.
+
+```bash
+node --check scripts/check_supply_chain_public_readiness.mjs
+```
+
+Result: PASS.
+
+```bash
+node scripts/check_supply_chain_public_readiness.mjs
+```
+
+Result: PASS. The readiness report was written to
+`.worker-state/supply-chain-public-readiness.json`.
+
+```bash
+git diff --check
+```
+
+Result: PASS.
+
+## Readiness Report Summary
+
+Latest report timestamp: `2026-06-13T17:12:08.137Z`.
+
+```json
+{
+  "status": "pass",
+  "counts": {
+    "incidents": 25,
+    "packages": 16,
+    "repositories": 10,
+    "organizations": 17,
+    "maintainers": 5,
+    "build_systems": 6,
+    "distribution_channels": 11,
+    "compromised_accounts": 8,
+    "relationships": 93,
+    "expected_routes": 74,
+    "enabled_generated_routes": 74
+  },
+  "checks": [
+    "incident validation: pass",
+    "graph validation: pass",
+    "page model test: pass",
+    "site dependency install: pass",
+    "disabled build smoke: pass",
+    "enabled build smoke: pass"
+  ],
+  "failures": []
+}
+```
+
+Checked featured incident routes:
+
+- `/supply-chain/incidents/SC-2024-XZ-UTILS/`
+- `/supply-chain/incidents/SC-2023-THREE-CX-DESKTOP/`
+- `/supply-chain/incidents/SC-2020-SOLARWINDS-ORION/`
+- `/supply-chain/incidents/SC-2018-NPM-EVENT-STREAM/`
+- `/supply-chain/incidents/SC-2021-UA-PARSER-JS/`
+
+## Known Unrelated Warnings
+
+The full Astro builds emit existing campaign validator warnings for campaign
+records that have fewer than the target two related incidents. The validator
+still exits successfully and reports that campaign validation passed. These
+warnings are unrelated to the Supply Chain stack and did not block the disabled
+build, enabled build, or readiness gate.
+
+## Merge Plan
+
+1. Reread live state for #1138 after pushing the rebuilt Phase 1G branch.
+2. Confirm the PR base is `main`, the head SHA matches the rebuilt branch, and
+   changed files are limited to the readiness gate and operator docs.
+3. If review requirements remain the only blocker, use the recorded owner
+   authorization to admin squash merge with a current head SHA guard.
+4. Do not enable `ENABLE_SUPPLY_CHAIN_PAGES=true` by default as part of this
+   stack. Public enablement remains an operator/deployment configuration step
+   after the readiness gate is merged and passing.

--- a/scripts/check_supply_chain_public_readiness.mjs
+++ b/scripts/check_supply_chain_public_readiness.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  SUPPLY_CHAIN_FEATURED_INCIDENT_IDS,
+  getSupplyChainRoutes,
+  loadSupplyChainData,
+} from '../site/src/lib/supplyChainPages.mjs';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..');
+const siteDir = path.join(repoRoot, 'site');
+const distDir = path.join(siteDir, 'dist');
+const reportPath = path.join(repoRoot, '.worker-state/supply-chain-public-readiness.json');
+
+const failures = [];
+const checks = [];
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function normalizeOutput(value) {
+  return String(value || '').split('\n').slice(-20).join('\n').trim();
+}
+
+function runCheck(name, command, options = {}) {
+  const startedAt = Date.now();
+  const result = spawnSync(command, {
+    cwd: options.cwd || repoRoot,
+    env: { ...process.env, ...(options.env || {}) },
+    shell: true,
+    encoding: 'utf-8',
+    maxBuffer: 1024 * 1024 * 20,
+  });
+  const check = {
+    name,
+    command,
+    status: result.status === 0 ? 'pass' : 'fail',
+    exit_code: result.status,
+    duration_ms: Date.now() - startedAt,
+    stdout_tail: normalizeOutput(result.stdout),
+    stderr_tail: normalizeOutput(result.stderr),
+  };
+  checks.push(check);
+  if (result.status !== 0) {
+    failures.push(`${name} failed with exit code ${result.status}`);
+  }
+  return result.status === 0;
+}
+
+function assertReady(condition, message) {
+  if (!condition) failures.push(message);
+}
+
+function readIfExists(filePath) {
+  return existsSync(filePath) ? readFileSync(filePath, 'utf-8') : '';
+}
+
+function htmlPathForRoute(routePath) {
+  const normalized = routePath.replace(/^\/+/, '').replace(/\/+$/, '');
+  return normalized ? path.join(distDir, normalized, 'index.html') : path.join(distDir, 'index.html');
+}
+
+function walkFiles(dir, predicate, files = []) {
+  if (!existsSync(dir)) return files;
+  readdirSync(dir, { withFileTypes: true }).forEach((entry) => {
+    const filePath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(filePath, predicate, files);
+      return;
+    }
+    if (entry.isFile() && (!predicate || predicate(filePath))) {
+      files.push(filePath);
+    }
+  });
+  return files;
+}
+
+function extractSupplyChainHrefs(html) {
+  const hrefs = new Set();
+  const hrefPattern = /\shref=(["'])(\/supply-chain\/[^"']*)\1/g;
+  let match;
+  while ((match = hrefPattern.exec(html)) !== null) {
+    const href = match[2].split('#')[0].split('?')[0];
+    if (href) hrefs.add(href.endsWith('/') ? href : `${href}/`);
+  }
+  return [...hrefs];
+}
+
+function extractJsonLdBlocks(html) {
+  const blocks = [];
+  const jsonLdPattern = /<script[^>]+type=(["'])application\/ld\+json\1[^>]*>([\s\S]*?)<\/script>/gi;
+  let match;
+  while ((match = jsonLdPattern.exec(html)) !== null) {
+    blocks.push(match[2].trim());
+  }
+  return blocks;
+}
+
+function assertSeo(filePath, routeLabel) {
+  const html = readIfExists(filePath);
+  assertReady(Boolean(html), `${routeLabel} was not generated`);
+  if (!html) return;
+
+  assertReady(/<title>[^<]+<\/title>/.test(html), `${routeLabel} missing title`);
+  assertReady(/<meta name="description" content="[^"]+"/.test(html), `${routeLabel} missing meta description`);
+  assertReady(/<link rel="canonical" href="[^"]+"/.test(html), `${routeLabel} missing canonical URL`);
+  assertReady(/<meta property="og:title" content="[^"]+"/.test(html), `${routeLabel} missing Open Graph title`);
+  assertReady(/<meta property="og:description" content="[^"]+"/.test(html), `${routeLabel} missing Open Graph description`);
+  assertReady(!/<meta name="robots" content="noindex, nofollow"/.test(html), `${routeLabel} should not be noindex when enabled`);
+
+  const jsonLdBlocks = extractJsonLdBlocks(html);
+  assertReady(jsonLdBlocks.length > 0, `${routeLabel} missing JSON-LD`);
+  jsonLdBlocks.forEach((block, index) => {
+    try {
+      JSON.parse(block);
+    } catch (error) {
+      failures.push(`${routeLabel} JSON-LD block ${index + 1} is invalid JSON: ${error.message}`);
+    }
+  });
+}
+
+function generatedSupplyChainPageCount() {
+  return walkFiles(path.join(distDir, 'supply-chain'), (filePath) => path.basename(filePath) === 'index.html').length;
+}
+
+function routeUrl(route) {
+  return route.slug ? `/supply-chain/${route.slug}/` : '/supply-chain/';
+}
+
+function writeReport(status, data, extra = {}) {
+  mkdirSync(path.dirname(reportPath), { recursive: true });
+  const enabledRoutes = getSupplyChainRoutes({ enabled: true, data });
+  const report = {
+    status,
+    timestamp: nowIso(),
+    counts: {
+      incidents: data.incidents.length,
+      packages: data.entities.packages.length,
+      repositories: data.entities.repositories.length,
+      organizations: data.entities.organizations.length,
+      maintainers: data.entities.maintainers.length,
+      build_systems: data.entities.build_systems.length,
+      distribution_channels: data.entities.distribution_channels.length,
+      compromised_accounts: data.entities.accounts.length,
+      relationships: data.relationships.length,
+      expected_routes: enabledRoutes.length,
+      ...extra.counts,
+    },
+    checked_routes: {
+      index: '/supply-chain/',
+      featured_incidents: SUPPLY_CHAIN_FEATURED_INCIDENT_IDS.map((id) => `/supply-chain/incidents/${id}/`),
+      sampled_routes: enabledRoutes.slice(0, 12).map(routeUrl),
+    },
+    checks,
+    failures,
+  };
+  writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+  return report;
+}
+
+function assertDisabledBuild() {
+  rmSync(distDir, { recursive: true, force: true });
+  const passed = runCheck('disabled build smoke', 'cd site && npm run build', {
+    env: { ENABLE_SUPPLY_CHAIN_PAGES: '' },
+  });
+  const homeHtml = readIfExists(path.join(distDir, 'index.html'));
+  assertReady(passed, 'disabled build did not complete');
+  assertReady(!existsSync(path.join(distDir, 'supply-chain')), '/supply-chain/ output exists when disabled');
+  assertReady(!homeHtml.includes('href="/supply-chain/"'), 'Supply Chain nav appears when disabled');
+  assertReady(!/<meta name="robots" content="noindex, nofollow"/.test(homeHtml), 'disabled homepage should not be noindex');
+  return passed;
+}
+
+function assertEnabledBuild(data) {
+  rmSync(distDir, { recursive: true, force: true });
+  const passed = runCheck('enabled build smoke', 'cd site && npm run build', {
+    env: { ENABLE_SUPPLY_CHAIN_PAGES: 'true' },
+  });
+  assertReady(passed, 'enabled build did not complete');
+
+  const expectedRoutes = getSupplyChainRoutes({ enabled: true, data });
+  const expectedRouteUrls = new Set(expectedRoutes.map(routeUrl));
+  const generatedCount = generatedSupplyChainPageCount();
+  assertReady(existsSync(htmlPathForRoute('/supply-chain/')), '/supply-chain/ index missing when enabled');
+  assertReady(generatedCount === expectedRoutes.length, `generated Supply Chain route count ${generatedCount} did not match expected ${expectedRoutes.length}`);
+
+  const homeHtml = readIfExists(path.join(distDir, 'index.html'));
+  const supplyChainHtmlFiles = walkFiles(path.join(distDir, 'supply-chain'), (filePath) => filePath.endsWith('.html'));
+  const supplyChainHtml = supplyChainHtmlFiles.map((filePath) => readIfExists(filePath)).join('\n');
+  assertReady(homeHtml.includes('href="/supply-chain/"'), 'Supply Chain nav missing when enabled');
+  assertReady(!/Canary/i.test(supplyChainHtml), 'public Supply Chain output contains Canary');
+
+  const indexPath = htmlPathForRoute('/supply-chain/');
+  assertSeo(indexPath, '/supply-chain/');
+
+  SUPPLY_CHAIN_FEATURED_INCIDENT_IDS.forEach((id) => {
+    const route = `/supply-chain/incidents/${id}/`;
+    const filePath = htmlPathForRoute(route);
+    const html = readIfExists(filePath);
+    assertReady(Boolean(html), `${route} missing when enabled`);
+    assertReady(/Executive Summary/.test(html), `${route} missing Executive Summary`);
+    assertReady(/Timeline/.test(html), `${route} missing Timeline`);
+    assertReady(/Attack Chain/.test(html), `${route} missing Attack Chain`);
+    assertReady(/Defensive Lessons/.test(html), `${route} missing Defensive Lessons`);
+    assertSeo(filePath, route);
+  });
+
+  supplyChainHtmlFiles.forEach((filePath) => {
+    const html = readIfExists(filePath);
+    extractSupplyChainHrefs(html).forEach((href) => {
+      assertReady(expectedRouteUrls.has(href), `generated page links to unknown Supply Chain route: ${href}`);
+      assertReady(existsSync(htmlPathForRoute(href)), `generated page links to missing Supply Chain HTML: ${href}`);
+    });
+    assertReady(!/<meta name="robots" content="noindex, nofollow"/.test(html), `${filePath} should not be noindex when enabled`);
+    extractJsonLdBlocks(html).forEach((block, index) => {
+      try {
+        JSON.parse(block);
+      } catch (error) {
+        failures.push(`${filePath} JSON-LD block ${index + 1} is invalid JSON: ${error.message}`);
+      }
+    });
+  });
+
+  return { passed, generatedCount };
+}
+
+const data = loadSupplyChainData();
+
+runCheck('incident validation', 'python3 scripts/validate_supply_chain_incidents.py');
+runCheck('graph validation', 'python3 scripts/validate_supply_chain_graph.py');
+runCheck('page model test', 'node scripts/test-supply-chain-pages.mjs');
+runCheck('site dependency install', 'cd site && npm ci --no-audit --no-fund');
+
+assertDisabledBuild();
+const enabledResult = assertEnabledBuild(data);
+
+const status = failures.length === 0 ? 'pass' : 'fail';
+const report = writeReport(status, data, {
+  counts: {
+    enabled_generated_routes: enabledResult.generatedCount,
+  },
+});
+
+console.log(`Supply Chain public readiness: ${report.status.toUpperCase()}`);
+console.log(`Report: ${path.relative(repoRoot, reportPath)}`);
+if (failures.length > 0) {
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(1);
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "check:supply-chain-public-readiness": "node check_supply_chain_public_readiness.mjs",
     "social:share-x": "node social-share-x.mjs",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
## Summary\n- add a single-command Supply Chain public readiness gate\n- write .worker-state/supply-chain-public-readiness.json with PASS/FAIL, counts, checked routes, command checks, and failures\n- verify disabled/enabled feature-flag builds, featured editorial pages, SEO metadata, JSON-LD, internal links, nav behavior, and route counts\n- document the operator readiness workflow and add a scripts package alias\n\n## Validation\n- node --check scripts/check_supply_chain_public_readiness.mjs\n- node scripts/check_supply_chain_public_readiness.mjs\n- cd scripts && npm run check:supply-chain-public-readiness\n- git diff --check\n\nStacked on Phase 1F PR #1136.