### PR TITLE
Supply Chain Phase 2C release entity layer

### DIFF
--- a/data/supply-chain-entities/releases.json
+++ b/data/supply-chain-entities/releases.json
@@ -1,0 +1,86 @@
+[
+  {
+    "aliases": [
+      "flatmap-stream@0.1.1",
+      "pkg:npm/flatmap-stream@0.1.1"
+    ],
+    "disclosed_at": "2018-11-26",
+    "ecosystem": "npm",
+    "id": "release-npm-flatmap-stream-0-1-1",
+    "malicious_range": "0.1.1",
+    "name": "flatmap-stream@0.1.1",
+    "package_name": "flatmap-stream",
+    "published_at": "2018-09-09",
+    "purl": "pkg:npm/flatmap-stream@0.1.1",
+    "references": [
+      "ref-github-event-stream-116"
+    ],
+    "source_incident_ids": [
+      "SC-2018-NPM-EVENT-STREAM"
+    ],
+    "version": "0.1.1"
+  },
+  {
+    "aliases": [
+      "pkg:npm/ua-parser-js@0.7.29",
+      "ua-parser-js@0.7.29"
+    ],
+    "disclosed_at": "2021-10-22",
+    "ecosystem": "npm",
+    "id": "release-npm-ua-parser-js-0-7-29",
+    "malicious_range": "0.7.29",
+    "name": "ua-parser-js@0.7.29",
+    "package_name": "ua-parser-js",
+    "published_at": "2021-10-22",
+    "purl": "pkg:npm/ua-parser-js@0.7.29",
+    "references": [
+      "ref-github-advisory-ua-parser-js"
+    ],
+    "source_incident_ids": [
+      "SC-2021-UA-PARSER-JS"
+    ],
+    "version": "0.7.29"
+  },
+  {
+    "aliases": [
+      "pkg:npm/ua-parser-js@0.8.0",
+      "ua-parser-js@0.8.0"
+    ],
+    "disclosed_at": "2021-10-22",
+    "ecosystem": "npm",
+    "id": "release-npm-ua-parser-js-0-8-0",
+    "malicious_range": "0.8.0",
+    "name": "ua-parser-js@0.8.0",
+    "package_name": "ua-parser-js",
+    "published_at": "2021-10-22",
+    "purl": "pkg:npm/ua-parser-js@0.8.0",
+    "references": [
+      "ref-github-advisory-ua-parser-js"
+    ],
+    "source_incident_ids": [
+      "SC-2021-UA-PARSER-JS"
+    ],
+    "version": "0.8.0"
+  },
+  {
+    "aliases": [
+      "pkg:npm/ua-parser-js@1.0.0",
+      "ua-parser-js@1.0.0"
+    ],
+    "disclosed_at": "2021-10-22",
+    "ecosystem": "npm",
+    "id": "release-npm-ua-parser-js-1-0-0",
+    "malicious_range": "1.0.0",
+    "name": "ua-parser-js@1.0.0",
+    "package_name": "ua-parser-js",
+    "published_at": "2021-10-22",
+    "purl": "pkg:npm/ua-parser-js@1.0.0",
+    "references": [
+      "ref-github-advisory-ua-parser-js"
+    ],
+    "source_incident_ids": [
+      "SC-2021-UA-PARSER-JS"
+    ],
+    "version": "1.0.0"
+  }
+]

--- a/data/supply-chain-incidents/incidents.json
+++ b/data/supply-chain-incidents/incidents.json
@@ -332,6 +332,20 @@
         "package_url": "pkg:npm/flatmap-stream"
       }
     ],
+    "releases": [
+      {
+        "package_name": "flatmap-stream",
+        "ecosystem": "npm",
+        "purl": "pkg:npm/flatmap-stream@0.1.1",
+        "version": "0.1.1",
+        "published_at": "2018-09-09",
+        "malicious_range": "0.1.1",
+        "references": [
+          "ref-github-event-stream-116"
+        ],
+        "disclosed_at": "2018-11-26"
+      }
+    ],
     "supply_chain_vectors": [
       "malicious_dependency"
     ],
@@ -1107,6 +1121,44 @@
         "name": "ua-parser-js",
         "vendor": "open source maintainers",
         "package_url": "pkg:npm/ua-parser-js"
+      }
+    ],
+    "releases": [
+      {
+        "package_name": "ua-parser-js",
+        "ecosystem": "npm",
+        "purl": "pkg:npm/ua-parser-js@0.7.29",
+        "version": "0.7.29",
+        "published_at": "2021-10-22",
+        "malicious_range": "0.7.29",
+        "references": [
+          "ref-github-advisory-ua-parser-js"
+        ],
+        "disclosed_at": "2021-10-22"
+      },
+      {
+        "package_name": "ua-parser-js",
+        "ecosystem": "npm",
+        "purl": "pkg:npm/ua-parser-js@0.8.0",
+        "version": "0.8.0",
+        "published_at": "2021-10-22",
+        "malicious_range": "0.8.0",
+        "references": [
+          "ref-github-advisory-ua-parser-js"
+        ],
+        "disclosed_at": "2021-10-22"
+      },
+      {
+        "package_name": "ua-parser-js",
+        "ecosystem": "npm",
+        "purl": "pkg:npm/ua-parser-js@1.0.0",
+        "version": "1.0.0",
+        "published_at": "2021-10-22",
+        "malicious_range": "1.0.0",
+        "references": [
+          "ref-github-advisory-ua-parser-js"
+        ],
+        "disclosed_at": "2021-10-22"
       }
     ],
     "supply_chain_vectors": [

--- a/data/supply-chain-incidents/schema.json
+++ b/data/supply-chain-incidents/schema.json
@@ -77,6 +77,12 @@
         "$ref": "#/$defs/affected_component"
       }
     },
+    "releases": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/release"
+      }
+    },
     "supply_chain_vectors": {
       "type": "array",
       "minItems": 1,
@@ -339,6 +345,57 @@
         },
         "published_at": {
           "type": "string",
+          "format": "date"
+        }
+      }
+    },
+    "release": {
+      "type": "object",
+      "required": [
+        "package_name",
+        "ecosystem",
+        "purl",
+        "version",
+        "published_at",
+        "malicious_range",
+        "references",
+        "disclosed_at"
+      ],
+      "properties": {
+        "package_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ecosystem": {
+          "type": "string",
+          "minLength": 1
+        },
+        "purl": {
+          "type": "string",
+          "pattern": "^pkg:[a-z0-9.+-]+/[^\\s]+@[A-Za-z0-9][^\\s]*$"
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "published_at": {
+          "type": "string",
+          "format": "date"
+        },
+        "malicious_range": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "references": {
+          "$ref": "#/$defs/reference_id_list"
+        },
+        "disclosed_at": {
+          "type": [
+            "string",
+            "null"
+          ],
           "format": "date"
         }
       }

--- a/data/supply-chain-relationships/relationships.json
+++ b/data/supply-chain-relationships/relationships.json
@@ -101,6 +101,11 @@
   },
   {
     "source": "incident-SC-2018-NPM-EVENT-STREAM",
+    "target": "release-npm-flatmap-stream-0-1-1",
+    "type": "INCIDENT_AFFECTED_RELEASE"
+  },
+  {
+    "source": "incident-SC-2018-NPM-EVENT-STREAM",
     "target": "channel-npm-package-registry-npm-registry",
     "type": "USED_DISTRIBUTION_CHANNEL"
   },
@@ -243,6 +248,21 @@
     "source": "incident-SC-2021-UA-PARSER-JS",
     "target": "account-npm-ua-parser-js-npm-maintainer-account",
     "type": "COMPROMISED_ACCOUNT"
+  },
+  {
+    "source": "incident-SC-2021-UA-PARSER-JS",
+    "target": "release-npm-ua-parser-js-0-7-29",
+    "type": "INCIDENT_AFFECTED_RELEASE"
+  },
+  {
+    "source": "incident-SC-2021-UA-PARSER-JS",
+    "target": "release-npm-ua-parser-js-0-8-0",
+    "type": "INCIDENT_AFFECTED_RELEASE"
+  },
+  {
+    "source": "incident-SC-2021-UA-PARSER-JS",
+    "target": "release-npm-ua-parser-js-1-0-0",
+    "type": "INCIDENT_AFFECTED_RELEASE"
   },
   {
     "source": "incident-SC-2021-UA-PARSER-JS",
@@ -503,5 +523,25 @@
     "source": "maintainer-jia-tan",
     "target": "actor-unc-xz-utils-operator",
     "type": "ATTRIBUTED_TO_ACTOR"
+  },
+  {
+    "source": "pkg-npm-flatmap-stream",
+    "target": "release-npm-flatmap-stream-0-1-1",
+    "type": "PACKAGE_RELEASE"
+  },
+  {
+    "source": "pkg-npm-ua-parser-js",
+    "target": "release-npm-ua-parser-js-0-7-29",
+    "type": "PACKAGE_RELEASE"
+  },
+  {
+    "source": "pkg-npm-ua-parser-js",
+    "target": "release-npm-ua-parser-js-0-8-0",
+    "type": "PACKAGE_RELEASE"
+  },
+  {
+    "source": "pkg-npm-ua-parser-js",
+    "target": "release-npm-ua-parser-js-1-0-0",
+    "type": "PACKAGE_RELEASE"
   }
 ]

--- a/docs/supply-chain-graph-primitives.md
+++ b/docs/supply-chain-graph-primitives.md
@@ -5,6 +5,8 @@ deepened those primitives by extracting build systems, distribution channels,
 and compromised accounts from the curated incident corpus. Phase 2B connects
 the supply-chain corpus to existing Threatpedia actor and campaign entities
 where public evidence supports the edge.
+Phase 2C adds version-addressable release entities for package incidents with
+precise public release evidence.
 
 This is a lightweight relationship layer, not a graph database.
 
