### PR TITLE
Supply Chain Phase 2B actor and campaign convergence

### DIFF
--- a/data/supply-chain-entities/actors.json
+++ b/data/supply-chain-entities/actors.json
@@ -1,0 +1,59 @@
+[
+  {
+    "actor_type": "public",
+    "aliases": [
+      "APT29",
+      "Cozy Bear",
+      "SVR"
+    ],
+    "attribution_confidence": "confirmed",
+    "href": "/threat-actors/apt29/",
+    "id": "actor-apt29",
+    "name": "APT29",
+    "source_incident_ids": [
+      "SC-2020-SOLARWINDS-ORION"
+    ]
+  },
+  {
+    "actor_type": "public",
+    "aliases": [
+      "Lazarus Group",
+      "UNC4736"
+    ],
+    "attribution_confidence": "likely",
+    "href": "/threat-actors/lazarus-group/",
+    "id": "actor-lazarus-group",
+    "name": "Lazarus Group",
+    "source_incident_ids": [
+      "SC-2023-THREE-CX-DESKTOP"
+    ]
+  },
+  {
+    "actor_type": "public",
+    "aliases": [
+      "GRU Unit 74455",
+      "Sandworm"
+    ],
+    "attribution_confidence": "confirmed",
+    "href": "/threat-actors/sandworm/",
+    "id": "actor-sandworm",
+    "name": "Sandworm",
+    "source_incident_ids": [
+      "SC-2017-NOTPETYA-MEDOC"
+    ]
+  },
+  {
+    "actor_type": "provisional",
+    "aliases": [
+      "Jia Tan operator cluster",
+      "UNC-XZ-UTILS"
+    ],
+    "attribution_confidence": "suspected",
+    "id": "actor-unc-xz-utils-operator",
+    "name": "UNC-XZ-UTILS",
+    "notes": "Provisional supply-chain operator node for the coherent Jia Tan maintainer identity and XZ Utils backdoor activity; no nation-state label is asserted.",
+    "source_incident_ids": [
+      "SC-2024-XZ-UTILS"
+    ]
+  }
+]

--- a/data/supply-chain-entities/campaigns.json
+++ b/data/supply-chain-entities/campaigns.json
@@ -1,0 +1,44 @@
+[
+  {
+    "aliases": [
+      "NotPetya Destructive Campaign: Sandworm Global Wiper Operation (2017)",
+      "TP-CAMP-2017-0002"
+    ],
+    "campaign_id": "TP-CAMP-2017-0002",
+    "href": "/campaigns/notpetya-destructive-campaign-2017/",
+    "id": "campaign-tp-camp-2017-0002",
+    "name": "NotPetya Destructive Campaign: Sandworm Global Wiper Operation (2017)",
+    "slug": "notpetya-destructive-campaign-2017",
+    "source_incident_ids": [
+      "SC-2017-NOTPETYA-MEDOC"
+    ]
+  },
+  {
+    "aliases": [
+      "SolarWinds Supply Chain Espionage Campaign",
+      "TP-CAMP-2020-0001"
+    ],
+    "campaign_id": "TP-CAMP-2020-0001",
+    "href": "/campaigns/solarwinds-supply-chain-campaign/",
+    "id": "campaign-tp-camp-2020-0001",
+    "name": "SolarWinds Supply Chain Espionage Campaign",
+    "slug": "solarwinds-supply-chain-campaign",
+    "source_incident_ids": [
+      "SC-2020-SOLARWINDS-ORION"
+    ]
+  },
+  {
+    "aliases": [
+      "Lazarus Group Operation SmoothOperator - 3CX Software Supply Chain Compromise",
+      "TP-CAMP-2023-0002"
+    ],
+    "campaign_id": "TP-CAMP-2023-0002",
+    "href": "/campaigns/lazarus-3cx-supply-chain-compromise-2023/",
+    "id": "campaign-tp-camp-2023-0002",
+    "name": "Lazarus Group Operation SmoothOperator - 3CX Software Supply Chain Compromise",
+    "slug": "lazarus-3cx-supply-chain-compromise-2023",
+    "source_incident_ids": [
+      "SC-2023-THREE-CX-DESKTOP"
+    ]
+  }
+]

--- a/data/supply-chain-incidents/incidents.json
+++ b/data/supply-chain-incidents/incidents.json
@@ -64,6 +64,7 @@
     "status": "confirmed",
     "first_observed_at": "2017-06-27",
     "disclosed_at": "2017-07-01",
+    "first_public_warning_at": "2017-07-01",
     "affected_ecosystems": [
       "windows",
       "vendor-update"
@@ -87,10 +88,65 @@
     ],
     "references": [
       {
+        "id": "ref-cisa-notpetya",
         "title": "Petya Ransomware",
         "publisher": "Cybersecurity and Infrastructure Security Agency",
         "url": "https://www.cisa.gov/news-events/alerts/2017/07/01/petya-ransomware",
         "published_at": "2017-07-01"
+      },
+      {
+        "id": "ref-doj-sandworm-notpetya",
+        "title": "Six Russian GRU Officers Charged in Connection with Worldwide Deployment of Destructive Malware",
+        "publisher": "U.S. Department of Justice",
+        "url": "https://www.justice.gov/opa/pr/six-russian-gru-officers-charged-connection-worldwide-deployment-destructive-malware-and",
+        "published_at": "2020-10-19"
+      }
+    ],
+    "threat_actors": [
+      {
+        "id": "actor-sandworm",
+        "name": "Sandworm",
+        "actor_type": "public",
+        "confidence": "confirmed",
+        "aliases": [
+          "Sandworm",
+          "GRU Unit 74455"
+        ],
+        "href": "/threat-actors/sandworm/",
+        "source_refs": [
+          "ref-doj-sandworm-notpetya"
+        ]
+      }
+    ],
+    "campaigns": [
+      {
+        "id": "campaign-tp-camp-2017-0002",
+        "campaign_id": "TP-CAMP-2017-0002",
+        "name": "NotPetya Destructive Campaign: Sandworm Global Wiper Operation (2017)",
+        "slug": "notpetya-destructive-campaign-2017",
+        "confidence": "confirmed",
+        "source_refs": [
+          "ref-doj-sandworm-notpetya"
+        ]
+      }
+    ],
+    "attribution_confidence": "confirmed",
+    "attribution_evidence": [
+      {
+        "target": "actor-sandworm",
+        "relationship_type": "ATTRIBUTED_TO_ACTOR",
+        "source_refs": [
+          "ref-doj-sandworm-notpetya"
+        ],
+        "summary": "The DOJ NotPetya charging document supports the Sandworm attribution used for this supply-chain incident edge."
+      },
+      {
+        "target": "campaign-tp-camp-2017-0002",
+        "relationship_type": "RELATED_CAMPAIGN",
+        "source_refs": [
+          "ref-doj-sandworm-notpetya"
+        ],
+        "summary": "The modeled campaign node covers the Sandworm NotPetya destructive campaign tied to the M.E.Doc update compromise."
       }
     ],
     "tags": [
@@ -555,6 +611,7 @@
     "status": "confirmed",
     "first_observed_at": "2020-03-01",
     "disclosed_at": "2020-12-13",
+    "first_public_warning_at": "2020-12-13",
     "affected_ecosystems": [
       "windows",
       "vendor-update"
@@ -578,11 +635,25 @@
     ],
   "references": [
     {
+      "id": "ref-cisa-ed-21-01",
+      "title": "Emergency Directive 21-01: Mitigate SolarWinds Orion Code Compromise",
+      "publisher": "Cybersecurity and Infrastructure Security Agency",
+      "url": "https://www.cisa.gov/news-events/directives/ed-21-01-mitigate-solarwinds-orion-code-compromise",
+      "published_at": "2020-12-13"
+    },
+    {
       "id": "ref-cisa-aa20-352a",
       "title": "Advanced Persistent Threat Compromise of Government Agencies, Critical Infrastructure, and Private Sector Organizations",
       "publisher": "Cybersecurity and Infrastructure Security Agency",
       "url": "https://www.cisa.gov/news-events/cybersecurity-advisories/aa20-352a",
       "published_at": "2020-12-17"
+    },
+    {
+      "id": "ref-whitehouse-solarwinds-svr",
+      "title": "Fact Sheet: Imposing Costs for Harmful Foreign Activities by the Russian Government",
+      "publisher": "The White House",
+      "url": "https://www.whitehouse.gov/briefing-room/statements-releases/2021/04/15/fact-sheet-imposing-costs-for-harmful-foreign-activities-by-the-russian-government/",
+      "published_at": "2021-04-15"
     }
   ],
   "executive_summary": [
@@ -676,6 +747,54 @@
       "reference_ids": [
         "ref-cisa-aa20-352a"
       ]
+    }
+  ],
+  "threat_actors": [
+    {
+      "id": "actor-apt29",
+      "name": "APT29",
+      "actor_type": "public",
+      "confidence": "confirmed",
+      "aliases": [
+        "APT29",
+        "Cozy Bear",
+        "SVR"
+      ],
+      "href": "/threat-actors/apt29/",
+      "source_refs": [
+        "ref-whitehouse-solarwinds-svr"
+      ]
+    }
+  ],
+  "campaigns": [
+    {
+      "id": "campaign-tp-camp-2020-0001",
+      "campaign_id": "TP-CAMP-2020-0001",
+      "name": "SolarWinds Supply Chain Espionage Campaign",
+      "slug": "solarwinds-supply-chain-campaign",
+      "confidence": "confirmed",
+      "source_refs": [
+        "ref-whitehouse-solarwinds-svr"
+      ]
+    }
+  ],
+  "attribution_confidence": "confirmed",
+  "attribution_evidence": [
+    {
+      "target": "actor-apt29",
+      "relationship_type": "ATTRIBUTED_TO_ACTOR",
+      "source_refs": [
+        "ref-whitehouse-solarwinds-svr"
+      ],
+      "summary": "The White House attribution statement supports the APT29/SVR actor edge for the SolarWinds supply-chain compromise."
+    },
+    {
+      "target": "campaign-tp-camp-2020-0001",
+      "relationship_type": "RELATED_CAMPAIGN",
+      "source_refs": [
+        "ref-whitehouse-solarwinds-svr"
+      ],
+      "summary": "The SolarWinds supply-chain campaign node captures the same SVR-attributed operation represented by this incident."
     }
   ],
   "tags": [
@@ -1480,6 +1599,7 @@
     "status": "confirmed",
     "first_observed_at": "2023-03-22",
     "disclosed_at": "2023-03-29",
+    "first_public_warning_at": "2023-03-29",
     "affected_ecosystems": [
       "windows",
       "macos",
@@ -1504,6 +1624,13 @@
       "downstream_customer_compromise"
     ],
   "references": [
+    {
+      "id": "ref-sentinelone-3cx",
+      "title": "SmoothOperator: Ongoing Campaign Trojanizes 3CX Software",
+      "publisher": "SentinelOne",
+      "url": "https://www.sentinelone.com/blog/smoothoperator-ongoing-campaign-trojanized-3cx-software",
+      "published_at": "2023-03-29"
+    },
     {
       "id": "ref-mandiant-3cx",
       "title": "3CX Software Supply Chain Compromise",
@@ -1603,6 +1730,53 @@
       "reference_ids": [
         "ref-mandiant-3cx"
       ]
+    }
+  ],
+  "threat_actors": [
+    {
+      "id": "actor-lazarus-group",
+      "name": "Lazarus Group",
+      "actor_type": "public",
+      "confidence": "likely",
+      "aliases": [
+        "Lazarus Group",
+        "UNC4736"
+      ],
+      "href": "/threat-actors/lazarus-group/",
+      "source_refs": [
+        "ref-mandiant-3cx"
+      ]
+    }
+  ],
+  "campaigns": [
+    {
+      "id": "campaign-tp-camp-2023-0002",
+      "campaign_id": "TP-CAMP-2023-0002",
+      "name": "Lazarus Group Operation SmoothOperator - 3CX Software Supply Chain Compromise",
+      "slug": "lazarus-3cx-supply-chain-compromise-2023",
+      "confidence": "likely",
+      "source_refs": [
+        "ref-mandiant-3cx"
+      ]
+    }
+  ],
+  "attribution_confidence": "likely",
+  "attribution_evidence": [
+    {
+      "target": "actor-lazarus-group",
+      "relationship_type": "ATTRIBUTED_TO_ACTOR",
+      "source_refs": [
+        "ref-mandiant-3cx"
+      ],
+      "summary": "Mandiant's 3CX report supports the Lazarus-associated actor edge through its UNC4736 attribution assessment."
+    },
+    {
+      "target": "campaign-tp-camp-2023-0002",
+      "relationship_type": "RELATED_CAMPAIGN",
+      "source_refs": [
+        "ref-mandiant-3cx"
+      ],
+      "summary": "The SmoothOperator campaign node covers the same 3CX software supply-chain compromise represented by this incident."
     }
   ],
   "tags": [
@@ -1705,6 +1879,7 @@
     "status": "confirmed",
     "first_observed_at": "2024-02-24",
     "disclosed_at": "2024-03-29",
+    "first_public_warning_at": "2024-03-29",
     "affected_ecosystems": [
       "linux",
       "source-release"
@@ -1825,6 +2000,36 @@
       "reference_ids": [
         "ref-openwall-xz"
       ]
+    }
+  ],
+  "threat_actors": [
+    {
+      "id": "actor-unc-xz-utils-operator",
+      "name": "UNC-XZ-UTILS",
+      "actor_type": "provisional",
+      "confidence": "suspected",
+      "aliases": [
+        "UNC-XZ-UTILS",
+        "Jia Tan operator cluster"
+      ],
+      "notes": "Provisional supply-chain operator node for the coherent Jia Tan maintainer identity and XZ Utils backdoor activity; no nation-state label is asserted.",
+      "entity_refs": [
+        "maintainer-jia-tan"
+      ],
+      "source_refs": [
+        "ref-openwall-xz"
+      ]
+    }
+  ],
+  "attribution_confidence": "suspected",
+  "attribution_evidence": [
+    {
+      "target": "actor-unc-xz-utils-operator",
+      "relationship_type": "ATTRIBUTED_TO_ACTOR",
+      "source_refs": [
+        "ref-openwall-xz"
+      ],
+      "summary": "The Openwall disclosure supports a provisional operator edge for the Jia Tan maintainer identity without assigning a named APT or state sponsor."
     }
   ],
   "tags": [

--- a/data/supply-chain-incidents/schema.json
+++ b/data/supply-chain-incidents/schema.json
@@ -56,6 +56,13 @@
       "type": "string",
       "format": "date"
     },
+    "first_public_warning_at": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date"
+    },
     "affected_ecosystems": {
       "type": "array",
       "minItems": 1,
@@ -186,6 +193,27 @@
       "type": "array",
       "items": {
         "$ref": "#/$defs/compromised_account"
+      }
+    },
+    "threat_actors": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/threat_actor_link"
+      }
+    },
+    "campaigns": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/campaign_link"
+      }
+    },
+    "attribution_confidence": {
+      "$ref": "#/$defs/attribution_confidence"
+    },
+    "attribution_evidence": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/attribution_evidence"
       }
     },
     "executive_summary": {
@@ -490,6 +518,134 @@
         },
         "role": {
           "type": "string"
+        }
+      }
+    },
+    "attribution_confidence": {
+      "enum": [
+        "confirmed",
+        "likely",
+        "suspected",
+        "disputed",
+        "unknown"
+      ]
+    },
+    "threat_actor_link": {
+      "type": "object",
+      "required": [
+        "id",
+        "name",
+        "actor_type",
+        "confidence",
+        "source_refs"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^actor-[a-z0-9][a-z0-9-]*$"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "actor_type": {
+          "enum": [
+            "public",
+            "provisional"
+          ]
+        },
+        "confidence": {
+          "$ref": "#/$defs/attribution_confidence"
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "href": {
+          "type": "string"
+        },
+        "notes": {
+          "type": "string"
+        },
+        "entity_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source_refs": {
+          "$ref": "#/$defs/reference_id_list"
+        }
+      }
+    },
+    "campaign_link": {
+      "type": "object",
+      "required": [
+        "id",
+        "campaign_id",
+        "name",
+        "slug",
+        "confidence",
+        "source_refs"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^campaign-[a-z0-9][a-z0-9-]*$"
+        },
+        "campaign_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "slug": {
+          "type": "string",
+          "minLength": 1
+        },
+        "confidence": {
+          "$ref": "#/$defs/attribution_confidence"
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source_refs": {
+          "$ref": "#/$defs/reference_id_list"
+        }
+      }
+    },
+    "attribution_evidence": {
+      "type": "object",
+      "required": [
+        "target",
+        "relationship_type",
+        "source_refs",
+        "summary"
+      ],
+      "properties": {
+        "target": {
+          "type": "string",
+          "pattern": "^(actor|campaign)-[a-z0-9][a-z0-9-]*$"
+        },
+        "relationship_type": {
+          "enum": [
+            "ATTRIBUTED_TO_ACTOR",
+            "RELATED_CAMPAIGN"
+          ]
+        },
+        "source_refs": {
+          "$ref": "#/$defs/reference_id_list"
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 20
         }
       }
     }

