### PR TITLE
Require justification for generic supply chain PURLs

### DIFF
--- a/data/supply-chain-entities/packages.json
+++ b/data/supply-chain-entities/packages.json
@@ -7,6 +7,7 @@
     "id": "pkg-multiple-internal-dependency-names",
     "name": "internal dependency names",
     "package_url": "pkg:generic/internal-dependency-names",
+    "purl_justification": "Dependency-confusion internal names are cross-ecosystem private identifiers with no public registry package home.",
     "source_incident_ids": [
       "SC-2021-DEPENDENCY-CONFUSION"
     ]

--- a/data/supply-chain-incidents/incidents.json
+++ b/data/supply-chain-incidents/incidents.json
@@ -724,7 +724,8 @@
         "ecosystem": "multiple",
         "name": "internal dependency names",
         "vendor": "multiple organizations",
-        "package_url": "pkg:generic/internal-dependency-names"
+        "package_url": "pkg:generic/internal-dependency-names",
+        "purl_justification": "Dependency-confusion internal names are cross-ecosystem private identifiers with no public registry package home."
       }
     ],
     "supply_chain_vectors": [

--- a/data/supply-chain-incidents/schema.json
+++ b/data/supply-chain-incidents/schema.json
@@ -263,6 +263,9 @@
         "package_url": {
           "type": ["string", "null"],
           "pattern": "^pkg:[a-z0-9.+-]+/[^\\s]+$"
+        },
+        "purl_justification": {
+          "type": "string"
         }
       }
     },

--- a/docs/supply-chain-graph-primitives.md
+++ b/docs/supply-chain-graph-primitives.md
@@ -32,7 +32,9 @@ Each entity has:
 - `source_incident_ids`: incident IDs that caused the entity to be emitted
 
 Package entities also carry `ecosystem` and a required canonical `package_url`
-PURL. See `docs/supply-chain-purl-model.md` for the canonical grammar.
+PURL. Generic package PURLs require `purl_justification` because they are
+reviewed exceptions, not registry-joinable package keys. See
+`docs/supply-chain-purl-model.md` for the canonical grammar.
 Repository entities also carry `host`, `url`, and `owner`.
 Build-system, distribution-channel, and account entities carry type-specific
 fields copied from the incident corpus.

--- a/docs/supply-chain-incident-schema.md
+++ b/docs/supply-chain-incident-schema.md
@@ -79,7 +79,8 @@ case studies.
 Package components must include a canonical `package_url` PURL. Non-package
 software, services, websites, and update channels should use `null`. See
 `docs/supply-chain-purl-model.md` for the canonical PURL grammar and validation
-contract.
+contract. `pkg:generic/...` is allowed only for reviewed cross-ecosystem
+placeholders and requires `purl_justification`.
 
 ## Attack Stages
 

--- a/docs/supply-chain-purl-model.md
+++ b/docs/supply-chain-purl-model.md
@@ -60,6 +60,8 @@ pkg:generic/internal-dependency-names
 
 This is reserved for explicit abstract package placeholders. It must not be used to avoid modeling a known npm, PyPI, or Go package.
 
+Every `pkg:generic/...` package component and package entity must include `purl_justification`. The justification records why no registry-specific PURL exists. This keeps `generic` visible as a reviewed exception because generic PURLs do not join cleanly to OSV, deps.dev, OpenSSF Scorecard, or release-feed package keys.
+
 ## Validator Contract
 
 The incident validator requires every `affected_components` item with `component_type: "package"` to carry a canonical `package_url`.
@@ -73,6 +75,7 @@ Both validators fail if a package PURL:
 - does not match the entity or component ecosystem
 - does not match the entity or component package name after canonical normalization
 - uses non-canonical spelling or encoding
+- uses the `generic` PURL type without an explicit `purl_justification`
 
 Non-package components, such as software, services, websites, and update channels, are not package records and do not require PURLs in Phase 2A.
 

