### PR TITLE
Add stalled ready-issue detector

### DIFF
--- a/.github/pipeline/config.yml
+++ b/.github/pipeline/config.yml
@@ -39,6 +39,13 @@ circuit_breaker:
   cooldown_minutes: 60           # How long to wait before retrying after trip
   alert_channel: "issues"        # Where to alert (GitHub Issues)
 
+# ── Ready-Issue Supervision ─────────────────────────────────────────────────
+ready_issue:
+  warn_minutes: 60               # Warn when a ready Issue has no PR after this many minutes of inactivity
+  stall_minutes: 180             # Open a pipeline/stalled-ready-issue alert after this many minutes
+  stall_minutes_by_priority:
+    P0: 60                       # P0 ready Issues page faster than the general stale handoff threshold
+
 # ── Validation Gates ─────────────────────────────────────────────────────────
 validation:
   min_sources: 3

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -329,6 +329,7 @@ same queue/validation path as discovery-generated tasks.
 | Review readiness gate | `pipeline-review-gate.yml` + `pipeline-review-gate.mjs` | Current-head validation for content PRs, current-head AI second review from Gemini Code Assist, `dangermouse-bot`, or `ernestpenfold-bot`, zero unresolved AI review threads; automatic PR-review runs are limited to configured AI reviewer logins; issue-comment runs require `/review-gate` or `/pipeline review-gate` | Live GitHub state |
 | Editorial queue backpressure (hysteresis) | `pipeline-dispatcher.yml` (via `scripts/pipeline-config.mjs`); state tracked via labeled GitHub Issue (`pipeline/backpressure`) | Pause at 100 pending · stay paused until queue < 80 (auto-resume + Issue auto-close) | `config.yml` (`queues.editorial.max_pending` / `backpressure_resume`) |
 | Stale-lock timeout | `pipeline-dispatcher.yml` (via `scripts/pipeline-config.mjs`) | 30 minutes | `config.yml` (`scheduling.stale_lock_minutes`) |
+| Ready-Issue stall alert | `pipeline-dispatcher.yml` | Warn after 60 minutes; alert after 180 minutes, or 60 minutes for P0 | `config.yml` (`ready_issue.*`) |
 | Circuit breaker | `pipeline-dispatcher.yml` (via `scripts/pipeline-config.mjs`) | 3 failures in 120min → Issue + halt; 60min cooldown | `config.yml` (`circuit_breaker.*`) |
 | Dependency blocking | `pipeline-dispatcher.yml` | Per-task `depends_on[]` | Task file |
 | Validation gates | `pipeline-run-task.mjs --validate` | See `config.yml` `validation.*` | `config.yml` |
@@ -390,6 +391,18 @@ falls below the resume threshold.
 The dispatcher task dispatch ceiling is configurable through
 `queues.dispatcher.tasks_per_run` in `.github/pipeline/config.yml`. Keep this
 below review backpressure thresholds; the default is 12 per dispatcher cycle.
+
+**Ready-Issue supervision:** a valid `pipeline/ready` Issue is a handoff to an
+agent or human worker, not proof that the work is moving. On every dispatcher
+tick, the dispatcher reconciles ready Issues against live task and PR state:
+it closes orphaned issues, closes issues covered by an open task PR, closes
+issues for tasks no longer in `pending`/`draft`, and deduplicates duplicate
+ready Issues. If the remaining valid ready Issue has no assignee, no covering
+PR, and no recent activity, the dispatcher opens or refreshes a
+`pipeline/alert` + `pipeline/stalled-ready-issue` Issue. Assigned ready Issues
+emit a warning but are treated as actively owned. This is a detective control:
+it makes a silent worker-consumption stall visible, but it does not draft
+content, auto-assign workers, or bypass review policy.
 
 ---
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -7,7 +7,7 @@
     "check:supply-chain-preview": "node check_supply_chain_preview.mjs",
     "check:supply-chain-public-readiness": "node check_supply_chain_public_readiness.mjs",
     "social:share-x": "node social-share-x.mjs",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test-vulncheck-kev-intake.mjs && node test-pipeline-dispatcher-stall.cjs"
   },
   "keywords": [],
   "author": "",