--- a/data/supply-chain-relationships/relationships.json
+++ b/data/supply-chain-relationships/relationships.json
@@ -31,6 +31,16 @@
   },
   {
     "source": "incident-SC-2017-NOTPETYA-MEDOC",
+    "target": "actor-sandworm",
+    "type": "ATTRIBUTED_TO_ACTOR"
+  },
+  {
+    "source": "incident-SC-2017-NOTPETYA-MEDOC",
+    "target": "campaign-tp-camp-2017-0002",
+    "type": "RELATED_CAMPAIGN"
+  },
+  {
+    "source": "incident-SC-2017-NOTPETYA-MEDOC",
     "target": "channel-vendor-update-software-update-vendor-software-update-channel",
     "type": "USED_DISTRIBUTION_CHANNEL"
   },
@@ -118,6 +128,16 @@
     "source": "incident-SC-2020-SOLARWINDS-ORION",
     "target": "org-solarwinds",
     "type": "AFFECTED_ORGANIZATION"
+  },
+  {
+    "source": "incident-SC-2020-SOLARWINDS-ORION",
+    "target": "actor-apt29",
+    "type": "ATTRIBUTED_TO_ACTOR"
+  },
+  {
+    "source": "incident-SC-2020-SOLARWINDS-ORION",
+    "target": "campaign-tp-camp-2020-0001",
+    "type": "RELATED_CAMPAIGN"
   },
   {
     "source": "incident-SC-2020-SOLARWINDS-ORION",
@@ -346,6 +366,16 @@
   },
   {
     "source": "incident-SC-2023-THREE-CX-DESKTOP",
+    "target": "actor-lazarus-group",
+    "type": "ATTRIBUTED_TO_ACTOR"
+  },
+  {
+    "source": "incident-SC-2023-THREE-CX-DESKTOP",
+    "target": "campaign-tp-camp-2023-0002",
+    "type": "RELATED_CAMPAIGN"
+  },
+  {
+    "source": "incident-SC-2023-THREE-CX-DESKTOP",
     "target": "build-3cx-3cx-desktopapp-build-pipeline",
     "type": "USED_BUILD_SYSTEM"
   },
@@ -431,6 +461,11 @@
   },
   {
     "source": "incident-SC-2024-XZ-UTILS",
+    "target": "actor-unc-xz-utils-operator",
+    "type": "ATTRIBUTED_TO_ACTOR"
+  },
+  {
+    "source": "incident-SC-2024-XZ-UTILS",
     "target": "channel-linux-source-release-upstream-source-release-tarball",
     "type": "SOURCE_ARTIFACT_DIVERGENCE"
   },
@@ -463,5 +498,10 @@
     "source": "incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
     "target": "channel-github-actions-ci-cd-marketplace-github-actions-marketplace",
     "type": "USED_DISTRIBUTION_CHANNEL"
+  },
+  {
+    "source": "maintainer-jia-tan",
+    "target": "actor-unc-xz-utils-operator",
+    "type": "ATTRIBUTED_TO_ACTOR"
   }
 ]

--- a/docs/supply-chain-graph-primitives.md
+++ b/docs/supply-chain-graph-primitives.md
@@ -1,8 +1,10 @@
 # Supply-Chain Graph Primitives
 
 Phase 1B introduced first-class entity and relationship JSON files. Phase 1C
-deepens those primitives by extracting build systems, distribution channels,
-and compromised accounts from the curated incident corpus.
+deepened those primitives by extracting build systems, distribution channels,
+and compromised accounts from the curated incident corpus. Phase 2B connects
+the supply-chain corpus to existing Threatpedia actor and campaign entities
+where public evidence supports the edge.
 
 This is a lightweight relationship layer, not a graph database.
 
@@ -22,6 +24,8 @@ data/supply-chain-entities/organizations.json
 data/supply-chain-entities/build_systems.json
 data/supply-chain-entities/distribution_channels.json
 data/supply-chain-entities/accounts.json
+data/supply-chain-entities/actors.json
+data/supply-chain-entities/campaigns.json
 ```
 
 Each entity has:
@@ -38,6 +42,10 @@ reviewed exceptions, not registry-joinable package keys. See
 Repository entities also carry `host`, `url`, and `owner`.
 Build-system, distribution-channel, and account entities carry type-specific
 fields copied from the incident corpus.
+Actor entities may point at an existing Threatpedia actor page or at a
+provisional supply-chain operator node. Provisional actor nodes are stable
+placeholders for coherent operators and must not invent a nation-state label or
+APT name. Campaign entities point at existing Threatpedia campaign pages.
 
 ## Relationship Store
 
@@ -51,7 +59,9 @@ Allowed relationship types are intentionally narrow:
 - `AFFECTED_MAINTAINER`
 - `AFFECTED_REPOSITORY`
 - `AFFECTED_ORGANIZATION`
+- `ATTRIBUTED_TO_ACTOR`
 - `RELATED_INCIDENT`
+- `RELATED_CAMPAIGN`
 - `USED_BUILD_SYSTEM`
 - `USED_DISTRIBUTION_CHANNEL`
 - `COMPROMISED_ACCOUNT`
@@ -67,18 +77,37 @@ Relationships usually use an incident node as the source:
 }
 ```
 