--- a/scripts/build_supply_chain_entities.py
+++ b/scripts/build_supply_chain_entities.py
@@ -15,7 +15,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
-from supply_chain_purl import PurlError, canonicalize_purl, purl_for_package
+from supply_chain_purl import PurlError, canonicalize_purl, parse_purl, purl_for_package
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -122,6 +122,7 @@ def upsert_package(packages: dict[str, dict[str, Any]], component: dict[str, Any
     ecosystem = component["ecosystem"]
     name = component["name"]
     package_url = component.get("package_url")
+    purl_justification = component.get("purl_justification")
     if package_url:
         try:
             package_url = canonicalize_purl(package_url, ecosystem=ecosystem, package_name=name)
@@ -129,6 +130,10 @@ def upsert_package(packages: dict[str, dict[str, Any]], component: dict[str, Any
             raise ValueError(f"{incident_id}: invalid package_url for {ecosystem}/{name}: {exc}") from exc
     else:
         package_url = purl_for_package(ecosystem, name)
+    if parse_purl(package_url).type == "generic" and (
+        not isinstance(purl_justification, str) or len(purl_justification.strip()) < 20
+    ):
+        raise ValueError(f"{incident_id}: generic package_url for {ecosystem}/{name} requires purl_justification")
     entity_id = stable_id("pkg", ecosystem, name)
     entity = packages.setdefault(
         entity_id,
@@ -137,12 +142,15 @@ def upsert_package(packages: dict[str, dict[str, Any]], component: dict[str, Any
             "name": name,
             "ecosystem": ecosystem,
             "package_url": package_url,
+            **({"purl_justification": purl_justification} if parse_purl(package_url).type == "generic" else {}),
             "aliases": sorted({name}),
             "source_incident_ids": [],
         },
     )
     if package_url and not entity.get("package_url"):
         entity["package_url"] = package_url
+    if parse_purl(package_url).type == "generic":
+        entity["purl_justification"] = purl_justification
     add_source(entity, incident_id)
     return entity_id
 

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -14,7 +14,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
-from supply_chain_purl import PurlError, canonicalize_purl
+from supply_chain_purl import PurlError, canonicalize_purl, parse_purl
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -125,6 +125,9 @@ def validate_entity_file(errors: list[str], entity_type: str, entities: Any, inc
             else:
                 if entity["package_url"] != canonical:
                     errors.append(f"{entity_id}.package_url: expected canonical package URL {canonical!r}")
+                if parse_purl(canonical).type == "generic":
+                    if not isinstance(entity.get("purl_justification"), str) or len(entity["purl_justification"].strip()) < 20:
+                        errors.append(f"{entity_id}.purl_justification: expected non-empty generic PURL justification")
         source_incident_ids = entity.get("source_incident_ids")
         if not isinstance(source_incident_ids, list) or not source_incident_ids:
             errors.append(f"{entity_id}.source_incident_ids: expected non-empty list")

--- a/scripts/validate_supply_chain_incidents.py
+++ b/scripts/validate_supply_chain_incidents.py
@@ -16,7 +16,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
-from supply_chain_purl import PurlError, canonicalize_purl
+from supply_chain_purl import PurlError, canonicalize_purl, parse_purl
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -221,6 +221,8 @@ def validate_component(errors: list[str], incident_id: str, index: int, componen
         else:
             if package_url != canonical:
                 errors.append(f"{path}.package_url: expected canonical package URL {canonical!r}")
+            if parse_purl(canonical).type == "generic":
+                require_string(errors, f"{path}.purl_justification", component.get("purl_justification"), min_length=20)
 
 
 def validate_reference(errors: list[str], incident_id: str, index: int, reference: Any) -> None:

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -153,6 +153,18 @@ class SupplyChainGraphTests(unittest.TestCase):
         self.assertTrue(any(".name: expected non-empty string" in error for error in errors))
         self.assertTrue(any(".ecosystem: expected non-empty string" in error for error in errors))
 
+    def test_generic_package_entities_require_justification(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        entities_by_type = validator.load_entities(ENTITY_DIR)
+        relationships = load_json(RELATIONSHIP_PATH)
+        entities_by_type["packages"] = copy.deepcopy(entities_by_type["packages"])
+        generic = next(entity for entity in entities_by_type["packages"] if entity["package_url"].startswith("pkg:generic/"))
+        del generic["purl_justification"]
+
+        errors = validator.validate_graph(corpus, entities_by_type, relationships)
+
+        self.assertTrue(any(".purl_justification: expected non-empty generic PURL justification" in error for error in errors))
+
     def test_relationship_type_must_target_expected_entity_class(self) -> None:
         corpus = load_json(CORPUS_PATH)
         entities_by_type = validator.load_entities(ENTITY_DIR)

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -139,6 +139,14 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
         self.assertTrue(any(".affected_components[0].name: expected non-empty string" in error for error in errors))
         self.assertTrue(any(".affected_components[0].ecosystem: expected non-empty string" in error for error in errors))
 
+    def test_generic_package_purls_require_justification(self) -> None:
+        incident = copy.deepcopy(next(item for item in load_json(CORPUS_PATH) if item["id"] == "SC-2021-DEPENDENCY-CONFUSION"))
+        del incident["affected_components"][0]["purl_justification"]
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any(".affected_components[0].purl_justification" in error for error in errors))
+
     def test_malformed_url_is_rejected_without_crashing(self) -> None:
         incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
         incident["references"][0]["url"] = "https://example.com:bad-port"


### PR DESCRIPTION
## Summary
- require `purl_justification` for every `pkg:generic/...` package component and package entity
- preserve the dependency-confusion placeholder as an explicit reviewed exception, not a silent fallback
- make the entity builder reject unjustified generic PURLs and copy the justification into package entities
- document that generic PURLs do not join cleanly to OSV, deps.dev, OpenSSF Scorecard, or release-feed keys

## Context
Follow-up to #1143. #1143 already included the Gemini generic mapping fix and the Codex non-string validator crash fixes. This PR addresses the remaining strategic issue: `pkg:generic` must be a decision with a recorded reason, not an easy path around registry-specific PURL resolution.

## Validation
- `python3 -m py_compile scripts/supply_chain_purl.py scripts/build_supply_chain_entities.py scripts/validate_supply_chain_incidents.py scripts/validate_supply_chain_graph.py` PASS
- `python3 scripts/validate_supply_chain_incidents.py` PASS: validated 25 incidents
- `python3 scripts/validate_supply_chain_graph.py` PASS: entities=73 relationships=93
- `python3 -m unittest tests/test_supply_chain_purl.py tests/test_supply_chain_incidents.py tests/test_supply_chain_graph.py` PASS: 44 tests
- `node scripts/test-supply-chain-pages.mjs` PASS: routes=74
- `ENABLE_SUPPLY_CHAIN_PAGES=true npm run build` PASS: 379 pages built; existing campaign relation warnings only
- `git diff --check` PASS

## 2B forward flag
The enabled build still emits pre-existing campaign relation warnings. They are out of scope here, but should be audited before Phase 2B converts actor/campaign convergence into hard dangling-edge checks.
