### PR TITLE
Add Supply Chain preview readiness check

### DIFF
--- a/docs/supply-chain-pages.md
+++ b/docs/supply-chain-pages.md
@@ -58,6 +58,17 @@ Focused page tests:
 node scripts/test-supply-chain-pages.mjs
 ```
 
+Preview readiness check:
+
+```bash
+node scripts/check_supply_chain_preview.mjs
+```
+
+The preview check builds the section with `ENABLE_SUPPLY_CHAIN_PAGES=true`,
+verifies representative generated pages, compares route counts with the public
+readiness report, and fails if the production deploy workflow has been changed
+to enable the flag.
+
 Run graph validation before page generation:
 
 ```bash
@@ -129,7 +140,24 @@ the page path also supports a noindex robots value.
 
 ## Public Enablement Checklist
 
-Before enabling the section publicly, run the readiness gate:
+Before enabling the section publicly, complete an enabled preview review:
+
+```bash
+node scripts/check_supply_chain_preview.mjs
+```
+
+Checklist for the preview:
+
+- `/supply-chain/`
+- all five featured incident pages
+- representative entity pages
+- Supply Chain nav visibility
+- SEO metadata and JSON-LD on index and featured incidents
+- no public `Canary` copy
+- no broken internal Supply Chain links
+- no unexpected `noindex` on enabled preview pages
+
+After preview review, run the readiness gate:
 
 ```bash
 node scripts/check_supply_chain_public_readiness.mjs

--- a/docs/supply-chain-public-readiness.md
+++ b/docs/supply-chain-public-readiness.md
@@ -68,3 +68,41 @@ output are safe to deploy with `ENABLE_SUPPLY_CHAIN_PAGES=true`.
 Existing campaign validator warnings may appear during the Astro build because
 the site build runs campaign validation first. Those warnings are not Supply
 Chain readiness failures unless the build exits non-zero.
+
+## Preview Deploy Review
+
+Before changing production deployment configuration, review an enabled preview
+build. From the repository root:
+
+```bash
+node scripts/check_supply_chain_preview.mjs
+```
+
+The preview check runs the public readiness gate, confirms the enabled static
+output includes `/supply-chain/` and the five featured incident pages, compares
+the generated route count to the readiness report, and verifies that this branch
+has not accidentally committed a production deploy flag change.
+
+To inspect the generated preview locally:
+
+```bash
+cd site
+ENABLE_SUPPLY_CHAIN_PAGES=true npm run build
+npm run preview -- --host 127.0.0.1
+```
+
+Preview review checklist:
+
+- `/supply-chain/` renders and shows corpus counts
+- the five featured incident pages render editorial sections
+- package, repository, organization, maintainer, build-system, distribution
+  channel, and compromised-account entity pages render from JSON data
+- the Supply Chain nav link is visible in the enabled preview
+- index and featured incident pages include title, description, canonical,
+  Open Graph metadata, and valid JSON-LD
+- public copy does not contain `Canary`
+- internal Supply Chain links resolve
+- pages do not show unexpected `noindex`
+
+Record the preview URL or local preview result before opening the production
+enablement PR.

--- a/scripts/check_supply_chain_preview.mjs
+++ b/scripts/check_supply_chain_preview.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  SUPPLY_CHAIN_FEATURED_INCIDENT_IDS,
+  getSupplyChainRoutes,
+  loadSupplyChainData,
+} from '../site/src/lib/supplyChainPages.mjs';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..');
+const siteDistDir = path.join(repoRoot, 'site', 'dist');
+const readinessReportPath = path.join(repoRoot, '.worker-state', 'supply-chain-public-readiness.json');
+const deployWorkflowPath = path.join(repoRoot, '.github', 'workflows', 'deploy.yml');
+
+const failures = [];
+
+function run(command, options = {}) {
+  const result = spawnSync(command, {
+    cwd: options.cwd || repoRoot,
+    env: { ...process.env, ...(options.env || {}) },
+    shell: true,
+    encoding: 'utf-8',
+    stdio: 'inherit',
+  });
+  if (result.status !== 0) {
+    failures.push(`${command} exited with ${result.status}`);
+  }
+  return result.status === 0;
+}
+
+function assertPreview(condition, message) {
+  if (!condition) failures.push(message);
+}
+
+function htmlPathForRoute(routePath) {
+  const normalized = routePath.replace(/^\/+/, '').replace(/\/+$/, '');
+  return normalized ? path.join(siteDistDir, normalized, 'index.html') : path.join(siteDistDir, 'index.html');
+}
+
+function walkIndexFiles(dir, files = []) {
+  if (!existsSync(dir)) return files;
+  readdirSync(dir, { withFileTypes: true }).forEach((entry) => {
+    const filePath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkIndexFiles(filePath, files);
+      return;
+    }
+    if (entry.isFile() && entry.name === 'index.html') {
+      files.push(filePath);
+    }
+  });
+  return files;
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, 'utf-8'));
+}
+
+function assertProductionFlagUnchanged() {
+  const workflow = readFileSync(deployWorkflowPath, 'utf-8');
+  const productionEnablePatterns = [
+    /ENABLE_SUPPLY_CHAIN_PAGES\s*:\s*['"]?true['"]?/i,
+    /ENABLE_SUPPLY_CHAIN_PAGES=true/i,
+    /ENABLE_SUPPLY_CHAIN_PAGES:\s*\$\{\{\s*vars\.ENABLE_SUPPLY_CHAIN_PAGES\s*\}\}/i,
+  ];
+  assertPreview(
+    productionEnablePatterns.every((pattern) => !pattern.test(workflow)),
+    'production deploy workflow appears to enable ENABLE_SUPPLY_CHAIN_PAGES',
+  );
+}
+
+assertProductionFlagUnchanged();
+
+run('node scripts/check_supply_chain_public_readiness.mjs');
+
+assertPreview(existsSync(readinessReportPath), 'readiness report was not written');
+const readinessReport = existsSync(readinessReportPath) ? readJson(readinessReportPath) : null;
+assertPreview(readinessReport?.status === 'pass', 'readiness report status is not pass');
+
+const data = loadSupplyChainData();
+const expectedRoutes = getSupplyChainRoutes({ enabled: true, data });
+const generatedRoutes = walkIndexFiles(path.join(siteDistDir, 'supply-chain')).length;
+
+assertPreview(existsSync(htmlPathForRoute('/supply-chain/')), '/supply-chain/ preview page was not generated');
+SUPPLY_CHAIN_FEATURED_INCIDENT_IDS.forEach((id) => {
+  assertPreview(
+    existsSync(htmlPathForRoute(`/supply-chain/incidents/${id}/`)),
+    `/supply-chain/incidents/${id}/ preview page was not generated`,
+  );
+});
+
+assertPreview(
+  generatedRoutes === expectedRoutes.length,
+  `generated preview route count ${generatedRoutes} did not match expected route count ${expectedRoutes.length}`,
+);
+assertPreview(
+  readinessReport?.counts?.expected_routes === expectedRoutes.length,
+  `readiness expected route count ${readinessReport?.counts?.expected_routes} did not match model route count ${expectedRoutes.length}`,
+);
+assertPreview(
+  readinessReport?.counts?.enabled_generated_routes === generatedRoutes,
+  `readiness generated route count ${readinessReport?.counts?.enabled_generated_routes} did not match preview route count ${generatedRoutes}`,
+);
+
+if (failures.length > 0) {
+  console.error('Supply Chain preview check: FAIL');
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(1);
+}
+
+console.log('Supply Chain preview check: PASS');
+console.log(`Generated routes: ${generatedRoutes}`);
+console.log(`Readiness report: ${path.relative(repoRoot, readinessReportPath)}`);

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "check:supply-chain-preview": "node check_supply_chain_preview.mjs",
     "check:supply-chain-public-readiness": "node check_supply_chain_public_readiness.mjs",
     "social:share-x": "node social-share-x.mjs",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## Summary

Implements Supply Chain Phase 1H: Preview Deploy Enablement.

- Adds `scripts/check_supply_chain_preview.mjs` for enabled preview verification.
- Adds `npm run check:supply-chain-preview` in `scripts/package.json`.
- Documents the preview build/review path in Supply Chain readiness and page docs.
- Keeps production disabled; no deploy workflow flag change is included.

## Validation

Run from a clean worktree on current `origin/main`:

- `node --check scripts/check_supply_chain_preview.mjs` PASS
- `node --check scripts/check_supply_chain_public_readiness.mjs` PASS
- `node scripts/test-supply-chain-pages.mjs` PASS, routes=74
- `python3 scripts/validate_supply_chain_incidents.py` PASS, 25 incidents
- `python3 scripts/validate_supply_chain_graph.py` PASS, entities=73 relationships=93
- `git diff --check` PASS
- `node scripts/check_supply_chain_preview.mjs` PASS
  - readiness status: PASS
  - generated routes: 74

## Preview Scope

The preview check verifies:

- enabled build/readiness passes
- `/supply-chain/` exists in generated preview output
- all five featured incident pages exist
- generated route count matches the readiness report
- no production `ENABLE_SUPPLY_CHAIN_PAGES=true` deploy change was committed

## Non-goals

- Does not enable production
- Does not change corpus data
- Does not add scoring, live feeds, graph DB, or attribution automation