+Actor and campaign edges are cross-corpus convergence edges:
+
+```json
+{
+  "source": "incident-SC-2023-THREE-CX-DESKTOP",
+  "target": "actor-lazarus-group",
+  "type": "ATTRIBUTED_TO_ACTOR"
+}
+```
+
+`RELATED_CAMPAIGN` must start from an incident node. `ATTRIBUTED_TO_ACTOR`
+may start from an incident node or, for a provisional operator case such as XZ
+Utils, from a maintainer node to preserve the relationship between the named
+maintainer identity and the provisional operator node. Every actor and campaign
+target must resolve to an emitted entity; dangling actor/campaign edges are hard
+validation failures.
+
 ## Current Graph Density
 
-The Phase 1C depth pass over the same 25 incidents currently emits:
+The Phase 2B pass over the same 25 incidents currently emits:
 
 - Maintainers: 5
 - Packages: 16
 - Repositories: 10
-- Organizations: 19
+- Organizations: 17
 - Build systems: 6
 - Distribution channels: 11
 - Compromised accounts: 8
-- Relationships: 95
+- Actors: 4
+- Campaigns: 3
+- Relationships: 101
 
 ## Build and Validate
 
@@ -111,12 +140,15 @@ This phase supports lookup questions such as:
 - incidents involving a build system
 - incidents involving a distribution channel
 - incidents involving a compromised account
+- supply-chain incidents connected to an existing actor or campaign
+- provisional operator edges where the evidence supports a coherent operator
+  but not a named public APT
 
 It does not implement:
 
 - Neo4j, Memgraph, or Apache AGE
 - scoring
-- actor attribution
+- automated actor attribution
 - trust scores
 - embeddings
 - machine learning

--- a/docs/supply-chain-incident-schema.md
+++ b/docs/supply-chain-incident-schema.md
@@ -39,6 +39,8 @@ The core fields are:
 - `status`: currently `confirmed`
 - `first_observed_at`: earliest known activity date in `YYYY-MM-DD`
 - `disclosed_at`: public disclosure date in `YYYY-MM-DD`
+- `first_public_warning_at`: optional first public warning date in `YYYY-MM-DD`
+  or `null`
 - `affected_ecosystems`: ecosystem labels such as `npm`, `pypi`, `windows`,
   `github-actions`, or `vendor-update`
 - `affected_components`: structured impacted packages, projects, services, or
@@ -61,6 +63,10 @@ The core fields are:
   releases, or download paths used by the incident
 - `compromised_accounts`: package-registry, source-control, or release-path
   accounts/tokens tied to the incident
+- `threat_actors`: optional evidence-backed actor links
+- `campaigns`: optional evidence-backed campaign links
+- `attribution_confidence`: optional incident-level attribution confidence
+- `attribution_evidence`: local evidence records for each actor/campaign edge
 
 Featured incident pages may also carry editorial fields:
 
@@ -107,6 +113,61 @@ Every incident must carry:
 Use `inferred` only when the structured field is clearly derived from the
 documented record and no stronger class applies. Do not use evidence quality as
 a severity score.
+
+## Attribution Convergence
+
+Phase 2B adds optional actor and campaign convergence fields. These fields are
+for explicit, evidence-backed links to existing Threatpedia actor/campaign
+records or to provisional operator nodes. They are not automated attribution and
+they are not scoring fields.
+
+Attribution confidence values are:
+
+- `confirmed`
+- `likely`
+- `suspected`
+- `disputed`
+- `unknown`
+
+Threat actor links use:
+
+```json
+{
+  "id": "actor-example",
+  "name": "Example Actor",
+  "actor_type": "public | provisional",
+  "confidence": "confirmed | likely | suspected | disputed | unknown",
+  "source_refs": ["ref-example"]
+}
+```
+
+Campaign links use:
+
+```json
+{
+  "id": "campaign-tp-camp-YYYY-NNNN",
+  "campaign_id": "TP-CAMP-YYYY-NNNN",
+  "name": "Example Campaign",
+  "slug": "example-campaign-slug",
+  "confidence": "confirmed | likely | suspected | disputed | unknown",
+  "source_refs": ["ref-example"]
+}
+```
+
+Every actor or campaign link must have a matching `attribution_evidence` record:
+
+```json
+{
+  "target": "actor-example",
+  "relationship_type": "ATTRIBUTED_TO_ACTOR",
+  "source_refs": ["ref-example"],
+  "summary": "bounded evidence basis for this edge"
+}
+```
+
+Provisional actor nodes are allowed when public evidence supports a coherent
+operator but does not support a named public APT. They must use stable
+placeholder identifiers and must not fabricate nation-state or APT labels.
 
 ## Vector Labels
 

--- a/docs/supply-chain-pages.md
+++ b/docs/supply-chain-pages.md
@@ -108,8 +108,12 @@ The index page shows counts for:
 
 Incident pages show corpus fields: summary, confidence, evidence level, attack
 stage, source-artifact divergence, affected entities, structured supply-chain
-primitives, compromised accounts, connected entities, and references. Featured
-incidents may additionally render validated editorial sections when present:
+primitives, compromised accounts, connected entities, and references. When
+Phase 2B actor or campaign links are present, incident pages also show threat
+actor links, campaign links, attribution confidence, and the local evidence
+basis for those edges. These links are corpus-driven convergence edges; they do
+not represent automated attribution or a risk score. Featured incidents may
+additionally render validated editorial sections when present:
 
 - Executive Summary
 - Timeline

--- a/scripts/build_supply_chain_entities.py
+++ b/scripts/build_supply_chain_entities.py
@@ -285,8 +285,6 @@ def upsert_actor(actors: dict[str, dict[str, Any]], item: dict[str, Any], incide
             "attribution_confidence": item["confidence"],
             "aliases": sorted(set(item_aliases)),
             "source_incident_ids": [],
-            **({"href": item["href"]} if item.get("href") else {}),
-            **({"notes": item["notes"]} if item.get("notes") else {}),
         },
     )
     entity["aliases"] = sorted(set(entity.get("aliases", []) + item_aliases))