@@ -19,6 +21,7 @@ data/supply-chain-incidents/incidents.json
 ```text
 data/supply-chain-entities/maintainers.json
 data/supply-chain-entities/packages.json
+data/supply-chain-entities/releases.json
 data/supply-chain-entities/repositories.json
 data/supply-chain-entities/organizations.json
 data/supply-chain-entities/build_systems.json
@@ -39,6 +42,10 @@ Package entities also carry `ecosystem` and a required canonical `package_url`
 PURL. Generic package PURLs require `purl_justification` because they are
 reviewed exceptions, not registry-joinable package keys. See
 `docs/supply-chain-purl-model.md` for the canonical grammar.
+Release entities carry `purl`, `package_name`, `version`, `published_at`,
+`ecosystem`, `malicious_range`, `references`, and nullable `disclosed_at`.
+Release PURLs are versioned canonical PURLs and must remain joinable to the
+release-event spine.
 Repository entities also carry `host`, `url`, and `owner`.
 Build-system, distribution-channel, and account entities carry type-specific
 fields copied from the incident corpus.
@@ -62,6 +69,8 @@ Allowed relationship types are intentionally narrow:
 - `ATTRIBUTED_TO_ACTOR`
 - `RELATED_INCIDENT`
 - `RELATED_CAMPAIGN`
+- `PACKAGE_RELEASE`
+- `INCIDENT_AFFECTED_RELEASE`
 - `USED_BUILD_SYSTEM`
 - `USED_DISTRIBUTION_CHANNEL`
 - `COMPROMISED_ACCOUNT`
@@ -94,12 +103,28 @@ maintainer identity and the provisional operator node. Every actor and campaign
 target must resolve to an emitted entity; dangling actor/campaign edges are hard
 validation failures.
 
+Release edges make specific malicious or affected versions graph-addressable:
+
+```json
+{
+  "source": "pkg-npm-flatmap-stream",
+  "target": "release-npm-flatmap-stream-0-1-1",
+  "type": "PACKAGE_RELEASE"
+}
+```
+
+`PACKAGE_RELEASE` starts from a package entity and targets a release entity.
+`INCIDENT_AFFECTED_RELEASE` starts from an incident node and targets the same
+release entity. Release nodes are not public-routed entity pages in Phase 2C,
+but incident pages can display them as affected releases.
+
 ## Current Graph Density
 
-The Phase 2B pass over the same 25 incidents currently emits:
+The Phase 2C pass over the same 25 incidents currently emits:
 
 - Maintainers: 5
 - Packages: 16
+- Releases: 4
 - Repositories: 10
 - Organizations: 17
 - Build systems: 6
@@ -107,7 +132,7 @@ The Phase 2B pass over the same 25 incidents currently emits:
 - Compromised accounts: 8
 - Actors: 4
 - Campaigns: 3
-- Relationships: 101
+- Relationships: 109
 
 ## Build and Validate
 
@@ -134,6 +159,7 @@ python3 -m unittest discover -s tests
 This phase supports lookup questions such as:
 
 - incidents involving a package
+- incidents involving a specific package release
 - incidents involving a maintainer
 - incidents involving a repository
 - incidents involving an organization

--- a/docs/supply-chain-incident-schema.md
+++ b/docs/supply-chain-incident-schema.md
@@ -45,6 +45,8 @@ The core fields are:
   `github-actions`, or `vendor-update`
 - `affected_components`: structured impacted packages, projects, services, or
   update channels
+- `releases`: optional version-addressable package releases with canonical
+  versioned PURLs, publish dates, malicious range notes, and local reference IDs
 - `supply_chain_vectors`: normalized vector labels
 - `impact_categories`: normalized impact labels
 - `references`: public documentation for the incident
@@ -87,6 +89,27 @@ software, services, websites, and update channels should use `null`. See
 `docs/supply-chain-purl-model.md` for the canonical PURL grammar and validation
 contract. `pkg:generic/...` is allowed only for reviewed cross-ecosystem
 placeholders and requires `purl_justification`.
+
+Release records are optional in Phase 2C and are used only when public evidence
+supports a precise package version and publish date. They use this shape:
+
+```json
+{
+  "package_name": "flatmap-stream",
+  "ecosystem": "npm",
+  "purl": "pkg:npm/flatmap-stream@0.1.1",
+  "version": "0.1.1",
+  "published_at": "YYYY-MM-DD",
+  "malicious_range": "0.1.1 or null",
+  "references": ["ref-example"],
+  "disclosed_at": "YYYY-MM-DD or null"
+}
+```
+
+Every release must match an affected package component in the same incident.
+The `purl` must be canonical, versioned, and backed by local reference IDs.
+Generic release PURLs are not accepted because they cannot join cleanly to the
+release-event spine.
 
 ## Attack Stages
 

--- a/docs/supply-chain-pages.md
+++ b/docs/supply-chain-pages.md
@@ -107,8 +107,10 @@ The index page shows counts for:
 - relationships
 
 Incident pages show corpus fields: summary, confidence, evidence level, attack
-stage, source-artifact divergence, affected entities, structured supply-chain
-primitives, compromised accounts, connected entities, and references. When
+stage, source-artifact divergence, affected packages, affected releases,
+structured supply-chain primitives, compromised accounts, connected entities,
+and references. Release rows are generated from `releases.json` and show the
+versioned PURL plus publish date when modeled. When
 Phase 2B actor or campaign links are present, incident pages also show threat
 actor links, campaign links, attribution confidence, and the local evidence
 basis for those edges. These links are corpus-driven convergence edges; they do
@@ -128,6 +130,10 @@ editorial sections.
 
 Entity pages show the entity name, entity type, connected incidents, and
 connected entities when relationships support those links.
+
+Release entities are graph-addressable but are not public-routed entity pages
+in Phase 2C. They appear through incident pages and package connected-entity
+sections.
 
 ## SEO Metadata
 

--- a/docs/supply-chain-purl-model.md
+++ b/docs/supply-chain-purl-model.md
@@ -1,6 +1,6 @@
 # Supply Chain PURL Model
 
-Threatpedia uses Package URL (PURL) strings as the canonical join key for supply-chain package and release records. The PURL model is intentionally narrow in Phase 2A: it covers package identity, validates existing package entities, and prepares the release layer for Phase 2C.
+Threatpedia uses Package URL (PURL) strings as the canonical join key for supply-chain package and release records. The PURL model is intentionally narrow: it covers package identity, validates package entities, and validates versioned release entities.
 
 ## Canonical Helper
 
@@ -68,6 +68,12 @@ The incident validator requires every `affected_components` item with `component
 
 The graph validator requires every package entity in `data/supply-chain-entities/packages.json` to carry a canonical `package_url`.
 
+The graph validator requires every release entity in `data/supply-chain-entities/releases.json` to carry a canonical versioned `purl`, a matching `version`, and a `published_at` date. Release PURLs must include a version suffix:
+
+```text
+pkg:npm/ua-parser-js@0.7.29
+```
+
 Both validators fail if a package PURL:
 
 - is missing
@@ -77,6 +83,11 @@ Both validators fail if a package PURL:
 - uses non-canonical spelling or encoding
 - uses the `generic` PURL type without an explicit `purl_justification`
 
+Release entities additionally fail if the PURL is unversioned, the PURL version
+does not match the `version` field, or the release uses `pkg:generic/...`.
+Generic releases are blocked because they cannot join to OSV, deps.dev,
+OpenSSF Scorecard, or the Phase 0 release feed.
+
 Non-package components, such as software, services, websites, and update channels, are not package records and do not require PURLs in Phase 2A.
 
 ## Relationship Integrity
@@ -84,7 +95,5 @@ Non-package components, such as software, services, websites, and update channel
 The graph validator also performs the foundation dangling-reference check. Every relationship endpoint must resolve to an incident node or an existing entity node. Missing relationship targets remain hard failures.
 
 ## Deferred Work
-
-Release PURL validation is wired through the same helper but becomes mandatory when Phase 2C adds `releases.json`.
 
 The full PURL and edge audit report is intentionally deferred to Phase 2F, after corpus expansion, so the closing audit covers the complete expanded corpus.

--- a/scripts/build_supply_chain_entities.py
+++ b/scripts/build_supply_chain_entities.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 from pathlib import Path
 import re
@@ -100,6 +101,31 @@ def stable_id(prefix: str, *parts: str) -> str:
     return f"{prefix}-{slug}"
 
 
+def same_release_identity(entity: dict[str, Any], ecosystem: str, package_name: str, version: str) -> bool:
+    return (
+        entity.get("ecosystem") == ecosystem
+        and entity.get("package_name") == package_name
+        and entity.get("version") == version
+    )
+
+
+def exact_version_suffix(version: str) -> str:
+    return hashlib.sha256(version.encode("utf-8")).hexdigest()[:12]
+
+
+def release_entity_id(releases: dict[str, dict[str, Any]], ecosystem: str, package_name: str, version: str) -> str:
+    base_id = stable_id("release", ecosystem, package_name, version)
+    existing = releases.get(base_id)
+    if existing is None or same_release_identity(existing, ecosystem, package_name, version):
+        return base_id
+
+    hashed_id = f"{base_id}-v{exact_version_suffix(version)}"
+    existing = releases.get(hashed_id)
+    if existing is not None and not same_release_identity(existing, ecosystem, package_name, version):
+        raise ValueError(f"release id collision for {ecosystem}/{package_name}@{version}: {hashed_id}")
+    return hashed_id
+
+
 def incident_node_id(incident_id: str) -> str:
     return f"incident-{incident_id}"
 