--- a/scripts/pipeline-config.mjs
+++ b/scripts/pipeline-config.mjs
@@ -61,6 +61,13 @@ export const DEFAULTS = Object.freeze({
     failure_window_minutes: 120,
     alert_channel: 'issues',
   },
+  ready_issue: {
+    warn_minutes: 60,
+    stall_minutes: 180,
+    stall_minutes_by_priority: {
+      P0: 60,
+    },
+  },
   validation: {
     min_sources: 3,
     min_h2_sections: 5,

--- a/scripts/pipeline-dispatcher-dispatch-step.cjs
+++ b/scripts/pipeline-dispatcher-dispatch-step.cjs
@@ -5,8 +5,9 @@ const path = require('path');
 
 const TASKS_DIR = '.github/pipeline/tasks';
 const DISPATCH_LABEL = 'pipeline/ready';
+const STALLED_READY_LABEL = 'pipeline/stalled-ready-issue';
 
-module.exports = async function runDispatcherDispatchStep({ github, context }) {
+module.exports = async function runDispatcherDispatchStep({ github, context, core = null }) {
   const DEFAULTS = {
     tasksPerRun: 12,
     maxEditorial: 100,
@@ -15,7 +16,28 @@ module.exports = async function runDispatcherDispatchStep({ github, context }) {
     staleLockMinutes: 30,
     cooldownMinutes: 60,
     failureWindowMinutes: 120,
+    readyIssueWarnMinutes: 60,
+    readyIssueStallMinutes: 180,
+    readyIssuePriorityStallMinutes: { P0: 60 },
   };
+
+  function parsePositiveInt(value, fallback) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  }
+
+  function parsePriorityStallMinutes(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return { ...DEFAULTS.readyIssuePriorityStallMinutes };
+    }
+
+    const parsed = {};
+    for (const [priority, minutes] of Object.entries(value)) {
+      const normalized = parsePositiveInt(minutes, null);
+      if (normalized) parsed[String(priority).toUpperCase()] = normalized;
+    }
+    return { ...DEFAULTS.readyIssuePriorityStallMinutes, ...parsed };
+  }
 
   function loadConfig() {
     try {
@@ -36,6 +58,17 @@ module.exports = async function runDispatcherDispatchStep({ github, context }) {
         staleLockMinutes: cfg?.scheduling?.stale_lock_minutes ?? DEFAULTS.staleLockMinutes,
         cooldownMinutes: cfg?.circuit_breaker?.cooldown_minutes ?? DEFAULTS.cooldownMinutes,
         failureWindowMinutes: cfg?.circuit_breaker?.failure_window_minutes ?? DEFAULTS.failureWindowMinutes,
+        readyIssueWarnMinutes: parsePositiveInt(
+          cfg?.ready_issue?.warn_minutes,
+          DEFAULTS.readyIssueWarnMinutes
+        ),
+        readyIssueStallMinutes: parsePositiveInt(
+          cfg?.ready_issue?.stall_minutes,
+          DEFAULTS.readyIssueStallMinutes
+        ),
+        readyIssuePriorityStallMinutes: parsePriorityStallMinutes(
+          cfg?.ready_issue?.stall_minutes_by_priority
+        ),
         _source: cfg._source || 'file',
         _reason: cfg._reason,
         _path: cfg._path,
@@ -59,6 +92,8 @@ module.exports = async function runDispatcherDispatchStep({ github, context }) {
   console.log(`  failureWindowMinutes: ${config.failureWindowMinutes}  (circuit_breaker.failure_window_minutes)`);
   console.log(`  cooldownMinutes:      ${config.cooldownMinutes}  (circuit_breaker.cooldown_minutes)`);
   console.log(`  staleLockMinutes:     ${config.staleLockMinutes}  (scheduling.stale_lock_minutes)`);
+  console.log(`  readyIssueWarnMin:    ${config.readyIssueWarnMinutes}  (ready_issue.warn_minutes)`);
+  console.log(`  readyIssueStallMin:   ${config.readyIssueStallMinutes}  (ready_issue.stall_minutes)`);
   console.log('──────────────────────────────────────────────────────────');
 
   function loadTasks() {
@@ -135,6 +170,136 @@ module.exports = async function runDispatcherDispatchStep({ github, context }) {
       state_reason: 'completed',
     });
     removeOpenIssue(issue.number);
+  }
+
+  function emitWarning(message) {
+    console.log(`::warning::${message}`);
+    if (core?.warning) core.warning(message);
+  }
+
+  function minutesSince(timestamp) {
+    const millis = Date.parse(timestamp || '');
+    if (!Number.isFinite(millis)) return 0;
+    return Math.max(0, (now.getTime() - millis) / 60000);
+  }
+
+  function readyIssueStallThreshold(task) {
+    const priority = String(task.priority || '').toUpperCase();
+    return config.readyIssuePriorityStallMinutes[priority] || config.readyIssueStallMinutes;
+  }
+
+  function readyIssueAgeMinutes(issue) {
+    return minutesSince(issue.updated_at || issue.created_at);
+  }
+
+  function readyIssueHasAssignee(issue) {
+    return Array.isArray(issue.assignees) && issue.assignees.length > 0;
+  }
+
+  function readyIssueTaskUrl(issue) {
+    return issue.html_url || `Issue #${issue.number}`;
+  }
+
+  async function findStalledReadyIssue(taskId) {
+    const { data } = await github.rest.issues.listForRepo({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      state: 'open',
+      labels: STALLED_READY_LABEL,
+      per_page: 100,
+    });
+    return data.find((issue) =>
+      String(issue.title || '').includes(taskId) ||
+      String(issue.body || '').includes(`\`${taskId}\``)
+    ) || null;
+  }
+
+  async function closeStalledReadyIssue(taskId, reason) {
+    const alertIssue = await findStalledReadyIssue(taskId);
+    if (!alertIssue) return;
+
+    console.log(`Closing stalled-ready alert #${alertIssue.number}: ${reason}`);
+    await github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: alertIssue.number,
+      body: `Auto-closing: ${reason}`,
+    });
+    await github.rest.issues.update({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: alertIssue.number,
+      state: 'closed',
+      state_reason: 'completed',
+    });
+  }
+
+  function stalledReadyIssueBody(task, readyIssue, ageMinutes, thresholdMinutes) {
+    return [
+      `The dispatcher found a valid \`${DISPATCH_LABEL}\` Issue for \`${task.task_id}\`, but no worker has consumed it.`,
+      '',
+      '| Field | Value |',
+      '|---|---|',
+      `| Task | \`${task.task_id}\` |`,
+      `| Type | \`${task.type || 'unknown'}\` |`,
+      `| Priority | \`${task.priority || 'unknown'}\` |`,
+      `| Ready Issue | ${readyIssueTaskUrl(readyIssue)} |`,
+      `| Ready Issue Age | ${Math.round(ageMinutes)} minutes since last activity |`,
+      `| Stall Threshold | ${thresholdMinutes} minutes |`,
+      `| Topic | ${task.input?.topic || 'unknown'} |`,
+      '',
+      'The dispatcher already checked for recoverable state before opening this alert:',
+      '',
+      '- no covering task PR is open',
+      '- the task is still `pending` in `draft` stage',
+      '- duplicate ready issues were reconciled separately',
+      '',
+      'This is a supervision failure, not an article-generation failure. Route the ready issue to a drafting worker, or assign it to signal active human ownership. The dispatcher will keep dispatching other eligible work.',
+    ].join('\n');
+  }
+
+  async function alertIfReadyIssueStalled(task, readyIssue) {
+    const ageMinutes = readyIssueAgeMinutes(readyIssue);
+    const stallThreshold = readyIssueStallThreshold(task);
+
+    if (ageMinutes < config.readyIssueWarnMinutes) return;
+
+    emitWarning(
+      `${task.task_id} has open ready Issue #${readyIssue.number} with no covering PR after ${Math.round(ageMinutes)} minutes.`
+    );
+
+    if (readyIssueHasAssignee(readyIssue)) {
+      console.log(`Ready Issue #${readyIssue.number} is assigned; treating it as actively owned.`);
+      await closeStalledReadyIssue(task.task_id, `${task.task_id} ready Issue #${readyIssue.number} is assigned`);
+      return;
+    }
+
+    if (ageMinutes < stallThreshold) return;
+
+    const title = `[PIPELINE ALERT] Stalled ready issue — ${task.task_id}`;
+    const body = stalledReadyIssueBody(task, readyIssue, ageMinutes, stallThreshold);
+    const existingAlert = await findStalledReadyIssue(task.task_id);
+
+    if (existingAlert) {
+      console.log(`Refreshing stalled-ready alert #${existingAlert.number} for ${task.task_id}`);
+      await github.rest.issues.update({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: existingAlert.number,
+        title,
+        body,
+      });
+      return;
+    }
+
+    console.log(`Opening stalled-ready alert for ${task.task_id}`);
+    await github.rest.issues.create({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      title,
+      body,
+      labels: ['pipeline/alert', STALLED_READY_LABEL],
+    });
   }
 
   async function loadPrForTask(task) {
@@ -293,6 +458,7 @@ module.exports = async function runDispatcherDispatchStep({ github, context }) {
             `${taskId} is already covered by open PR #${coveringPr.number}`
           );
         }
+        await closeStalledReadyIssue(taskId, `${taskId} is now covered by open PR #${coveringPr.number}`);
         continue;
       }
 
@@ -303,13 +469,18 @@ module.exports = async function runDispatcherDispatchStep({ github, context }) {
             `${taskId} is no longer ready for pickup (status=${task.status}, stage=${task.stage})`
           );
         }
+        await closeStalledReadyIssue(
+          taskId,
+          `${taskId} is no longer ready for pickup (status=${task.status}, stage=${task.stage})`
+        );
         continue;
       }
 
-      const [, ...duplicates] = issues;
+      const [primary, ...duplicates] = issues;
       for (const issue of duplicates) {
         await closePipelineIssue(issue, `duplicate pipeline issue for ${taskId}`);
       }
+      await alertIfReadyIssueStalled(task, primary);
     }
   }
 