--- a/scripts/build_supply_chain_entities.py
+++ b/scripts/build_supply_chain_entities.py
@@ -25,7 +25,9 @@ DEFAULT_RELATIONSHIP_DIR = REPO_ROOT / "data" / "supply-chain-relationships"
 
 ENTITY_FILES = {
     "accounts": "accounts.json",
+    "actors": "actors.json",
     "build_systems": "build_systems.json",
+    "campaigns": "campaigns.json",
     "distribution_channels": "distribution_channels.json",
     "maintainers": "maintainers.json",
     "packages": "packages.json",
@@ -37,8 +39,10 @@ RELATIONSHIP_TYPES = {
     "AFFECTED_MAINTAINER",
     "AFFECTED_REPOSITORY",
     "AFFECTED_ORGANIZATION",
+    "ATTRIBUTED_TO_ACTOR",
     "COMPROMISED_ACCOUNT",
     "RELATED_INCIDENT",
+    "RELATED_CAMPAIGN",
     "SOURCE_ARTIFACT_DIVERGENCE",
     "USED_BUILD_SYSTEM",
     "USED_DISTRIBUTION_CHANNEL",
@@ -262,6 +266,45 @@ def upsert_account(accounts: dict[str, dict[str, Any]], item: dict[str, str], in
     return entity_id
 
 
+def upsert_actor(actors: dict[str, dict[str, Any]], item: dict[str, Any], incident_id: str) -> str:
+    entity_id = item["id"]
+    entity = actors.setdefault(
+        entity_id,
+        {
+            "id": entity_id,
+            "name": item["name"],
+            "actor_type": item["actor_type"],
+            "attribution_confidence": item["confidence"],
+            "aliases": sorted(set(item.get("aliases") or [item["name"]])),
+            "source_incident_ids": [],
+            **({"href": item["href"]} if item.get("href") else {}),
+            **({"notes": item["notes"]} if item.get("notes") else {}),
+        },
+    )
+    entity["aliases"] = sorted(set(entity.get("aliases", []) + (item.get("aliases") or [item["name"]])))
+    add_source(entity, incident_id)
+    return entity_id
+
+
+def upsert_campaign(campaigns: dict[str, dict[str, Any]], item: dict[str, Any], incident_id: str) -> str:
+    entity_id = item["id"]
+    entity = campaigns.setdefault(
+        entity_id,
+        {
+            "id": entity_id,
+            "name": item["name"],
+            "campaign_id": item["campaign_id"],
+            "slug": item["slug"],
+            "aliases": sorted(set(item.get("aliases") or [item["name"], item["campaign_id"]])),
+            "source_incident_ids": [],
+            "href": f"/campaigns/{item['slug']}/",
+        },
+    )
+    entity["aliases"] = sorted(set(entity.get("aliases", []) + (item.get("aliases") or [item["name"], item["campaign_id"]])))
+    add_source(entity, incident_id)
+    return entity_id
+
+
 def relationship(source: str, target: str, relationship_type: str) -> dict[str, str]:
     if relationship_type not in RELATIONSHIP_TYPES:
         raise ValueError(f"invalid relationship type: {relationship_type}")
@@ -270,7 +313,9 @@ def relationship(source: str, target: str, relationship_type: str) -> dict[str, 
 
 def build_graph(corpus: list[dict[str, Any]]) -> dict[str, Any]:
     accounts: dict[str, dict[str, Any]] = {}
+    actors: dict[str, dict[str, Any]] = {}
     build_systems: dict[str, dict[str, Any]] = {}
+    campaigns: dict[str, dict[str, Any]] = {}
     distribution_channels: dict[str, dict[str, Any]] = {}
     maintainers: dict[str, dict[str, Any]] = {}
     packages: dict[str, dict[str, Any]] = {}
@@ -315,13 +360,25 @@ def build_graph(corpus: list[dict[str, Any]]) -> dict[str, Any]:
             account_id = upsert_account(accounts, item, incident_id)
             add_relationship(relationship(source, account_id, "COMPROMISED_ACCOUNT"))
 
+        for item in incident.get("threat_actors") or []:
+            actor_id = upsert_actor(actors, item, incident_id)
+            add_relationship(relationship(source, actor_id, "ATTRIBUTED_TO_ACTOR"))
+            for entity_ref in item.get("entity_refs") or []:
+                add_relationship(relationship(entity_ref, actor_id, "ATTRIBUTED_TO_ACTOR"))
+
+        for item in incident.get("campaigns") or []:
+            campaign_id = upsert_campaign(campaigns, item, incident_id)
+            add_relationship(relationship(source, campaign_id, "RELATED_CAMPAIGN"))
+
         if incident.get("source_artifact_divergence") is True:
             for channel_id in divergence_channel_targets:
                 add_relationship(relationship(source, channel_id, "SOURCE_ARTIFACT_DIVERGENCE"))
 
     return {
         "accounts": sorted(accounts.values(), key=lambda item: item["id"]),
+        "actors": sorted(actors.values(), key=lambda item: item["id"]),
         "build_systems": sorted(build_systems.values(), key=lambda item: item["id"]),
+        "campaigns": sorted(campaigns.values(), key=lambda item: item["id"]),
         "distribution_channels": sorted(distribution_channels.values(), key=lambda item: item["id"]),
         "maintainers": sorted(maintainers.values(), key=lambda item: item["id"]),
         "packages": sorted(packages.values(), key=lambda item: item["id"]),
@@ -350,6 +407,8 @@ def main(argv: list[str] | None = None) -> int:
     print(
         "Built supply-chain graph primitives: "
         f"maintainers={len(graph['maintainers'])} "
+        f"actors={len(graph['actors'])} "
+        f"campaigns={len(graph['campaigns'])} "
         f"packages={len(graph['packages'])} "
         f"repositories={len(graph['repositories'])} "
         f"organizations={len(graph['organizations'])} "

--- a/scripts/build_supply_chain_entities.py
+++ b/scripts/build_supply_chain_entities.py
@@ -275,6 +275,7 @@ def upsert_account(accounts: dict[str, dict[str, Any]], item: dict[str, str], in
 
 def upsert_actor(actors: dict[str, dict[str, Any]], item: dict[str, Any], incident_id: str) -> str:
     entity_id = item["id"]
+    item_aliases = (item.get("aliases") or []) + [item["name"]]
     entity = actors.setdefault(
         entity_id,
         {
@@ -282,13 +283,17 @@ def upsert_actor(actors: dict[str, dict[str, Any]], item: dict[str, Any], incide
             "name": item["name"],
             "actor_type": item["actor_type"],
             "attribution_confidence": item["confidence"],
-            "aliases": sorted(set(item.get("aliases") or [item["name"]])),
+            "aliases": sorted(set(item_aliases)),
             "source_incident_ids": [],
             **({"href": item["href"]} if item.get("href") else {}),
             **({"notes": item["notes"]} if item.get("notes") else {}),
         },
     )
-    entity["aliases"] = sorted(set(entity.get("aliases", []) + (item.get("aliases") or [item["name"]])))
+    entity["aliases"] = sorted(set(entity.get("aliases", []) + item_aliases))
+    if "href" not in entity and item.get("href"):
+        entity["href"] = item["href"]
+    if "notes" not in entity and item.get("notes"):
+        entity["notes"] = item["notes"]
     if ATTRIBUTION_CONFIDENCE_PRIORITY.get(item["confidence"], 0) > ATTRIBUTION_CONFIDENCE_PRIORITY.get(
         entity["attribution_confidence"],
         0,
@@ -300,6 +305,7 @@ def upsert_actor(actors: dict[str, dict[str, Any]], item: dict[str, Any], incide
 
 def upsert_campaign(campaigns: dict[str, dict[str, Any]], item: dict[str, Any], incident_id: str) -> str:
     entity_id = item["id"]
+    item_aliases = (item.get("aliases") or []) + [item["name"], item["campaign_id"]]
     entity = campaigns.setdefault(
         entity_id,
         {
@@ -307,12 +313,12 @@ def upsert_campaign(campaigns: dict[str, dict[str, Any]], item: dict[str, Any], 
             "name": item["name"],
             "campaign_id": item["campaign_id"],
             "slug": item["slug"],
-            "aliases": sorted(set(item.get("aliases") or [item["name"], item["campaign_id"]])),
+            "aliases": sorted(set(item_aliases)),
             "source_incident_ids": [],
             "href": f"/campaigns/{item['slug']}/",
         },
     )
-    entity["aliases"] = sorted(set(entity.get("aliases", []) + (item.get("aliases") or [item["name"], item["campaign_id"]])))
+    entity["aliases"] = sorted(set(entity.get("aliases", []) + item_aliases))
     add_source(entity, incident_id)
     return entity_id
 

--- a/scripts/build_supply_chain_entities.py
+++ b/scripts/build_supply_chain_entities.py
@@ -71,6 +71,13 @@ GITHUB_SYSTEM_PATHS = {
     "topics",
     "trending",
 }
+ATTRIBUTION_CONFIDENCE_PRIORITY = {
+    "confirmed": 4,
+    "likely": 3,
+    "suspected": 2,
+    "disputed": 1,
+    "unknown": 0,
+}
 
 def load_json(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
@@ -282,6 +289,11 @@ def upsert_actor(actors: dict[str, dict[str, Any]], item: dict[str, Any], incide
         },
     )
     entity["aliases"] = sorted(set(entity.get("aliases", []) + (item.get("aliases") or [item["name"]])))
+    if ATTRIBUTION_CONFIDENCE_PRIORITY.get(item["confidence"], 0) > ATTRIBUTION_CONFIDENCE_PRIORITY.get(
+        entity["attribution_confidence"],
+        0,
+    ):
+        entity["attribution_confidence"] = item["confidence"]
     add_source(entity, incident_id)
     return entity_id
 

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -221,6 +221,11 @@ assert.ok(
   ),
   'maintainer page should surface provisional actor connections even without a public actor route'
 );
+assert.equal(
+  jiaTanMaintainer.connectedEntities.filter((entity) => entity.id === 'actor-unc-xz-utils-operator').length,
+  1,
+  'maintainer page should not duplicate actor connections that are both direct and incident-derived'
+);
 
 const brokenData = {
   ...data,

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -133,6 +133,32 @@ assert.deepEqual(
   'incident JSON-LD should expose supply-chain vectors as Thing objects'
 );
 
+const xz = getSupplyChainIncidentPage('SC-2024-XZ-UTILS', data);
+assert.equal(xz.incident.attribution_confidence, 'suspected', 'XZ page should expose attribution confidence');
+assert.ok(
+  xz.sections.actors.some((actor) => actor.id === 'actor-unc-xz-utils-operator'),
+  'XZ page should include provisional operator link'
+);
+assert.ok(
+  xz.connectedEntities.some((entity) => entity.id === 'actor-unc-xz-utils-operator' && entity.entityType === 'Threat Actor'),
+  'incident connected entities should include actor nodes with display labels'
+);
+assert.ok(xz.sections.attributionEvidence.length > 0, 'incident page should include attribution evidence');
+assert.ok(
+  xz.sections.attributionEvidence.every((item) => item.references.length > 0),
+  'attribution evidence references should resolve'
+);
+
+const threeCx = getSupplyChainIncidentPage('SC-2023-THREE-CX-DESKTOP', data);
+assert.ok(
+  threeCx.sections.actors.some((actor) => actor.href === '/threat-actors/lazarus-group/'),
+  '3CX page should link to the existing Lazarus actor page'
+);
+assert.ok(
+  threeCx.sections.campaigns.some((campaign) => campaign.href === '/campaigns/lazarus-3cx-supply-chain-compromise-2023/'),
+  '3CX page should link to the existing campaign page'
+);
+
 const eventStreamPackage = getSupplyChainEntityPage('packages', 'pkg-npm-event-stream', data);
 assert.ok(eventStreamPackage.relatedIncidents.length > 0, 'entity page should include related incidents');
 eventStreamPackage.relatedIncidents.forEach((incident) => {

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -148,6 +148,31 @@ assert.ok(
   xz.sections.attributionEvidence.every((item) => item.references.length > 0),
   'attribution evidence references should resolve'
 );
+const staleAttributionRelationshipData = {
+  ...data,
+  relationships: data.relationships.filter(
+    (relationship) =>
+      !(
+        relationship.source === 'incident-SC-2024-XZ-UTILS' &&
+        relationship.target === 'actor-unc-xz-utils-operator' &&
+        relationship.type === 'ATTRIBUTED_TO_ACTOR'
+      )
+  ),
+};
+assert.equal(
+  validateSupplyChainPageData(staleAttributionRelationshipData).length,
+  0,
+  'page data validator should still pass when an actor remains connected elsewhere'
+);
+const staleXz = getSupplyChainIncidentPage('SC-2024-XZ-UTILS', staleAttributionRelationshipData);
+assert.ok(
+  staleXz.sections.actors.some((actor) => actor.id === 'actor-unc-xz-utils-operator'),
+  'incident pages should fall back to corpus threat_actors when generated incident attribution edges are stale'
+);
+assert.ok(
+  staleXz.connectedEntities.some((entity) => entity.id === 'actor-unc-xz-utils-operator' && entity.entityType === 'Threat Actor'),
+  'incident connected entities should fall back to corpus threat_actors when generated incident attribution edges are stale'
+);
 
 const threeCx = getSupplyChainIncidentPage('SC-2023-THREE-CX-DESKTOP', data);
 assert.ok(

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -189,6 +189,14 @@ assert.equal(
 assert.ok(eventStreamPackage.seo.ogTitle, 'entity page should include Open Graph title');
 assert.ok(eventStreamPackage.seo.jsonLd, 'entity page should include JSON-LD');
 
+const jiaTanMaintainer = getSupplyChainEntityPage('maintainers', 'maintainer-jia-tan', data);
+assert.ok(
+  jiaTanMaintainer.connectedEntities.some(
+    (entity) => entity.id === 'actor-unc-xz-utils-operator' && entity.entityType === 'Threat Actor' && entity.href === null
+  ),
+  'maintainer page should surface provisional actor connections even without a public actor route'
+);
+
 const brokenData = {
   ...data,
   relationships: data.relationships.map((relationship, index) =>

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -225,12 +225,27 @@ def validate_corpus_implied_relationships(corpus: list[dict[str, Any]], relation
         for relationship in relationships
         if isinstance(relationship, dict)
     }
+    relationship_keys = {
+        (relationship.get("source"), relationship.get("target"), relationship.get("type"))
+        for relationship in relationships
+        if isinstance(relationship, dict)
+    }
     for incident in corpus:
         if not isinstance(incident, dict) or not isinstance(incident.get("id"), str):
             continue
         source = incident_node_id(incident["id"])
         if incident.get("source_artifact_divergence") is True and (source, "SOURCE_ARTIFACT_DIVERGENCE") not in relationships_by_source_type:
             errors.append(f"{source}: missing SOURCE_ARTIFACT_DIVERGENCE relationship")
+        for actor in incident.get("threat_actors") or []:
+            if isinstance(actor, dict) and isinstance(actor.get("id"), str):
+                key = (source, actor["id"], "ATTRIBUTED_TO_ACTOR")
+                if key not in relationship_keys:
+                    errors.append(f"{source}: missing ATTRIBUTED_TO_ACTOR relationship for {actor['id']}")
+        for campaign in incident.get("campaigns") or []:
+            if isinstance(campaign, dict) and isinstance(campaign.get("id"), str):
+                key = (source, campaign["id"], "RELATED_CAMPAIGN")
+                if key not in relationship_keys:
+                    errors.append(f"{source}: missing RELATED_CAMPAIGN relationship for {campaign['id']}")
     return errors
 
 

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -24,7 +24,9 @@ DEFAULT_RELATIONSHIP_PATH = REPO_ROOT / "data" / "supply-chain-relationships" / 
 
 ENTITY_FILES = {
     "accounts": "accounts.json",
+    "actors": "actors.json",
     "build_systems": "build_systems.json",
+    "campaigns": "campaigns.json",
     "distribution_channels": "distribution_channels.json",
     "maintainers": "maintainers.json",
     "packages": "packages.json",
@@ -36,27 +38,33 @@ VALID_RELATIONSHIP_TYPES = {
     "AFFECTED_MAINTAINER",
     "AFFECTED_REPOSITORY",
     "AFFECTED_ORGANIZATION",
+    "ATTRIBUTED_TO_ACTOR",
     "COMPROMISED_ACCOUNT",
     "RELATED_INCIDENT",
+    "RELATED_CAMPAIGN",
     "SOURCE_ARTIFACT_DIVERGENCE",
     "USED_BUILD_SYSTEM",
     "USED_DISTRIBUTION_CHANNEL",
 }
-ENTITY_ID_PATTERN = re.compile(r"^(account|build|channel|maintainer|pkg|repo|org)-[a-z0-9][a-z0-9-]*$")
+ENTITY_ID_PATTERN = re.compile(r"^(account|actor|build|campaign|channel|maintainer|pkg|repo|org)-[a-z0-9][a-z0-9-]*$")
 RELATIONSHIP_TARGET_PREFIXES = {
     "AFFECTED_PACKAGE": "pkg-",
     "AFFECTED_MAINTAINER": "maintainer-",
     "AFFECTED_REPOSITORY": "repo-",
     "AFFECTED_ORGANIZATION": "org-",
+    "ATTRIBUTED_TO_ACTOR": "actor-",
     "COMPROMISED_ACCOUNT": "account-",
     "RELATED_INCIDENT": "incident-",
+    "RELATED_CAMPAIGN": "campaign-",
     "SOURCE_ARTIFACT_DIVERGENCE": ("repo-", "channel-"),
     "USED_BUILD_SYSTEM": "build-",
     "USED_DISTRIBUTION_CHANNEL": "channel-",
 }
 ENTITY_TYPE_REQUIRED_FIELDS = {
     "accounts": ["provider", "account_type", "role"],
+    "actors": ["actor_type", "attribution_confidence"],
     "build_systems": ["provider", "category"],
+    "campaigns": ["campaign_id", "slug"],
     "distribution_channels": ["channel_type", "ecosystem"],
     "maintainers": [],
     "organizations": [],
@@ -181,10 +189,14 @@ def validate_relationships(
             expected_prefix = RELATIONSHIP_TARGET_PREFIXES[rel_type]
             if rel_type.startswith("AFFECTED_") and not source.startswith("incident-"):
                 errors.append(f"{path}.source: {rel_type} must start from an incident node")
+            if rel_type == "ATTRIBUTED_TO_ACTOR" and not (source.startswith("incident-") or source.startswith("maintainer-")):
+                errors.append(f"{path}.source: ATTRIBUTED_TO_ACTOR must start from an incident or maintainer node")
             if not target.startswith(expected_prefix):
                 errors.append(f"{path}.target: {rel_type} target must start with {expected_prefix!r}")
             if rel_type == "RELATED_INCIDENT" and not source.startswith("incident-"):
                 errors.append(f"{path}.source: RELATED_INCIDENT must start from an incident node")
+            if rel_type == "RELATED_CAMPAIGN" and not source.startswith("incident-"):
+                errors.append(f"{path}.source: RELATED_CAMPAIGN must start from an incident node")
         if source not in valid_nodes:
             errors.append(f"{path}.source: unknown source {source!r}")
         if target not in valid_nodes:

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -241,6 +241,11 @@ def validate_corpus_implied_relationships(corpus: list[dict[str, Any]], relation
                 key = (source, actor["id"], "ATTRIBUTED_TO_ACTOR")
                 if key not in relationship_keys:
                     errors.append(f"{source}: missing ATTRIBUTED_TO_ACTOR relationship for {actor['id']}")
+                for entity_ref in actor.get("entity_refs") or []:
+                    if isinstance(entity_ref, str):
+                        key = (entity_ref, actor["id"], "ATTRIBUTED_TO_ACTOR")
+                        if key not in relationship_keys:
+                            errors.append(f"{source}: missing ATTRIBUTED_TO_ACTOR relationship from {entity_ref} to {actor['id']}")
         for campaign in incident.get("campaigns") or []:
             if isinstance(campaign, dict) and isinstance(campaign.get("id"), str):
                 key = (source, campaign["id"], "RELATED_CAMPAIGN")

--- a/scripts/validate_supply_chain_incidents.py
+++ b/scripts/validate_supply_chain_incidents.py
@@ -438,13 +438,16 @@ def validate_attribution_link(
     for field in required_fields:
         if field not in record:
             errors.append(f"{path}.{field}: missing required field")
-    require_string(errors, f"{path}.id", record.get("id"))
-    require_string(errors, f"{path}.name", record.get("name"))
-    if record.get("confidence") not in VALID_ATTRIBUTION_CONFIDENCE:
+    if "id" in record:
+        require_string(errors, f"{path}.id", record.get("id"))
+    if "name" in record:
+        require_string(errors, f"{path}.name", record.get("name"))
+    if "confidence" in record and record.get("confidence") not in VALID_ATTRIBUTION_CONFIDENCE:
         errors.append(f"{path}.confidence: invalid value {record.get('confidence')!r}")
-    validate_reference_id_list(errors, incident_id, f"{path}.source_refs", record.get("source_refs"), valid_reference_ids)
+    if "source_refs" in record:
+        validate_reference_id_list(errors, incident_id, f"{path}.source_refs", record.get("source_refs"), valid_reference_ids)
     if field_name == "threat_actors":
-        if record.get("actor_type") not in VALID_ACTOR_TYPES:
+        if "actor_type" in record and record.get("actor_type") not in VALID_ACTOR_TYPES:
             errors.append(f"{path}.actor_type: invalid value {record.get('actor_type')!r}")
         if isinstance(record.get("id"), str) and not record["id"].startswith("actor-"):
             errors.append(f"{path}.id: expected actor-* identifier")
@@ -459,8 +462,10 @@ def validate_attribution_link(
                     errors.append(f"{path}.entity_refs[{entity_index}]: expected maintainer-* or incident-* identifier")
         return ("ATTRIBUTED_TO_ACTOR", record.get("id")) if isinstance(record.get("id"), str) else None
     if field_name == "campaigns":
-        require_string(errors, f"{path}.campaign_id", record.get("campaign_id"))
-        require_string(errors, f"{path}.slug", record.get("slug"))
+        if "campaign_id" in record:
+            require_string(errors, f"{path}.campaign_id", record.get("campaign_id"))
+        if "slug" in record:
+            require_string(errors, f"{path}.slug", record.get("slug"))
         if isinstance(record.get("id"), str) and not record["id"].startswith("campaign-"):
             errors.append(f"{path}.id: expected campaign-* identifier")
         return ("RELATED_CAMPAIGN", record.get("id")) if isinstance(record.get("id"), str) else None
@@ -512,14 +517,18 @@ def validate_attribution_fields(errors: list[str], incident: dict[str, Any]) -> 
         for field in REQUIRED_ATTRIBUTION_EVIDENCE_FIELDS:
             if field not in record:
                 errors.append(f"{path}.{field}: missing required field")
-        require_string(errors, f"{path}.target", record.get("target"))
-        require_string(errors, f"{path}.summary", record.get("summary"), min_length=20)
-        relationship_type = record.get("relationship_type")
-        if relationship_type not in VALID_ATTRIBUTION_RELATIONSHIPS:
-            errors.append(f"{path}.relationship_type: invalid value {relationship_type!r}")
-        validate_reference_id_list(errors, incident_id, f"{path}.source_refs", record.get("source_refs"), valid_reference_ids)
-        if isinstance(record.get("target"), str) and isinstance(relationship_type, str):
-            seen_evidence.add((relationship_type, record["target"]))
+        if "target" in record:
+            require_string(errors, f"{path}.target", record.get("target"))
+        if "summary" in record:
+            require_string(errors, f"{path}.summary", record.get("summary"), min_length=20)
+        if "relationship_type" in record:
+            relationship_type = record.get("relationship_type")
+            if relationship_type not in VALID_ATTRIBUTION_RELATIONSHIPS:
+                errors.append(f"{path}.relationship_type: invalid value {relationship_type!r}")
+        if "source_refs" in record:
+            validate_reference_id_list(errors, incident_id, f"{path}.source_refs", record.get("source_refs"), valid_reference_ids)
+        if isinstance(record.get("target"), str) and isinstance(record.get("relationship_type"), str):
+            seen_evidence.add((record["relationship_type"], record["target"]))
 
     for relationship_type, target in sorted(expected_evidence - seen_evidence):
         errors.append(f"{incident_id}.attribution_evidence: missing {relationship_type} evidence for {target}")

--- a/scripts/validate_supply_chain_incidents.py
+++ b/scripts/validate_supply_chain_incidents.py
@@ -455,6 +455,8 @@ def validate_attribution_link(
             for entity_index, entity_ref in enumerate(entity_refs):
                 if not isinstance(entity_ref, str) or not entity_ref.strip():
                     errors.append(f"{path}.entity_refs[{entity_index}]: expected non-empty string")
+                elif not (entity_ref.startswith("maintainer-") or entity_ref.startswith("incident-")):
+                    errors.append(f"{path}.entity_refs[{entity_index}]: expected maintainer-* or incident-* identifier")
         return ("ATTRIBUTED_TO_ACTOR", record.get("id")) if isinstance(record.get("id"), str) else None
     if field_name == "campaigns":
         require_string(errors, f"{path}.campaign_id", record.get("campaign_id"))
@@ -521,6 +523,8 @@ def validate_attribution_fields(errors: list[str], incident: dict[str, Any]) -> 
 
     for relationship_type, target in sorted(expected_evidence - seen_evidence):
         errors.append(f"{incident_id}.attribution_evidence: missing {relationship_type} evidence for {target}")
+    for relationship_type, target in sorted(seen_evidence - expected_evidence):
+        errors.append(f"{incident_id}.attribution_evidence: unexpected {relationship_type} evidence for {target} without matching link")
 
 
 def validate_incident(incident: Any) -> list[str]:

--- a/scripts/validate_supply_chain_incidents.py
+++ b/scripts/validate_supply_chain_incidents.py
@@ -60,6 +60,9 @@ REQUIRED_REPOSITORY_FIELDS = ["name", "host", "owner", "url"]
 REQUIRED_BUILD_SYSTEM_FIELDS = ["name", "provider", "category"]
 REQUIRED_DISTRIBUTION_CHANNEL_FIELDS = ["name", "channel_type", "ecosystem"]
 REQUIRED_COMPROMISED_ACCOUNT_FIELDS = ["name", "provider", "account_type", "role"]
+REQUIRED_THREAT_ACTOR_FIELDS = ["id", "name", "actor_type", "confidence", "source_refs"]
+REQUIRED_CAMPAIGN_FIELDS = ["id", "campaign_id", "name", "slug", "confidence", "source_refs"]
+REQUIRED_ATTRIBUTION_EVIDENCE_FIELDS = ["target", "relationship_type", "source_refs", "summary"]
 FEATURED_INCIDENT_IDS = {
     "SC-2018-NPM-EVENT-STREAM",
     "SC-2020-SOLARWINDS-ORION",
@@ -126,6 +129,9 @@ VALID_IMPACTS = {
     "protest_payload",
     "ransomware_delivery",
 }
+VALID_ATTRIBUTION_CONFIDENCE = {"confirmed", "likely", "suspected", "disputed", "unknown"}
+VALID_ACTOR_TYPES = {"public", "provisional"}
+VALID_ATTRIBUTION_RELATIONSHIPS = {"ATTRIBUTED_TO_ACTOR", "RELATED_CAMPAIGN"}
 
 
 def load_json(path: Path) -> Any:
@@ -416,6 +422,107 @@ def validate_named_fields(
                 require_string(errors, f"{path}.{field}", record[field])
 
 
+def validate_attribution_link(
+    errors: list[str],
+    incident_id: str,
+    field_name: str,
+    required_fields: list[str],
+    record: Any,
+    index: int,
+    valid_reference_ids: set[str],
+) -> tuple[str, str] | None:
+    path = f"{incident_id}.{field_name}[{index}]"
+    if not isinstance(record, dict):
+        errors.append(f"{path}: expected object")
+        return None
+    for field in required_fields:
+        if field not in record:
+            errors.append(f"{path}.{field}: missing required field")
+    require_string(errors, f"{path}.id", record.get("id"))
+    require_string(errors, f"{path}.name", record.get("name"))
+    if record.get("confidence") not in VALID_ATTRIBUTION_CONFIDENCE:
+        errors.append(f"{path}.confidence: invalid value {record.get('confidence')!r}")
+    validate_reference_id_list(errors, incident_id, f"{path}.source_refs", record.get("source_refs"), valid_reference_ids)
+    if field_name == "threat_actors":
+        if record.get("actor_type") not in VALID_ACTOR_TYPES:
+            errors.append(f"{path}.actor_type: invalid value {record.get('actor_type')!r}")
+        if isinstance(record.get("id"), str) and not record["id"].startswith("actor-"):
+            errors.append(f"{path}.id: expected actor-* identifier")
+        entity_refs = record.get("entity_refs", [])
+        if not isinstance(entity_refs, list):
+            errors.append(f"{path}.entity_refs: expected list")
+        else:
+            for entity_index, entity_ref in enumerate(entity_refs):
+                if not isinstance(entity_ref, str) or not entity_ref.strip():
+                    errors.append(f"{path}.entity_refs[{entity_index}]: expected non-empty string")
+        return ("ATTRIBUTED_TO_ACTOR", record.get("id")) if isinstance(record.get("id"), str) else None
+    if field_name == "campaigns":
+        require_string(errors, f"{path}.campaign_id", record.get("campaign_id"))
+        require_string(errors, f"{path}.slug", record.get("slug"))
+        if isinstance(record.get("id"), str) and not record["id"].startswith("campaign-"):
+            errors.append(f"{path}.id: expected campaign-* identifier")
+        return ("RELATED_CAMPAIGN", record.get("id")) if isinstance(record.get("id"), str) else None
+    return None
+
+
+def validate_attribution_fields(errors: list[str], incident: dict[str, Any]) -> None:
+    incident_id = incident.get("id") if isinstance(incident.get("id"), str) else "<missing-id>"
+    valid_reference_ids = reference_ids_for(incident)
+    expected_evidence: set[tuple[str, str]] = set()
+
+    if "attribution_confidence" in incident and incident.get("attribution_confidence") not in VALID_ATTRIBUTION_CONFIDENCE:
+        errors.append(f"{incident_id}.attribution_confidence: invalid value {incident.get('attribution_confidence')!r}")
+
+    for field_name, required_fields in (
+        ("threat_actors", REQUIRED_THREAT_ACTOR_FIELDS),
+        ("campaigns", REQUIRED_CAMPAIGN_FIELDS),
+    ):
+        records = incident.get(field_name, [])
+        if not isinstance(records, list):
+            errors.append(f"{incident_id}.{field_name}: expected list")
+            continue
+        for index, record in enumerate(records):
+            expected = validate_attribution_link(
+                errors,
+                incident_id,
+                field_name,
+                required_fields,
+                record,
+                index,
+                valid_reference_ids,
+            )
+            if expected:
+                expected_evidence.add(expected)
+
+    if expected_evidence and "attribution_confidence" not in incident:
+        errors.append(f"{incident_id}.attribution_confidence: required when threat_actors or campaigns are present")
+
+    attribution_evidence = incident.get("attribution_evidence", [])
+    if not isinstance(attribution_evidence, list):
+        errors.append(f"{incident_id}.attribution_evidence: expected list")
+        attribution_evidence = []
+    seen_evidence: set[tuple[str, str]] = set()
+    for index, record in enumerate(attribution_evidence):
+        path = f"{incident_id}.attribution_evidence[{index}]"
+        if not isinstance(record, dict):
+            errors.append(f"{path}: expected object")
+            continue
+        for field in REQUIRED_ATTRIBUTION_EVIDENCE_FIELDS:
+            if field not in record:
+                errors.append(f"{path}.{field}: missing required field")
+        require_string(errors, f"{path}.target", record.get("target"))
+        require_string(errors, f"{path}.summary", record.get("summary"), min_length=20)
+        relationship_type = record.get("relationship_type")
+        if relationship_type not in VALID_ATTRIBUTION_RELATIONSHIPS:
+            errors.append(f"{path}.relationship_type: invalid value {relationship_type!r}")
+        validate_reference_id_list(errors, incident_id, f"{path}.source_refs", record.get("source_refs"), valid_reference_ids)
+        if isinstance(record.get("target"), str) and isinstance(relationship_type, str):
+            seen_evidence.add((relationship_type, record["target"]))
+
+    for relationship_type, target in sorted(expected_evidence - seen_evidence):
+        errors.append(f"{incident_id}.attribution_evidence: missing {relationship_type} evidence for {target}")
+
+
 def validate_incident(incident: Any) -> list[str]:
     errors: list[str] = []
     if not isinstance(incident, dict):
@@ -460,6 +567,12 @@ def validate_incident(incident: Any) -> list[str]:
         errors.append(f"{incident_id}.disclosed_at: expected YYYY-MM-DD date")
     if first_observed_at and disclosed_at and disclosed_at < first_observed_at:
         errors.append(f"{incident_id}.disclosed_at: cannot be before first_observed_at")
+    if "first_public_warning_at" in incident and incident.get("first_public_warning_at") is not None:
+        first_public_warning_at = parse_date(incident.get("first_public_warning_at"))
+        if first_public_warning_at is None:
+            errors.append(f"{incident_id}.first_public_warning_at: expected YYYY-MM-DD date or null")
+        elif first_observed_at and first_public_warning_at < first_observed_at:
+            errors.append(f"{incident_id}.first_public_warning_at: cannot be before first_observed_at")
 
     require_string_list(errors, f"{incident_id}.affected_ecosystems", incident.get("affected_ecosystems"))
     require_enum_list(errors, f"{incident_id}.supply_chain_vectors", incident.get("supply_chain_vectors"), VALID_VECTORS)
@@ -509,6 +622,7 @@ def validate_incident(incident: Any) -> list[str]:
         REQUIRED_COMPROMISED_ACCOUNT_FIELDS,
         incident.get("compromised_accounts"),
     )
+    validate_attribution_fields(errors, incident)
     validate_editorial_fields(errors, incident)
 
     return errors
@@ -579,6 +693,12 @@ def validate_schema_file(schema: Any) -> list[str]:
         errors.append("schema.$defs.affected_component.if: must match generic package URLs")
     if not isinstance(generic_then, dict) or generic_then.get("required") != ["purl_justification"]:
         errors.append("schema.$defs.affected_component.then: must require purl_justification")
+    for def_name in ["attribution_confidence", "threat_actor_link", "campaign_link", "attribution_evidence"]:
+        if def_name not in defs:
+            errors.append(f"schema.$defs.{def_name}: missing required Phase 2B definition")
+    attribution_confidence = defs.get("attribution_confidence") if isinstance(defs, dict) else None
+    if not isinstance(attribution_confidence, dict) or set(attribution_confidence.get("enum", [])) != VALID_ATTRIBUTION_CONFIDENCE:
+        errors.append("schema.$defs.attribution_confidence.enum: does not match validator")
     return errors
 
 

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -281,13 +281,14 @@ function entityConnectionsFor(data, entityId) {
       type: row.type,
       entityType: entityTypeLabel(row.entity),
     }));
+  const directEntityIds = new Set(direct.map((row) => row.id));
 
   const incidentNodes = relationshipRows(data, entityId)
     .filter((row) => row.incident)
     .map((row) => `incident-${row.incident.id}`);
   const throughIncidents = incidentNodes.flatMap((incidentNode) =>
     relationshipRows(data, incidentNode)
-      .filter((row) => row.entity && row.entity.id !== entityId)
+      .filter((row) => row.entity && row.entity.id !== entityId && !directEntityIds.has(row.entity.id))
       .map((row) => ({
         href: linkForEntity(row.entity),
         label: row.entity.name,

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -232,6 +232,14 @@ function entityLink(data, entityId) {
   return { href, label: entity.name, id: entity.id };
 }
 
+function attributionItemLink(data, item, collectionKey) {
+  if (!item?.id) return null;
+  const linkedEntity = entityLink(data, item.id);
+  if (linkedEntity) return linkedEntity;
+  const href = item.href || (collectionKey === 'campaigns' && item.slug ? `/campaigns/${item.slug}/` : null);
+  return { href, label: item.name || item.id, id: item.id };
+}
+
 function compareLabel(a, b) {
   return (a.label || '').localeCompare(b.label || '');
 }
@@ -295,6 +303,7 @@ function entityConnectionsFor(data, entityId) {
 
 function incidentConnectedEntities(data, incidentId) {
   const nodeId = `incident-${incidentId}`;
+  const incident = data.incidents.find((item) => item.id === incidentId);
   const rows = relationshipRows(data, nodeId)
     .filter((row) => row.entity)
     .map((row) => ({
@@ -304,7 +313,16 @@ function incidentConnectedEntities(data, incidentId) {
       type: row.type,
       entityType: entityTypeLabel(row.entity),
     }));
-  return dedupeRows(rows).sort(compareLabel);
+  const actorRows = (incident?.threat_actors || [])
+    .map((item) => attributionItemLink(data, item, 'actors'))
+    .filter(Boolean)
+    .map((item) => ({ ...item, type: 'ATTRIBUTED_TO_ACTOR', entityType: 'Threat Actor' }));
+  const campaignRows = (incident?.campaigns || [])
+    .map((item) => attributionItemLink(data, item, 'campaigns'))
+    .filter(Boolean)
+    .map((item) => ({ ...item, type: 'RELATED_CAMPAIGN', entityType: 'Campaign' }));
+  const attributionRows = [...actorRows, ...campaignRows];
+  return dedupeRows([...rows, ...attributionRows]).sort(compareLabel);
 }
 
 function incidentEntityLinks(data, incidentId, relationshipType) {
@@ -314,6 +332,15 @@ function incidentEntityLinks(data, incidentId, relationshipType) {
     .map((relationship) => entityLink(data, relationship.target))
     .filter(Boolean)
     .sort(compareLabel);
+}
+
+function incidentAttributionLinks(data, incidentId, relationshipType, collectionKey) {
+  const relationshipLinks = incidentEntityLinks(data, incidentId, relationshipType);
+  const incident = data.incidents.find((item) => item.id === incidentId);
+  const corpusLinks = (incident?.[collectionKey] || [])
+    .map((item) => attributionItemLink(data, item, collectionKey))
+    .filter(Boolean);
+  return dedupeRows([...relationshipLinks, ...corpusLinks]).sort(compareLabel);
 }
 
 function incidentEntities(data, incidentId, collectionKey, relationshipType) {
@@ -465,8 +492,8 @@ export function getSupplyChainIncidentPage(id, data = loadSupplyChainData()) {
       repositories: incidentEntityLinks(data, id, 'AFFECTED_REPOSITORY'),
       organizations: incidentEntityLinks(data, id, 'AFFECTED_ORGANIZATION'),
       maintainers: incidentEntityLinks(data, id, 'AFFECTED_MAINTAINER'),
-      actors: incidentEntityLinks(data, id, 'ATTRIBUTED_TO_ACTOR'),
-      campaigns: incidentEntityLinks(data, id, 'RELATED_CAMPAIGN'),
+      actors: incidentAttributionLinks(data, id, 'ATTRIBUTED_TO_ACTOR', 'threat_actors'),
+      campaigns: incidentAttributionLinks(data, id, 'RELATED_CAMPAIGN', 'campaigns'),
       buildSystems: incidentEntities(data, id, 'build_systems', 'USED_BUILD_SYSTEM'),
       distributionChannels: incidentEntities(data, id, 'distribution_channels', 'USED_DISTRIBUTION_CHANNEL'),
       compromisedAccounts: incidentEntities(data, id, 'compromised_accounts', 'COMPROMISED_ACCOUNT'),

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -272,8 +272,7 @@ function entityConnectionsFor(data, entityId) {
       id: row.entity.id,
       type: row.type,
       entityType: entityTypeLabel(row.entity),
-    }))
-    .filter((item) => item.href);
+    }));
 
   const incidentNodes = relationshipRows(data, entityId)
     .filter((row) => row.incident)
@@ -289,7 +288,6 @@ function entityConnectionsFor(data, entityId) {
         entityType: entityTypeLabel(row.entity),
         context: data.incidentByNodeId.get(incidentNode)?.title,
       }))
-      .filter((item) => item.href)
   );
 
   return dedupeRows([...direct, ...throughIncidents]).sort(compareLabel);

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -82,7 +82,9 @@ const indexDescription =
 
 const allEntityFiles = {
   accounts: 'accounts.json',
+  actors: 'actors.json',
   build_systems: 'build_systems.json',
+  campaigns: 'campaigns.json',
   distribution_channels: 'distribution_channels.json',
   maintainers: 'maintainers.json',
   organizations: 'organizations.json',
@@ -145,6 +147,8 @@ const ENTITY_COLLECTION_LABELS = {
   build_systems: 'Build System',
   distribution_channels: 'Distribution Channel',
   accounts: 'Compromised Account',
+  actors: 'Threat Actor',
+  campaigns: 'Campaign',
 };
 
 const editorialSectionDefinitions = [
@@ -216,6 +220,7 @@ function relationshipRows(data, nodeId) {
 }
 
 function linkForEntity(entity) {
+  if (entity.href) return entity.href;
   const type = SUPPLY_CHAIN_ENTITY_TYPES.find((item) => item.key === entity.entityCollection);
   return type ? `/supply-chain/${type.segment}/${entity.id}/` : null;
 }
@@ -326,6 +331,14 @@ function referenceMapFor(incident) {
 
 function referencesForItem(item, referenceById) {
   return (item.reference_ids || []).map((referenceId) => referenceById.get(referenceId)).filter(Boolean);
+}
+
+function attributionEvidenceFor(incident) {
+  const referenceById = referenceMapFor(incident);
+  return (incident.attribution_evidence || []).map((item) => ({
+    ...item,
+    references: (item.source_refs || []).map((referenceId) => referenceById.get(referenceId)).filter(Boolean),
+  }));
 }
 
 function editorialSectionsFor(incident) {
@@ -454,9 +467,12 @@ export function getSupplyChainIncidentPage(id, data = loadSupplyChainData()) {
       repositories: incidentEntityLinks(data, id, 'AFFECTED_REPOSITORY'),
       organizations: incidentEntityLinks(data, id, 'AFFECTED_ORGANIZATION'),
       maintainers: incidentEntityLinks(data, id, 'AFFECTED_MAINTAINER'),
+      actors: incidentEntityLinks(data, id, 'ATTRIBUTED_TO_ACTOR'),
+      campaigns: incidentEntityLinks(data, id, 'RELATED_CAMPAIGN'),
       buildSystems: incidentEntities(data, id, 'build_systems', 'USED_BUILD_SYSTEM'),
       distributionChannels: incidentEntities(data, id, 'distribution_channels', 'USED_DISTRIBUTION_CHANNEL'),
       compromisedAccounts: incidentEntities(data, id, 'compromised_accounts', 'COMPROMISED_ACCOUNT'),
+      attributionEvidence: attributionEvidenceFor(incident),
     },
   };
 }

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -145,6 +145,9 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
         <div><span>Evidence Level</span><strong>{titleCase(page.incident.evidence_level)}</strong></div>
         <div><span>Attack Stage</span><strong>{titleCase(page.incident.attack_stage)}</strong></div>
         <div><span>Source Artifact Divergence</span><strong>{titleCase(page.incident.source_artifact_divergence)}</strong></div>
+        {page.incident.attribution_confidence && (
+          <div><span>Attribution Confidence</span><strong>{titleCase(page.incident.attribution_confidence)}</strong></div>
+        )}
       </section>
 
       {page.editorialSections.length > 0 && (
@@ -206,10 +209,30 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
       <EntityList title="Repositories" items={page.sections.repositories} />
       <EntityList title="Organizations" items={page.sections.organizations} />
       <EntityList title="Maintainers" items={page.sections.maintainers} />
+      <EntityList title="Threat Actors" items={page.sections.actors} />
+      <EntityList title="Campaigns" items={page.sections.campaigns} />
       <EntityList title="Build Systems" items={page.sections.buildSystems} />
       <EntityList title="Distribution Channels" items={page.sections.distributionChannels} />
       <EntityList title="Compromised Accounts" items={page.sections.compromisedAccounts} />
       <EntityList title="Connected Entities" items={page.connectedEntities} />
+
+      {page.sections.attributionEvidence.length > 0 && (
+        <section class="sc-section">
+          <h2>Attribution Evidence</h2>
+          <div class="editorial-card-list">
+            {page.sections.attributionEvidence.map((item) => (
+              <article class="editorial-card">
+                <p>{item.summary}</p>
+                <ul class="citation-list">
+                  {item.references.map((reference) => (
+                    <li><a href={reference.url} target="_blank" rel="noopener noreferrer">{referenceLabel(reference)}</a></li>
+                  ))}
+                </ul>
+              </article>
+            ))}
+          </div>
+        </section>
+      )}
 
       <section class="sc-section">
         <h2>References</h2>

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -342,6 +342,28 @@ class SupplyChainGraphTests(unittest.TestCase):
             any("missing RELATED_CAMPAIGN relationship for campaign-tp-camp-2023-0002" in error for error in errors)
         )
 
+    def test_actor_entity_refs_require_graph_relationships(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        entities_by_type = validator.load_entities(ENTITY_DIR)
+        relationships = [
+            relationship
+            for relationship in copy.deepcopy(load_json(RELATIONSHIP_PATH))
+            if not (
+                relationship["source"] == "maintainer-jia-tan"
+                and relationship["target"] == "actor-unc-xz-utils-operator"
+                and relationship["type"] == "ATTRIBUTED_TO_ACTOR"
+            )
+        ]
+
+        errors = validator.validate_graph(corpus, entities_by_type, relationships)
+
+        self.assertTrue(
+            any(
+                "missing ATTRIBUTED_TO_ACTOR relationship from maintainer-jia-tan to actor-unc-xz-utils-operator" in error
+                for error in errors
+            )
+        )
+
     def test_new_entity_type_required_fields_are_validated(self) -> None:
         corpus = load_json(CORPUS_PATH)
         entities_by_type = validator.load_entities(ENTITY_DIR)

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -315,6 +315,33 @@ class SupplyChainGraphTests(unittest.TestCase):
         self.assertTrue(any("ATTRIBUTED_TO_ACTOR must start from an incident or maintainer node" in error for error in errors))
         self.assertTrue(any("RELATED_CAMPAIGN must start from an incident node" in error for error in errors))
 
+    def test_incident_attribution_links_require_incident_scoped_relationships(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        entities_by_type = validator.load_entities(ENTITY_DIR)
+        relationships = [
+            relationship
+            for relationship in copy.deepcopy(load_json(RELATIONSHIP_PATH))
+            if not (
+                relationship["source"] == "incident-SC-2024-XZ-UTILS"
+                and relationship["target"] == "actor-unc-xz-utils-operator"
+                and relationship["type"] == "ATTRIBUTED_TO_ACTOR"
+            )
+            and not (
+                relationship["source"] == "incident-SC-2023-THREE-CX-DESKTOP"
+                and relationship["target"] == "campaign-tp-camp-2023-0002"
+                and relationship["type"] == "RELATED_CAMPAIGN"
+            )
+        ]
+
+        errors = validator.validate_graph(corpus, entities_by_type, relationships)
+
+        self.assertTrue(
+            any("missing ATTRIBUTED_TO_ACTOR relationship for actor-unc-xz-utils-operator" in error for error in errors)
+        )
+        self.assertTrue(
+            any("missing RELATED_CAMPAIGN relationship for campaign-tp-camp-2023-0002" in error for error in errors)
+        )
+
     def test_new_entity_type_required_fields_are_validated(self) -> None:
         corpus = load_json(CORPUS_PATH)
         entities_by_type = validator.load_entities(ENTITY_DIR)

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -66,6 +66,17 @@ class SupplyChainGraphTests(unittest.TestCase):
         self.assertIn("actor-lazarus-group", actor_ids)
         self.assertIn("campaign-tp-camp-2023-0002", campaign_ids)
 
+    def test_builder_uses_highest_actor_confidence_across_incidents(self) -> None:
+        corpus = copy.deepcopy(load_json(CORPUS_PATH))
+        first = next(item for item in corpus if item["id"] == "SC-2024-XZ-UTILS")
+        second = copy.deepcopy(first)
+        second["id"] = "SC-2024-XZ-UTILS-SIBLING"
+        second["threat_actors"][0]["confidence"] = "confirmed"
+        graph = builder.build_graph([first, second])
+        actor = next(entity for entity in graph["actors"] if entity["id"] == "actor-unc-xz-utils-operator")
+
+        self.assertEqual(actor["attribution_confidence"], "confirmed")
+
     def test_source_artifact_divergence_targets_distribution_channels(self) -> None:
         graph = builder.build_graph(load_json(CORPUS_PATH))
         relationships = [

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -77,6 +77,55 @@ class SupplyChainGraphTests(unittest.TestCase):
 
         self.assertEqual(actor["attribution_confidence"], "confirmed")
 
+    def test_actor_and_campaign_aliases_include_canonical_names(self) -> None:
+        actors: dict[str, dict] = {}
+        campaigns: dict[str, dict] = {}
+        actor_id = builder.upsert_actor(
+            actors,
+            {
+                "id": "actor-example",
+                "name": "Example Actor",
+                "actor_type": "public",
+                "confidence": "suspected",
+                "aliases": ["Alias Only"],
+                "href": "/threat-actors/example/",
+            },
+            "SC-2024-XZ-UTILS",
+        )
+        builder.upsert_actor(
+            actors,
+            {
+                "id": "actor-example",
+                "name": "Example Actor",
+                "actor_type": "public",
+                "confidence": "confirmed",
+                "aliases": ["Second Alias"],
+                "notes": "Later incident adds notes.",
+            },
+            "SC-2024-XZ-UTILS-SIBLING",
+        )
+        campaign_id = builder.upsert_campaign(
+            campaigns,
+            {
+                "id": "campaign-example",
+                "campaign_id": "TP-CAMP-2024-9999",
+                "name": "Example Campaign",
+                "slug": "example-campaign",
+                "aliases": ["Campaign Alias"],
+            },
+            "SC-2024-XZ-UTILS",
+        )
+
+        self.assertEqual(actor_id, "actor-example")
+        self.assertIn("Example Actor", actors["actor-example"]["aliases"])
+        self.assertIn("Second Alias", actors["actor-example"]["aliases"])
+        self.assertEqual(actors["actor-example"]["href"], "/threat-actors/example/")
+        self.assertEqual(actors["actor-example"]["notes"], "Later incident adds notes.")
+        self.assertEqual(actors["actor-example"]["attribution_confidence"], "confirmed")
+        self.assertEqual(campaign_id, "campaign-example")
+        self.assertIn("Example Campaign", campaigns["campaign-example"]["aliases"])
+        self.assertIn("TP-CAMP-2024-9999", campaigns["campaign-example"]["aliases"])
+
     def test_source_artifact_divergence_targets_distribution_channels(self) -> None:
         graph = builder.build_graph(load_json(CORPUS_PATH))
         relationships = [

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -48,8 +48,10 @@ class SupplyChainGraphTests(unittest.TestCase):
         build_system_ids = {entity["id"] for entity in graph["build_systems"]}
         channel_ids = {entity["id"] for entity in graph["distribution_channels"]}
         account_ids = {entity["id"] for entity in graph["accounts"]}
+        actor_ids = {entity["id"] for entity in graph["actors"]}
+        campaign_ids = {entity["id"] for entity in graph["campaigns"]}
 
-        self.assertGreaterEqual(len(graph["relationships"]), 90)
+        self.assertGreaterEqual(len(graph["relationships"]), 100)
         self.assertIn("pkg-npm-event-stream", package_ids)
         self.assertIn("pkg-npm-flatmap-stream", package_ids)
         self.assertIn("maintainer-jia-tan", maintainer_ids)
@@ -60,6 +62,9 @@ class SupplyChainGraphTests(unittest.TestCase):
         self.assertIn("build-github-github-actions", build_system_ids)
         self.assertIn("channel-npm-package-registry-npm-registry", channel_ids)
         self.assertIn("account-npm-eslint-scope-npm-maintainer-account", account_ids)
+        self.assertIn("actor-unc-xz-utils-operator", actor_ids)
+        self.assertIn("actor-lazarus-group", actor_ids)
+        self.assertIn("campaign-tp-camp-2023-0002", campaign_ids)
 
     def test_source_artifact_divergence_targets_distribution_channels(self) -> None:
         graph = builder.build_graph(load_json(CORPUS_PATH))
@@ -201,6 +206,54 @@ class SupplyChainGraphTests(unittest.TestCase):
         errors = validator.validate_graph(corpus, entities_by_type, relationships)
 
         self.assertTrue(any("invalid relationship type" in error for error in errors))
+
+    def test_dangling_actor_and_campaign_edges_fail(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        entities_by_type = validator.load_entities(ENTITY_DIR)
+        relationships = copy.deepcopy(load_json(RELATIONSHIP_PATH))
+        relationships.append(
+            {
+                "source": "incident-SC-2024-XZ-UTILS",
+                "target": "actor-does-not-exist",
+                "type": "ATTRIBUTED_TO_ACTOR",
+            }
+        )
+        relationships.append(
+            {
+                "source": "incident-SC-2023-THREE-CX-DESKTOP",
+                "target": "campaign-does-not-exist",
+                "type": "RELATED_CAMPAIGN",
+            }
+        )
+
+        errors = validator.validate_graph(corpus, entities_by_type, relationships)
+
+        self.assertTrue(any("unknown target 'actor-does-not-exist'" in error for error in errors))
+        self.assertTrue(any("unknown target 'campaign-does-not-exist'" in error for error in errors))
+
+    def test_actor_and_campaign_relationship_sources_are_bounded(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        entities_by_type = validator.load_entities(ENTITY_DIR)
+        relationships = copy.deepcopy(load_json(RELATIONSHIP_PATH))
+        relationships.append(
+            {
+                "source": "pkg-npm-event-stream",
+                "target": "actor-lazarus-group",
+                "type": "ATTRIBUTED_TO_ACTOR",
+            }
+        )
+        relationships.append(
+            {
+                "source": "maintainer-jia-tan",
+                "target": "campaign-tp-camp-2023-0002",
+                "type": "RELATED_CAMPAIGN",
+            }
+        )
+
+        errors = validator.validate_graph(corpus, entities_by_type, relationships)
+
+        self.assertTrue(any("ATTRIBUTED_TO_ACTOR must start from an incident or maintainer node" in error for error in errors))
+        self.assertTrue(any("RELATED_CAMPAIGN must start from an incident node" in error for error in errors))
 
     def test_new_entity_type_required_fields_are_validated(self) -> None:
         corpus = load_json(CORPUS_PATH)

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -292,6 +292,22 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
         self.assertTrue(any("unknown reference ID 'ref-missing'" in error for error in errors))
         self.assertTrue(any("missing ATTRIBUTED_TO_ACTOR evidence" in error for error in errors))
 
+    def test_attribution_evidence_cannot_be_orphaned(self) -> None:
+        incident = copy.deepcopy(next(item for item in load_json(CORPUS_PATH) if item["id"] == "SC-2024-XZ-UTILS"))
+        incident["threat_actors"] = []
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any("unexpected ATTRIBUTED_TO_ACTOR evidence" in error for error in errors))
+
+    def test_actor_entity_refs_are_bounded_to_incident_or_maintainer_nodes(self) -> None:
+        incident = copy.deepcopy(next(item for item in load_json(CORPUS_PATH) if item["id"] == "SC-2024-XZ-UTILS"))
+        incident["threat_actors"][0]["entity_refs"] = ["pkg-npm-event-stream"]
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any("expected maintainer-* or incident-* identifier" in error for error in errors))
+
     def test_attribution_confidence_enum_is_enforced(self) -> None:
         incident = copy.deepcopy(next(item for item in load_json(CORPUS_PATH) if item["id"] == "SC-2023-THREE-CX-DESKTOP"))
         incident["attribution_confidence"] = "apt-score"

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -224,6 +224,14 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
         del schema["$defs"]["affected_component"]["then"]
         self.assertTrue(any("affected_component.then" in error for error in validator.validate_schema_file(schema)))
 
+    def test_schema_includes_attribution_contract(self) -> None:
+        schema = load_json(SCHEMA_PATH)
+
+        self.assertEqual(validator.validate_schema_file(schema), [])
+
+        del schema["$defs"]["attribution_confidence"]
+        self.assertTrue(any("attribution_confidence" in error for error in validator.validate_schema_file(schema)))
+
     def test_source_artifact_divergence_requires_distribution_channels(self) -> None:
         incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
         incident["source_artifact_divergence"] = True
@@ -273,6 +281,36 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
         errors = validator.validate_incident(incident)
 
         self.assertTrue(any(".timeline[0].date: expected YYYY-MM-DD date or YYYY-MM-DD/YYYY-MM-DD range" in error for error in errors))
+
+    def test_attribution_links_require_local_evidence(self) -> None:
+        incident = copy.deepcopy(next(item for item in load_json(CORPUS_PATH) if item["id"] == "SC-2024-XZ-UTILS"))
+        incident["threat_actors"][0]["source_refs"] = ["ref-missing"]
+        incident["attribution_evidence"] = []
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any("unknown reference ID 'ref-missing'" in error for error in errors))
+        self.assertTrue(any("missing ATTRIBUTED_TO_ACTOR evidence" in error for error in errors))
+
+    def test_attribution_confidence_enum_is_enforced(self) -> None:
+        incident = copy.deepcopy(next(item for item in load_json(CORPUS_PATH) if item["id"] == "SC-2023-THREE-CX-DESKTOP"))
+        incident["attribution_confidence"] = "apt-score"
+        incident["threat_actors"][0]["confidence"] = "certain"
+        incident["campaigns"][0]["confidence"] = "maybe"
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any(".attribution_confidence: invalid value" in error for error in errors))
+        self.assertTrue(any(".threat_actors[0].confidence: invalid value" in error for error in errors))
+        self.assertTrue(any(".campaigns[0].confidence: invalid value" in error for error in errors))
+
+    def test_first_public_warning_date_is_validated(self) -> None:
+        incident = copy.deepcopy(next(item for item in load_json(CORPUS_PATH) if item["id"] == "SC-2020-SOLARWINDS-ORION"))
+        incident["first_public_warning_at"] = "20201213"
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any(".first_public_warning_at: expected YYYY-MM-DD date or null" in error for error in errors))
 
 
 if __name__ == "__main__":

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -308,6 +308,27 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
 
         self.assertTrue(any("expected maintainer-* or incident-* identifier" in error for error in errors))
 
+    def test_missing_attribution_link_fields_report_once(self) -> None:
+        incident = copy.deepcopy(next(item for item in load_json(CORPUS_PATH) if item["id"] == "SC-2023-THREE-CX-DESKTOP"))
+        del incident["threat_actors"][0]["source_refs"]
+        del incident["campaigns"][0]["campaign_id"]
+        del incident["attribution_evidence"][0]["summary"]
+
+        errors = validator.validate_incident(incident)
+
+        self.assertEqual(
+            [error for error in errors if ".threat_actors[0].source_refs" in error],
+            [f"{incident['id']}.threat_actors[0].source_refs: missing required field"],
+        )
+        self.assertEqual(
+            [error for error in errors if ".campaigns[0].campaign_id" in error],
+            [f"{incident['id']}.campaigns[0].campaign_id: missing required field"],
+        )
+        self.assertEqual(
+            [error for error in errors if ".attribution_evidence[0].summary" in error],
+            [f"{incident['id']}.attribution_evidence[0].summary: missing required field"],
+        )
+
     def test_attribution_confidence_enum_is_enforced(self) -> None:
         incident = copy.deepcopy(next(item for item in load_json(CORPUS_PATH) if item["id"] == "SC-2023-THREE-CX-DESKTOP"))
         incident["attribution_confidence"] = "apt-score"


### PR DESCRIPTION
## Summary

- Adds Phase 2B actor and campaign convergence fields to the supply-chain incident schema and validator.
- Emits actor and campaign entity files plus ATTRIBUTED_TO_ACTOR and RELATED_CAMPAIGN relationships from evidence-backed incident fields.
- Connects XZ Utils to a provisional operator node, and connects 3CX, SolarWinds, and NotPetya to existing actor/campaign entities with local evidence records.
- Renders actor/campaign links and attribution evidence on Supply Chain incident pages when present.
- Documents the convergence model and adds regression coverage for dangling actor/campaign edges.

## Validation

- python3 scripts/validate_supply_chain_incidents.py: PASS
- python3 scripts/validate_supply_chain_graph.py: PASS
- python3 -m unittest tests.test_supply_chain_incidents tests.test_supply_chain_graph: PASS, 46 tests
- node --check site/src/lib/supplyChainPages.mjs && node scripts/test-supply-chain-pages.mjs: PASS, routes=74
- python3 -m unittest discover -s tests: PASS, 60 tests
- node --check scripts/check_supply_chain_public_readiness.mjs && node scripts/check_supply_chain_public_readiness.mjs: PASS
- git diff --check: PASS
- cd site && rm -rf dist && npm run build: PASS; known campaign related-incident warnings only
- cd site && rm -rf dist && ENABLE_SUPPLY_CHAIN_PAGES=true npm run build: PASS; known campaign related-incident warnings only

## Review focus

- Confirm provisional XZ operator node does not imply named APT or nation-state attribution.
- Confirm actor/campaign edges remain evidence-backed and non-scoring.
- Confirm RELATED_CAMPAIGN hard-edge validation is limited to supply-chain graph relationships, not the existing soft campaign related-incident-count warnings.
