### PR TITLE
Enable Supply Chain pages in production deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Build Astro site
         working-directory: site
+        env:
+          ENABLE_SUPPLY_CHAIN_PAGES: "true"
         run: npm run build
 
       - name: Upload artifact

--- a/.github/workflows/pipeline-post-merge-audit.yml
+++ b/.github/workflows/pipeline-post-merge-audit.yml
@@ -96,6 +96,8 @@ jobs:
         id: build
         if: steps.changed.outputs.count != '0'
         continue-on-error: true
+        env:
+          ENABLE_SUPPLY_CHAIN_PAGES: "true"
         run: |
           cd site && npm run build
 

--- a/.github/workflows/pipeline-validate.yml
+++ b/.github/workflows/pipeline-validate.yml
@@ -63,6 +63,8 @@ jobs:
         id: build
         if: steps.changed.outputs.count != '0'
         continue-on-error: true
+        env:
+          ENABLE_SUPPLY_CHAIN_PAGES: "true"
         run: |
           cd site && npm run build
 

--- a/docs/supply-chain-pages.md
+++ b/docs/supply-chain-pages.md
@@ -214,6 +214,29 @@ checks are:
    - non-featured incidents still render without editorial sections
    - no scoring, recommendations, live-feed copy, or generated conclusions
 
+## Production Enablement
+
+Production deployment was enabled on 2026-06-13 by setting
+`ENABLE_SUPPLY_CHAIN_PAGES=true` on the GitHub Pages Astro build step in
+`.github/workflows/deploy.yml`.
+
+Validation result at enablement: PASS.
+
+Required checks before and after changing production deployment configuration:
+
+```bash
+python3 scripts/validate_supply_chain_incidents.py
+python3 scripts/validate_supply_chain_graph.py
+node scripts/test-supply-chain-pages.mjs
+node scripts/check_supply_chain_public_readiness.mjs
+cd site && rm -rf dist && ENABLE_SUPPLY_CHAIN_PAGES=true npm run build
+```
+
+Rollback is a deployment configuration change: set
+`ENABLE_SUPPLY_CHAIN_PAGES=false` or remove the build-step environment variable
+from `.github/workflows/deploy.yml`, redeploy, and confirm `/supply-chain/` and
+the Supply Chain nav link are absent.
+
 ## Supply Chain Editorial Checklist
 
 Use this checklist before adding or changing a featured incident editorial page:

--- a/docs/supply-chain-pages.md
+++ b/docs/supply-chain-pages.md
@@ -66,8 +66,9 @@ node scripts/check_supply_chain_preview.mjs
 
 The preview check builds the section with `ENABLE_SUPPLY_CHAIN_PAGES=true`,
 verifies representative generated pages, compares route counts with the public
-readiness report, and fails if the production deploy workflow has been changed
-to enable the flag.
+readiness report, and remains usable after production enablement. For
+pre-production branches that must prove they did not change deployment
+configuration, run it with `--require-production-disabled`.
 
 Run graph validation before page generation:
 
@@ -230,6 +231,17 @@ python3 scripts/validate_supply_chain_graph.py
 node scripts/test-supply-chain-pages.mjs
 node scripts/check_supply_chain_public_readiness.mjs
 cd site && rm -rf dist && ENABLE_SUPPLY_CHAIN_PAGES=true npm run build
