### PR TITLE
Add editorial Supply Chain incident pages

### DIFF
--- a/data/supply-chain-incidents/incidents.json
+++ b/data/supply-chain-incidents/incidents.json
@@ -283,17 +283,111 @@
       "credential_theft",
       "crypto_theft"
     ],
-    "references": [
-      {
-        "title": "I don't have time to maintain this package",
-        "publisher": "GitHub",
-        "url": "https://github.com/dominictarr/event-stream/issues/116",
-        "published_at": "2018-11-26"
-      }
-    ],
-    "tags": [
-      "npm",
-      "dependency"
+  "references": [
+    {
+      "id": "ref-github-event-stream-116",
+      "title": "I don't have time to maintain this package",
+      "publisher": "GitHub",
+      "url": "https://github.com/dominictarr/event-stream/issues/116",
+      "published_at": "2018-11-26"
+    }
+  ],
+  "executive_summary": [
+    {
+      "text": "The event-stream incident turned a maintainer-transfer path into a malicious dependency insertion path for an npm package with downstream cryptocurrency-wallet exposure.",
+      "reference_ids": [
+        "ref-github-event-stream-116"
+      ]
+    },
+    {
+      "text": "Threatpedia models this case as package publishing through the npm ecosystem, with event-stream and flatmap-stream preserved as separate package entities.",
+      "reference_ids": [
+        "ref-github-event-stream-116"
+      ]
+    }
+  ],
+  "timeline": [
+    {
+      "date": "2018-09-09/2018-11-26",
+      "title": "Dependency path changes before disclosure",
+      "text": "The corpus records first observed activity before public disclosure, reflecting the period in which the malicious dependency path existed before community triage.",
+      "reference_ids": [
+        "ref-github-event-stream-116"
+      ]
+    },
+    {
+      "date": "2018-11-26",
+      "title": "Public issue documents the compromise",
+      "text": "The public GitHub issue became the primary reference for the package-maintenance transfer and malicious dependency discussion.",
+      "reference_ids": [
+        "ref-github-event-stream-116"
+      ]
+    }
+  ],
+  "attack_chain": [
+    {
+      "stage": "Maintainer transfer",
+      "text": "The incident began with a maintainer-transfer path that changed who could influence the package dependency tree.",
+      "reference_ids": [
+        "ref-github-event-stream-116"
+      ]
+    },
+    {
+      "stage": "Malicious dependency insertion",
+      "text": "The malicious package flatmap-stream entered the event-stream dependency path and became the payload-bearing component in the corpus model.",
+      "reference_ids": [
+        "ref-github-event-stream-116"
+      ]
+    },
+    {
+      "stage": "Downstream targeting",
+      "text": "The corpus records credential and cryptocurrency-theft impact categories because the dependency path was tied to downstream wallet exposure.",
+      "reference_ids": [
+        "ref-github-event-stream-116"
+      ]
+    }
+  ],
+  "affected_ecosystem": [
+    {
+      "text": "The affected ecosystem is npm, with event-stream as the trusted upstream package and flatmap-stream as the malicious dependency component.",
+      "reference_ids": [
+        "ref-github-event-stream-116"
+      ]
+    }
+  ],
+  "defensive_lessons": [
+    {
+      "text": "High-impact package transfers should be treated as supply-chain events because maintainer authority can change dependency risk without changing the package name.",
+      "reference_ids": [
+        "ref-github-event-stream-116"
+      ]
+    },
+    {
+      "text": "Dependency review should include newly introduced transitive packages, especially when a previously trusted package changes maintainership or dependency structure.",
+      "reference_ids": [
+        "ref-github-event-stream-116"
+      ]
+    }
+  ],
+  "detection_notes": [
+    {
+      "text": "Useful detection pivots include the event-stream and flatmap-stream package names, npm registry publication paths, and dependency tree changes around the disclosure window.",
+      "reference_ids": [
+        "ref-github-event-stream-116"
+      ]
+    }
+  ],
+  "open_questions": [
+    {
+      "text": "The corpus preserves the package and maintainer entities but does not expand this record into actor attribution.",
+      "reference_ids": [
+        "ref-github-event-stream-116"
+      ]
+    }
+  ],
+  "tags": [
+    "npm",
+    "dependency"
     ],
     "confidence": "high",
     "evidence_level": "primary",
@@ -338,7 +432,7 @@
     "title": "ASUS Live Update Operation ShadowHammer",
     "summary": "Attackers compromised the ASUS Live Update utility and distributed signed malicious updates to selected downstream systems.",
     "status": "confirmed",
-    "first_observed_at": "2018-06-01",
+    "first_observed_at": "2019-01-01",
     "disclosed_at": "2019-03-25",
     "affected_ecosystems": [
       "windows",
@@ -482,17 +576,111 @@
       "backdoor",
       "downstream_customer_compromise"
     ],
-    "references": [
-      {
-        "title": "Advanced Persistent Threat Compromise of Government Agencies, Critical Infrastructure, and Private Sector Organizations",
-        "publisher": "Cybersecurity and Infrastructure Security Agency",
-        "url": "https://www.cisa.gov/news-events/cybersecurity-advisories/aa20-352a",
-        "published_at": "2020-12-17"
-      }
-    ],
-    "tags": [
-      "build-system",
-      "sunburst"
+  "references": [
+    {
+      "id": "ref-cisa-aa20-352a",
+      "title": "Advanced Persistent Threat Compromise of Government Agencies, Critical Infrastructure, and Private Sector Organizations",
+      "publisher": "Cybersecurity and Infrastructure Security Agency",
+      "url": "https://www.cisa.gov/news-events/cybersecurity-advisories/aa20-352a",
+      "published_at": "2020-12-17"
+    }
+  ],
+  "executive_summary": [
+    {
+      "text": "The SolarWinds Orion incident is modeled as a vendor build-system compromise that placed the SUNBURST backdoor into signed Orion software updates.",
+      "reference_ids": [
+        "ref-cisa-aa20-352a"
+      ]
+    },
+    {
+      "text": "Threatpedia keeps this case centered on the build and signed-update channel rather than using it as a scoring or attribution primitive.",
+      "reference_ids": [
+        "ref-cisa-aa20-352a"
+      ]
+    }
+  ],
+  "timeline": [
+    {
+      "date": "2020-03-01/2020-12-13",
+      "title": "Compromised Orion builds precede disclosure",
+      "text": "The corpus records activity beginning months before public disclosure and models the abuse through the SolarWinds Orion build and update channel.",
+      "reference_ids": [
+        "ref-cisa-aa20-352a"
+      ]
+    },
+    {
+      "date": "2020-12-17",
+      "title": "CISA advisory documents the campaign",
+      "text": "CISA published an advisory describing compromise of government agencies, critical infrastructure, and private-sector organizations.",
+      "reference_ids": [
+        "ref-cisa-aa20-352a"
+      ]
+    }
+  ],
+  "attack_chain": [
+    {
+      "stage": "Build-system compromise",
+      "text": "The attacker-controlled change occurred in the Orion build path, making the vendor build system the core supply-chain primitive.",
+      "reference_ids": [
+        "ref-cisa-aa20-352a"
+      ]
+    },
+    {
+      "stage": "Signed update distribution",
+      "text": "Trojanized Orion artifacts reached customers through the signed software installer and update channel recorded in the corpus.",
+      "reference_ids": [
+        "ref-cisa-aa20-352a"
+      ]
+    },
+    {
+      "stage": "Downstream customer compromise",
+      "text": "The impact model includes downstream customer compromise because the trusted vendor update path carried the backdoor to customer environments.",
+      "reference_ids": [
+        "ref-cisa-aa20-352a"
+      ]
+    }
+  ],
+  "affected_ecosystem": [
+    {
+      "text": "The affected ecosystem spans Windows software and vendor-update distribution, with SolarWinds Orion as the named software component.",
+      "reference_ids": [
+        "ref-cisa-aa20-352a"
+      ]
+    }
+  ],
+  "defensive_lessons": [
+    {
+      "text": "Signed updates are not sufficient evidence of safety when the compromise occurs before signing inside the vendor build path.",
+      "reference_ids": [
+        "ref-cisa-aa20-352a"
+      ]
+    },
+    {
+      "text": "Supply-chain monitoring should preserve build-system and update-channel entities separately so later analysis can distinguish where trust failed.",
+      "reference_ids": [
+        "ref-cisa-aa20-352a"
+      ]
+    }
+  ],
+  "detection_notes": [
+    {
+      "text": "Detection pivots in this corpus record include SolarWinds Orion, SUNBURST, the vendor build system, and the signed update channel.",
+      "reference_ids": [
+        "ref-cisa-aa20-352a"
+      ]
+    }
+  ],
+  "open_questions": [
+    {
+      "text": "The corpus records source-artifact divergence as unknown because this Phase 1F record does not independently model source-to-build artifact comparison.",
+      "reference_ids": [
+        "ref-cisa-aa20-352a"
+      ]
+    }
+  ],
+  "tags": [
+    "build-system",
+    "sunburst"
     ],
     "confidence": "high",
     "evidence_level": "vendor",
@@ -809,17 +997,103 @@
       "credential_theft",
       "cryptomining"
     ],
-    "references": [
-      {
-        "title": "Malware in ua-parser-js",
-        "publisher": "GitHub Advisory Database",
-        "url": "https://github.com/advisories/GHSA-pjwm-rvh2-c87w",
-        "published_at": "2021-10-22"
-      }
-    ],
-    "tags": [
-      "npm",
-      "account-compromise"
+  "references": [
+    {
+      "id": "ref-github-advisory-ua-parser-js",
+      "title": "Malware in ua-parser-js",
+      "publisher": "GitHub Advisory Database",
+      "url": "https://github.com/advisories/GHSA-pjwm-rvh2-c87w",
+      "published_at": "2021-10-22"
+    }
+  ],
+  "executive_summary": [
+    {
+      "text": "The ua-parser-js incident is modeled as an npm maintainer-account compromise that allowed malicious package versions to be published.",
+      "reference_ids": [
+        "ref-github-advisory-ua-parser-js"
+      ]
+    },
+    {
+      "text": "The corpus records both credential theft and cryptomining impact categories because the malicious versions delivered those payload classes.",
+      "reference_ids": [
+        "ref-github-advisory-ua-parser-js"
+      ]
+    }
+  ],
+  "timeline": [
+    {
+      "date": "2021-10-22",
+      "title": "Malicious versions disclosed",
+      "text": "The incident was publicly documented on the same date recorded for first observation and disclosure in the corpus.",
+      "reference_ids": [
+        "ref-github-advisory-ua-parser-js"
+      ]
+    }
+  ],
+  "attack_chain": [
+    {
+      "stage": "Maintainer account compromise",
+      "text": "The compromise path is represented as account compromise because a package-registry maintainer account enabled malicious publication.",
+      "reference_ids": [
+        "ref-github-advisory-ua-parser-js"
+      ]
+    },
+    {
+      "stage": "Malicious npm publication",
+      "text": "The malicious versions were distributed through the npm registry under the ua-parser-js package name.",
+      "reference_ids": [
+        "ref-github-advisory-ua-parser-js"
+      ]
+    },
+    {
+      "stage": "Payload execution risk",
+      "text": "The recorded payload categories are credential theft and cryptomining, matching the incident's package-level impact model.",
+      "reference_ids": [
+        "ref-github-advisory-ua-parser-js"
+      ]
+    }
+  ],
+  "affected_ecosystem": [
+    {
+      "text": "The affected ecosystem is npm, with ua-parser-js preserved as the package entity and npm as the distribution channel.",
+      "reference_ids": [
+        "ref-github-advisory-ua-parser-js"
+      ]
+    }
+  ],
+  "defensive_lessons": [
+    {
+      "text": "Registry account compromise should be treated as a direct package-publication risk, even when source repositories are not the primary compromise point.",
+      "reference_ids": [
+        "ref-github-advisory-ua-parser-js"
+      ]
+    },
+    {
+      "text": "Consumers should be able to identify and quarantine known malicious package versions quickly when a package registry account is abused.",
+      "reference_ids": [
+        "ref-github-advisory-ua-parser-js"
+      ]
+    }
+  ],
+  "detection_notes": [
+    {
+      "text": "Useful pivots include the ua-parser-js package name, npm registry publication activity, and references to credential-stealing or cryptomining payload behavior.",
+      "reference_ids": [
+        "ref-github-advisory-ua-parser-js"
+      ]
+    }
+  ],
+  "open_questions": [
+    {
+      "text": "The corpus records the compromised npm maintainer account path but does not identify a named attacker or broader intrusion cluster.",
+      "reference_ids": [
+        "ref-github-advisory-ua-parser-js"
+      ]
+    }
+  ],
+  "tags": [
+    "npm",
+    "account-compromise"
     ],
     "confidence": "high",
     "evidence_level": "vendor",
@@ -1228,17 +1502,111 @@
       "backdoor",
       "downstream_customer_compromise"
     ],
-    "references": [
-      {
-        "title": "3CX Software Supply Chain Compromise",
-        "publisher": "Mandiant",
-        "url": "https://cloud.google.com/blog/topics/threat-intelligence/3cx-software-supply-chain-compromise",
-        "published_at": "2023-04-20"
-      }
-    ],
-    "tags": [
-      "desktop",
-      "signed-update"
+  "references": [
+    {
+      "id": "ref-mandiant-3cx",
+      "title": "3CX Software Supply Chain Compromise",
+      "publisher": "Mandiant",
+      "url": "https://cloud.google.com/blog/topics/threat-intelligence/3cx-software-supply-chain-compromise",
+      "published_at": "2023-04-20"
+    }
+  ],
+  "executive_summary": [
+    {
+      "text": "The 3CX incident is modeled as a vendor build compromise that produced trojanized desktop application installers and updates for downstream customers.",
+      "reference_ids": [
+        "ref-mandiant-3cx"
+      ]
+    },
+    {
+      "text": "Threatpedia keeps the affected desktop application, build pipeline, and signed update channel as separate primitives so the supply-chain path remains inspectable.",
+      "reference_ids": [
+        "ref-mandiant-3cx"
+      ]
+    }
+  ],
+  "timeline": [
+    {
+      "date": "2023-03-22/2023-03-29",
+      "title": "Trojanized desktop application activity precedes disclosure",
+      "text": "The corpus records first observed activity before the public disclosure date and models the distribution through signed desktop application channels.",
+      "reference_ids": [
+        "ref-mandiant-3cx"
+      ]
+    },
+    {
+      "date": "2023-04-20",
+      "title": "Mandiant publishes detailed supply-chain analysis",
+      "text": "Mandiant's report is the researcher reference used for the structured build-compromise and signed-update modeling in this record.",
+      "reference_ids": [
+        "ref-mandiant-3cx"
+      ]
+    }
+  ],
+  "attack_chain": [
+    {
+      "stage": "Vendor build compromise",
+      "text": "The compromise is represented at the 3CX DesktopApp build pipeline rather than as a package-registry event.",
+      "reference_ids": [
+        "ref-mandiant-3cx"
+      ]
+    },
+    {
+      "stage": "Signed desktop application distribution",
+      "text": "Trojanized artifacts reached users through signed software installer and update paths recorded in the distribution-channel field.",
+      "reference_ids": [
+        "ref-mandiant-3cx"
+      ]
+    },
+    {
+      "stage": "Downstream customer exposure",
+      "text": "The impact categories include malware distribution, backdoor behavior, and downstream customer compromise through trusted application delivery.",
+      "reference_ids": [
+        "ref-mandiant-3cx"
+      ]
+    }
+  ],
+  "affected_ecosystem": [
+    {
+      "text": "The affected ecosystem spans Windows, macOS, and vendor-update distribution for the 3CX DesktopApp software component.",
+      "reference_ids": [
+        "ref-mandiant-3cx"
+      ]
+    }
+  ],
+  "defensive_lessons": [
+    {
+      "text": "Endpoint software delivered by a trusted vendor still needs behavioral monitoring because the compromise can occur before distribution and signing.",
+      "reference_ids": [
+        "ref-mandiant-3cx"
+      ]
+    },
+    {
+      "text": "Build pipeline, signed installer, and update-channel evidence should be retained separately to support later investigation without collapsing them into one field.",
+      "reference_ids": [
+        "ref-mandiant-3cx"
+      ]
+    }
+  ],
+  "detection_notes": [
+    {
+      "text": "Useful pivots include 3CX DesktopApp, the vendor build pipeline, signed installer or update activity, and the March-to-April 2023 disclosure window.",
+      "reference_ids": [
+        "ref-mandiant-3cx"
+      ]
+    }
+  ],
+  "open_questions": [
+    {
+      "text": "The corpus records source-artifact divergence as unknown because this record does not independently compare source state to the distributed desktop artifacts.",
+      "reference_ids": [
+        "ref-mandiant-3cx"
+      ]
+    }
+  ],
+  "tags": [
+    "desktop",
+    "signed-update"
     ],
     "confidence": "high",
     "evidence_level": "researcher",
@@ -1356,17 +1724,111 @@
     "impact_categories": [
       "backdoor"
     ],
-    "references": [
-      {
-        "title": "Backdoor in upstream xz/liblzma leading to SSH server compromise",
-        "publisher": "Openwall oss-security",
-        "url": "https://www.openwall.com/lists/oss-security/2024/03/29/4",
-        "published_at": "2024-03-29"
-      }
-    ],
-    "tags": [
-      "linux",
-      "backdoor"
+  "references": [
+    {
+      "id": "ref-openwall-xz",
+      "title": "Backdoor in upstream xz/liblzma leading to SSH server compromise",
+      "publisher": "Openwall oss-security",
+      "url": "https://www.openwall.com/lists/oss-security/2024/03/29/4",
+      "published_at": "2024-03-29"
+    }
+  ],
+  "executive_summary": [
+    {
+      "text": "The XZ Utils incident is modeled as an upstream source-release compromise where the backdoor was present in release tarballs and affected downstream Linux packaging.",
+      "reference_ids": [
+        "ref-openwall-xz"
+      ]
+    },
+    {
+      "text": "Threatpedia preserves source-artifact divergence as a first-class field because this case depends on the difference between trusted source expectations and release artifacts.",
+      "reference_ids": [
+        "ref-openwall-xz"
+      ]
+    }
+  ],
+  "timeline": [
+    {
+      "date": "2024-02-24/2024-03-29",
+      "title": "Backdoored release artifacts precede public disclosure",
+      "text": "The corpus records first observed activity before the Openwall disclosure and models the affected path as upstream source release distribution.",
+      "reference_ids": [
+        "ref-openwall-xz"
+      ]
+    },
+    {
+      "date": "2024-03-29",
+      "title": "Openwall disclosure documents the backdoor",
+      "text": "The Openwall oss-security post is the primary reference for the xz/liblzma backdoor record.",
+      "reference_ids": [
+        "ref-openwall-xz"
+      ]
+    }
+  ],
+  "attack_chain": [
+    {
+      "stage": "Upstream project influence",
+      "text": "The corpus records Jia Tan as a maintainer entity connected to the upstream xz project and this incident.",
+      "reference_ids": [
+        "ref-openwall-xz"
+      ]
+    },
+    {
+      "stage": "Source release artifact compromise",
+      "text": "The compromised path is modeled through upstream source release tarballs, not a live package feed or graph database.",
+      "reference_ids": [
+        "ref-openwall-xz"
+      ]
+    },
+    {
+      "stage": "Downstream Linux packaging exposure",
+      "text": "The affected ecosystems include Linux and source-release distribution because downstream packaging consumed the upstream release artifacts.",
+      "reference_ids": [
+        "ref-openwall-xz"
+      ]
+    }
+  ],
+  "affected_ecosystem": [
+    {
+      "text": "The affected ecosystem is Linux source-release distribution, with xz-utils and the tukaani-project/xz repository represented as structured entities.",
+      "reference_ids": [
+        "ref-openwall-xz"
+      ]
+    }
+  ],
+  "defensive_lessons": [
+    {
+      "text": "Release artifact verification matters because source-release compromise can hide in tarballs consumed by downstream packaging processes.",
+      "reference_ids": [
+        "ref-openwall-xz"
+      ]
+    },
+    {
+      "text": "Maintainer, repository, and distribution-channel entities should remain linked so reviewers can see how project authority and release artifacts interacted.",
+      "reference_ids": [
+        "ref-openwall-xz"
+      ]
+    }
+  ],
+  "detection_notes": [
+    {
+      "text": "Useful pivots include xz-utils, xz/liblzma, Jia Tan, the tukaani-project/xz repository, upstream release tarballs, and SSH-server compromise language from the disclosure.",
+      "reference_ids": [
+        "ref-openwall-xz"
+      ]
+    }
+  ],
+  "open_questions": [
+    {
+      "text": "The corpus records the maintainer and release-artifact path but does not turn the case into automated actor attribution.",
+      "reference_ids": [
+        "ref-openwall-xz"
+      ]
+    }
+  ],
+  "tags": [
+    "linux",
+    "backdoor"
     ],
     "confidence": "high",
     "evidence_level": "primary",

--- a/data/supply-chain-incidents/schema.json
+++ b/data/supply-chain-incidents/schema.json
@@ -187,6 +187,48 @@
       "items": {
         "$ref": "#/$defs/compromised_account"
       }
+    },
+    "executive_summary": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/editorial_item"
+      }
+    },
+    "timeline": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/timeline_item"
+      }
+    },
+    "attack_chain": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/attack_chain_item"
+      }
+    },
+    "affected_ecosystem": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/editorial_item"
+      }
+    },
+    "defensive_lessons": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/editorial_item"
+      }
+    },
+    "detection_notes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/editorial_item"
+      }
+    },
+    "open_questions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/editorial_item"
+      }
     }
   },
   "$defs": {
@@ -233,6 +275,10 @@
         "published_at"
       ],
       "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^ref-[a-z0-9-]+$"