@@ -179,7 +205,7 @@ def upsert_release(releases: dict[str, dict[str, Any]], item: dict[str, Any], in
     parsed = parse_purl(purl)
     if parsed.version != version:
         raise ValueError(f"{incident_id}: release version {version!r} does not match PURL {purl!r}")
-    entity_id = stable_id("release", ecosystem, package_name, version)
+    entity_id = release_entity_id(releases, ecosystem, package_name, version)
     name = f"{package_name}@{version}"
     entity = releases.setdefault(
         entity_id,

--- a/scripts/build_supply_chain_entities.py
+++ b/scripts/build_supply_chain_entities.py
@@ -113,17 +113,29 @@ def exact_version_suffix(version: str) -> str:
     return hashlib.sha256(version.encode("utf-8")).hexdigest()[:12]
 
 
-def release_entity_id(releases: dict[str, dict[str, Any]], ecosystem: str, package_name: str, version: str) -> str:
+def release_entity_id(collision_base_ids: set[str], ecosystem: str, package_name: str, version: str) -> str:
     base_id = stable_id("release", ecosystem, package_name, version)
-    existing = releases.get(base_id)
-    if existing is None or same_release_identity(existing, ecosystem, package_name, version):
+    if base_id not in collision_base_ids:
         return base_id
 
-    hashed_id = f"{base_id}-v{exact_version_suffix(version)}"
-    existing = releases.get(hashed_id)
-    if existing is not None and not same_release_identity(existing, ecosystem, package_name, version):
-        raise ValueError(f"release id collision for {ecosystem}/{package_name}@{version}: {hashed_id}")
-    return hashed_id
+    return f"{base_id}-v{exact_version_suffix(version)}"
+
+
+def release_collision_base_ids(corpus: list[dict[str, Any]]) -> set[str]:
+    identities_by_base_id: dict[str, set[tuple[str, str, str]]] = {}
+    for incident in corpus:
+        if not isinstance(incident, dict):
+            continue
+        for release in incident.get("releases") or []:
+            if not isinstance(release, dict):
+                continue
+            ecosystem = release.get("ecosystem")
+            package_name = release.get("package_name")
+            version = release.get("version")
+            if all(isinstance(value, str) for value in (ecosystem, package_name, version)):
+                base_id = stable_id("release", ecosystem, package_name, version)
+                identities_by_base_id.setdefault(base_id, set()).add((ecosystem, package_name, version))
+    return {base_id for base_id, identities in identities_by_base_id.items() if len(identities) > 1}
 
 
 def incident_node_id(incident_id: str) -> str:
@@ -197,7 +209,12 @@ def upsert_package(packages: dict[str, dict[str, Any]], component: dict[str, Any
     return entity_id
 
 
-def upsert_release(releases: dict[str, dict[str, Any]], item: dict[str, Any], incident_id: str) -> str:
+def upsert_release(
+    releases: dict[str, dict[str, Any]],
+    item: dict[str, Any],
+    incident_id: str,
+    collision_base_ids: set[str],
+) -> str:
     ecosystem = item["ecosystem"]
     package_name = item["package_name"]
     version = item["version"]
@@ -205,7 +222,10 @@ def upsert_release(releases: dict[str, dict[str, Any]], item: dict[str, Any], in
     parsed = parse_purl(purl)
     if parsed.version != version:
         raise ValueError(f"{incident_id}: release version {version!r} does not match PURL {purl!r}")
-    entity_id = release_entity_id(releases, ecosystem, package_name, version)
+    entity_id = release_entity_id(collision_base_ids, ecosystem, package_name, version)
+    existing = releases.get(entity_id)
+    if existing is not None and not same_release_identity(existing, ecosystem, package_name, version):
+        raise ValueError(f"{incident_id}: release id collision for {ecosystem}/{package_name}@{version}: {entity_id}")
     name = f"{package_name}@{version}"
     entity = releases.setdefault(
         entity_id,
@@ -400,6 +420,7 @@ def build_graph(corpus: list[dict[str, Any]]) -> dict[str, Any]:
     repositories: dict[str, dict[str, Any]] = {}
     organizations: dict[str, dict[str, Any]] = {}
     relationships: dict[tuple[str, str, str], dict[str, str]] = {}
+    collision_base_ids = release_collision_base_ids(corpus)
 
     def add_relationship(item: dict[str, str]) -> None:
         relationships[(item["source"], item["target"], item["type"])] = item
@@ -417,7 +438,7 @@ def build_graph(corpus: list[dict[str, Any]]) -> dict[str, Any]:
                 add_relationship(relationship(source, org_id, "AFFECTED_ORGANIZATION"))
 
         for item in incident.get("releases") or []:
-            release_id = upsert_release(releases, item, incident_id)
+            release_id = upsert_release(releases, item, incident_id, collision_base_ids)
             package_id = stable_id("pkg", item["ecosystem"], item["package_name"])
             add_relationship(relationship(package_id, release_id, "PACKAGE_RELEASE"))
             add_relationship(relationship(source, release_id, "INCIDENT_AFFECTED_RELEASE"))

--- a/scripts/build_supply_chain_entities.py
+++ b/scripts/build_supply_chain_entities.py
@@ -31,6 +31,7 @@ ENTITY_FILES = {
     "distribution_channels": "distribution_channels.json",
     "maintainers": "maintainers.json",
     "packages": "packages.json",
+    "releases": "releases.json",
     "repositories": "repositories.json",
     "organizations": "organizations.json",
 }
@@ -46,6 +47,8 @@ RELATIONSHIP_TYPES = {
     "SOURCE_ARTIFACT_DIVERGENCE",
     "USED_BUILD_SYSTEM",
     "USED_DISTRIBUTION_CHANNEL",
+    "PACKAGE_RELEASE",
+    "INCIDENT_AFFECTED_RELEASE",
 }
 GENERIC_VENDOR_NAMES = {
     "malicious publisher",
@@ -164,6 +167,38 @@ def upsert_package(packages: dict[str, dict[str, Any]], component: dict[str, Any
         entity["package_url"] = package_url
     if is_generic_purl:
         entity["purl_justification"] = purl_justification
+    add_source(entity, incident_id)
+    return entity_id
+
+
+def upsert_release(releases: dict[str, dict[str, Any]], item: dict[str, Any], incident_id: str) -> str:
+    ecosystem = item["ecosystem"]
+    package_name = item["package_name"]
+    version = item["version"]
+    purl = canonicalize_purl(item["purl"], ecosystem=ecosystem, package_name=package_name)
+    parsed = parse_purl(purl)
+    if parsed.version != version:
+        raise ValueError(f"{incident_id}: release version {version!r} does not match PURL {purl!r}")
+    entity_id = stable_id("release", ecosystem, package_name, version)
+    name = f"{package_name}@{version}"
+    entity = releases.setdefault(
+        entity_id,
+        {
+            "id": entity_id,
+            "name": name,
+            "purl": purl,
+            "package_name": package_name,
+            "version": version,
+            "published_at": item["published_at"],
+            "ecosystem": ecosystem,
+            "malicious_range": item.get("malicious_range"),
+            "references": sorted(item.get("references") or []),
+            "disclosed_at": item.get("disclosed_at"),
+            "aliases": sorted({name, purl}),
+            "source_incident_ids": [],
+        },
+    )
+    entity["references"] = sorted(set(entity.get("references", []) + (item.get("references") or [])))
     add_source(entity, incident_id)
     return entity_id
 
@@ -335,6 +370,7 @@ def build_graph(corpus: list[dict[str, Any]]) -> dict[str, Any]:
     distribution_channels: dict[str, dict[str, Any]] = {}
     maintainers: dict[str, dict[str, Any]] = {}
     packages: dict[str, dict[str, Any]] = {}
+    releases: dict[str, dict[str, Any]] = {}
     repositories: dict[str, dict[str, Any]] = {}
     organizations: dict[str, dict[str, Any]] = {}
     relationships: dict[tuple[str, str, str], dict[str, str]] = {}
@@ -353,6 +389,12 @@ def build_graph(corpus: list[dict[str, Any]]) -> dict[str, Any]:
             org_id = upsert_organization(organizations, component["vendor"], incident_id)
             if org_id:
                 add_relationship(relationship(source, org_id, "AFFECTED_ORGANIZATION"))
+
+        for item in incident.get("releases") or []:
+            release_id = upsert_release(releases, item, incident_id)
+            package_id = stable_id("pkg", item["ecosystem"], item["package_name"])
+            add_relationship(relationship(package_id, release_id, "PACKAGE_RELEASE"))
+            add_relationship(relationship(source, release_id, "INCIDENT_AFFECTED_RELEASE"))
 
         divergence_channel_targets: list[str] = []
         for maintainer in incident.get("maintainers") or []:
@@ -398,6 +440,7 @@ def build_graph(corpus: list[dict[str, Any]]) -> dict[str, Any]:
         "distribution_channels": sorted(distribution_channels.values(), key=lambda item: item["id"]),
         "maintainers": sorted(maintainers.values(), key=lambda item: item["id"]),
         "packages": sorted(packages.values(), key=lambda item: item["id"]),
+        "releases": sorted(releases.values(), key=lambda item: item["id"]),
         "repositories": sorted(repositories.values(), key=lambda item: item["id"]),
         "organizations": sorted(organizations.values(), key=lambda item: item["id"]),
         "relationships": sorted(relationships.values(), key=lambda item: (item["source"], item["type"], item["target"])),
@@ -426,6 +469,7 @@ def main(argv: list[str] | None = None) -> int:
         f"actors={len(graph['actors'])} "
         f"campaigns={len(graph['campaigns'])} "
         f"packages={len(graph['packages'])} "
+        f"releases={len(graph['releases'])} "
         f"repositories={len(graph['repositories'])} "
         f"organizations={len(graph['organizations'])} "
         f"build_systems={len(graph['build_systems'])} "

--- a/scripts/build_supply_chain_entities.py
+++ b/scripts/build_supply_chain_entities.py
@@ -82,6 +82,7 @@ ATTRIBUTION_CONFIDENCE_PRIORITY = {
     "disputed": 1,
     "unknown": 0,
 }
+RELEASE_METADATA_FIELDS = ("published_at", "malicious_range", "disclosed_at")
 
 def load_json(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
@@ -226,6 +227,12 @@ def upsert_release(
     existing = releases.get(entity_id)
     if existing is not None and not same_release_identity(existing, ecosystem, package_name, version):
         raise ValueError(f"{incident_id}: release id collision for {ecosystem}/{package_name}@{version}: {entity_id}")
+    if existing is not None:
+        for field in RELEASE_METADATA_FIELDS:
+            if existing.get(field) != item.get(field):
+                raise ValueError(
+                    f"{incident_id}: conflicting release metadata for {ecosystem}/{package_name}@{version}: {field}"
+                )
     name = f"{package_name}@{version}"
     entity = releases.setdefault(
         entity_id,

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -53,6 +53,7 @@ assert.equal(routes.length, expectedRouteCount, 'enabled route count should matc
 const index = getSupplyChainIndexModel(data);
 assert.equal(index.counts.incidents, data.incidents.length, 'index should expose incident count');
 assert.equal(index.counts.relationships, data.relationships.length, 'index should expose relationship count');
+assert.equal(index.counts.releases, data.entities.releases.length, 'index should expose release count');
 assert.equal(index.counts.buildSystems, data.entities.build_systems.length, 'index should expose build system count');
 assert.equal(index.counts.distributionChannels, data.entities.distribution_channels.length, 'index should expose distribution channel count');
 assert.ok(/supply chain/i.test(index.lede), 'index should include polished public copy');
@@ -172,6 +173,17 @@ assert.ok(
 assert.ok(
   staleXz.connectedEntities.some((entity) => entity.id === 'actor-unc-xz-utils-operator' && entity.entityType === 'Threat Actor'),
   'incident connected entities should fall back to corpus threat_actors when generated incident attribution edges are stale'
+);
+
+const uaParser = getSupplyChainIncidentPage('SC-2021-UA-PARSER-JS', data);
+assert.equal(uaParser.sections.releases.length, 3, 'ua-parser-js page should include three affected releases');
+assert.ok(
+  uaParser.sections.releases.some((release) => release.id === 'release-npm-ua-parser-js-0-7-29'),
+  'ua-parser-js page should include release entity details'
+);
+assert.ok(
+  uaParser.sections.releases.every((release) => release.context.includes('pkg:npm/ua-parser-js@')),
+  'release rows should expose versioned PURL context'
 );
 
 const threeCx = getSupplyChainIncidentPage('SC-2023-THREE-CX-DESKTOP', data);

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -153,7 +153,12 @@ def validate_entity_file(errors: list[str], entity_type: str, entities: Any, inc
                 if parse_purl(canonical).type == "generic":
                     if not isinstance(entity.get("purl_justification"), str) or len(entity["purl_justification"].strip()) < 20:
                         errors.append(f"{entity_id}.purl_justification: expected non-empty generic PURL justification")
-        if entity_type == "releases" and isinstance(entity.get("purl"), str):
+        if (
+            entity_type == "releases"
+            and isinstance(entity.get("purl"), str)
+            and isinstance(entity.get("ecosystem"), str)
+            and isinstance(entity.get("package_name"), str)
+        ):
             try:
                 canonical = canonicalize_purl(
                     entity["purl"],

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -153,30 +153,29 @@ def validate_entity_file(errors: list[str], entity_type: str, entities: Any, inc
                 if parse_purl(canonical).type == "generic":
                     if not isinstance(entity.get("purl_justification"), str) or len(entity["purl_justification"].strip()) < 20:
                         errors.append(f"{entity_id}.purl_justification: expected non-empty generic PURL justification")
-        if (
-            entity_type == "releases"
-            and isinstance(entity.get("purl"), str)
-            and isinstance(entity.get("ecosystem"), str)
-            and isinstance(entity.get("package_name"), str)
-        ):
-            try:
-                canonical = canonicalize_purl(
-                    entity["purl"],
-                    ecosystem=entity.get("ecosystem"),
-                    package_name=entity.get("package_name"),
-                )
-            except PurlError as exc:
-                errors.append(f"{entity_id}.purl: invalid canonical release PURL: {exc}")
-            else:
-                parsed = parse_purl(canonical)
-                if entity["purl"] != canonical:
-                    errors.append(f"{entity_id}.purl: expected canonical release PURL {canonical!r}")
-                if not parsed.version:
-                    errors.append(f"{entity_id}.purl: expected versioned package URL")
-                elif parsed.version != entity.get("version"):
-                    errors.append(f"{entity_id}.version: does not match PURL version {parsed.version!r}")
-                if parsed.type == "generic":
-                    errors.append(f"{entity_id}.purl: generic release PURLs are not joinable")
+        if entity_type == "releases":
+            purl = entity.get("purl")
+            ecosystem = entity.get("ecosystem")
+            package_name = entity.get("package_name")
+            if isinstance(purl, str) and isinstance(ecosystem, str) and isinstance(package_name, str):
+                try:
+                    canonical = canonicalize_purl(
+                        purl,
+                        ecosystem=ecosystem,
+                        package_name=package_name,
+                    )
+                except PurlError as exc:
+                    errors.append(f"{entity_id}.purl: invalid canonical release PURL: {exc}")
+                else:
+                    parsed = parse_purl(canonical)
+                    if purl != canonical:
+                        errors.append(f"{entity_id}.purl: expected canonical release PURL {canonical!r}")
+                    if not parsed.version:
+                        errors.append(f"{entity_id}.purl: expected versioned package URL")
+                    elif parsed.version != entity.get("version"):
+                        errors.append(f"{entity_id}.version: does not match PURL version {parsed.version!r}")
+                    if parsed.type == "generic":
+                        errors.append(f"{entity_id}.purl: generic release PURLs are not joinable")
             if parse_date(entity.get("published_at")) is None:
                 errors.append(f"{entity_id}.published_at: expected YYYY-MM-DD date")
             if entity.get("disclosed_at") is not None and parse_date(entity.get("disclosed_at")) is None:

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -150,6 +150,20 @@ def collect_incident_ids(corpus: list[dict[str, Any]]) -> set[str]:
     return {incident_node_id(incident["id"]) for incident in corpus if isinstance(incident, dict) and isinstance(incident.get("id"), str)}
 
 
+def collect_reference_ids_by_incident(corpus: list[dict[str, Any]]) -> dict[str, set[str]]:
+    references_by_incident: dict[str, set[str]] = {}
+    for incident in corpus:
+        if not isinstance(incident, dict) or not isinstance(incident.get("id"), str):
+            continue
+        reference_ids = {
+            reference["id"]
+            for reference in incident.get("references") or []
+            if isinstance(reference, dict) and isinstance(reference.get("id"), str)
+        }
+        references_by_incident[incident["id"]] = reference_ids
+    return references_by_incident
+
+
 def validate_entity_file(errors: list[str], entity_type: str, entities: Any, incident_ids: set[str]) -> set[str]:
     ids: set[str] = set()
     alias_owners: dict[str, str] = {}
@@ -262,6 +276,30 @@ def validate_entity_file(errors: list[str], entity_type: str, entities: Any, inc
                 errors.append(f"{entity_type}: normalized alias {normalized!r} belongs to both {owner} and {entity_id}")
             alias_owners[alias_key] = entity_id
     return ids
+
+
+def validate_release_references(
+    errors: list[str],
+    releases: Any,
+    references_by_incident: dict[str, set[str]],
+) -> None:
+    if not isinstance(releases, list):
+        return
+    for index, release in enumerate(releases):
+        if not isinstance(release, dict):
+            continue
+        entity_id = release.get("id", f"releases[{index}]")
+        source_incident_ids = release.get("source_incident_ids")
+        references = release.get("references")
+        if not isinstance(source_incident_ids, list) or not isinstance(references, list):
+            continue
+        allowed_references: set[str] = set()
+        for source_id in source_incident_ids:
+            if isinstance(source_id, str):
+                allowed_references.update(references_by_incident.get(source_id, set()))
+        for reference_index, reference in enumerate(references):
+            if isinstance(reference, str) and reference not in allowed_references:
+                errors.append(f"{entity_id}.references[{reference_index}]: unknown source reference id {reference!r}")
 
 
 def validate_relationships(
@@ -381,6 +419,7 @@ def validate_graph(corpus: Any, entities_by_type: dict[str, Any], relationships:
         corpus = []
 
     raw_incident_ids = collect_raw_incident_ids(corpus)
+    references_by_incident = collect_reference_ids_by_incident(corpus)
     incident_ids = collect_incident_ids(corpus)
     all_entity_ids: set[str] = set()
     for entity_type, entities in entities_by_type.items():
@@ -390,6 +429,7 @@ def validate_graph(corpus: Any, entities_by_type: dict[str, Any], relationships:
             errors.append(f"{entity_id}: duplicate id across entity files")
         all_entity_ids |= entity_ids
 
+    validate_release_references(errors, entities_by_type.get("releases"), references_by_incident)
     errors.extend(
         validate_relationships(
             relationships,

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -96,29 +96,33 @@ def stable_id(prefix: str, *parts: str) -> str:
     return f"{prefix}-{slug}"
 
 
-def same_release_identity(entity: dict[str, Any], ecosystem: str, package_name: str, version: str) -> bool:
-    return (
-        entity.get("ecosystem") == ecosystem
-        and entity.get("package_name") == package_name
-        and entity.get("version") == version
-    )
-
-
 def exact_version_suffix(version: str) -> str:
     return hashlib.sha256(version.encode("utf-8")).hexdigest()[:12]
 
 
-def release_entity_id(releases: dict[str, dict[str, Any]], ecosystem: str, package_name: str, version: str) -> str:
+def release_entity_id(collision_base_ids: set[str], ecosystem: str, package_name: str, version: str) -> str:
     base_id = stable_id("release", ecosystem, package_name, version)
-    existing = releases.get(base_id)
-    if existing is None or same_release_identity(existing, ecosystem, package_name, version):
+    if base_id not in collision_base_ids:
         return base_id
 
-    hashed_id = f"{base_id}-v{exact_version_suffix(version)}"
-    existing = releases.get(hashed_id)
-    if existing is not None and not same_release_identity(existing, ecosystem, package_name, version):
-        raise ValueError(f"release id collision for {ecosystem}/{package_name}@{version}: {hashed_id}")
-    return hashed_id
+    return f"{base_id}-v{exact_version_suffix(version)}"
+
+
+def release_collision_base_ids(corpus: list[dict[str, Any]]) -> set[str]:
+    identities_by_base_id: dict[str, set[tuple[str, str, str]]] = {}
+    for incident in corpus:
+        if not isinstance(incident, dict):
+            continue
+        for release in incident.get("releases") or []:
+            if not isinstance(release, dict):
+                continue
+            ecosystem = release.get("ecosystem")
+            package_name = release.get("package_name")
+            version = release.get("version")
+            if all(isinstance(value, str) for value in (ecosystem, package_name, version)):
+                base_id = stable_id("release", ecosystem, package_name, version)
+                identities_by_base_id.setdefault(base_id, set()).add((ecosystem, package_name, version))
+    return {base_id for base_id, identities in identities_by_base_id.items() if len(identities) > 1}
 
 
 def parse_date(value: Any) -> date | None:
@@ -332,7 +336,7 @@ def validate_corpus_implied_relationships(corpus: list[dict[str, Any]], relation
         for relationship in relationships
         if isinstance(relationship, dict)
     }
-    implied_releases: dict[str, dict[str, Any]] = {}
+    collision_base_ids = release_collision_base_ids(corpus)
     for incident in corpus:
         if not isinstance(incident, dict) or not isinstance(incident.get("id"), str):
             continue
@@ -362,15 +366,7 @@ def validate_corpus_implied_relationships(corpus: list[dict[str, Any]], relation
             version = release.get("version")
             if all(isinstance(value, str) for value in (ecosystem, package_name, version)):
                 package_id = stable_id("pkg", ecosystem, package_name)
-                release_id = release_entity_id(implied_releases, ecosystem, package_name, version)
-                implied_releases.setdefault(
-                    release_id,
-                    {
-                        "ecosystem": ecosystem,
-                        "package_name": package_name,
-                        "version": version,
-                    },
-                )
+                release_id = release_entity_id(collision_base_ids, ecosystem, package_name, version)
                 if (package_id, release_id, "PACKAGE_RELEASE") not in relationship_keys:
                     errors.append(f"{source}: missing PACKAGE_RELEASE relationship for {release_id}")
                 if (source, release_id, "INCIDENT_AFFECTED_RELEASE") not in relationship_keys:

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -75,7 +75,7 @@ ENTITY_TYPE_REQUIRED_FIELDS = {
     "maintainers": [],
     "organizations": [],
     "packages": ["ecosystem", "package_url"],
-    "releases": ["purl", "package_name", "version", "published_at", "ecosystem"],
+    "releases": ["purl", "package_name", "version", "published_at", "disclosed_at", "ecosystem"],
     "repositories": ["host", "url", "owner"],
 }
 DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -170,7 +170,7 @@ def validate_entity_file(errors: list[str], entity_type: str, entities: Any, inc
                     errors.append(f"{entity_id}.purl: expected versioned package URL")
                 elif parsed.version != entity.get("version"):
                     errors.append(f"{entity_id}.version: does not match PURL version {parsed.version!r}")
-                if parse_purl(canonical).type == "generic":
+                if parsed.type == "generic":
                     errors.append(f"{entity_id}.purl: generic release PURLs are not joinable")
             if parse_date(entity.get("published_at")) is None:
                 errors.append(f"{entity_id}.published_at: expected YYYY-MM-DD date")

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 from datetime import date
+import hashlib
 import json
 from pathlib import Path
 import re
@@ -88,6 +89,36 @@ def load_json(path: Path) -> Any:
 
 def normalize_alias(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", value.strip().lower()).strip("-")
+
+
+def stable_id(prefix: str, *parts: str) -> str:
+    slug = "-".join(filter(None, (normalize_alias(part) for part in parts)))
+    return f"{prefix}-{slug}"
+
+
+def same_release_identity(entity: dict[str, Any], ecosystem: str, package_name: str, version: str) -> bool:
+    return (
+        entity.get("ecosystem") == ecosystem
+        and entity.get("package_name") == package_name
+        and entity.get("version") == version
+    )
+
+
+def exact_version_suffix(version: str) -> str:
+    return hashlib.sha256(version.encode("utf-8")).hexdigest()[:12]
+
+
+def release_entity_id(releases: dict[str, dict[str, Any]], ecosystem: str, package_name: str, version: str) -> str:
+    base_id = stable_id("release", ecosystem, package_name, version)
+    existing = releases.get(base_id)
+    if existing is None or same_release_identity(existing, ecosystem, package_name, version):
+        return base_id
+
+    hashed_id = f"{base_id}-v{exact_version_suffix(version)}"
+    existing = releases.get(hashed_id)
+    if existing is not None and not same_release_identity(existing, ecosystem, package_name, version):
+        raise ValueError(f"release id collision for {ecosystem}/{package_name}@{version}: {hashed_id}")
+    return hashed_id
 
 
 def parse_date(value: Any) -> date | None:
@@ -211,7 +242,17 @@ def validate_entity_file(errors: list[str], entity_type: str, entities: Any, inc
                 errors.append(f"{entity_id}.aliases: expected non-empty string aliases")
                 continue
             normalized = normalize_alias(alias)
-            alias_key = f"{entity.get('ecosystem', '')}:{normalized}" if entity_type == "packages" else normalized
+            if entity_type == "packages":
+                alias_key = f"{entity.get('ecosystem', '')}:{normalized}"
+            elif entity_type == "releases":
+                alias_key = (
+                    f"{entity.get('ecosystem', '')}:"
+                    f"{entity.get('package_name', '')}:"
+                    f"{entity.get('version', '')}:"
+                    f"{normalized}"
+                )
+            else:
+                alias_key = normalized
             owner = alias_owners.get(alias_key)
             if owner and owner != entity_id:
                 errors.append(f"{entity_type}: normalized alias {normalized!r} belongs to both {owner} and {entity_id}")
@@ -291,6 +332,7 @@ def validate_corpus_implied_relationships(corpus: list[dict[str, Any]], relation
         for relationship in relationships
         if isinstance(relationship, dict)
     }
+    implied_releases: dict[str, dict[str, Any]] = {}
     for incident in corpus:
         if not isinstance(incident, dict) or not isinstance(incident.get("id"), str):
             continue
@@ -319,8 +361,16 @@ def validate_corpus_implied_relationships(corpus: list[dict[str, Any]], relation
             package_name = release.get("package_name")
             version = release.get("version")
             if all(isinstance(value, str) for value in (ecosystem, package_name, version)):
-                package_id = f"pkg-{normalize_alias(ecosystem)}-{normalize_alias(package_name)}"
-                release_id = f"release-{normalize_alias(ecosystem)}-{normalize_alias(package_name)}-{normalize_alias(version)}"
+                package_id = stable_id("pkg", ecosystem, package_name)
+                release_id = release_entity_id(implied_releases, ecosystem, package_name, version)
+                implied_releases.setdefault(
+                    release_id,
+                    {
+                        "ecosystem": ecosystem,
+                        "package_name": package_name,
+                        "version": version,
+                    },
+                )
                 if (package_id, release_id, "PACKAGE_RELEASE") not in relationship_keys:
                     errors.append(f"{source}: missing PACKAGE_RELEASE relationship for {release_id}")
                 if (source, release_id, "INCIDENT_AFFECTED_RELEASE") not in relationship_keys:

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+from datetime import date
 import json
 from pathlib import Path
 import re
@@ -30,6 +31,7 @@ ENTITY_FILES = {
     "distribution_channels": "distribution_channels.json",
     "maintainers": "maintainers.json",
     "packages": "packages.json",
+    "releases": "releases.json",
     "repositories": "repositories.json",
     "organizations": "organizations.json",
 }
@@ -45,8 +47,10 @@ VALID_RELATIONSHIP_TYPES = {
     "SOURCE_ARTIFACT_DIVERGENCE",
     "USED_BUILD_SYSTEM",
     "USED_DISTRIBUTION_CHANNEL",
+    "PACKAGE_RELEASE",
+    "INCIDENT_AFFECTED_RELEASE",
 }
-ENTITY_ID_PATTERN = re.compile(r"^(account|actor|build|campaign|channel|maintainer|pkg|repo|org)-[a-z0-9][a-z0-9-]*$")
+ENTITY_ID_PATTERN = re.compile(r"^(account|actor|build|campaign|channel|maintainer|pkg|release|repo|org)-[a-z0-9][a-z0-9-]*$")
 RELATIONSHIP_TARGET_PREFIXES = {
     "AFFECTED_PACKAGE": "pkg-",
     "AFFECTED_MAINTAINER": "maintainer-",
@@ -59,6 +63,8 @@ RELATIONSHIP_TARGET_PREFIXES = {
     "SOURCE_ARTIFACT_DIVERGENCE": ("repo-", "channel-"),
     "USED_BUILD_SYSTEM": "build-",
     "USED_DISTRIBUTION_CHANNEL": "channel-",
+    "PACKAGE_RELEASE": "release-",
+    "INCIDENT_AFFECTED_RELEASE": "release-",
 }
 ENTITY_TYPE_REQUIRED_FIELDS = {
     "accounts": ["provider", "account_type", "role"],
@@ -69,8 +75,10 @@ ENTITY_TYPE_REQUIRED_FIELDS = {
     "maintainers": [],
     "organizations": [],
     "packages": ["ecosystem", "package_url"],
+    "releases": ["purl", "package_name", "version", "published_at", "ecosystem"],
     "repositories": ["host", "url", "owner"],
 }
+DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
 def load_json(path: Path) -> Any:
@@ -80,6 +88,15 @@ def load_json(path: Path) -> Any:
 
 def normalize_alias(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", value.strip().lower()).strip("-")
+
+
+def parse_date(value: Any) -> date | None:
+    if not isinstance(value, str) or not DATE_PATTERN.fullmatch(value):
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None
 
 
 def incident_node_id(incident_id: str) -> str:
@@ -136,6 +153,40 @@ def validate_entity_file(errors: list[str], entity_type: str, entities: Any, inc
                 if parse_purl(canonical).type == "generic":
                     if not isinstance(entity.get("purl_justification"), str) or len(entity["purl_justification"].strip()) < 20:
                         errors.append(f"{entity_id}.purl_justification: expected non-empty generic PURL justification")
+        if entity_type == "releases" and isinstance(entity.get("purl"), str):
+            try:
+                canonical = canonicalize_purl(
+                    entity["purl"],
+                    ecosystem=entity.get("ecosystem"),
+                    package_name=entity.get("package_name"),
+                )
+            except PurlError as exc:
+                errors.append(f"{entity_id}.purl: invalid canonical release PURL: {exc}")
+            else:
+                parsed = parse_purl(canonical)
+                if entity["purl"] != canonical:
+                    errors.append(f"{entity_id}.purl: expected canonical release PURL {canonical!r}")
+                if not parsed.version:
+                    errors.append(f"{entity_id}.purl: expected versioned package URL")
+                elif parsed.version != entity.get("version"):
+                    errors.append(f"{entity_id}.version: does not match PURL version {parsed.version!r}")
+                if parse_purl(canonical).type == "generic":
+                    errors.append(f"{entity_id}.purl: generic release PURLs are not joinable")
+            if parse_date(entity.get("published_at")) is None:
+                errors.append(f"{entity_id}.published_at: expected YYYY-MM-DD date")
+            if entity.get("disclosed_at") is not None and parse_date(entity.get("disclosed_at")) is None:
+                errors.append(f"{entity_id}.disclosed_at: expected YYYY-MM-DD date or null")
+            if "malicious_range" not in entity:
+                errors.append(f"{entity_id}.malicious_range: missing required field")
+            elif entity.get("malicious_range") is not None and (
+                not isinstance(entity.get("malicious_range"), str) or not entity["malicious_range"].strip()
+            ):
+                errors.append(f"{entity_id}.malicious_range: expected non-empty string or null")
+            references = entity.get("references")
+            if not isinstance(references, list) or not references:
+                errors.append(f"{entity_id}.references: expected non-empty list")
+            elif not all(isinstance(ref, str) and ref.strip() for ref in references):
+                errors.append(f"{entity_id}.references: expected non-empty string references")
         source_incident_ids = entity.get("source_incident_ids")
         if not isinstance(source_incident_ids, list) or not source_incident_ids:
             errors.append(f"{entity_id}.source_incident_ids: expected non-empty list")
@@ -197,6 +248,10 @@ def validate_relationships(
                 errors.append(f"{path}.source: RELATED_INCIDENT must start from an incident node")
             if rel_type == "RELATED_CAMPAIGN" and not source.startswith("incident-"):
                 errors.append(f"{path}.source: RELATED_CAMPAIGN must start from an incident node")
+            if rel_type == "PACKAGE_RELEASE" and not source.startswith("pkg-"):
+                errors.append(f"{path}.source: PACKAGE_RELEASE must start from a package node")
+            if rel_type == "INCIDENT_AFFECTED_RELEASE" and not source.startswith("incident-"):
+                errors.append(f"{path}.source: INCIDENT_AFFECTED_RELEASE must start from an incident node")
         if source not in valid_nodes:
             errors.append(f"{path}.source: unknown source {source!r}")
         if target not in valid_nodes:
@@ -251,6 +306,19 @@ def validate_corpus_implied_relationships(corpus: list[dict[str, Any]], relation
                 key = (source, campaign["id"], "RELATED_CAMPAIGN")
                 if key not in relationship_keys:
                     errors.append(f"{source}: missing RELATED_CAMPAIGN relationship for {campaign['id']}")
+        for release in incident.get("releases") or []:
+            if not isinstance(release, dict):
+                continue
+            ecosystem = release.get("ecosystem")
+            package_name = release.get("package_name")
+            version = release.get("version")
+            if all(isinstance(value, str) for value in (ecosystem, package_name, version)):
+                package_id = f"pkg-{normalize_alias(ecosystem)}-{normalize_alias(package_name)}"
+                release_id = f"release-{normalize_alias(ecosystem)}-{normalize_alias(package_name)}-{normalize_alias(version)}"
+                if (package_id, release_id, "PACKAGE_RELEASE") not in relationship_keys:
+                    errors.append(f"{source}: missing PACKAGE_RELEASE relationship for {release_id}")
+                if (source, release_id, "INCIDENT_AFFECTED_RELEASE") not in relationship_keys:
+                    errors.append(f"{source}: missing INCIDENT_AFFECTED_RELEASE relationship for {release_id}")
     return errors
 
 

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -75,7 +75,7 @@ ENTITY_TYPE_REQUIRED_FIELDS = {
     "maintainers": [],
     "organizations": [],
     "packages": ["ecosystem", "package_url"],
-    "releases": ["purl", "package_name", "version", "published_at", "disclosed_at", "ecosystem"],
+    "releases": ["purl", "package_name", "version", "published_at", "ecosystem"],
     "repositories": ["host", "url", "owner"],
 }
 DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
@@ -178,7 +178,9 @@ def validate_entity_file(errors: list[str], entity_type: str, entities: Any, inc
                         errors.append(f"{entity_id}.purl: generic release PURLs are not joinable")
             if parse_date(entity.get("published_at")) is None:
                 errors.append(f"{entity_id}.published_at: expected YYYY-MM-DD date")
-            if entity.get("disclosed_at") is not None and parse_date(entity.get("disclosed_at")) is None:
+            if "disclosed_at" not in entity:
+                errors.append(f"{entity_id}.disclosed_at: missing required field")
+            elif entity.get("disclosed_at") is not None and parse_date(entity.get("disclosed_at")) is None:
                 errors.append(f"{entity_id}.disclosed_at: expected YYYY-MM-DD date or null")
             if "malicious_range" not in entity:
                 errors.append(f"{entity_id}.malicious_range: missing required field")

--- a/scripts/validate_supply_chain_incidents.py
+++ b/scripts/validate_supply_chain_incidents.py
@@ -291,6 +291,8 @@ def validate_release(
                 errors.append(f"{path}.purl: expected versioned package URL")
             elif isinstance(version, str) and parsed.version != version:
                 errors.append(f"{path}.version: does not match PURL version {parsed.version!r}")
+            if parsed.type == "generic":
+                errors.append(f"{path}.purl: generic release PURLs are not joinable")
 
 
 def validate_reference(errors: list[str], incident_id: str, index: int, reference: Any) -> None:

--- a/scripts/validate_supply_chain_incidents.py
+++ b/scripts/validate_supply_chain_incidents.py
@@ -60,6 +60,16 @@ REQUIRED_REPOSITORY_FIELDS = ["name", "host", "owner", "url"]
 REQUIRED_BUILD_SYSTEM_FIELDS = ["name", "provider", "category"]
 REQUIRED_DISTRIBUTION_CHANNEL_FIELDS = ["name", "channel_type", "ecosystem"]
 REQUIRED_COMPROMISED_ACCOUNT_FIELDS = ["name", "provider", "account_type", "role"]
+REQUIRED_RELEASE_FIELDS = [
+    "package_name",
+    "ecosystem",
+    "purl",
+    "version",
+    "published_at",
+    "malicious_range",
+    "references",
+    "disclosed_at",
+]
 REQUIRED_THREAT_ACTOR_FIELDS = ["id", "name", "actor_type", "confidence", "source_refs"]
 REQUIRED_CAMPAIGN_FIELDS = ["id", "campaign_id", "name", "slug", "confidence", "source_refs"]
 REQUIRED_ATTRIBUTION_EVIDENCE_FIELDS = ["target", "relationship_type", "source_refs", "summary"]
@@ -229,6 +239,58 @@ def validate_component(errors: list[str], incident_id: str, index: int, componen
                 errors.append(f"{path}.package_url: expected canonical package URL {canonical!r}")
             if parse_purl(canonical).type == "generic":
                 require_string(errors, f"{path}.purl_justification", component.get("purl_justification"), min_length=20)
+
+
+def validate_release(
+    errors: list[str],
+    incident_id: str,
+    index: int,
+    release: Any,
+    valid_reference_ids: set[str],
+    package_components: set[tuple[str, str]],
+) -> None:
+    path = f"{incident_id}.releases[{index}]"
+    if not isinstance(release, dict):
+        errors.append(f"{path}: expected object")
+        return
+    for field in REQUIRED_RELEASE_FIELDS:
+        if field not in release:
+            errors.append(f"{path}.{field}: missing required field")
+
+    for field in ["package_name", "ecosystem", "purl", "version"]:
+        if field in release:
+            require_string(errors, f"{path}.{field}", release.get(field))
+
+    if "published_at" in release and parse_date(release.get("published_at")) is None:
+        errors.append(f"{path}.published_at: expected YYYY-MM-DD date")
+    if "disclosed_at" in release and release.get("disclosed_at") is not None and parse_date(release.get("disclosed_at")) is None:
+        errors.append(f"{path}.disclosed_at: expected YYYY-MM-DD date or null")
+    if "malicious_range" in release and release.get("malicious_range") is not None:
+        require_string(errors, f"{path}.malicious_range", release.get("malicious_range"))
+
+    if "references" in release:
+        validate_reference_id_list(errors, incident_id, f"{path}.references", release.get("references"), valid_reference_ids)
+
+    package_name = release.get("package_name")
+    ecosystem = release.get("ecosystem")
+    purl = release.get("purl")
+    version = release.get("version")
+    if isinstance(package_name, str) and isinstance(ecosystem, str):
+        if (ecosystem, package_name) not in package_components:
+            errors.append(f"{path}: release package must match an affected package component")
+    if isinstance(purl, str):
+        try:
+            canonical = canonicalize_purl(purl, ecosystem=ecosystem, package_name=package_name)
+        except PurlError as exc:
+            errors.append(f"{path}.purl: invalid canonical release PURL: {exc}")
+        else:
+            parsed = parse_purl(canonical)
+            if purl != canonical:
+                errors.append(f"{path}.purl: expected canonical release PURL {canonical!r}")
+            if not parsed.version:
+                errors.append(f"{path}.purl: expected versioned package URL")
+            elif isinstance(version, str) and parsed.version != version:
+                errors.append(f"{path}.version: does not match PURL version {parsed.version!r}")
 
 
 def validate_reference(errors: list[str], incident_id: str, index: int, reference: Any) -> None:
@@ -605,6 +667,19 @@ def validate_incident(incident: Any) -> list[str]:
     else:
         for index, reference in enumerate(references):
             validate_reference(errors, incident_id, index, reference)
+    valid_reference_ids = reference_ids_for(incident)
+
+    releases = incident.get("releases", [])
+    package_components = {
+        (component.get("ecosystem"), component.get("name"))
+        for component in (components if isinstance(components, list) else [])
+        if isinstance(component, dict) and component.get("component_type") == "package"
+    }
+    if not isinstance(releases, list):
+        errors.append(f"{incident_id}.releases: expected list")
+    else:
+        for index, release in enumerate(releases):
+            validate_release(errors, incident_id, index, release, valid_reference_ids, package_components)
 
     maintainers = incident.get("maintainers")
     if not isinstance(maintainers, list):

--- a/scripts/validate_supply_chain_incidents.py
+++ b/scripts/validate_supply_chain_incidents.py
@@ -275,10 +275,11 @@ def validate_release(
     ecosystem = release.get("ecosystem")
     purl = release.get("purl")
     version = release.get("version")
-    if isinstance(package_name, str) and isinstance(ecosystem, str):
+    release_identity_fields_are_strings = isinstance(package_name, str) and isinstance(ecosystem, str)
+    if release_identity_fields_are_strings:
         if (ecosystem, package_name) not in package_components:
             errors.append(f"{path}: release package must match an affected package component")
-    if isinstance(purl, str):
+    if isinstance(purl, str) and release_identity_fields_are_strings:
         try:
             canonical = canonicalize_purl(purl, ecosystem=ecosystem, package_name=package_name)
         except PurlError as exc:

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -89,6 +89,7 @@ const allEntityFiles = {
   maintainers: 'maintainers.json',
   organizations: 'organizations.json',
   packages: 'packages.json',
+  releases: 'releases.json',
   repositories: 'repositories.json',
 };
 
@@ -144,6 +145,7 @@ const ENTITY_COLLECTION_LABELS = {
   repositories: 'Repository',
   organizations: 'Organization',
   maintainers: 'Maintainer',
+  releases: 'Release',
   build_systems: 'Build System',
   distribution_channels: 'Distribution Channel',
   accounts: 'Compromised Account',
@@ -335,6 +337,28 @@ function incidentEntityLinks(data, incidentId, relationshipType) {
     .sort(compareLabel);
 }
 
+function incidentReleaseLinks(data, incidentId) {
+  const nodeId = `incident-${incidentId}`;
+  return data.relationships
+    .filter((relationship) => relationship.source === nodeId && relationship.type === 'INCIDENT_AFFECTED_RELEASE')
+    .map((relationship) => {
+      const release = data.entityById.get(relationship.target);
+      if (!release) return null;
+      return {
+        href: null,
+        label: release.name,
+        id: release.id,
+        type: relationship.type,
+        entityType: entityTypeLabel(release),
+        context: [release.purl, release.published_at ? `published ${release.published_at}` : null]
+          .filter(Boolean)
+          .join(' · '),
+      };
+    })
+    .filter(Boolean)
+    .sort(compareLabel);
+}
+
 function incidentAttributionLinks(data, incidentId, relationshipType, collectionKey) {
   const relationshipLinks = incidentEntityLinks(data, incidentId, relationshipType);
   const incident = data.incidents.find((item) => item.id === incidentId);
@@ -428,6 +452,7 @@ export function getSupplyChainIndexModel(data = loadSupplyChainData()) {
     counts: {
       incidents: data.incidents.length,
       packages: data.entities.packages.length,
+      releases: data.entities.releases.length,
       repositories: data.entities.repositories.length,
       organizations: data.entities.organizations.length,
       maintainers: data.entities.maintainers.length,
@@ -490,6 +515,7 @@ export function getSupplyChainIncidentPage(id, data = loadSupplyChainData()) {
     },
     sections: {
       packages: incidentEntityLinks(data, id, 'AFFECTED_PACKAGE'),
+      releases: incidentReleaseLinks(data, id),
       repositories: incidentEntityLinks(data, id, 'AFFECTED_REPOSITORY'),
       organizations: incidentEntityLinks(data, id, 'AFFECTED_ORGANIZATION'),
       maintainers: incidentEntityLinks(data, id, 'AFFECTED_MAINTAINER'),

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -206,6 +206,7 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
       )}
 
       <EntityList title="Affected Packages" items={page.sections.packages} />
+      <EntityList title="Affected Releases" items={page.sections.releases} />
       <EntityList title="Repositories" items={page.sections.repositories} />
       <EntityList title="Organizations" items={page.sections.organizations} />
       <EntityList title="Maintainers" items={page.sections.maintainers} />

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -240,11 +240,13 @@ class SupplyChainGraphTests(unittest.TestCase):
         entities_by_type["releases"] = copy.deepcopy(entities_by_type["releases"])
         entities_by_type["releases"][0]["purl"] = "pkg:npm/flatmap-stream"
         entities_by_type["releases"][1]["published_at"] = "2021-99-99"
+        del entities_by_type["releases"][2]["disclosed_at"]
 
         errors = validator.validate_graph(corpus, entities_by_type, relationships)
 
         self.assertTrue(any(".purl: expected versioned package URL" in error for error in errors))
         self.assertTrue(any(".published_at: expected YYYY-MM-DD date" in error for error in errors))
+        self.assertTrue(any(".disclosed_at: expected non-empty string" in error for error in errors))
 
     def test_release_purl_validation_does_not_crash_on_malformed_identity_fields(self) -> None:
         corpus = load_json(CORPUS_PATH)

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -111,15 +111,21 @@ class SupplyChainGraphTests(unittest.TestCase):
         ]
 
         graph = builder.build_graph(corpus)
+        reversed_corpus = copy.deepcopy(corpus)
+        reversed_corpus[0]["releases"] = list(reversed(reversed_corpus[0]["releases"]))
+        reversed_graph = builder.build_graph(reversed_corpus)
         entities_by_type = {entity_type: graph[entity_type] for entity_type in validator.ENTITY_FILES}
         release_ids = {entity["id"] for entity in graph["releases"]}
+        reversed_release_ids = {entity["id"] for entity in reversed_graph["releases"]}
         release_versions = {entity["version"] for entity in graph["releases"]}
         base_id = "release-npm-example-pkg-1-0-0-alpha-1"
 
         self.assertEqual(len(graph["releases"]), 2)
         self.assertEqual(release_versions, {"1.0.0-alpha.1", "1.0.0-alpha-1"})
-        self.assertIn(base_id, release_ids)
+        self.assertNotIn(base_id, release_ids)
+        self.assertIn(f"{base_id}-v{builder.exact_version_suffix('1.0.0-alpha.1')}", release_ids)
         self.assertIn(f"{base_id}-v{builder.exact_version_suffix('1.0.0-alpha-1')}", release_ids)
+        self.assertEqual(release_ids, reversed_release_ids)
         self.assertEqual(validator.validate_graph(corpus, entities_by_type, graph["relationships"]), [])
 
     def test_builder_uses_highest_actor_confidence_across_incidents(self) -> None:

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -69,6 +69,59 @@ class SupplyChainGraphTests(unittest.TestCase):
         self.assertIn("actor-lazarus-group", actor_ids)
         self.assertIn("campaign-tp-camp-2023-0002", campaign_ids)
 
+    def test_builder_preserves_exact_release_versions_when_normalized_slugs_collide(self) -> None:
+        corpus = [
+            {
+                "schema_version": "supply-chain-incident/1",
+                "id": "SC-TEST-RELEASE-COLLISION",
+                "title": "release collision fixture",
+                "affected_components": [
+                    {
+                        "component_type": "package",
+                        "ecosystem": "npm",
+                        "name": "example-pkg",
+                        "vendor": "example",
+                        "package_url": "pkg:npm/example-pkg",
+                    }
+                ],
+                "releases": [
+                    {
+                        "package_name": "example-pkg",
+                        "ecosystem": "npm",
+                        "purl": "pkg:npm/example-pkg@1.0.0-alpha.1",
+                        "version": "1.0.0-alpha.1",
+                        "published_at": "2026-01-01",
+                        "malicious_range": "1.0.0-alpha.1",
+                        "references": ["ref-example"],
+                        "disclosed_at": "2026-01-02",
+                    },
+                    {
+                        "package_name": "example-pkg",
+                        "ecosystem": "npm",
+                        "purl": "pkg:npm/example-pkg@1.0.0-alpha-1",
+                        "version": "1.0.0-alpha-1",
+                        "published_at": "2026-01-03",
+                        "malicious_range": "1.0.0-alpha-1",
+                        "references": ["ref-example"],
+                        "disclosed_at": "2026-01-04",
+                    },
+                ],
+                "source_artifact_divergence": False,
+            }
+        ]
+
+        graph = builder.build_graph(corpus)
+        entities_by_type = {entity_type: graph[entity_type] for entity_type in validator.ENTITY_FILES}
+        release_ids = {entity["id"] for entity in graph["releases"]}
+        release_versions = {entity["version"] for entity in graph["releases"]}
+        base_id = "release-npm-example-pkg-1-0-0-alpha-1"
+
+        self.assertEqual(len(graph["releases"]), 2)
+        self.assertEqual(release_versions, {"1.0.0-alpha.1", "1.0.0-alpha-1"})
+        self.assertIn(base_id, release_ids)
+        self.assertIn(f"{base_id}-v{builder.exact_version_suffix('1.0.0-alpha-1')}", release_ids)
+        self.assertEqual(validator.validate_graph(corpus, entities_by_type, graph["relationships"]), [])
+
     def test_builder_uses_highest_actor_confidence_across_incidents(self) -> None:
         corpus = copy.deepcopy(load_json(CORPUS_PATH))
         first = next(item for item in corpus if item["id"] == "SC-2024-XZ-UTILS")

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -50,10 +50,13 @@ class SupplyChainGraphTests(unittest.TestCase):
         account_ids = {entity["id"] for entity in graph["accounts"]}
         actor_ids = {entity["id"] for entity in graph["actors"]}
         campaign_ids = {entity["id"] for entity in graph["campaigns"]}
+        release_ids = {entity["id"] for entity in graph["releases"]}
 
         self.assertGreaterEqual(len(graph["relationships"]), 100)
         self.assertIn("pkg-npm-event-stream", package_ids)
         self.assertIn("pkg-npm-flatmap-stream", package_ids)
+        self.assertIn("release-npm-flatmap-stream-0-1-1", release_ids)
+        self.assertIn("release-npm-ua-parser-js-0-7-29", release_ids)
         self.assertIn("maintainer-jia-tan", maintainer_ids)
         self.assertIn("maintainer-dominictarr", maintainer_ids)
         self.assertIn("org-codecov", organization_ids)
@@ -229,6 +232,43 @@ class SupplyChainGraphTests(unittest.TestCase):
         errors = validator.validate_graph(corpus, entities_by_type, relationships)
 
         self.assertTrue(any(".purl_justification: expected non-empty generic PURL justification" in error for error in errors))
+
+    def test_release_entities_require_versioned_canonical_purls(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        entities_by_type = validator.load_entities(ENTITY_DIR)
+        relationships = load_json(RELATIONSHIP_PATH)
+        entities_by_type["releases"] = copy.deepcopy(entities_by_type["releases"])
+        entities_by_type["releases"][0]["purl"] = "pkg:npm/flatmap-stream"
+        entities_by_type["releases"][1]["published_at"] = "2021-99-99"
+
+        errors = validator.validate_graph(corpus, entities_by_type, relationships)
+
+        self.assertTrue(any(".purl: expected versioned package URL" in error for error in errors))
+        self.assertTrue(any(".published_at: expected YYYY-MM-DD date" in error for error in errors))
+
+    def test_release_relationship_sources_are_bounded(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        entities_by_type = validator.load_entities(ENTITY_DIR)
+        relationships = copy.deepcopy(load_json(RELATIONSHIP_PATH))
+        relationships.append(
+            {
+                "source": "incident-SC-2018-NPM-EVENT-STREAM",
+                "target": "release-npm-flatmap-stream-0-1-1",
+                "type": "PACKAGE_RELEASE",
+            }
+        )
+        relationships.append(
+            {
+                "source": "pkg-npm-flatmap-stream",
+                "target": "release-npm-flatmap-stream-0-1-1",
+                "type": "INCIDENT_AFFECTED_RELEASE",
+            }
+        )
+
+        errors = validator.validate_graph(corpus, entities_by_type, relationships)
+
+        self.assertTrue(any("PACKAGE_RELEASE must start from a package node" in error for error in errors))
+        self.assertTrue(any("INCIDENT_AFFECTED_RELEASE must start from an incident node" in error for error in errors))
 
     def test_relationship_type_must_target_expected_entity_class(self) -> None:
         corpus = load_json(CORPUS_PATH)

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -106,6 +106,7 @@ class SupplyChainGraphTests(unittest.TestCase):
                         "disclosed_at": "2026-01-04",
                     },
                 ],
+                "references": [{"id": "ref-example", "title": "Example", "url": "https://example.com"}],
                 "source_artifact_divergence": False,
             }
         ]
@@ -127,6 +128,44 @@ class SupplyChainGraphTests(unittest.TestCase):
         self.assertIn(f"{base_id}-v{builder.exact_version_suffix('1.0.0-alpha-1')}", release_ids)
         self.assertEqual(release_ids, reversed_release_ids)
         self.assertEqual(validator.validate_graph(corpus, entities_by_type, graph["relationships"]), [])
+
+    def test_builder_rejects_conflicting_duplicate_release_metadata(self) -> None:
+        first = {
+            "schema_version": "supply-chain-incident/1",
+            "id": "SC-TEST-DUPLICATE-RELEASE-A",
+            "title": "duplicate release fixture A",
+            "affected_components": [
+                {
+                    "component_type": "package",
+                    "ecosystem": "npm",
+                    "name": "example-pkg",
+                    "vendor": "example",
+                    "package_url": "pkg:npm/example-pkg",
+                }
+            ],
+            "releases": [
+                {
+                    "package_name": "example-pkg",
+                    "ecosystem": "npm",
+                    "purl": "pkg:npm/example-pkg@1.0.0",
+                    "version": "1.0.0",
+                    "published_at": "2026-01-01",
+                    "malicious_range": "1.0.0",
+                    "references": ["ref-example-a"],
+                    "disclosed_at": "2026-01-02",
+                }
+            ],
+            "source_artifact_divergence": False,
+        }
+        second = copy.deepcopy(first)
+        second["id"] = "SC-TEST-DUPLICATE-RELEASE-B"
+        second["releases"][0]["published_at"] = "2026-01-03"
+        second["releases"][0]["references"] = ["ref-example-b"]
+
+        with self.assertRaisesRegex(ValueError, "conflicting release metadata"):
+            builder.build_graph([first, second])
+        with self.assertRaisesRegex(ValueError, "conflicting release metadata"):
+            builder.build_graph([second, first])
 
     def test_builder_uses_highest_actor_confidence_across_incidents(self) -> None:
         corpus = copy.deepcopy(load_json(CORPUS_PATH))
@@ -306,6 +345,17 @@ class SupplyChainGraphTests(unittest.TestCase):
         self.assertTrue(any(".purl: expected versioned package URL" in error for error in errors))
         self.assertTrue(any(".published_at: expected YYYY-MM-DD date" in error for error in errors))
         self.assertTrue(any(".disclosed_at: missing required field" in error for error in errors))
+
+    def test_release_entity_references_must_exist_in_source_incidents(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        entities_by_type = validator.load_entities(ENTITY_DIR)
+        relationships = load_json(RELATIONSHIP_PATH)
+        entities_by_type["releases"] = copy.deepcopy(entities_by_type["releases"])
+        entities_by_type["releases"][0]["references"] = ["ref-does-not-exist"]
+
+        errors = validator.validate_graph(corpus, entities_by_type, relationships)
+
+        self.assertTrue(any(".references[0]: unknown source reference id 'ref-does-not-exist'" in error for error in errors))
 
     def test_release_purl_validation_does_not_crash_on_malformed_identity_fields(self) -> None:
         corpus = load_json(CORPUS_PATH)

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -246,6 +246,19 @@ class SupplyChainGraphTests(unittest.TestCase):
         self.assertTrue(any(".purl: expected versioned package URL" in error for error in errors))
         self.assertTrue(any(".published_at: expected YYYY-MM-DD date" in error for error in errors))
 
+    def test_release_purl_validation_does_not_crash_on_malformed_identity_fields(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        entities_by_type = validator.load_entities(ENTITY_DIR)
+        relationships = load_json(RELATIONSHIP_PATH)
+        entities_by_type["releases"] = copy.deepcopy(entities_by_type["releases"])
+        entities_by_type["releases"][0]["package_name"] = None
+        entities_by_type["releases"][0]["ecosystem"] = None
+
+        errors = validator.validate_graph(corpus, entities_by_type, relationships)
+
+        self.assertTrue(any(".package_name: expected non-empty string" in error for error in errors))
+        self.assertTrue(any(".ecosystem: expected non-empty string" in error for error in errors))
+
     def test_release_relationship_sources_are_bounded(self) -> None:
         corpus = load_json(CORPUS_PATH)
         entities_by_type = validator.load_entities(ENTITY_DIR)

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -253,11 +253,17 @@ class SupplyChainGraphTests(unittest.TestCase):
         entities_by_type["releases"] = copy.deepcopy(entities_by_type["releases"])
         entities_by_type["releases"][0]["package_name"] = None
         entities_by_type["releases"][0]["ecosystem"] = None
+        entities_by_type["releases"][0]["published_at"] = "2021-99-99"
+        entities_by_type["releases"][0]["malicious_range"] = ""
+        entities_by_type["releases"][0]["references"] = []
 
         errors = validator.validate_graph(corpus, entities_by_type, relationships)
 
         self.assertTrue(any(".package_name: expected non-empty string" in error for error in errors))
         self.assertTrue(any(".ecosystem: expected non-empty string" in error for error in errors))
+        self.assertTrue(any(".published_at: expected YYYY-MM-DD date" in error for error in errors))
+        self.assertTrue(any(".malicious_range: expected non-empty string or null" in error for error in errors))
+        self.assertTrue(any(".references: expected non-empty list" in error for error in errors))
 
     def test_release_relationship_sources_are_bounded(self) -> None:
         corpus = load_json(CORPUS_PATH)

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -246,7 +246,7 @@ class SupplyChainGraphTests(unittest.TestCase):
 
         self.assertTrue(any(".purl: expected versioned package URL" in error for error in errors))
         self.assertTrue(any(".published_at: expected YYYY-MM-DD date" in error for error in errors))
-        self.assertTrue(any(".disclosed_at: expected non-empty string" in error for error in errors))
+        self.assertTrue(any(".disclosed_at: missing required field" in error for error in errors))
 
     def test_release_purl_validation_does_not_crash_on_malformed_identity_fields(self) -> None:
         corpus = load_json(CORPUS_PATH)

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -179,6 +179,16 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
 
         self.assertTrue(any(".releases[0].purl: generic release PURLs are not joinable" in error for error in errors))
 
+    def test_release_purl_validation_does_not_crash_on_malformed_identity_fields(self) -> None:
+        incident = copy.deepcopy(next(item for item in load_json(CORPUS_PATH) if item["id"] == "SC-2021-UA-PARSER-JS"))
+        incident["releases"][0]["package_name"] = None
+        incident["releases"][0]["ecosystem"] = None
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any(".releases[0].package_name: expected non-empty string" in error for error in errors))
+        self.assertTrue(any(".releases[0].ecosystem: expected non-empty string" in error for error in errors))
+
     def test_malformed_url_is_rejected_without_crashing(self) -> None:
         incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
         incident["references"][0]["url"] = "https://example.com:bad-port"

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -159,6 +159,26 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
         self.assertTrue(any(".releases[1].references[0]: unknown reference ID" in error for error in errors))
         self.assertTrue(any(".releases[2]: release package must match an affected package component" in error for error in errors))
 
+    def test_release_records_reject_generic_purls(self) -> None:
+        incident = copy.deepcopy(next(item for item in load_json(CORPUS_PATH) if item["id"] == "SC-2021-DEPENDENCY-CONFUSION"))
+        incident["releases"] = [
+            {
+                "package_name": "internal dependency names",
+                "ecosystem": "multiple",
+                "purl": "pkg:generic/internal-dependency-names@1.0.0",
+                "version": "1.0.0",
+                "published_at": "2021-02-09",
+                "malicious_range": "1.0.0",
+                "references": ["ref-does-not-exist"],
+                "disclosed_at": "2021-02-09",
+            }
+        ]
+        incident["references"][0]["id"] = "ref-does-not-exist"
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any(".releases[0].purl: generic release PURLs are not joinable" in error for error in errors))
+
     def test_malformed_url_is_rejected_without_crashing(self) -> None:
         incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
         incident["references"][0]["url"] = "https://example.com:bad-port"

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -147,6 +147,18 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
 
         self.assertTrue(any(".affected_components[0].purl_justification" in error for error in errors))
 
+    def test_release_records_require_versioned_canonical_purls_and_references(self) -> None:
+        incident = copy.deepcopy(next(item for item in load_json(CORPUS_PATH) if item["id"] == "SC-2021-UA-PARSER-JS"))
+        incident["releases"][0]["purl"] = "pkg:npm/ua-parser-js"
+        incident["releases"][1]["references"] = ["ref-does-not-exist"]
+        incident["releases"][2]["package_name"] = "not-affected"
+
+        errors = validator.validate_incident(incident)
+
+        self.assertTrue(any(".releases[0].purl: expected versioned package URL" in error for error in errors))
+        self.assertTrue(any(".releases[1].references[0]: unknown reference ID" in error for error in errors))
+        self.assertTrue(any(".releases[2]: release package must match an affected package component" in error for error in errors))
+
     def test_malformed_url_is_rejected_without_crashing(self) -> None:
         incident = copy.deepcopy(load_json(CORPUS_PATH)[0])
         incident["references"][0]["url"] = "https://example.com:bad-port"


### PR DESCRIPTION
## Summary\n- Add optional corpus release records with versioned canonical PURLs and source-backed release metadata.\n- Generate first-class release entities plus PACKAGE_RELEASE and INCIDENT_AFFECTED_RELEASE relationships.\n- Extend incident and graph validators, page data, tests, and docs for release details.\n\n## Scope boundaries\n- No scoring, risk engine, soak/canary logic, graph database, ML, AI inference, or automated attribution.\n- Release entities are graph-addressable but not public-routed entity pages in this phase.\n- Seeded only source-backed package releases for event-stream/flatmap-stream and ua-parser-js.\n\n## Validation\n- python3 scripts/validate_supply_chain_incidents.py: PASS\n- python3 scripts/validate_supply_chain_graph.py: PASS\n- python3 -m unittest discover -s tests: PASS (70 tests)\n- node --check site/src/lib/supplyChainPages.mjs: PASS\n- node scripts/test-supply-chain-pages.mjs: PASS (routes=74)\n- node scripts/check_supply_chain_public_readiness.mjs: PASS\n- cd site && rm -rf dist && npm run build && rm -rf dist && ENABLE_SUPPLY_CHAIN_PAGES=true npm run build: PASS\n- git diff --check: PASS\n\n## Notes\n- Slice 0 generic-PURL schema/validator parity was already present on main before this branch.\n- A first parallel enabled/disabled build attempt collided on site/dist; rerun sequentially with clean dist passed.\n\n@dangermouse-bot @ernestpenfold-bot