### PR TITLE
Supply Chain Phase 2A: PURL foundation

### DIFF
--- a/.github/workflows/supply-chain-validate.yml
+++ b/.github/workflows/supply-chain-validate.yml
@@ -1,0 +1,56 @@
+name: "Supply Chain: Validate Corpus"
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - ".github/workflows/supply-chain-validate.yml"
+      - "data/supply-chain-entities/**"
+      - "data/supply-chain-incidents/**"
+      - "data/supply-chain-relationships/**"
+      - "docs/supply-chain*.md"
+      - "scripts/build_supply_chain_entities.py"
+      - "scripts/supply_chain_purl.py"
+      - "scripts/validate_supply_chain_graph.py"
+      - "scripts/validate_supply_chain_incidents.py"
+      - "scripts/test-supply-chain-pages.mjs"
+      - "site/src/lib/supplyChainPages.mjs"
+      - "tests/test_supply_chain*.py"
+  workflow_dispatch:
+
+jobs:
+  validate-supply-chain:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Python syntax
+        run: |
+          python3 -m py_compile \
+            scripts/supply_chain_purl.py \
+            scripts/build_supply_chain_entities.py \
+            scripts/validate_supply_chain_incidents.py \
+            scripts/validate_supply_chain_graph.py
+
+      - name: Validate incident corpus
+        run: python3 scripts/validate_supply_chain_incidents.py
+
+      - name: Validate graph primitives
+        run: python3 scripts/validate_supply_chain_graph.py
+
+      - name: Run supply-chain unit tests
+        run: python3 -m unittest tests/test_supply_chain_purl.py tests/test_supply_chain_incidents.py tests/test_supply_chain_graph.py
+
+      - name: Run page model test
+        run: node scripts/test-supply-chain-pages.mjs

--- a/data/supply-chain-entities/packages.json
+++ b/data/supply-chain-entities/packages.json
@@ -6,7 +6,7 @@
     "ecosystem": "multiple",
     "id": "pkg-multiple-internal-dependency-names",
     "name": "internal dependency names",
-    "package_url": null,
+    "package_url": "pkg:generic/internal-dependency-names",
     "source_incident_ids": [
       "SC-2021-DEPENDENCY-CONFUSION"
     ]

--- a/data/supply-chain-incidents/incidents.json
+++ b/data/supply-chain-incidents/incidents.json
@@ -724,7 +724,7 @@
         "ecosystem": "multiple",
         "name": "internal dependency names",
         "vendor": "multiple organizations",
