### PR TITLE
Align generic PURL schema contract

### DIFF
--- a/data/supply-chain-incidents/schema.json
+++ b/data/supply-chain-incidents/schema.json
@@ -265,8 +265,25 @@
           "pattern": "^pkg:[a-z0-9.+-]+/[^\\s]+$"
         },
         "purl_justification": {
-          "type": "string"
+          "type": "string",
+          "minLength": 20
         }
+      },
+      "if": {
+        "properties": {
+          "package_url": {
+            "type": "string",
+            "pattern": "^pkg:generic/"
+          }
+        },
+        "required": [
+          "package_url"
+        ]
+      },
+      "then": {
+        "required": [
+          "purl_justification"
+        ]
       }
     },
     "reference": {

--- a/scripts/build_supply_chain_entities.py
+++ b/scripts/build_supply_chain_entities.py
@@ -130,7 +130,9 @@ def upsert_package(packages: dict[str, dict[str, Any]], component: dict[str, Any
             raise ValueError(f"{incident_id}: invalid package_url for {ecosystem}/{name}: {exc}") from exc
     else:
         package_url = purl_for_package(ecosystem, name)
-    if parse_purl(package_url).type == "generic" and (
+    parsed_purl = parse_purl(package_url)
+    is_generic_purl = parsed_purl.type == "generic"
+    if is_generic_purl and (
         not isinstance(purl_justification, str) or len(purl_justification.strip()) < 20
     ):
         raise ValueError(f"{incident_id}: generic package_url for {ecosystem}/{name} requires purl_justification")
@@ -142,14 +144,14 @@ def upsert_package(packages: dict[str, dict[str, Any]], component: dict[str, Any
             "name": name,
             "ecosystem": ecosystem,
             "package_url": package_url,
-            **({"purl_justification": purl_justification} if parse_purl(package_url).type == "generic" else {}),
+            **({"purl_justification": purl_justification} if is_generic_purl else {}),
             "aliases": sorted({name}),
             "source_incident_ids": [],
         },
     )
     if package_url and not entity.get("package_url"):
         entity["package_url"] = package_url
-    if parse_purl(package_url).type == "generic":
+    if is_generic_purl:
         entity["purl_justification"] = purl_justification
     add_source(entity, incident_id)
     return entity_id

--- a/scripts/validate_supply_chain_incidents.py
+++ b/scripts/validate_supply_chain_incidents.py
@@ -545,12 +545,40 @@ def validate_schema_file(schema: Any) -> list[str]:
         return ["schema.properties: expected object"]
     schema_version = properties.get("schema_version")
     if not isinstance(schema_version, dict):
-        return ["schema.properties.schema_version: expected object"]
+        errors.append("schema.properties.schema_version: expected object")
+        return errors
     if schema_version.get("const") != SCHEMA_VERSION:
         errors.append("schema.schema_version.const: does not match validator schema version")
     required = schema.get("required")
     if not isinstance(required, list) or set(required) != set(REQUIRED_FIELDS):
         errors.append("schema.required: does not match validator required fields")
+    defs = schema.get("$defs")
+    affected_component = defs.get("affected_component") if isinstance(defs, dict) else None
+    if not isinstance(affected_component, dict):
+        errors.append("schema.$defs.affected_component: expected object")
+        return errors
+    component_properties = affected_component.get("properties")
+    if not isinstance(component_properties, dict):
+        errors.append("schema.$defs.affected_component.properties: expected object")
+        return errors
+    purl_justification = component_properties.get("purl_justification")
+    if not isinstance(purl_justification, dict) or purl_justification.get("minLength") != 20:
+        errors.append("schema.$defs.affected_component.properties.purl_justification.minLength: expected 20")
+    generic_if = affected_component.get("if")
+    generic_then = affected_component.get("then")
+    generic_pattern = None
+    generic_required = None
+    if isinstance(generic_if, dict):
+        generic_required = generic_if.get("required")
+        if_properties = generic_if.get("properties")
+        if isinstance(if_properties, dict):
+            package_url = if_properties.get("package_url")
+            if isinstance(package_url, dict):
+                generic_pattern = package_url.get("pattern")
+    if generic_pattern != "^pkg:generic/" or generic_required != ["package_url"]:
+        errors.append("schema.$defs.affected_component.if: must match generic package URLs")
+    if not isinstance(generic_then, dict) or generic_then.get("required") != ["purl_justification"]:
+        errors.append("schema.$defs.affected_component.then: must require purl_justification")
     return errors
 
 

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -207,6 +207,23 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
         schema["required"].pop()
         self.assertEqual(validator.validate_schema_file(schema), ["schema.required: does not match validator required fields"])
 
+    def test_schema_requires_generic_purl_justification_contract(self) -> None:
+        schema = load_json(SCHEMA_PATH)
+        affected_component = schema["$defs"]["affected_component"]
+
+        self.assertEqual(validator.validate_schema_file(schema), [])
+
+        affected_component["properties"]["purl_justification"]["minLength"] = 1
+        self.assertTrue(any("purl_justification.minLength" in error for error in validator.validate_schema_file(schema)))
+
+        schema = load_json(SCHEMA_PATH)
+        del schema["$defs"]["affected_component"]["if"]
+        self.assertTrue(any("affected_component.if" in error for error in validator.validate_schema_file(schema)))
+
+        schema = load_json(SCHEMA_PATH)
+        del schema["$defs"]["affected_component"]["then"]
+        self.assertTrue(any("affected_component.then" in error for error in validator.validate_schema_file(schema)))
+
     def test_source_artifact_divergence_requires_distribution_channels(self) -> None:
         incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
         incident["source_artifact_divergence"] = True


### PR DESCRIPTION
## Summary
- encode the generic-PURL justification rule in `data/supply-chain-incidents/schema.json` with JSON Schema `if`/`then`
- require `purl_justification` and `minLength: 20` when `package_url` matches `^pkg:generic/`
- add validator sanity checks so the schema cannot drift from the Python gate
- add regression tests for missing conditional, missing `then`, and weakened `minLength`
- clean up repeated PURL parsing in the entity builder

## Validation
- `python3 scripts/build_supply_chain_entities.py` PASS: no graph data drift
- `python3 -m py_compile scripts/supply_chain_purl.py scripts/build_supply_chain_entities.py scripts/validate_supply_chain_incidents.py scripts/validate_supply_chain_graph.py` PASS
- `python3 scripts/validate_supply_chain_incidents.py` PASS: validated 25 incidents
- `python3 scripts/validate_supply_chain_graph.py` PASS: entities=73 relationships=93
- `python3 -m unittest tests/test_supply_chain_purl.py tests/test_supply_chain_incidents.py tests/test_supply_chain_graph.py` PASS: 45 tests
- `node scripts/test-supply-chain-pages.mjs` PASS: routes=74
- `ENABLE_SUPPLY_CHAIN_PAGES=true npm run build` PASS: 379 pages built; existing campaign relation warnings only
- `git diff --check` PASS

## Note
This closes the contract gap where Python validation required generic-PURL justification but the published JSON schema did not.