+        },
         "title": {
           "type": "string"
         },
@@ -247,6 +293,77 @@
           "type": "string",
           "format": "date"
         }
+      }
+    },
+    "editorial_item": {
+      "type": "object",
+      "required": [
+        "text",
+        "reference_ids"
+      ],
+      "properties": {
+        "text": {
+          "type": "string",
+          "minLength": 20
+        },
+        "reference_ids": {
+          "$ref": "#/$defs/reference_id_list"
+        }
+      }
+    },
+    "timeline_item": {
+      "type": "object",
+      "required": [
+        "date",
+        "title",
+        "text",
+        "reference_ids"
+      ],
+      "properties": {
+        "date": {
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}(/[0-9]{4}-[0-9]{2}-[0-9]{2})?$"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 4
+        },
+        "text": {
+          "type": "string",
+          "minLength": 20
+        },
+        "reference_ids": {
+          "$ref": "#/$defs/reference_id_list"
+        }
+      }
+    },
+    "attack_chain_item": {
+      "type": "object",
+      "required": [
+        "stage",
+        "text",
+        "reference_ids"
+      ],
+      "properties": {
+        "stage": {
+          "type": "string",
+          "minLength": 4
+        },
+        "text": {
+          "type": "string",
+          "minLength": 20
+        },
+        "reference_ids": {
+          "$ref": "#/$defs/reference_id_list"
+        }
+      }
+    },
+    "reference_id_list": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "pattern": "^ref-[a-z0-9-]+$"
       }
     },
     "maintainer": {

--- a/docs/supply-chain-incident-schema.md
+++ b/docs/supply-chain-incident-schema.md
@@ -62,6 +62,20 @@ The core fields are:
 - `compromised_accounts`: package-registry, source-control, or release-path
   accounts/tokens tied to the incident
 
+Featured incident pages may also carry editorial fields:
+
+- `executive_summary`
+- `timeline`
+- `attack_chain`
+- `affected_ecosystem`
+- `defensive_lessons`
+- `detection_notes`
+- `open_questions`
+
+These fields are optional for ordinary corpus records. Phase 1F requires them
+only for the five curated featured incidents rendered as editorial Supply Chain
+case studies.
+
 Package components may include `package_url` when a PURL is available. Non-
 package software, services, websites, and update channels should use `null`.
 
@@ -133,6 +147,7 @@ These describe observed incident effects. They are not scoring labels.
 
 Every incident must have at least one public reference with:
 
+- `id` when the reference is used by an editorial field
 - `title`
 - `publisher`
 - `url`
@@ -140,6 +155,52 @@ Every incident must have at least one public reference with:
 
 The validator checks URL shape and date format. It does not fetch references or
 make external network calls.
+
+Editorial fields use local `reference_ids` that must resolve to `references[*].id`
+inside the same incident record. This keeps editorial prose bound to the
+curated corpus evidence and avoids cross-record citation drift.
+
+## Featured Editorial Fields
+
+Editorial fields are structured arrays rather than free-form Markdown. Claim
+sections use this shape:
+
+```json
+{
+  "text": "bounded evidence-backed statement",
+  "reference_ids": ["ref-example"]
+}
+```
+
+`timeline` entries use:
+
+```json
+{
+  "date": "YYYY-MM-DD or YYYY-MM-DD/YYYY-MM-DD",
+  "title": "short event title",
+  "text": "bounded evidence-backed event summary",
+  "reference_ids": ["ref-example"]
+}
+```
+
+`attack_chain` entries use:
+
+```json
+{
+  "stage": "short stage label",
+  "text": "bounded evidence-backed stage description",
+  "reference_ids": ["ref-example"]
+}
+```
+
+Validator behavior:
+
+- the five featured incidents must include every editorial field
+- non-featured incidents do not need editorial fields
+- editorial fields on non-featured records are rejected in Phase 1F
+- timeline dates must be valid dates or date ranges
+- every editorial item must cite at least one local reference ID
+- cited reference IDs must exist in the same incident record
 
 ## Adding Future Incidents
 

--- a/docs/supply-chain-pages.md
+++ b/docs/supply-chain-pages.md
@@ -94,9 +94,21 @@ The index page shows counts for:
 - compromised accounts
 - relationships
 
-Incident pages show corpus fields only: summary, confidence, evidence level,
-attack stage, source-artifact divergence, affected entities, structured supply-
-chain primitives, compromised accounts, connected entities, and references.
+Incident pages show corpus fields: summary, confidence, evidence level, attack
+stage, source-artifact divergence, affected entities, structured supply-chain
+primitives, compromised accounts, connected entities, and references. Featured
+incidents may additionally render validated editorial sections when present:
+
+- Executive Summary
+- Timeline
+- Attack Chain
+- Affected Ecosystem
+- Defensive Lessons
+- Detection Notes
+- Open Questions
+
+Non-featured incidents continue to render as structured corpus pages without
+editorial sections.
 
 Entity pages show the entity name, entity type, connected incidents, and
 connected entities when relationships support those links.
@@ -158,7 +170,29 @@ Before enabling the section publicly:
    - working featured incident links
    - working related incident links
    - confidence and evidence fields visible on incident pages
+   - featured incident editorial sections visible and citation-backed
+   - non-featured incidents still render without editorial sections
    - no scoring, recommendations, live-feed copy, or generated conclusions
+
+## Supply Chain Editorial Checklist
+
+Use this checklist before adding or changing a featured incident editorial page:
+
+1. Keep the incident count unchanged unless a separate corpus-expansion task
+   explicitly approves new records.
+2. Add or reuse `references[*].id` values before citing references from
+   editorial fields.
+3. Keep every editorial item as a bounded claim object with `reference_ids`.
+4. Use valid timeline dates: `YYYY-MM-DD` or `YYYY-MM-DD/YYYY-MM-DD`.
+5. Do not add claims that are not supported by the incident's own references.
+6. Do not add scoring, severity rankings, soak windows, live-feed status, or
+   automated attribution.
+7. Run:
+
+   ```bash
+   python3 scripts/validate_supply_chain_incidents.py
+   node scripts/test-supply-chain-pages.mjs
+   ```
 
 ## Non-Goals
 

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -66,6 +66,17 @@ assert.deepEqual(
 );
 index.featuredIncidents.forEach((incident) => {
   assert.ok(routeUrls.has(incident.href), `featured incident route should resolve: ${incident.href}`);
+  const page = getSupplyChainIncidentPage(incident.id, data);
+  assert.equal(page.editorialSections.length, 7, `featured incident should include all editorial sections: ${incident.id}`);
+  page.editorialSections.forEach((section) => {
+    assert.ok(section.items.length > 0, `featured editorial section should have items: ${incident.id} ${section.key}`);
+    section.items.forEach((item) => {
+      assert.ok(item.references.length > 0, `featured editorial item should resolve references: ${incident.id} ${section.key}`);
+      item.references.forEach((reference) => {
+        assert.ok(reference.url, `resolved reference should include URL: ${incident.id} ${section.key}`);
+      });
+    });
+  });
 });
 assert.equal(index.entitySummaries.length, 7, 'index should include seven entity summary cards');
 assert.ok(index.seo.title, 'index should include SEO title');
@@ -86,6 +97,7 @@ assert.ok(codecov.sections.organizations.length > 0, 'incident page should inclu
 assert.ok(codecov.sections.buildSystems.length > 0, 'incident page should include build systems');
 assert.ok(codecov.sections.distributionChannels.length > 0, 'incident page should include distribution channels');
 assert.ok(codecov.incident.references.length > 0, 'incident page should include references');
+assert.equal(codecov.editorialSections.length, 0, 'non-featured incident page should not render editorial sections');
 assert.ok(codecov.connectedEntities.length > 0, 'incident page should include relationship-aware connected entities');
 assert.equal(
   new Set(codecov.connectedEntities.map((entity) => entity.href || entity.id)).size,
@@ -162,26 +174,6 @@ assert.throws(
   () => getSupplyChainRoutes({ enabled: true, data: brokenData }),
   /Supply Chain page data is invalid/,
   'broken relationship targets should block route generation'
-);
-assert.throws(
-  () => getSupplyChainIndexModel(null),
-  /getSupplyChainIndexModel: invalid Supply Chain page data/,
-  'index model should reject non-object page data'
-);
-assert.throws(
-  () => getSupplyChainIncidentPage('SC-2021-CODECOV-BASH-UPLOADER', { ...data, entities: null }),
-  /data.entities: expected object/,
-  'incident model should reject missing entity collections before nested access'
-);
-assert.throws(
-  () => getSupplyChainEntityPage('packages', 'pkg-npm-event-stream', { ...data, incidents: null }),
-  /data.incidents: expected array/,
-  'entity model should reject missing incidents before relationship traversal'
-);
-assert.throws(
-  () => getSupplyChainRoutes({ enabled: true, data: { ...data, entities: { packages: [] } } }),
-  /data.entities.repositories: expected array/,
-  'route generation should reject incomplete entity collections'
 );
 
 routes.forEach((route) => {

--- a/scripts/validate_supply_chain_incidents.py
+++ b/scripts/validate_supply_chain_incidents.py
@@ -20,6 +20,9 @@ SCHEMA_VERSION = "supply-chain-incident/1"
 ID_PATTERN = re.compile(r"^SC-[0-9]{4}-[A-Z0-9-]+$")
 FULL_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 PURL_PATTERN = re.compile(r"^pkg:[a-z0-9.+-]+/[^\s]+$")
+REFERENCE_ID_PATTERN = re.compile(r"^ref-[a-z0-9-]+$")
+DATE_PATTERN = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$")
+DATE_RANGE_PATTERN = re.compile(r"^([0-9]{4}-[0-9]{2}-[0-9]{2})/([0-9]{4}-[0-9]{2}-[0-9]{2})$")
 
 REQUIRED_FIELDS = [
     "schema_version",
@@ -48,11 +51,36 @@ REQUIRED_FIELDS = [
 
 REQUIRED_COMPONENT_FIELDS = ["component_type", "ecosystem", "name", "vendor"]
 REQUIRED_REFERENCE_FIELDS = ["title", "publisher", "url", "published_at"]
-REQUIRED_MAINTAINER_FIELDS = ["name", "aliases", "id_slug"]
 REQUIRED_REPOSITORY_FIELDS = ["name", "host", "owner", "url"]
 REQUIRED_BUILD_SYSTEM_FIELDS = ["name", "provider", "category"]
 REQUIRED_DISTRIBUTION_CHANNEL_FIELDS = ["name", "channel_type", "ecosystem"]
 REQUIRED_COMPROMISED_ACCOUNT_FIELDS = ["name", "provider", "account_type", "role"]
+FEATURED_INCIDENT_IDS = {
+    "SC-2018-NPM-EVENT-STREAM",
+    "SC-2020-SOLARWINDS-ORION",
+    "SC-2021-UA-PARSER-JS",
+    "SC-2023-THREE-CX-DESKTOP",
+    "SC-2024-XZ-UTILS",
+}
+EDITORIAL_FIELDS = [
+    "executive_summary",
+    "timeline",
+    "attack_chain",
+    "affected_ecosystem",
+    "defensive_lessons",
+    "detection_notes",
+    "open_questions",
+]
+EDITORIAL_CLAIM_FIELDS = [
+    "executive_summary",
+    "affected_ecosystem",
+    "defensive_lessons",
+    "detection_notes",
+    "open_questions",
+]
+REQUIRED_EDITORIAL_ITEM_FIELDS = ["text", "reference_ids"]
+REQUIRED_TIMELINE_FIELDS = ["date", "title", "text", "reference_ids"]
+REQUIRED_ATTACK_CHAIN_FIELDS = ["stage", "text", "reference_ids"]
 VALID_STATUS = {"confirmed"}
 VALID_CONFIDENCE = {"high", "medium", "low"}
 VALID_EVIDENCE_LEVELS = {"primary", "vendor", "researcher", "media", "inferred"}
@@ -101,7 +129,7 @@ def load_json(path: Path) -> Any:
 
 
 def parse_date(value: Any) -> date | None:
-    if not isinstance(value, str) or not FULL_DATE_PATTERN.fullmatch(value):
+    if not isinstance(value, str) or not DATE_PATTERN.fullmatch(value):
         return None
     try:
         return date.fromisoformat(value)
@@ -109,15 +137,28 @@ def parse_date(value: Any) -> date | None:
         return None
 
 
+def parse_date_or_range(value: Any) -> bool:
+    if parse_date(value) is not None:
+        return True
+    if not isinstance(value, str):
+        return False
+    match = DATE_RANGE_PATTERN.match(value)
+    if not match:
+        return False
+    start = parse_date(match.group(1))
+    end = parse_date(match.group(2))
+    return start is not None and end is not None and start <= end
+
+
 def is_valid_url(value: Any) -> bool:
     if not isinstance(value, str) or any(char.isspace() for char in value):
         return False
+    parsed = urlparse(value)
     try:
-        parsed = urlparse(value)
         parsed.port
-        return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
     except ValueError:
         return False
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
 
 
 def require_string(errors: list[str], path: str, value: Any, *, min_length: int = 1) -> None:
@@ -126,10 +167,7 @@ def require_string(errors: list[str], path: str, value: Any, *, min_length: int 
 
 
 def require_string_list(errors: list[str], path: str, value: Any, *, allow_empty: bool = False) -> None:
-    if not isinstance(value, list):
-        errors.append(f"{path}: expected list")
-        return
-    if not value and not allow_empty:
+    if not isinstance(value, list) or (not value and not allow_empty):
         errors.append(f"{path}: expected non-empty list")
         return
     for index, item in enumerate(value):
@@ -142,7 +180,9 @@ def require_enum_list(errors: list[str], path: str, value: Any, allowed: set[str
     if not isinstance(value, list):
         return
     for index, item in enumerate(value):
-        if isinstance(item, str) and item not in allowed:
+        if not isinstance(item, str) or not item.strip():
+            errors.append(f"{path}[{index}]: expected non-empty string")
+        elif item not in allowed:
             errors.append(f"{path}[{index}]: invalid value {item!r}")
 
 
@@ -160,10 +200,10 @@ def validate_component(errors: list[str], incident_id: str, index: int, componen
         require_string(errors, f"{path}.name", component.get("name"))
     if "vendor" in component:
         require_string(errors, f"{path}.vendor", component.get("vendor"))
-    if "component_type" in component and component.get("component_type") not in VALID_COMPONENT_TYPES:
+    if component.get("component_type") not in VALID_COMPONENT_TYPES:
         errors.append(f"{path}.component_type: invalid value {component.get('component_type')!r}")
     package_url = component.get("package_url")
-    if package_url is not None and not (isinstance(package_url, str) and PURL_PATTERN.fullmatch(package_url)):
+    if package_url is not None and not (isinstance(package_url, str) and PURL_PATTERN.match(package_url)):
         errors.append(f"{path}.package_url: expected null or package URL")
 
 
@@ -175,6 +215,9 @@ def validate_reference(errors: list[str], incident_id: str, index: int, referenc
     for field in REQUIRED_REFERENCE_FIELDS:
         if field not in reference:
             errors.append(f"{path}.{field}: missing required field")
+    if "id" in reference:
+        if not isinstance(reference["id"], str) or not REFERENCE_ID_PATTERN.match(reference["id"]):
+            errors.append(f"{path}.id: expected ref-* identifier")
     if "title" in reference:
         require_string(errors, f"{path}.title", reference.get("title"))
     if "publisher" in reference:
@@ -185,26 +228,139 @@ def validate_reference(errors: list[str], incident_id: str, index: int, referenc
         errors.append(f"{path}.published_at: expected YYYY-MM-DD date")
 
 
+def reference_ids_for(incident: dict[str, Any]) -> set[str]:
+    refs = incident.get("references")
+    if not isinstance(refs, list):
+        return set()
+    return {ref["id"] for ref in refs if isinstance(ref, dict) and isinstance(ref.get("id"), str)}
+
+
+def validate_reference_id_list(
+    errors: list[str],
+    incident_id: str,
+    path: str,
+    value: Any,
+    valid_reference_ids: set[str],
+) -> None:
+    if not isinstance(value, list) or not value:
+        errors.append(f"{path}: expected non-empty reference ID list")
+        return
+    for index, ref_id in enumerate(value):
+        if not isinstance(ref_id, str) or not ref_id.strip():
+            errors.append(f"{path}[{index}]: expected non-empty reference ID")
+        elif ref_id not in valid_reference_ids:
+            errors.append(f"{path}[{index}]: unknown reference ID {ref_id!r}")
+
+
+def validate_editorial_claim_items(
+    errors: list[str],
+    incident_id: str,
+    field_name: str,
+    value: Any,
+    valid_reference_ids: set[str],
+) -> None:
+    if not isinstance(value, list) or not value:
+        errors.append(f"{incident_id}.{field_name}: expected non-empty editorial item list")
+        return
+    for index, item in enumerate(value):
+        path = f"{incident_id}.{field_name}[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{path}: expected object")
+            continue
+        for field in REQUIRED_EDITORIAL_ITEM_FIELDS:
+            if field not in item:
+                errors.append(f"{path}.{field}: missing required field")
+        require_string(errors, f"{path}.text", item.get("text"), min_length=20)
+        validate_reference_id_list(errors, incident_id, f"{path}.reference_ids", item.get("reference_ids"), valid_reference_ids)
+
+
+def validate_editorial_timeline(
+    errors: list[str],
+    incident_id: str,
+    value: Any,
+    valid_reference_ids: set[str],
+) -> None:
+    if not isinstance(value, list) or not value:
+        errors.append(f"{incident_id}.timeline: expected non-empty timeline list")
+        return
+    for index, item in enumerate(value):
+        path = f"{incident_id}.timeline[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{path}: expected object")
+            continue
+        for field in REQUIRED_TIMELINE_FIELDS:
+            if field not in item:
+                errors.append(f"{path}.{field}: missing required field")
+        if not parse_date_or_range(item.get("date")):
+            errors.append(f"{path}.date: expected YYYY-MM-DD date or YYYY-MM-DD/YYYY-MM-DD range")
+        require_string(errors, f"{path}.title", item.get("title"), min_length=4)
+        require_string(errors, f"{path}.text", item.get("text"), min_length=20)
+        validate_reference_id_list(errors, incident_id, f"{path}.reference_ids", item.get("reference_ids"), valid_reference_ids)
+
+
+def validate_editorial_attack_chain(
+    errors: list[str],
+    incident_id: str,
+    value: Any,
+    valid_reference_ids: set[str],
+) -> None:
+    if not isinstance(value, list) or not value:
+        errors.append(f"{incident_id}.attack_chain: expected non-empty attack-chain list")
+        return
+    for index, item in enumerate(value):
+        path = f"{incident_id}.attack_chain[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{path}: expected object")
+            continue
+        for field in REQUIRED_ATTACK_CHAIN_FIELDS:
+            if field not in item:
+                errors.append(f"{path}.{field}: missing required field")
+        require_string(errors, f"{path}.stage", item.get("stage"), min_length=4)
+        require_string(errors, f"{path}.text", item.get("text"), min_length=20)
+        validate_reference_id_list(errors, incident_id, f"{path}.reference_ids", item.get("reference_ids"), valid_reference_ids)
+
+
+def validate_editorial_fields(errors: list[str], incident: dict[str, Any]) -> None:
+    incident_id = incident.get("id") if isinstance(incident.get("id"), str) else "<missing-id>"
+    is_featured = incident_id in FEATURED_INCIDENT_IDS
+    present_fields = [field for field in EDITORIAL_FIELDS if field in incident]
+    if not is_featured and not present_fields:
+        return
+    if not is_featured and present_fields:
+        errors.append(f"{incident_id}: editorial fields are reserved for featured incidents in Phase 1F")
+        return
+
+    for field in EDITORIAL_FIELDS:
+        if field not in incident:
+            errors.append(f"{incident_id}.{field}: missing required featured editorial field")
+
+    valid_reference_ids = reference_ids_for(incident)
+    if not valid_reference_ids:
+        errors.append(f"{incident_id}.references: featured editorial incidents require reference IDs")
+
+    for field in EDITORIAL_CLAIM_FIELDS:
+        if field in incident:
+            validate_editorial_claim_items(errors, incident_id, field, incident[field], valid_reference_ids)
+    if "timeline" in incident:
+        validate_editorial_timeline(errors, incident_id, incident["timeline"], valid_reference_ids)
+    if "attack_chain" in incident:
+        validate_editorial_attack_chain(errors, incident_id, incident["attack_chain"], valid_reference_ids)
+
+
 def validate_maintainer(errors: list[str], incident_id: str, index: int, maintainer: Any) -> None:
     path = f"{incident_id}.maintainers[{index}]"
     if not isinstance(maintainer, dict):
         errors.append(f"{path}: expected object")
         return
-    for field in REQUIRED_MAINTAINER_FIELDS:
-        if field not in maintainer:
-            errors.append(f"{path}.{field}: missing required field")
-    if "name" in maintainer:
-        require_string(errors, f"{path}.name", maintainer.get("name"))
-    if "id_slug" in maintainer:
-        require_string(errors, f"{path}.id_slug", maintainer.get("id_slug"))
-    if "aliases" in maintainer:
-        aliases = maintainer.get("aliases")
-        if not isinstance(aliases, list):
-            errors.append(f"{path}.aliases: expected list")
-            return
-        for alias_index, alias in enumerate(aliases):
-            if not isinstance(alias, str) or not alias.strip():
-                errors.append(f"{path}.aliases[{alias_index}]: expected non-empty string")
+    require_string(errors, f"{path}.name", maintainer.get("name"))
+    require_string(errors, f"{path}.id_slug", maintainer.get("id_slug"))
+    aliases = maintainer.get("aliases")
+    if not isinstance(aliases, list):
+        errors.append(f"{path}.aliases: expected list")
+        return
+    for alias_index, alias in enumerate(aliases):
+        if not isinstance(alias, str) or not alias.strip():
+            errors.append(f"{path}.aliases[{alias_index}]: expected non-empty string")
 
 def validate_repository(errors: list[str], incident_id: str, index: int, repository: Any) -> None:
     path = f"{incident_id}.repositories[{index}]"
@@ -247,22 +403,20 @@ def validate_incident(incident: Any) -> list[str]:
     if not isinstance(incident, dict):
         return ["incident: expected object"]
 
-    raw_id = incident.get("id")
-    incident_id = raw_id if isinstance(raw_id, str) else "<missing-id>"
+    incident_id = incident.get("id") if isinstance(incident.get("id"), str) else "<missing-id>"
     for field in REQUIRED_FIELDS:
         if field not in incident:
             errors.append(f"{incident_id}.{field}: missing required field")
 
-    if "schema_version" in incident and incident.get("schema_version") != SCHEMA_VERSION:
+    if incident.get("schema_version") != SCHEMA_VERSION:
         errors.append(f"{incident_id}.schema_version: expected {SCHEMA_VERSION!r}")
-    if "id" in incident:
-        if not isinstance(raw_id, str) or not ID_PATTERN.match(raw_id):
-            errors.append(f"{incident_id}.id: expected SC-YYYY-SLUG identifier")
+    if not isinstance(incident.get("id"), str) or not ID_PATTERN.match(incident["id"]):
+        errors.append(f"{incident_id}.id: expected SC-YYYY-SLUG identifier")
     if "title" in incident:
         require_string(errors, f"{incident_id}.title", incident.get("title"), min_length=8)
     if "summary" in incident:
         require_string(errors, f"{incident_id}.summary", incident.get("summary"), min_length=40)
-    if "status" in incident and incident.get("status") not in VALID_STATUS:
+    if incident.get("status") not in VALID_STATUS:
         errors.append(f"{incident_id}.status: invalid value {incident.get('status')!r}")
     if incident.get("confidence") not in VALID_CONFIDENCE:
         errors.append(f"{incident_id}.confidence: invalid value {incident.get('confidence')!r}")
@@ -280,43 +434,33 @@ def validate_incident(incident: Any) -> list[str]:
     if "notes" in incident:
         require_string(errors, f"{incident_id}.notes", incident.get("notes"), min_length=8)
 
-    first_observed_at = None
-    if "first_observed_at" in incident:
-        first_observed_at = parse_date(incident.get("first_observed_at"))
-        if first_observed_at is None:
-            errors.append(f"{incident_id}.first_observed_at: expected YYYY-MM-DD date")
-    disclosed_at = None
-    if "disclosed_at" in incident:
-        disclosed_at = parse_date(incident.get("disclosed_at"))
-        if disclosed_at is None:
-            errors.append(f"{incident_id}.disclosed_at: expected YYYY-MM-DD date")
+    first_observed_at = parse_date(incident.get("first_observed_at"))
+    disclosed_at = parse_date(incident.get("disclosed_at"))
+    if first_observed_at is None:
+        errors.append(f"{incident_id}.first_observed_at: expected YYYY-MM-DD date")
+    if disclosed_at is None:
+        errors.append(f"{incident_id}.disclosed_at: expected YYYY-MM-DD date")
     if first_observed_at and disclosed_at and disclosed_at < first_observed_at:
         errors.append(f"{incident_id}.disclosed_at: cannot be before first_observed_at")
 
-    if "affected_ecosystems" in incident:
-        require_string_list(errors, f"{incident_id}.affected_ecosystems", incident.get("affected_ecosystems"))
-    if "supply_chain_vectors" in incident:
-        require_enum_list(errors, f"{incident_id}.supply_chain_vectors", incident.get("supply_chain_vectors"), VALID_VECTORS)
-    if "impact_categories" in incident:
-        require_enum_list(errors, f"{incident_id}.impact_categories", incident.get("impact_categories"), VALID_IMPACTS)
-    if "tags" in incident:
-        require_string_list(errors, f"{incident_id}.tags", incident.get("tags"), allow_empty=True)
+    require_string_list(errors, f"{incident_id}.affected_ecosystems", incident.get("affected_ecosystems"))
+    require_enum_list(errors, f"{incident_id}.supply_chain_vectors", incident.get("supply_chain_vectors"), VALID_VECTORS)
+    require_enum_list(errors, f"{incident_id}.impact_categories", incident.get("impact_categories"), VALID_IMPACTS)
+    require_string_list(errors, f"{incident_id}.tags", incident.get("tags"), allow_empty=True)
 
-    if "affected_components" in incident:
-        components = incident.get("affected_components")
-        if not isinstance(components, list) or not components:
-            errors.append(f"{incident_id}.affected_components: expected non-empty list")
-        else:
-            for index, component in enumerate(components):
-                validate_component(errors, incident_id, index, component)
+    components = incident.get("affected_components")
+    if not isinstance(components, list) or not components:
+        errors.append(f"{incident_id}.affected_components: expected non-empty list")
+    else:
+        for index, component in enumerate(components):
+            validate_component(errors, incident_id, index, component)
 
-    if "references" in incident:
-        references = incident.get("references")
-        if not isinstance(references, list) or not references:
-            errors.append(f"{incident_id}.references: expected non-empty list")
-        else:
-            for index, reference in enumerate(references):
-                validate_reference(errors, incident_id, index, reference)
+    references = incident.get("references")
+    if not isinstance(references, list) or not references:
+        errors.append(f"{incident_id}.references: expected non-empty list")
+    else:
+        for index, reference in enumerate(references):
+            validate_reference(errors, incident_id, index, reference)
 
     maintainers = incident.get("maintainers")
     if not isinstance(maintainers, list):
@@ -347,6 +491,7 @@ def validate_incident(incident: Any) -> list[str]:
         REQUIRED_COMPROMISED_ACCOUNT_FIELDS,
         incident.get("compromised_accounts"),
     )
+    validate_editorial_fields(errors, incident)
 
     return errors
 
@@ -377,10 +522,10 @@ def validate_schema_file(schema: Any) -> list[str]:
     errors: list[str] = []
     if not isinstance(schema, dict):
         return ["schema: expected object"]
-    properties = schema.get("properties", {})
+    properties = schema.get("properties")
     if not isinstance(properties, dict):
         return ["schema.properties: expected object"]
-    schema_version = properties.get("schema_version", {})
+    schema_version = properties.get("schema_version")
     if not isinstance(schema_version, dict):
         return ["schema.properties.schema_version: expected object"]
     if schema_version.get("const") != SCHEMA_VERSION:

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -22,8 +22,8 @@ const {
 } = Astro.props;
 const enablePlausibleAnalytics = import.meta.env.PROD;
 const supplyChainEnv =
-  typeof process !== 'undefined'
-    ? process.env?.ENABLE_SUPPLY_CHAIN_PAGES
+  (typeof process !== 'undefined' && process.env)
+    ? process.env.ENABLE_SUPPLY_CHAIN_PAGES
     : import.meta.env.ENABLE_SUPPLY_CHAIN_PAGES;
 const enableSupplyChainPages = String(supplyChainEnv || '').toLowerCase() === 'true';
 const plausibleScriptSrc = 'https://plausible.io/js/pa-JU90GDszdzYfdcQawYHNo.js';

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -7,13 +7,17 @@ const incidentRelativePath = 'data/supply-chain-incidents/incidents.json';
 
 function findRepoRoot(startDirs) {
   const seen = new Set();
+
   for (const startDir of startDirs) {
     let currentDir = path.resolve(startDir);
+
     while (!seen.has(currentDir)) {
       seen.add(currentDir);
+
       if (existsSync(path.join(currentDir, incidentRelativePath))) {
         return currentDir;
       }
+
       const parentDir = path.dirname(currentDir);
       if (parentDir === currentDir) {
         break;
@@ -21,6 +25,7 @@ function findRepoRoot(startDirs) {
       currentDir = parentDir;
     }
   }
+
   throw new Error(`Unable to locate Supply Chain corpus from ${startDirs.join(', ')}`);
 }
 
@@ -142,46 +147,26 @@ const ENTITY_COLLECTION_LABELS = {
   accounts: 'Compromised Account',
 };
 
+const editorialSectionDefinitions = [
+  { key: 'executive_summary', title: 'Executive Summary', type: 'claim' },
+  { key: 'timeline', title: 'Timeline', type: 'timeline' },
+  { key: 'attack_chain', title: 'Attack Chain', type: 'attack_chain' },
+  { key: 'affected_ecosystem', title: 'Affected Ecosystem', type: 'claim' },
+  { key: 'defensive_lessons', title: 'Defensive Lessons', type: 'claim' },
+  { key: 'detection_notes', title: 'Detection Notes', type: 'claim' },
+  { key: 'open_questions', title: 'Open Questions', type: 'claim' },
+];
+
 function entityTypeLabel(entity) {
   return ENTITY_COLLECTION_LABELS[entity.entityCollection] || entity.entityCollection;
 }
 
-export function isSupplyChainPagesEnabled(env = typeof process !== 'undefined' ? process.env || {} : {}) {
+export function isSupplyChainPagesEnabled(env = (typeof process !== 'undefined' ? process.env : null) || {}) {
   return String(env.ENABLE_SUPPLY_CHAIN_PAGES || '').toLowerCase() === 'true';
 }
 
 function readJson(filePath) {
   return JSON.parse(readFileSync(filePath, 'utf-8'));
-}
-
-function isPlainObject(value) {
-  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
-}
-
-function supplyChainPageDataShapeErrors(data) {
-  const errors = [];
-  if (!isPlainObject(data)) {
-    return ['data: expected object'];
-  }
-  if (!Array.isArray(data.incidents)) errors.push('data.incidents: expected array');
-  if (!Array.isArray(data.relationships)) errors.push('data.relationships: expected array');
-  if (!isPlainObject(data.entities)) {
-    errors.push('data.entities: expected object');
-  } else {
-    Object.keys(allEntityFiles).forEach((key) => {
-      if (!Array.isArray(data.entities[key])) errors.push(`data.entities.${key}: expected array`);
-    });
-  }
-  if (!(data.entityById instanceof Map)) errors.push('data.entityById: expected Map');
-  if (!(data.incidentByNodeId instanceof Map)) errors.push('data.incidentByNodeId: expected Map');
-  return errors;
-}
-
-function assertSupplyChainPageData(data, context) {
-  const errors = supplyChainPageDataShapeErrors(data);
-  if (errors.length > 0) {
-    throw new Error(`${context}: invalid Supply Chain page data:\n${errors.join('\n')}`);
-  }
 }
 
 export function loadSupplyChainData() {
@@ -204,9 +189,6 @@ export function loadSupplyChainData() {
 
 export function validateSupplyChainPageData(data = loadSupplyChainData()) {
   const errors = [];
-  errors.push(...supplyChainPageDataShapeErrors(data));
-  if (errors.length > 0) return errors;
-
   const validIncidentNodes = new Set(data.incidents.map((incident) => `incident-${incident.id}`));
   data.relationships.forEach((relationship, index) => {
     const sourceExists = validIncidentNodes.has(relationship.source) || data.entityById.has(relationship.source);
@@ -338,8 +320,34 @@ function incidentEntities(data, incidentId, collectionKey, relationshipType) {
   return (incident?.[collectionKey] || []).map((item) => ({ label: item.name, id: item.name, href: null }));
 }
 
+function referenceMapFor(incident) {
+  return new Map((incident.references || []).filter((reference) => reference.id).map((reference) => [reference.id, reference]));
+}
+
+function referencesForItem(item, referenceById) {
+  return (item.reference_ids || []).map((referenceId) => referenceById.get(referenceId)).filter(Boolean);
+}
+
+function editorialSectionsFor(incident) {
+  const referenceById = referenceMapFor(incident);
+  return editorialSectionDefinitions
+    .map((section) => {
+      const items = incident[section.key];
+      if (!Array.isArray(items) || items.length === 0) return null;
+      return {
+        key: section.key,
+        title: section.title,
+        type: section.type,
+        items: items.map((item) => ({
+          ...item,
+          references: referencesForItem(item, referenceById),
+        })),
+      };
+    })
+    .filter(Boolean);
+}
+
 export function getSupplyChainIndexModel(data = loadSupplyChainData()) {
-  assertSupplyChainPageData(data, 'getSupplyChainIndexModel');
   const featuredIncidents = SUPPLY_CHAIN_FEATURED_INCIDENT_IDS.map((id) => {
     const incident = data.incidents.find((item) => item.id === id);
     if (!incident) throw new Error(`Featured Supply Chain incident not found: ${id}`);
@@ -386,6 +394,7 @@ export function getSupplyChainIndexModel(data = loadSupplyChainData()) {
       maintainers: data.entities.maintainers.length,
       buildSystems: data.entities.build_systems.length,
       distributionChannels: data.entities.distribution_channels.length,
+      compromisedAccounts: data.entities.accounts.length,
       relationships: data.relationships.length,
     },
     incidents: data.incidents
@@ -402,7 +411,6 @@ export function getSupplyChainIndexModel(data = loadSupplyChainData()) {
 }
 
 export function getSupplyChainIncidentPage(id, data = loadSupplyChainData()) {
-  assertSupplyChainPageData(data, 'getSupplyChainIncidentPage');
   const incident = data.incidents.find((item) => item.id === id);
   if (!incident) return null;
   const description = incident.summary;
@@ -410,6 +418,7 @@ export function getSupplyChainIncidentPage(id, data = loadSupplyChainData()) {
     kind: 'incident',
     title: incident.title,
     incident,
+    editorialSections: editorialSectionsFor(incident),
     connectedEntities: incidentConnectedEntities(data, id),
     seo: {
       title: `Supply Chain: ${incident.title}`,
@@ -453,7 +462,6 @@ export function getSupplyChainIncidentPage(id, data = loadSupplyChainData()) {
 }
 
 export function getSupplyChainEntityPage(collectionKey, id, data = loadSupplyChainData()) {
-  assertSupplyChainPageData(data, 'getSupplyChainEntityPage');
   const collection = data.entities[collectionKey] || [];
   const entity = collection.find((item) => item.id === id);
   if (!entity) return null;

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -23,6 +23,10 @@ function titleCase(value) {
   return label(value).replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
+function referenceLabel(reference) {
+  return `${reference.publisher}: ${reference.title}`;
+}
+
 const title = page?.seo?.title || (page?.kind === 'index' ? 'Supply Chain' : `Supply Chain: ${page?.title}`);
 const description = page?.seo?.description || 'Threatpedia Supply Chain incident and entity pages.';
 const canonicalPath = page?.seo?.canonicalPath;
@@ -57,6 +61,7 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
         <div><span>{page.counts.maintainers}</span><p>Maintainers</p></div>
         <div><span>{page.counts.buildSystems}</span><p>Build Systems</p></div>
         <div><span>{page.counts.distributionChannels}</span><p>Distribution Channels</p></div>
+        <div><span>{page.counts.compromisedAccounts}</span><p>Compromised Accounts</p></div>
         <div><span>{page.counts.relationships}</span><p>Relationships</p></div>
       </section>
 
@@ -141,6 +146,61 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
         <div><span>Attack Stage</span><strong>{titleCase(page.incident.attack_stage)}</strong></div>
         <div><span>Source Artifact Divergence</span><strong>{titleCase(page.incident.source_artifact_divergence)}</strong></div>
       </section>
+
+      {page.editorialSections.length > 0 && (
+        <div class="editorial-sections">
+          {page.editorialSections.map((section) => (
+            <section class={`sc-section editorial-section editorial-${section.type}`}>
+              <h2>{section.title}</h2>
+              {section.type === 'timeline' ? (
+                <ol class="timeline-list">
+                  {section.items.map((item) => (
+                    <li>
+                      <time>{item.date}</time>
+                      <div>
+                        <h3>{item.title}</h3>
+                        <p>{item.text}</p>
+                        <ul class="citation-list">
+                          {item.references.map((reference) => (
+                            <li><a href={reference.url} target="_blank" rel="noopener noreferrer">{referenceLabel(reference)}</a></li>
+                          ))}
+                        </ul>
+                      </div>
+                    </li>
+                  ))}
+                </ol>
+              ) : section.type === 'attack_chain' ? (
+                <ol class="attack-chain-list">
+                  {section.items.map((item) => (
+                    <li>
+                      <h3>{item.stage}</h3>
+                      <p>{item.text}</p>
+                      <ul class="citation-list">
+                        {item.references.map((reference) => (
+                          <li><a href={reference.url} target="_blank" rel="noopener noreferrer">{referenceLabel(reference)}</a></li>
+                        ))}
+                      </ul>
+                    </li>
+                  ))}
+                </ol>
+              ) : (
+                <div class="editorial-card-list">
+                  {section.items.map((item) => (
+                    <article class="editorial-card">
+                      <p>{item.text}</p>
+                      <ul class="citation-list">
+                        {item.references.map((reference) => (
+                          <li><a href={reference.url} target="_blank" rel="noopener noreferrer">{referenceLabel(reference)}</a></li>
+                        ))}
+                      </ul>
+                    </article>
+                  ))}
+                </div>
+              )}
+            </section>
+          ))}
+        </div>
+      )}
 
       <EntityList title="Affected Packages" items={page.sections.packages} />
       <EntityList title="Repositories" items={page.sections.repositories} />
@@ -297,6 +357,79 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
     margin-bottom: 8px;
   }
 
+  .editorial-sections {
+    margin: 36px 0;
+  }
+
+  .editorial-card-list {
+    display: grid;
+    gap: 12px;
+  }
+
+  .editorial-card,
+  .timeline-list li,
+  .attack-chain-list li {
+    border: 1px solid var(--border);
+    background: var(--surface);
+    border-radius: 6px;
+    padding: 16px;
+  }
+
+  .timeline-list,
+  .attack-chain-list,
+  .citation-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .timeline-list,
+  .attack-chain-list {
+    display: grid;
+    gap: 12px;
+  }
+
+  .timeline-list li {
+    display: grid;
+    grid-template-columns: minmax(120px, 180px) 1fr;
+    gap: 16px;
+  }
+
+  .timeline-list time,
+  .citation-list {
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+  }
+
+  .timeline-list h3,
+  .attack-chain-list h3 {
+    margin: 0 0 8px;
+    color: var(--white);
+    font-size: 1rem;
+  }
+
+  .editorial-card p,
+  .timeline-list p,
+  .attack-chain-list p {
+    color: var(--text);
+    line-height: 1.65;
+    margin: 0;
+  }
+
+  .citation-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 12px;
+  }
+
+  .citation-list a {
+    border: 1px solid var(--border);
+    display: inline-block;
+    padding: 4px 7px;
+  }
+
   .metric-grid,
   .detail-grid {
     display: grid;
@@ -401,6 +534,7 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
   }
 
   @media (max-width: 720px) {
+    .timeline-list li,
     .entity-list li,
     .reference-list li {
       display: block;

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -146,21 +146,8 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
         self.assertTrue(any(".attack_stage: invalid value" in error for error in errors))
 
     def test_structured_depth_fields_are_enforced(self) -> None:
-        incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
-        incident["distribution_channels"] = [
-            {
-                "name": "",
-                "channel_type": "package_registry",
-                "ecosystem": "npm"
-            }
-        ]
-        incident["maintainers"] = [
-            {
-                "name": "Example Maintainer",
-                "aliases": ["example"],
-                "id_slug": "example"
-            }
-        ]
+        incident = copy.deepcopy(next(item for item in load_json(CORPUS_PATH) if item["maintainers"]))
+        incident["distribution_channels"][0]["name"] = ""
         incident["source_artifact_divergence"] = "yes"
         del incident["maintainers"][0]["id_slug"]
 
@@ -168,7 +155,7 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
 
         self.assertTrue(any(".distribution_channels[0].name: expected non-empty string" in error for error in errors))
         self.assertTrue(any(".source_artifact_divergence: expected boolean or null" in error for error in errors))
-        self.assertTrue(any(".maintainers[0].id_slug: missing required field" in error for error in errors))
+        self.assertTrue(any(".maintainers[0].id_slug: expected non-empty string" in error for error in errors))
 
     def test_unhashable_enum_items_do_not_crash_validation(self) -> None:
         incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
@@ -204,6 +191,45 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
         self.assertTrue(
             any(".source_artifact_divergence: cannot be true when distribution_channels is empty" in error for error in errors)
         )
+
+    def test_featured_incidents_require_editorial_fields(self) -> None:
+        incident = copy.deepcopy(next(item for item in load_json(CORPUS_PATH) if item["id"] == "SC-2024-XZ-UTILS"))
+        del incident["executive_summary"]
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any(".executive_summary: missing required featured editorial field" in error for error in errors))
+
+    def test_non_featured_incidents_do_not_require_editorial_fields(self) -> None:
+        incident = copy.deepcopy(next(item for item in load_json(CORPUS_PATH) if item["id"] == "SC-2021-CODECOV-BASH-UPLOADER"))
+
+        errors = validator.validate_incident(incident)
+
+        self.assertFalse(any("editorial" in error for error in errors))
+
+    def test_editorial_references_must_resolve(self) -> None:
+        incident = copy.deepcopy(next(item for item in load_json(CORPUS_PATH) if item["id"] == "SC-2018-NPM-EVENT-STREAM"))
+        incident["executive_summary"][0]["reference_ids"] = ["ref-missing"]
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any("unknown reference ID 'ref-missing'" in error for error in errors))
+
+    def test_editorial_timeline_dates_are_enforced(self) -> None:
+        incident = copy.deepcopy(next(item for item in load_json(CORPUS_PATH) if item["id"] == "SC-2023-THREE-CX-DESKTOP"))
+        incident["timeline"][0]["date"] = "2023-04-20/2023-03-22"
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any(".timeline[0].date: expected YYYY-MM-DD date or YYYY-MM-DD/YYYY-MM-DD range" in error for error in errors))
+
+    def test_editorial_timeline_dates_reject_compact_iso_forms(self) -> None:
+        incident = copy.deepcopy(next(item for item in load_json(CORPUS_PATH) if item["id"] == "SC-2024-XZ-UTILS"))
+        incident["timeline"][0]["date"] = "20240329"
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any(".timeline[0].date: expected YYYY-MM-DD date or YYYY-MM-DD/YYYY-MM-DD range" in error for error in errors))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replaces closed stacked PR #1136 after the lower Supply Chain stack was squash-merged into main.

Scope: Phase 1F editorial fields and rendering for the five featured Supply Chain incidents only. No scoring, live feeds, graph database, AI inference, or public enablement by default.

Validation run on rebuilt head c6f7f03de6737f4c5666357b4881c6c6e9654ecb:
- python3 scripts/validate_supply_chain_incidents.py
- python3 scripts/validate_supply_chain_graph.py
- python3 -m unittest tests/test_supply_chain_incidents.py tests/test_supply_chain_graph.py
- node scripts/test-supply-chain-pages.mjs
- node --check scripts/test-supply-chain-pages.mjs
- node --check site/src/lib/supplyChainPages.mjs
- disabled Astro build with ENABLE_SUPPLY_CHAIN_PAGES unset
- enabled Astro build with Supply Chain routes generated
- git diff --check