-        "package_url": null
+        "package_url": "pkg:generic/internal-dependency-names"
       }
     ],
     "supply_chain_vectors": [

--- a/docs/supply-chain-graph-primitives.md
+++ b/docs/supply-chain-graph-primitives.md
@@ -31,7 +31,8 @@ Each entity has:
 - `aliases`: normalized duplicate-detection surface
 - `source_incident_ids`: incident IDs that caused the entity to be emitted
 
-Package entities also carry `ecosystem` and `package_url` when available.
+Package entities also carry `ecosystem` and a required canonical `package_url`
+PURL. See `docs/supply-chain-purl-model.md` for the canonical grammar.
 Repository entities also carry `host`, `url`, and `owner`.
 Build-system, distribution-channel, and account entities carry type-specific
 fields copied from the incident corpus.

--- a/docs/supply-chain-incident-schema.md
+++ b/docs/supply-chain-incident-schema.md
@@ -76,8 +76,10 @@ These fields are optional for ordinary corpus records. Phase 1F requires them
 only for the five curated featured incidents rendered as editorial Supply Chain
 case studies.
 
-Package components may include `package_url` when a PURL is available. Non-
-package software, services, websites, and update channels should use `null`.
+Package components must include a canonical `package_url` PURL. Non-package
+software, services, websites, and update channels should use `null`. See
+`docs/supply-chain-purl-model.md` for the canonical PURL grammar and validation
+contract.
 
 ## Attack Stages
 

--- a/docs/supply-chain-purl-model.md
+++ b/docs/supply-chain-purl-model.md
@@ -1,0 +1,87 @@
+# Supply Chain PURL Model
+
+Threatpedia uses Package URL (PURL) strings as the canonical join key for supply-chain package and release records. The PURL model is intentionally narrow in Phase 2A: it covers package identity, validates existing package entities, and prepares the release layer for Phase 2C.
+
+## Canonical Helper
+
+The single source of truth for PURL parsing, normalization, and emission is:
+
+```text
+scripts/supply_chain_purl.py
+```
+
+Validators and corpus builders must use this helper rather than ad hoc regular expressions. Page generation should consume the already-normalized `package_url` values from the validated JSON data and should not re-normalize PURLs independently.
+
+## Supported Ecosystems
+
+The Phase 2A grammar supports the package ecosystems currently needed by the corpus and the release-event spine.
+
+### npm
+
+Unscoped npm packages use lowercase package names:
+
+```text
+pkg:npm/event-stream
+```
+
+Scoped npm packages encode the leading `@` as `%40`:
+
+```text
+pkg:npm/%40ledgerhq/connect-kit
+```
+
+The canonical helper lowercases npm names and rejects whitespace, empty scopes, and malformed scoped names.
+
+### PyPI
+
+PyPI package names use PEP 503-style normalization: lowercase, with runs of `-`, `_`, and `.` collapsed to `-`.
+
+```text
+pkg:pypi/torchtriton
+```
+
+### Go
+
+Go modules use the `golang` PURL type and preserve the module import path.
+
+```text
+pkg:golang/github.com/boltdb/bolt
+```
+
+Go module paths must be non-empty, contain no whitespace, and start with an import host.
+
+### Generic Cross-Ecosystem Placeholders
+
+When an incident intentionally models a cross-ecosystem package placeholder, such as dependency-confusion internal names, the corpus uses the `generic` PURL type.
+
+```text
+pkg:generic/internal-dependency-names
+```
+
+This is reserved for explicit abstract package placeholders. It must not be used to avoid modeling a known npm, PyPI, or Go package.
+
+## Validator Contract
+
+The incident validator requires every `affected_components` item with `component_type: "package"` to carry a canonical `package_url`.
+
+The graph validator requires every package entity in `data/supply-chain-entities/packages.json` to carry a canonical `package_url`.
+
+Both validators fail if a package PURL:
+
+- is missing
+- has an unsupported PURL type
+- does not match the entity or component ecosystem
+- does not match the entity or component package name after canonical normalization
+- uses non-canonical spelling or encoding
+
+Non-package components, such as software, services, websites, and update channels, are not package records and do not require PURLs in Phase 2A.
+
+## Relationship Integrity
+
+The graph validator also performs the foundation dangling-reference check. Every relationship endpoint must resolve to an incident node or an existing entity node. Missing relationship targets remain hard failures.
+
+## Deferred Work
+
+Release PURL validation is wired through the same helper but becomes mandatory when Phase 2C adds `releases.json`.
+
+The full PURL and edge audit report is intentionally deferred to Phase 2F, after corpus expansion, so the closing audit covers the complete expanded corpus.

--- a/scripts/build_supply_chain_entities.py
+++ b/scripts/build_supply_chain_entities.py
@@ -7,8 +7,15 @@ import argparse
 import json
 from pathlib import Path
 import re
+import sys
 from typing import Any
 from urllib.parse import urlparse
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from supply_chain_purl import PurlError, canonicalize_purl, purl_for_package
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -115,6 +122,13 @@ def upsert_package(packages: dict[str, dict[str, Any]], component: dict[str, Any
     ecosystem = component["ecosystem"]
     name = component["name"]
     package_url = component.get("package_url")
+    if package_url:
+        try:
+            package_url = canonicalize_purl(package_url, ecosystem=ecosystem, package_name=name)
+        except PurlError as exc:
+            raise ValueError(f"{incident_id}: invalid package_url for {ecosystem}/{name}: {exc}") from exc
+    else:
+        package_url = purl_for_package(ecosystem, name)
     entity_id = stable_id("pkg", ecosystem, name)
     entity = packages.setdefault(
         entity_id,

--- a/scripts/supply_chain_purl.py
+++ b/scripts/supply_chain_purl.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Canonical PURL helpers for Threatpedia supply-chain data."""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+import re
+from urllib.parse import quote, unquote
+
+
+VALID_TYPES = {"generic", "golang", "npm", "pypi"}
+ECOSYSTEM_TO_TYPE = {
+    "generic": "generic",
+    "go": "golang",
+    "golang": "golang",
+    "multiple": "generic",
+    "npm": "npm",
+    "pypi": "pypi",
+}
+
+PYPI_SEPARATOR_PATTERN = re.compile(r"[-_.]+")
+GENERIC_SEPARATOR_PATTERN = re.compile(r"[^a-z0-9]+")
+NPM_NAME_PATTERN = re.compile(r"^(?:@[a-z0-9][a-z0-9._~-]*/)?[a-z0-9][a-z0-9._~-]*$")
+
+
+class PurlError(ValueError):
+    """Raised when a package URL cannot be parsed or normalized."""
+
+
+class ParsedPurl(NamedTuple):
+    type: str
+    name: str
+    namespace: str | None = None
+    version: str | None = None
+
+    @property
+    def package_name(self) -> str:
+        if self.namespace:
+            return f"{self.namespace}/{self.name}"
+        return self.name
+
+
+def purl_type_for_ecosystem(ecosystem: str | None) -> str | None:
+    if not isinstance(ecosystem, str):
+        return None
+    return ECOSYSTEM_TO_TYPE.get(ecosystem.strip().lower())
+
+
+def normalize_pypi_name(name: str) -> str:
+    normalized = PYPI_SEPARATOR_PATTERN.sub("-", name.strip().lower()).strip("-")
+    if not normalized:
+        raise PurlError("empty PyPI package name")
+    return normalized
+
+
+def normalize_generic_name(name: str) -> str:
+    normalized = GENERIC_SEPARATOR_PATTERN.sub("-", name.strip().lower()).strip("-")
+    if not normalized:
+        raise PurlError("empty generic package name")
+    return normalized
+
+
+def normalize_npm_name(name: str) -> tuple[str | None, str]:
+    normalized = name.strip().lower()
+    if normalized.startswith("%40"):
+        normalized = "@" + normalized[3:]
+    if not normalized or " " in normalized:
+        raise PurlError("invalid npm package name")
+    if normalized.startswith("@"):
+        parts = normalized.split("/")
+        if len(parts) != 2 or not parts[0][1:] or not parts[1]:
+            raise PurlError("invalid scoped npm package name")
+        candidate = f"{parts[0]}/{parts[1]}"
+        if not NPM_NAME_PATTERN.fullmatch(candidate):
+            raise PurlError("invalid scoped npm package name")
+        return parts[0], parts[1]
+    if "/" in normalized or not NPM_NAME_PATTERN.fullmatch(normalized):
+        raise PurlError("invalid npm package name")
+    return None, normalized
+
+
+def normalize_go_module(name: str) -> str:
+    normalized = name.strip()
+    if not normalized or any(char.isspace() for char in normalized):
+        raise PurlError("invalid Go module path")
+    if normalized.startswith("/") or normalized.endswith("/") or "//" in normalized:
+        raise PurlError("invalid Go module path")
+    if "." not in normalized.split("/", 1)[0]:
+        raise PurlError("Go module path must start with an import host")
+    return normalized
+
+
+def parse_purl(value: str) -> ParsedPurl:
+    if not isinstance(value, str) or not value.startswith("pkg:") or any(char.isspace() for char in value):
+        raise PurlError("expected package URL")
+    if "?" in value or "#" in value:
+        raise PurlError("qualifiers and subpaths are not supported in canonical corpus PURLs")
+
+    body = value[4:]
+    if "/" not in body:
+        raise PurlError("package URL missing type or name")
+    purl_type, path = body.split("/", 1)
+    if not purl_type or purl_type != purl_type.lower() or purl_type not in VALID_TYPES:
+        raise PurlError(f"unsupported PURL type {purl_type!r}")
+    if not path:
+        raise PurlError("package URL missing name")
+
+    version = None
+    if "@" in path:
+        path, version = path.rsplit("@", 1)
+        if not path or not version:
+            raise PurlError("invalid package URL version")
+
+    decoded_path = unquote(path)
+    if purl_type == "npm":
+        namespace, name = normalize_npm_name(decoded_path)
+        return ParsedPurl(type=purl_type, namespace=namespace, name=name, version=version)
+    if purl_type == "pypi":
+        if "/" in decoded_path:
+            raise PurlError("PyPI PURL must not include a namespace")
+        return ParsedPurl(type=purl_type, name=normalize_pypi_name(decoded_path), version=version)
+    if purl_type == "golang":
+        return ParsedPurl(type=purl_type, name=normalize_go_module(decoded_path), version=version)
+    if "/" in decoded_path:
+        raise PurlError("generic PURL must not include a namespace")
+    return ParsedPurl(type=purl_type, name=normalize_generic_name(decoded_path), version=version)
+
+
+def emit_purl(parsed: ParsedPurl) -> str:
+    if parsed.type == "npm":
+        if parsed.namespace:
+            package_path = f"{quote(parsed.namespace, safe='')}/{quote(parsed.name, safe='')}"
+        else:
+            package_path = quote(parsed.name, safe="")
+    elif parsed.type in {"generic", "pypi"}:
+        package_path = quote(parsed.name, safe="")
+    elif parsed.type == "golang":
+        package_path = quote(parsed.name, safe="/")
+    else:
+        raise PurlError(f"unsupported PURL type {parsed.type!r}")
+
+    version = f"@{parsed.version}" if parsed.version else ""
+    return f"pkg:{parsed.type}/{package_path}{version}"
+
+
+def canonicalize_purl(value: str, *, ecosystem: str | None = None, package_name: str | None = None) -> str:
+    parsed = parse_purl(value)
+    expected_type = purl_type_for_ecosystem(ecosystem)
+    if expected_type and parsed.type != expected_type:
+        raise PurlError(f"PURL type {parsed.type!r} does not match ecosystem {ecosystem!r}")
+    canonical = emit_purl(parsed)
+    if package_name is not None:
+        expected = purl_for_package(ecosystem or parsed.type, package_name, version=parsed.version)
+        if canonical != expected:
+            raise PurlError("PURL does not match package name and ecosystem")
+    return canonical
+
+
+def purl_for_package(ecosystem: str, name: str, *, version: str | None = None) -> str:
+    if not isinstance(ecosystem, str):
+        raise PurlError(f"unsupported package ecosystem {ecosystem!r}")
+    if not isinstance(name, str):
+        raise PurlError("package name must be a string")
+    purl_type = purl_type_for_ecosystem(ecosystem)
+    if purl_type is None:
+        raise PurlError(f"unsupported package ecosystem {ecosystem!r}")
+    if purl_type == "npm":
+        namespace, package_name = normalize_npm_name(name)
+        return emit_purl(ParsedPurl(type=purl_type, namespace=namespace, name=package_name, version=version))
+    if purl_type == "pypi":
+        return emit_purl(ParsedPurl(type=purl_type, name=normalize_pypi_name(name), version=version))
+    if purl_type == "golang":
+        return emit_purl(ParsedPurl(type=purl_type, name=normalize_go_module(name), version=version))
+    return emit_purl(ParsedPurl(type=purl_type, name=normalize_generic_name(name), version=version))

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -10,6 +10,12 @@ import re
 import sys
 from typing import Any
 
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from supply_chain_purl import PurlError, canonicalize_purl
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_CORPUS_PATH = REPO_ROOT / "data" / "supply-chain-incidents" / "incidents.json"
@@ -54,7 +60,7 @@ ENTITY_TYPE_REQUIRED_FIELDS = {
     "distribution_channels": ["channel_type", "ecosystem"],
     "maintainers": [],
     "organizations": [],
-    "packages": ["ecosystem"],
+    "packages": ["ecosystem", "package_url"],
     "repositories": ["host", "url", "owner"],
 }
 
@@ -107,6 +113,18 @@ def validate_entity_file(errors: list[str], entity_type: str, entities: Any, inc
         for field in ENTITY_TYPE_REQUIRED_FIELDS.get(entity_type, []):
             if not isinstance(entity.get(field), str) or not entity[field].strip():
                 errors.append(f"{entity_id}.{field}: expected non-empty string")
+        if entity_type == "packages" and isinstance(entity.get("package_url"), str):
+            try:
+                canonical = canonicalize_purl(
+                    entity["package_url"],
+                    ecosystem=entity.get("ecosystem"),
+                    package_name=entity.get("name"),
+                )
+            except PurlError as exc:
+                errors.append(f"{entity_id}.package_url: invalid canonical package URL: {exc}")
+            else:
+                if entity["package_url"] != canonical:
+                    errors.append(f"{entity_id}.package_url: expected canonical package URL {canonical!r}")
         source_incident_ids = entity.get("source_incident_ids")
         if not isinstance(source_incident_ids, list) or not source_incident_ids:
             errors.append(f"{entity_id}.source_incident_ids: expected non-empty list")

--- a/scripts/validate_supply_chain_incidents.py
+++ b/scripts/validate_supply_chain_incidents.py
@@ -12,6 +12,12 @@ import sys
 from typing import Any
 from urllib.parse import urlparse
 
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from supply_chain_purl import PurlError, canonicalize_purl
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_CORPUS_PATH = REPO_ROOT / "data" / "supply-chain-incidents" / "incidents.json"
@@ -19,7 +25,6 @@ DEFAULT_SCHEMA_PATH = REPO_ROOT / "data" / "supply-chain-incidents" / "schema.js
 SCHEMA_VERSION = "supply-chain-incident/1"
 ID_PATTERN = re.compile(r"^SC-[0-9]{4}-[A-Z0-9-]+$")
 FULL_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
-PURL_PATTERN = re.compile(r"^pkg:[a-z0-9.+-]+/[^\s]+$")
 REFERENCE_ID_PATTERN = re.compile(r"^ref-[a-z0-9-]+$")
 DATE_PATTERN = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$")
 DATE_RANGE_PATTERN = re.compile(r"^([0-9]{4}-[0-9]{2}-[0-9]{2})/([0-9]{4}-[0-9]{2}-[0-9]{2})$")
@@ -203,8 +208,19 @@ def validate_component(errors: list[str], incident_id: str, index: int, componen
     if component.get("component_type") not in VALID_COMPONENT_TYPES:
         errors.append(f"{path}.component_type: invalid value {component.get('component_type')!r}")
     package_url = component.get("package_url")
-    if package_url is not None and not (isinstance(package_url, str) and PURL_PATTERN.match(package_url)):
-        errors.append(f"{path}.package_url: expected null or package URL")
+    if component.get("component_type") == "package" and package_url is None:
+        errors.append(f"{path}.package_url: expected canonical package URL for package component")
+    if package_url is not None:
+        if not isinstance(package_url, str):
+            errors.append(f"{path}.package_url: expected canonical package URL")
+            return
+        try:
+            canonical = canonicalize_purl(package_url, ecosystem=component.get("ecosystem"), package_name=component.get("name"))
+        except PurlError as exc:
+            errors.append(f"{path}.package_url: invalid canonical package URL: {exc}")
+        else:
+            if package_url != canonical:
+                errors.append(f"{path}.package_url: expected canonical package URL {canonical!r}")
 
 
 def validate_reference(errors: list[str], incident_id: str, index: int, reference: Any) -> None:

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -129,6 +129,30 @@ class SupplyChainGraphTests(unittest.TestCase):
 
         self.assertTrue(any("unknown incident id 'SC-DOES-NOT-EXIST'" in error for error in errors))
 
+    def test_package_entities_require_canonical_purls(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        entities_by_type = validator.load_entities(ENTITY_DIR)
+        relationships = load_json(RELATIONSHIP_PATH)
+        entities_by_type["packages"] = copy.deepcopy(entities_by_type["packages"])
+        entities_by_type["packages"][0]["package_url"] = None
+
+        errors = validator.validate_graph(corpus, entities_by_type, relationships)
+
+        self.assertTrue(any(".package_url: expected non-empty string" in error for error in errors))
+
+    def test_package_purl_validation_does_not_crash_on_malformed_entity_fields(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        entities_by_type = validator.load_entities(ENTITY_DIR)
+        relationships = load_json(RELATIONSHIP_PATH)
+        entities_by_type["packages"] = copy.deepcopy(entities_by_type["packages"])
+        entities_by_type["packages"][0]["name"] = None
+        entities_by_type["packages"][0]["ecosystem"] = None
+
+        errors = validator.validate_graph(corpus, entities_by_type, relationships)
+
+        self.assertTrue(any(".name: expected non-empty string" in error for error in errors))
+        self.assertTrue(any(".ecosystem: expected non-empty string" in error for error in errors))
+
     def test_relationship_type_must_target_expected_entity_class(self) -> None:
         corpus = load_json(CORPUS_PATH)
         entities_by_type = validator.load_entities(ENTITY_DIR)

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -119,7 +119,25 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
 
         errors = validator.validate_incident(incident)
 
-        self.assertTrue(any(".affected_components[0].package_url: expected null or package URL" in error for error in errors))
+        self.assertTrue(any(".affected_components[0].package_url: invalid canonical package URL" in error for error in errors))
+
+    def test_package_components_require_canonical_purls(self) -> None:
+        incident = copy.deepcopy(next(item for item in load_json(CORPUS_PATH) if item["id"] == "SC-2018-NPM-EVENT-STREAM"))
+        incident["affected_components"][0]["package_url"] = None
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any(".affected_components[0].package_url: expected canonical package URL" in error for error in errors))
+
+    def test_package_purl_validation_does_not_crash_on_malformed_component_fields(self) -> None:
+        incident = copy.deepcopy(next(item for item in load_json(CORPUS_PATH) if item["id"] == "SC-2018-NPM-EVENT-STREAM"))
+        incident["affected_components"][0]["name"] = None
+        incident["affected_components"][0]["ecosystem"] = None
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any(".affected_components[0].name: expected non-empty string" in error for error in errors))
+        self.assertTrue(any(".affected_components[0].ecosystem: expected non-empty string" in error for error in errors))
 
     def test_malformed_url_is_rejected_without_crashing(self) -> None:
         incident = copy.deepcopy(load_json(CORPUS_PATH)[0])

--- a/tests/test_supply_chain_purl.py
+++ b/tests/test_supply_chain_purl.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PURL_PATH = REPO_ROOT / "scripts" / "supply_chain_purl.py"
+
+
+def load_purl_module():
+    spec = importlib.util.spec_from_file_location("supply_chain_purl", PURL_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load supply_chain_purl")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+purl = load_purl_module()
+
+
+class SupplyChainPurlTests(unittest.TestCase):
+    def test_npm_purls_are_canonicalized(self) -> None:
+        self.assertEqual(purl.purl_for_package("npm", "Event-Stream"), "pkg:npm/event-stream")
+        self.assertEqual(purl.purl_for_package("npm", "@LedgerHQ/Connect-Kit"), "pkg:npm/%40ledgerhq/connect-kit")
+        self.assertEqual(
+            purl.canonicalize_purl("pkg:npm/%40LedgerHQ/connect-kit", ecosystem="npm", package_name="@ledgerhq/connect-kit"),
+            "pkg:npm/%40ledgerhq/connect-kit",
+        )
+
+    def test_pypi_names_use_pep_503_style_normalization(self) -> None:
+        self.assertEqual(purl.purl_for_package("pypi", "Torch_Trition.Name"), "pkg:pypi/torch-trition-name")
+
+    def test_go_module_purls_preserve_module_path(self) -> None:
+        self.assertEqual(
+            purl.purl_for_package("go", "github.com/boltdb/bolt", version="v1.3.1"),
+            "pkg:golang/github.com/boltdb/bolt@v1.3.1",
+        )
+
+    def test_multiple_ecosystem_packages_use_generic_purl(self) -> None:
+        self.assertEqual(
+            purl.purl_for_package("multiple", "internal dependency names"),
+            "pkg:generic/internal-dependency-names",
+        )
+        self.assertEqual(
+            purl.purl_for_package("generic", "internal dependency names"),
+            "pkg:generic/internal-dependency-names",
+        )
+        self.assertEqual(
+            purl.canonicalize_purl("pkg:generic/internal-dependency-names", package_name="internal dependency names"),
+            "pkg:generic/internal-dependency-names",
+        )
+
+    def test_malformed_or_noncanonical_purls_are_rejected(self) -> None:
+        with self.assertRaises(purl.PurlError):
+            purl.canonicalize_purl("pkg:npm/example package", ecosystem="npm", package_name="example")
+        with self.assertRaises(purl.PurlError):
+            purl.canonicalize_purl("pkg:pypi/torch_triton", ecosystem="pypi", package_name="torchtriton")
+        with self.assertRaises(purl.PurlError):
+            purl.canonicalize_purl("pkg:npm/event-stream", ecosystem="pypi", package_name="event-stream")
+        with self.assertRaises(purl.PurlError):
+            purl.purl_for_package("npm", None)
+        with self.assertRaises(purl.PurlError):
+            purl.canonicalize_purl("pkg:npm/event-stream", ecosystem=None, package_name=[])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `scripts/supply_chain_purl.py` as the single canonical PURL parser/normalizer/emitter for supply-chain package records
- require canonical package PURLs in incident package components and package entities
- add a path-scoped supply-chain validation workflow so the incident/graph/PURL checks run as a standing PR gate
- document the PURL model and update existing supply-chain schema/graph docs

## Scope boundaries
- no scoring, risk engine, soak/canary logic, ML, or automated attribution
- no release entity layer yet; release PURL enforcement remains Phase 2C
- no PURL audit report yet; final audit remains Phase 2F after expansion

## Validation
- `python3 -m py_compile scripts/supply_chain_purl.py scripts/build_supply_chain_entities.py scripts/validate_supply_chain_incidents.py scripts/validate_supply_chain_graph.py` PASS
- `python3 scripts/validate_supply_chain_incidents.py` PASS: validated 25 incidents
- `python3 scripts/validate_supply_chain_graph.py` PASS: entities=73 relationships=93
- `python3 -m unittest tests/test_supply_chain_purl.py tests/test_supply_chain_incidents.py tests/test_supply_chain_graph.py` PASS: 40 tests
- `node scripts/test-supply-chain-pages.mjs` PASS: routes=74
- `ENABLE_SUPPLY_CHAIN_PAGES=true npm run build` PASS: 379 pages built; existing campaign relation warnings only
- `git diff --check` PASS