--- a/scripts/pipeline-dispatcher-dispatch-step.cjs
+++ b/scripts/pipeline-dispatcher-dispatch-step.cjs
@@ -148,9 +148,30 @@ module.exports = async function runDispatcherDispatchStep({ github, context, cor
   const openPipelineIssues = await loadOpenPipelineIssues();
   const taskIndex = new Map(allTasks.map((task) => [task.task_id, task]));
 
+  async function loadOpenStalledReadyIssues() {
+    const issues = await github.paginate(
+      github.rest.issues.listForRepo,
+      {
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        state: 'open',
+        labels: STALLED_READY_LABEL,
+        per_page: 100,
+      }
+    );
+    return issues.filter((issue) => !issue.pull_request);
+  }
+
+  const openStalledReadyIssues = await loadOpenStalledReadyIssues();
+
   function removeOpenIssue(issueNumber) {
     const index = openPipelineIssues.findIndex((issue) => issue.number === issueNumber);
     if (index >= 0) openPipelineIssues.splice(index, 1);
+  }
+
+  function removeOpenStalledReadyIssue(issueNumber) {
+    const index = openStalledReadyIssues.findIndex((issue) => issue.number === issueNumber);
+    if (index >= 0) openStalledReadyIssues.splice(index, 1);
   }
 
   function findOpenPipelineIssue(taskId) {
@@ -201,14 +222,7 @@ module.exports = async function runDispatcherDispatchStep({ github, context, cor
   }
 
   async function findStalledReadyIssue(taskId) {
-    const { data } = await github.rest.issues.listForRepo({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      state: 'open',
-      labels: STALLED_READY_LABEL,
-      per_page: 100,
-    });
-    return data.find((issue) =>
+    return openStalledReadyIssues.find((issue) =>
       String(issue.title || '').includes(taskId) ||
       String(issue.body || '').includes(`\`${taskId}\``)
     ) || null;
@@ -232,6 +246,7 @@ module.exports = async function runDispatcherDispatchStep({ github, context, cor
       state: 'closed',
       state_reason: 'completed',
     });
+    removeOpenStalledReadyIssue(alertIssue.number);
   }
 
   function stalledReadyIssueBody(task, readyIssue, ageMinutes, thresholdMinutes) {
@@ -282,24 +297,26 @@ module.exports = async function runDispatcherDispatchStep({ github, context, cor
 
     if (existingAlert) {
       console.log(`Refreshing stalled-ready alert #${existingAlert.number} for ${task.task_id}`);
-      await github.rest.issues.update({
+      const { data: refreshedAlert } = await github.rest.issues.update({
         owner: context.repo.owner,
         repo: context.repo.repo,
         issue_number: existingAlert.number,
         title,
         body,
       });
+      Object.assign(existingAlert, refreshedAlert);
       return;
     }
 
     console.log(`Opening stalled-ready alert for ${task.task_id}`);
-    await github.rest.issues.create({
+    const { data: createdAlert } = await github.rest.issues.create({
       owner: context.repo.owner,
       repo: context.repo.repo,
       title,
       body,
       labels: ['pipeline/alert', STALLED_READY_LABEL],
     });
+    openStalledReadyIssues.push(createdAlert);
   }
 
   async function loadPrForTask(task) {
@@ -381,6 +398,7 @@ module.exports = async function runDispatcherDispatchStep({ github, context, cor
           });
           saveTask(task);
         }
+        await closeStalledReadyIssue(task.task_id, `${task.task_id} is already covered by open PR #${pr.number}`);
         continue;
       }
 

--- a/scripts/test-pipeline-dispatcher-stall.cjs
+++ b/scripts/test-pipeline-dispatcher-stall.cjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const runDispatcher = require('./pipeline-dispatcher-dispatch-step.cjs');
+
+const ORIGINAL_CWD = process.cwd();
+const ORIGINAL_CONFIG_JSON = process.env.CONFIG_JSON;
+
+function isoMinutesAgo(minutes) {
+  return new Date(Date.now() - minutes * 60000).toISOString();
+}
+
+function baseTask(overrides = {}) {
+  return {
+    task_id: 'TASK-2026-9999',
+    type: 'zero-day',
+    priority: 'P0',
+    status: 'pending',
+    stage: 'draft',
+    created: isoMinutesAgo(180),
+    updated: isoMinutesAgo(180),
+    locked_by: null,
+    locked_at: null,
+    input: {
+      topic: 'Synthetic stale ready issue test',
+      sources: ['https://example.com/a', 'https://example.com/b', 'https://example.com/c'],
+    },
+    output: {
+      branch: 'pipeline/TASK-2026-9999',
+      path: 'site/src/content/zero-days/synthetic.md',
+    },
+    acceptance_criteria: { min_sources: 3 },
+    history: [
+      {
+        timestamp: isoMinutesAgo(180),
+        action: 'created',
+        from: 'none',
+        to: 'pending',
+        agent: 'test',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function readyIssue(overrides = {}) {
+  return {
+    number: 4001,
+    title: '[PIPELINE] TASK-2026-9999: Synthetic stale ready issue test',
+    body: '## Pipeline Task: `TASK-2026-9999`',
+    html_url: 'https://github.com/example/repo/issues/4001',
+    state: 'open',
+    created_at: isoMinutesAgo(120),
+    updated_at: isoMinutesAgo(120),
+    assignees: [],
+    ...overrides,
+  };
+}
+
+function alertIssue(overrides = {}) {
+  return {
+    number: 5001,
+    title: '[PIPELINE ALERT] Stalled ready issue — TASK-2026-9999',
+    body: '`TASK-2026-9999` is stale',
+    html_url: 'https://github.com/example/repo/issues/5001',
+    state: 'open',
+    created_at: isoMinutesAgo(90),
+    updated_at: isoMinutesAgo(90),
+    assignees: [],
+    ...overrides,
+  };
+}
+
+function writeTaskFixture(task) {
+  fs.mkdirSync(path.join(process.cwd(), '.github', 'pipeline', 'tasks'), { recursive: true });
+  fs.writeFileSync(
+    path.join(process.cwd(), '.github', 'pipeline', 'tasks', `${task.task_id}.json`),
+    `${JSON.stringify(task, null, 2)}\n`
+  );
+}
+
+function createMockGithub({ readyIssues = [], alertIssues = [], openPrs = [] } = {}) {
+  const calls = {
+    createdIssues: [],
+    updatedIssues: [],
+    comments: [],
+    pullsListed: [],
+  };
+
+  const state = {
+    readyIssues: [...readyIssues],
+    alertIssues: [...alertIssues],
+    openPrs: [...openPrs],
+  };
+
+  function findIssue(number) {
+    return [...state.readyIssues, ...state.alertIssues, ...calls.createdIssues]
+      .find((issue) => issue.number === number);
+  }
+
+  const github = {
+    paginate: async (method, params) => {
+      const result = await method(params);
+      return result.data;
+    },
+    rest: {
+      issues: {
+        listForRepo: async ({ labels }) => {
+          if (labels === 'pipeline/ready') {
+            return { data: state.readyIssues.filter((issue) => issue.state === 'open') };
+          }
+          if (labels === 'pipeline/stalled-ready-issue') {
+            const createdAlerts = calls.createdIssues.filter((issue) =>
+              issue.labels?.includes('pipeline/stalled-ready-issue')
+            );
+            return {
+              data: [...state.alertIssues, ...createdAlerts].filter((issue) => issue.state === 'open'),
+            };
+          }
+          if (labels === 'pipeline/backpressure') return { data: [] };
+          return { data: [] };
+        },
+        create: async (params) => {
+          const issue = {
+            number: 9000 + calls.createdIssues.length,
+            html_url: `https://github.com/example/repo/issues/${9000 + calls.createdIssues.length}`,
+            state: 'open',
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+            assignees: [],
+            ...params,
+          };
+          calls.createdIssues.push(issue);
+          return { data: issue };
+        },
+        update: async (params) => {
+          calls.updatedIssues.push(params);
+          const issue = findIssue(params.issue_number);
+          if (issue) Object.assign(issue, params);
+          return { data: issue || params };
+        },
+        createComment: async (params) => {
+          calls.comments.push(params);
+          return { data: params };
+        },
+      },
+      pulls: {
+        get: async ({ pull_number }) => {
+          const pr = state.openPrs.find((candidate) => candidate.number === pull_number);
+          if (!pr) {
+            const error = new Error('not found');
+            error.status = 404;
+            throw error;
+          }
+          return { data: pr };
+        },
+        list: async (params) => {
+          calls.pullsListed.push(params);
+          return { data: state.openPrs };
+        },
+      },
+    },
+  };
+
+  return { github, calls, state };
+}
+
+async function runScenario({ task = baseTask(), mock }) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'threatpedia-dispatcher-test-'));
+  process.chdir(tempDir);
+  process.env.CONFIG_JSON = JSON.stringify({
+    ready_issue: {
+      warn_minutes: 30,
+      stall_minutes: 90,
+      stall_minutes_by_priority: { P0: 60 },
+    },
+  });
+
+  try {
+    writeTaskFixture(task);
+    await runDispatcher({
+      github: mock.github,
+      context: { repo: { owner: 'example', repo: 'repo' } },
+      core: { warning: () => {} },
+    });
+  } finally {
+    process.chdir(ORIGINAL_CWD);
+    if (ORIGINAL_CONFIG_JSON === undefined) delete process.env.CONFIG_JSON;
+    else process.env.CONFIG_JSON = ORIGINAL_CONFIG_JSON;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function testStaleUnassignedReadyIssueCreatesAlert() {
+  const mock = createMockGithub({ readyIssues: [readyIssue()] });
+
+  await runScenario({ mock });
+
+  const alert = mock.calls.createdIssues.find((issue) =>
+    issue.labels?.includes('pipeline/stalled-ready-issue')
+  );
+  assert.ok(alert, 'expected a stalled-ready alert to be created');
+  assert.match(alert.title, /TASK-2026-9999/);
+  assert.match(alert.body, /no worker has consumed it/);
+}
+
+async function testAssignedReadyIssueDoesNotCreateAlert() {
+  const existingAlert = alertIssue();
+  const mock = createMockGithub({
+    readyIssues: [
+      readyIssue({
+        assignees: [{ login: 'human-owner' }],
+      }),
+    ],
+    alertIssues: [existingAlert],
+  });
+
+  await runScenario({ mock });
+
+  const newAlerts = mock.calls.createdIssues.filter((issue) =>
+    issue.labels?.includes('pipeline/stalled-ready-issue')
+  );
+  assert.equal(newAlerts.length, 0, 'assigned ready issue should not create a new stalled alert');
+  assert.equal(existingAlert.state, 'closed', 'existing stalled alert should close after ownership appears');
+}
+
+async function testCoveringPrClosesReadyIssueAndAlert() {
+  const primaryIssue = readyIssue();
+  const existingAlert = alertIssue();
+  const mock = createMockGithub({
+    readyIssues: [primaryIssue],
+    alertIssues: [existingAlert],
+    openPrs: [
+      {
+        number: 7001,
+        state: 'open',
+        html_url: 'https://github.com/example/repo/pull/7001',
+      },
+    ],
+  });
+
+  await runScenario({ mock });
+
+  assert.equal(primaryIssue.state, 'closed', 'ready issue should close when a covering PR exists');
+  assert.equal(existingAlert.state, 'closed', 'stalled alert should close when a covering PR exists');
+  assert.ok(
+    mock.calls.updatedIssues.some((update) => update.issue_number === primaryIssue.number),
+    'expected the ready issue close to call issues.update'
+  );
+}
+
+async function main() {
+  await testStaleUnassignedReadyIssueCreatesAlert();
+  await testAssignedReadyIssueDoesNotCreateAlert();
+  await testCoveringPrClosesReadyIssueAndAlert();
+  console.log('pipeline-dispatcher stall tests passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/test-pipeline-dispatcher-stall.cjs
+++ b/scripts/test-pipeline-dispatcher-stall.cjs
@@ -89,6 +89,7 @@ function createMockGithub({ readyIssues = [], alertIssues = [], openPrs = [] } =
     createdIssues: [],
     updatedIssues: [],
     comments: [],
+    issueLists: [],
     pullsListed: [],
   };
 
@@ -111,6 +112,7 @@ function createMockGithub({ readyIssues = [], alertIssues = [], openPrs = [] } =
     rest: {
       issues: {
         listForRepo: async ({ labels }) => {
+          calls.issueLists.push(labels);
           if (labels === 'pipeline/ready') {
             return { data: state.readyIssues.filter((issue) => issue.state === 'open') };
           }
@@ -170,7 +172,7 @@ function createMockGithub({ readyIssues = [], alertIssues = [], openPrs = [] } =
   return { github, calls, state };
 }
 
-async function runScenario({ task = baseTask(), mock }) {
+async function runScenario({ task = baseTask(), tasks = null, mock }) {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'threatpedia-dispatcher-test-'));
   process.chdir(tempDir);
   process.env.CONFIG_JSON = JSON.stringify({
@@ -182,7 +184,9 @@ async function runScenario({ task = baseTask(), mock }) {
   });
 
   try {
-    writeTaskFixture(task);
+    for (const item of tasks || [task]) {
+      writeTaskFixture(item);
+    }
     await runDispatcher({
       github: mock.github,
       context: { repo: { owner: 'example', repo: 'repo' } },
@@ -207,6 +211,37 @@ async function testStaleUnassignedReadyIssueCreatesAlert() {
   assert.ok(alert, 'expected a stalled-ready alert to be created');
   assert.match(alert.title, /TASK-2026-9999/);
   assert.match(alert.body, /no worker has consumed it/);
+}
+
+async function testStalledReadyIssueLookupIsCachedPerRun() {
+  const firstTask = baseTask({ task_id: 'TASK-2026-9999' });
+  const secondTask = baseTask({
+    task_id: 'TASK-2026-9998',
+    output: {
+      branch: 'pipeline/TASK-2026-9998',
+      path: 'site/src/content/zero-days/synthetic-2.md',
+    },
+  });
+  const mock = createMockGithub({
+    readyIssues: [
+      readyIssue(),
+      readyIssue({
+        number: 4002,
+        title: '[PIPELINE] TASK-2026-9998: Synthetic stale ready issue test',
+        body: '## Pipeline Task: `TASK-2026-9998`',
+      }),
+    ],
+  });
+
+  await runScenario({ tasks: [firstTask, secondTask], mock });
+
+  const stalledListCalls = mock.calls.issueLists.filter((label) => label === 'pipeline/stalled-ready-issue');
+  assert.equal(stalledListCalls.length, 1, 'stalled-ready alerts should be listed once per dispatcher run');
+  assert.equal(
+    mock.calls.createdIssues.filter((issue) => issue.labels?.includes('pipeline/stalled-ready-issue')).length,
+    2,
+    'both stale ready issues should still create alerts from the cached list'
+  );
 }
 
 async function testAssignedReadyIssueDoesNotCreateAlert() {
@@ -254,10 +289,41 @@ async function testCoveringPrClosesReadyIssueAndAlert() {
   );
 }
 
+async function testPrBackedTaskClosesAlertWithoutReadyIssue() {
+  const existingAlert = alertIssue();
+  const mock = createMockGithub({
+    alertIssues: [existingAlert],
+    openPrs: [
+      {
+        number: 7001,
+        state: 'open',
+        html_url: 'https://github.com/example/repo/pull/7001',
+      },
+    ],
+  });
+
+  await runScenario({
+    task: baseTask({
+      status: 'pr_open',
+      pr_number: 7001,
+      pr_url: 'https://github.com/example/repo/pull/7001',
+    }),
+    mock,
+  });
+
+  assert.equal(existingAlert.state, 'closed', 'pr_open task should close stale alert even without a ready issue');
+  assert.ok(
+    mock.calls.comments.some((comment) => comment.issue_number === existingAlert.number),
+    'expected stale alert close to leave an explanatory comment'
+  );
+}
+
 async function main() {
   await testStaleUnassignedReadyIssueCreatesAlert();
+  await testStalledReadyIssueLookupIsCachedPerRun();
   await testAssignedReadyIssueDoesNotCreateAlert();
   await testCoveringPrClosesReadyIssueAndAlert();
+  await testPrBackedTaskClosesAlertWithoutReadyIssue();
   console.log('pipeline-dispatcher stall tests passed');
 }
 


### PR DESCRIPTION
## Summary

Adds dispatcher supervision for valid `pipeline/ready` issues that are stale, unassigned, and have no covering task PR. The dispatcher now opens or refreshes a `pipeline/alert` + `pipeline/stalled-ready-issue` issue instead of silently skipping duplicate dispatch forever.

## Root cause

The dispatcher already dedupes ready issues and reconciles recoverable state, but it had no SLA detector for the valid-but-unconsumed case. A ready issue could sit open indefinitely while scheduled dispatcher runs stayed green.

## Changes

- Add configurable `ready_issue` warn/stall thresholds, including a faster P0 threshold.
- Extend existing ready-issue reconciliation instead of adding a parallel recovery path.
- Auto-close stalled-ready alerts when ownership appears, a covering PR exists, or the task is no longer ready.
- Document ready-issue supervision as a detective control, not auto-drafting.
- Add mocked dispatcher tests and wire `npm test` for scripts.

## Validation

- `npm ci --no-audit --no-fund`
- `npm test`
- `node scripts/pipeline-config.mjs --section ready_issue`
- `node scripts/validate-pipeline-tasks.mjs --all`

## Policy note

This does not auto-draft, auto-assign, bypass review, or hard-fail the dispatcher loop. It follows the existing Issue-as-state pattern used by backpressure and circuit-breaker controls.