+git diff --check
+```
+
+When the change also edits incident Markdown/MDX metadata, body content, or
+MITRE ATT&CK mappings, also run the shared content validator against the changed
+article files using the same `--files-file` / `--new-files-file` pattern used by
+`.github/workflows/pipeline-validate.yml`. When the change edits pipeline task
+JSON, run:
+
+```bash
+node scripts/validate-pipeline-tasks.mjs --all
 ```
 
 Rollback is a deployment configuration change: set

--- a/docs/supply-chain-public-readiness.md
+++ b/docs/supply-chain-public-readiness.md
@@ -106,3 +106,23 @@ Preview review checklist:
 
 Record the preview URL or local preview result before opening the production
 enablement PR.
+
+## Production Enablement Record
+
+Production deployment was enabled on 2026-06-13 by setting
+`ENABLE_SUPPLY_CHAIN_PAGES=true` on the GitHub Pages Astro build step in
+`.github/workflows/deploy.yml`.
+
+The public enablement PR must record operator approval, the preview-review
+result, and the latest readiness-gate result. At enablement, the required
+validation result was PASS for:
+
+- `python3 scripts/validate_supply_chain_incidents.py`
+- `python3 scripts/validate_supply_chain_graph.py`
+- `node scripts/test-supply-chain-pages.mjs`
+- `node scripts/check_supply_chain_public_readiness.mjs`
+- production-equivalent enabled Astro build
+
+Rollback: set `ENABLE_SUPPLY_CHAIN_PAGES=false` or remove the build-step
+environment variable from `.github/workflows/deploy.yml`, redeploy, then confirm
+`/supply-chain/` and the Supply Chain nav link are absent.

--- a/docs/supply-chain-public-readiness.md
+++ b/docs/supply-chain-public-readiness.md
@@ -122,6 +122,17 @@ validation result was PASS for:
 - `node scripts/test-supply-chain-pages.mjs`
 - `node scripts/check_supply_chain_public_readiness.mjs`
 - production-equivalent enabled Astro build
+- `git diff --check`
+
+When a production-enable PR also changes incident Markdown/MDX metadata, article
+body content, or MITRE ATT&CK mappings, run the shared content validator against
+the changed article files using the same `--files-file` / `--new-files-file`
+inputs as `.github/workflows/pipeline-validate.yml`. When the change edits
+pipeline task JSON, run:
+
+```bash
+node scripts/validate-pipeline-tasks.mjs --all
+```
 
 Rollback: set `ENABLE_SUPPLY_CHAIN_PAGES=false` or remove the build-step
 environment variable from `.github/workflows/deploy.yml`, redeploy, then confirm

--- a/scripts/check_supply_chain_preview.mjs
+++ b/scripts/check_supply_chain_preview.mjs
@@ -60,20 +60,27 @@ function readJson(filePath) {
   return JSON.parse(readFileSync(filePath, 'utf-8'));
 }
 
-function assertProductionFlagUnchanged() {
+function productionDeployEnablesSupplyChain() {
   const workflow = readFileSync(deployWorkflowPath, 'utf-8');
   const productionEnablePatterns = [
     /ENABLE_SUPPLY_CHAIN_PAGES\s*:\s*['"]?true['"]?/i,
     /ENABLE_SUPPLY_CHAIN_PAGES=true/i,
     /ENABLE_SUPPLY_CHAIN_PAGES:\s*\$\{\{\s*vars\.ENABLE_SUPPLY_CHAIN_PAGES\s*\}\}/i,
   ];
-  assertPreview(
-    productionEnablePatterns.every((pattern) => !pattern.test(workflow)),
-    'production deploy workflow appears to enable ENABLE_SUPPLY_CHAIN_PAGES',
-  );
+  return productionEnablePatterns.some((pattern) => pattern.test(workflow));
 }
 
-assertProductionFlagUnchanged();
+const requireProductionDisabled = process.argv.includes('--require-production-disabled')
+  || String(process.env.SUPPLY_CHAIN_PREVIEW_REQUIRE_PRODUCTION_DISABLED || '').toLowerCase() === 'true';
+
+if (requireProductionDisabled) {
+  assertPreview(
+    !productionDeployEnablesSupplyChain(),
+    'production deploy workflow appears to enable ENABLE_SUPPLY_CHAIN_PAGES',
+  );
+} else if (productionDeployEnablesSupplyChain()) {
+  console.log('Production deploy already enables ENABLE_SUPPLY_CHAIN_PAGES; continuing preview output checks.');
+}
 
 run('node scripts/check_supply_chain_public_readiness.mjs');
 


### PR DESCRIPTION
## Summary

Implements Supply Chain Phase 1I: Public Enablement.

- Sets `ENABLE_SUPPLY_CHAIN_PAGES=true` for the GitHub Pages Astro build step.
- Records production enablement date and validation status in Supply Chain docs.
- Documents rollback by setting the flag false or removing the build-step env var and redeploying.

## Operator approval

Operator approval recorded from Mahdi in the implementation thread after Phase 1H was merged: “I merged it, continue.” Phase 1H preview enablement is on `main` via #1140.

## Validation

Run from clean worktree on current `origin/main` after #1140:

- `python3 scripts/validate_supply_chain_incidents.py` PASS, 25 incidents
- `python3 scripts/validate_supply_chain_graph.py` PASS, entities=73 relationships=93
- `node scripts/test-supply-chain-pages.mjs` PASS, routes=74
- `node scripts/check_supply_chain_public_readiness.mjs` PASS
- `git diff --check` PASS
- production-equivalent enabled build PASS:
  - `cd site && npm ci --no-audit --no-fund && rm -rf dist && ENABLE_SUPPLY_CHAIN_PAGES=true npm run build`
  - confirmed `dist/supply-chain/index.html`
  - confirmed `dist/supply-chain/incidents/SC-2024-XZ-UTILS/index.html`
  - confirmed `dist/supply-chain/packages/pkg-npm-event-stream/index.html`
  - confirmed homepage contains `/supply-chain/` nav link

Known unrelated warning: Astro build still emits existing campaign related-incident warnings, but campaign validation exits successfully.

## Non-goals

- No corpus data changes
- No scoring
- No new ingestion or live feeds
- No graph DB
- No attribution automation