### PR TITLE
Supply Chain Phase 2E connectivity-driven corpus expansion

### DIFF
--- a/data/supply-chain-entities/accounts.json
+++ b/data/supply-chain-entities/accounts.json
@@ -2,19 +2,6 @@
   {
     "account_type": "source_control_account",
     "aliases": [
-      "boltdb-go GitHub account"
-    ],
-    "id": "account-github-boltdb-go-github-account",
-    "name": "boltdb-go GitHub account",
-    "provider": "GitHub",
-    "role": "source_repository_owner",
-    "source_incident_ids": [
-      "SC-2025-GO-BOLTDB-TYPOSQUAT"
-    ]
-  },
-  {
-    "account_type": "source_control_account",
-    "aliases": [
       "tj-actions GitHub Action release path"
     ],
     "id": "account-github-tj-actions-github-action-release-path",

--- a/data/supply-chain-entities/accounts.json
+++ b/data/supply-chain-entities/accounts.json
@@ -2,6 +2,19 @@
   {
     "account_type": "source_control_account",
     "aliases": [
+      "boltdb-go GitHub account"
+    ],
+    "id": "account-github-boltdb-go-github-account",
+    "name": "boltdb-go GitHub account",
+    "provider": "GitHub",
+    "role": "source_repository_owner",
+    "source_incident_ids": [
+      "SC-2025-GO-BOLTDB-TYPOSQUAT"
+    ]
+  },
+  {
+    "account_type": "source_control_account",
+    "aliases": [
       "tj-actions GitHub Action release path"
     ],
     "id": "account-github-tj-actions-github-action-release-path",
@@ -10,6 +23,32 @@
     "role": "action_release",
     "source_incident_ids": [
       "SC-2025-TJ-ACTIONS-CHANGED-FILES"
+    ]
+  },
+  {
+    "account_type": "source_control_account",
+    "aliases": [
+      "victim GitHub tokens"
+    ],
+    "id": "account-github-victim-github-tokens",
+    "name": "victim GitHub tokens",
+    "provider": "GitHub",
+    "role": "workflow_secret_access",
+    "source_incident_ids": [
+      "SC-2025-NPM-SHAI-HULUD"
+    ]
+  },
+  {
+    "account_type": "package_registry_account",
+    "aliases": [
+      "compromised npm maintainer tokens"
+    ],
+    "id": "account-npm-compromised-npm-maintainer-tokens",
+    "name": "compromised npm maintainer tokens",
+    "provider": "npm",
+    "role": "maintainer_publish",
+    "source_incident_ids": [
+      "SC-2025-NPM-SHAI-HULUD"
     ]
   },
   {

--- a/data/supply-chain-entities/actors.json
+++ b/data/supply-chain-entities/actors.json
@@ -15,6 +15,20 @@
     ]
   },
   {
+    "actor_type": "provisional",
+    "aliases": [
+      "boltdb-go",
+      "boltdb-go operator"
+    ],
+    "attribution_confidence": "suspected",
+    "id": "actor-boltdb-go-operator",
+    "name": "boltdb-go operator",
+    "notes": "Provisional operator node for the GitHub alias used to distribute the backdoored Go typosquat; no public APT or nation-state label is asserted.",
+    "source_incident_ids": [
+      "SC-2025-GO-BOLTDB-TYPOSQUAT"
+    ]
+  },
+  {
     "actor_type": "public",
     "aliases": [
       "Lazarus Group",
@@ -40,6 +54,19 @@
     "name": "Sandworm",
     "source_incident_ids": [
       "SC-2017-NOTPETYA-MEDOC"
+    ]
+  },
+  {
+    "actor_type": "provisional",
+    "aliases": [
+      "Shai-Hulud operator"
+    ],
+    "attribution_confidence": "suspected",
+    "id": "actor-shai-hulud-operator",
+    "name": "Shai-Hulud operator",
+    "notes": "Provisional operator node for the self-propagating npm campaign; no public APT or nation-state label is asserted.",
+    "source_incident_ids": [
+      "SC-2025-NPM-SHAI-HULUD"
     ]
   },
   {

--- a/data/supply-chain-entities/build_systems.json
+++ b/data/supply-chain-entities/build_systems.json
@@ -33,6 +33,7 @@
     "provider": "GitHub",
     "source_incident_ids": [
       "SC-2024-ULTRALYTICS-PYPI",
+      "SC-2025-NPM-SHAI-HULUD",
       "SC-2025-TJ-ACTIONS-CHANGED-FILES"
     ]
   },

--- a/data/supply-chain-entities/distribution_channels.json
+++ b/data/supply-chain-entities/distribution_channels.json
@@ -25,6 +25,42 @@
   },
   {
     "aliases": [
+      "GitHub Actions workflow"
+    ],
+    "channel_type": "ci_cd_workflow",
+    "ecosystem": "github-actions",
+    "id": "channel-github-actions-ci-cd-workflow-github-actions-workflow",
+    "name": "GitHub Actions workflow",
+    "source_incident_ids": [
+      "SC-2025-NPM-SHAI-HULUD"
+    ]
+  },
+  {
+    "aliases": [
+      "GitHub repository"
+    ],
+    "channel_type": "source_repository",
+    "ecosystem": "github",
+    "id": "channel-github-source-repository-github-repository",
+    "name": "GitHub repository",
+    "source_incident_ids": [
+      "SC-2025-GO-BOLTDB-TYPOSQUAT"
+    ]
+  },
+  {
+    "aliases": [
+      "Go Module Proxy"
+    ],
+    "channel_type": "package_registry",
+    "ecosystem": "golang",
+    "id": "channel-golang-package-registry-go-module-proxy",
+    "name": "Go Module Proxy",
+    "source_incident_ids": [
+      "SC-2025-GO-BOLTDB-TYPOSQUAT"
+    ]
+  },
+  {
+    "aliases": [
       "Upstream source release tarball"
     ],
     "channel_type": "source_release",
@@ -64,7 +100,8 @@
       "SC-2022-COLORS-FAKER",
       "SC-2022-NODE-IPC",
       "SC-2023-LEDGER-CONNECT-KIT",
-      "SC-2024-LOTTIE-PLAYER"
+      "SC-2024-LOTTIE-PLAYER",
+      "SC-2025-NPM-SHAI-HULUD"
     ]
   },
   {

--- a/data/supply-chain-entities/organizations.json
+++ b/data/supply-chain-entities/organizations.json
@@ -21,16 +21,6 @@
   },
   {
     "aliases": [
-      "boltdb-go"
-    ],
-    "id": "org-boltdb-go",
-    "name": "boltdb-go",
-    "source_incident_ids": [
-      "SC-2025-GO-BOLTDB-TYPOSQUAT"
-    ]
-  },
-  {
-    "aliases": [
       "Codecov"
     ],
     "id": "org-codecov",

--- a/data/supply-chain-entities/organizations.json
+++ b/data/supply-chain-entities/organizations.json
@@ -21,12 +21,32 @@
   },
   {
     "aliases": [
+      "boltdb-go"
+    ],
+    "id": "org-boltdb-go",
+    "name": "boltdb-go",
+    "source_incident_ids": [
+      "SC-2025-GO-BOLTDB-TYPOSQUAT"
+    ]
+  },
+  {
+    "aliases": [
       "Codecov"
     ],
     "id": "org-codecov",
     "name": "Codecov",
     "source_incident_ids": [
       "SC-2021-CODECOV-BASH-UPLOADER"
+    ]
+  },
+  {
+    "aliases": [
+      "ctrl"
+    ],
+    "id": "org-ctrl",
+    "name": "ctrl",
+    "source_incident_ids": [
+      "SC-2025-NPM-SHAI-HULUD"
     ]
   },
   {
@@ -127,6 +147,16 @@
     "name": "PyTorch",
     "source_incident_ids": [
       "SC-2022-PYTORCH-NIGHTLY"
+    ]
+  },
+  {
+    "aliases": [
+      "rxnt"
+    ],
+    "id": "org-rxnt",
+    "name": "rxnt",
+    "source_incident_ids": [
+      "SC-2025-NPM-SHAI-HULUD"
     ]
   },
   {

--- a/data/supply-chain-entities/packages.json
+++ b/data/supply-chain-entities/packages.json
@@ -1,6 +1,18 @@
 [
   {
     "aliases": [
+      "github.com/boltdb-go/bolt"
+    ],
+    "ecosystem": "golang",
+    "id": "pkg-golang-github-com-boltdb-go-bolt",
+    "name": "github.com/boltdb-go/bolt",
+    "package_url": "pkg:golang/github.com/boltdb-go/bolt",
+    "source_incident_ids": [
+      "SC-2025-GO-BOLTDB-TYPOSQUAT"
+    ]
+  },
+  {
+    "aliases": [
       "internal dependency names"
     ],
     "ecosystem": "multiple",
@@ -22,6 +34,18 @@
     "package_url": "pkg:npm/colors",
     "source_incident_ids": [
       "SC-2022-COLORS-FAKER"
+    ]
+  },
+  {
+    "aliases": [
+      "@ctrl/tinycolor"
+    ],
+    "ecosystem": "npm",
+    "id": "pkg-npm-ctrl-tinycolor",
+    "name": "@ctrl/tinycolor",
+    "package_url": "pkg:npm/%40ctrl/tinycolor",
+    "source_incident_ids": [
+      "SC-2025-NPM-SHAI-HULUD"
     ]
   },
   {
@@ -142,6 +166,18 @@
     "package_url": "pkg:npm/rc",
     "source_incident_ids": [
       "SC-2021-NPM-RC"
+    ]
+  },
+  {
+    "aliases": [
+      "rxnt-authentication"
+    ],
+    "ecosystem": "npm",
+    "id": "pkg-npm-rxnt-authentication",
+    "name": "rxnt-authentication",
+    "package_url": "pkg:npm/rxnt-authentication",
+    "source_incident_ids": [
+      "SC-2025-NPM-SHAI-HULUD"
     ]
   },
   {

--- a/data/supply-chain-entities/releases.json
+++ b/data/supply-chain-entities/releases.json
@@ -1,6 +1,71 @@
 [
   {
     "aliases": [
+      "github.com/boltdb-go/bolt@v1.3.1",
+      "pkg:golang/github.com/boltdb-go/bolt@v1.3.1"
+    ],
+    "disclosed_at": "2025-02-04",
+    "ecosystem": "golang",
+    "id": "release-golang-github-com-boltdb-go-bolt-v1-3-1",
+    "malicious_range": "v1.3.1",
+    "name": "github.com/boltdb-go/bolt@v1.3.1",
+    "package_name": "github.com/boltdb-go/bolt",
+    "published_at": "2021-11-01",
+    "purl": "pkg:golang/github.com/boltdb-go/bolt@v1.3.1",
+    "references": [
+      "ref-socket-boltdb-go"
+    ],
+    "source_incident_ids": [
+      "SC-2025-GO-BOLTDB-TYPOSQUAT"
+    ],
+    "version": "v1.3.1"
+  },
+  {
+    "aliases": [
+      "@ctrl/tinycolor@4.1.1",
+      "pkg:npm/%40ctrl/tinycolor@4.1.1"
+    ],
+    "disclosed_at": "2025-09-16",
+    "ecosystem": "npm",
+    "id": "release-npm-ctrl-tinycolor-4-1-1",
+    "malicious_range": "4.1.1",
+    "name": "@ctrl/tinycolor@4.1.1",
+    "package_name": "@ctrl/tinycolor",
+    "published_at": "2025-09-15",
+    "purl": "pkg:npm/%40ctrl/tinycolor@4.1.1",
+    "references": [
+      "ref-npm-tinycolor-registry",
+      "ref-wiz-shai-hulud"
+    ],
+    "source_incident_ids": [
+      "SC-2025-NPM-SHAI-HULUD"
+    ],
+    "version": "4.1.1"
+  },
+  {
+    "aliases": [
+      "@ctrl/tinycolor@4.1.2",
+      "pkg:npm/%40ctrl/tinycolor@4.1.2"
+    ],
+    "disclosed_at": "2025-09-16",
+    "ecosystem": "npm",
+    "id": "release-npm-ctrl-tinycolor-4-1-2",
+    "malicious_range": "4.1.2",
+    "name": "@ctrl/tinycolor@4.1.2",
+    "package_name": "@ctrl/tinycolor",
+    "published_at": "2025-09-15",
+    "purl": "pkg:npm/%40ctrl/tinycolor@4.1.2",
+    "references": [
+      "ref-npm-tinycolor-registry",
+      "ref-wiz-shai-hulud"
+    ],
+    "source_incident_ids": [
+      "SC-2025-NPM-SHAI-HULUD"
+    ],
+    "version": "4.1.2"
+  },
+  {
+    "aliases": [
       "flatmap-stream@0.1.1",
       "pkg:npm/flatmap-stream@0.1.1"
     ],

--- a/data/supply-chain-entities/repositories.json
+++ b/data/supply-chain-entities/repositories.json
@@ -1,6 +1,19 @@
 [
   {
     "aliases": [
+      "boltdb-go/bolt"
+    ],
+    "host": "github.com",
+    "id": "repo-github-com-boltdb-go-bolt",
+    "name": "boltdb-go/bolt",
+    "owner": "boltdb-go",
+    "source_incident_ids": [
+      "SC-2025-GO-BOLTDB-TYPOSQUAT"
+    ],
+    "url": "https://github.com/boltdb-go/bolt"
+  },
+  {
+    "aliases": [
       "codecov/codecov-bash"
     ],
     "host": "github.com",

--- a/data/supply-chain-incidents/incidents.json
+++ b/data/supply-chain-incidents/incidents.json
@@ -2431,7 +2431,7 @@
     "title": "Shai-Hulud npm self-propagating package compromise",
     "summary": "The Shai-Hulud campaign compromised npm packages with credential-harvesting malware that used stolen npm tokens to publish malicious versions of additional packages.",
     "status": "confirmed",
-    "first_observed_at": "2025-09-15",
+    "first_observed_at": "2025-09-14",
     "first_public_warning_at": "2025-09-15",
     "disclosed_at": "2025-09-16",
     "affected_ecosystems": [
@@ -2526,7 +2526,7 @@
     "evidence_level": "researcher",
     "attack_stage": "package_publish",
     "source_artifact_divergence": false,
-    "notes": "Modeled with @ctrl/tinycolor release dates confirmed from npm registry metadata and broader package scope from StepSecurity/Wiz reporting.",
+    "notes": "Modeled with @ctrl/tinycolor release dates confirmed from npm registry metadata and broader package scope from StepSecurity/Wiz reporting; first observed date follows public reporting that rxnt-authentication was updated before the @ctrl/tinycolor wave.",
     "maintainers": [],
     "repositories": [],
     "build_systems": [
@@ -2610,7 +2610,7 @@
         "component_type": "package",
         "ecosystem": "golang",
         "name": "github.com/boltdb-go/bolt",
-        "vendor": "boltdb-go",
+        "vendor": "malicious publisher",
         "package_url": "pkg:golang/github.com/boltdb-go/bolt"
       }
     ],
@@ -2629,8 +2629,8 @@
       }
     ],
     "supply_chain_vectors": [
-      "package_repository_compromise",
-      "source_repository_compromise"
+      "dependency_confusion",
+      "malicious_dependency"
     ],
     "impact_categories": [
       "backdoor",
@@ -2685,14 +2685,7 @@
         "ecosystem": "github"
       }
     ],
-    "compromised_accounts": [
-      {
-        "name": "boltdb-go GitHub account",
-        "provider": "GitHub",
-        "account_type": "source_control_account",
-        "role": "source_repository_owner"
-      }
-    ],
+    "compromised_accounts": [],
     "threat_actors": [
       {
         "id": "actor-boltdb-go-operator",

--- a/data/supply-chain-incidents/incidents.json
+++ b/data/supply-chain-incidents/incidents.json
@@ -2424,5 +2424,300 @@
         "role": "action_release"
       }
     ]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2025-NPM-SHAI-HULUD",
+    "title": "Shai-Hulud npm self-propagating package compromise",
+    "summary": "The Shai-Hulud campaign compromised npm packages with credential-harvesting malware that used stolen npm tokens to publish malicious versions of additional packages.",
+    "status": "confirmed",
+    "first_observed_at": "2025-09-15",
+    "first_public_warning_at": "2025-09-15",
+    "disclosed_at": "2025-09-16",
+    "affected_ecosystems": [
+      "npm",
+      "github-actions",
+      "ci-cd"
+    ],
+    "affected_components": [
+      {
+        "component_type": "package",
+        "ecosystem": "npm",
+        "name": "@ctrl/tinycolor",
+        "vendor": "ctrl",
+        "package_url": "pkg:npm/%40ctrl/tinycolor"
+      },
+      {
+        "component_type": "package",
+        "ecosystem": "npm",
+        "name": "rxnt-authentication",
+        "vendor": "rxnt",
+        "package_url": "pkg:npm/rxnt-authentication"
+      }
+    ],
+    "releases": [
+      {
+        "package_name": "@ctrl/tinycolor",
+        "ecosystem": "npm",
+        "purl": "pkg:npm/%40ctrl/tinycolor@4.1.1",
+        "version": "4.1.1",
+        "published_at": "2025-09-15",
+        "malicious_range": "4.1.1",
+        "references": [
+          "ref-wiz-shai-hulud",
+          "ref-npm-tinycolor-registry"
+        ],
+        "disclosed_at": "2025-09-16"
+      },
+      {
+        "package_name": "@ctrl/tinycolor",
+        "ecosystem": "npm",
+        "purl": "pkg:npm/%40ctrl/tinycolor@4.1.2",
+        "version": "4.1.2",
+        "published_at": "2025-09-15",
+        "malicious_range": "4.1.2",
+        "references": [
+          "ref-wiz-shai-hulud",
+          "ref-npm-tinycolor-registry"
+        ],
+        "disclosed_at": "2025-09-16"
+      }
+    ],
+    "supply_chain_vectors": [
+      "maintainer_account_compromise",
+      "package_repository_compromise",
+      "ci_cd_action_compromise"
+    ],
+    "impact_categories": [
+      "credential_theft",
+      "developer_workstation_compromise",
+      "downstream_customer_compromise"
+    ],
+    "references": [
+      {
+        "id": "ref-stepsecurity-shai-hulud",
+        "title": "Shai-Hulud: Self-Replicating Worm Compromises 500+ NPM Packages",
+        "publisher": "StepSecurity",
+        "url": "https://www.stepsecurity.io/blog/ctrl-tinycolor-and-40-npm-packages-compromised",
+        "published_at": "2025-09-15"
+      },
+      {
+        "id": "ref-wiz-shai-hulud",
+        "title": "Shai-Hulud: Ongoing Package Supply Chain Worm Delivering Data-Stealing Malware",
+        "publisher": "Wiz",
+        "url": "https://www.wiz.io/blog/shai-hulud-npm-supply-chain-attack",
+        "published_at": "2025-09-16"
+      },
+      {
+        "id": "ref-npm-tinycolor-registry",
+        "title": "@ctrl/tinycolor npm registry metadata",
+        "publisher": "npm",
+        "url": "https://registry.npmjs.org/@ctrl%2ftinycolor",
+        "published_at": "2025-09-15"
+      }
+    ],
+    "tags": [
+      "npm",
+      "self-propagating",
+      "credential-theft",
+      "github-actions"
+    ],
+    "confidence": "high",
+    "evidence_level": "researcher",
+    "attack_stage": "package_publish",
+    "source_artifact_divergence": false,
+    "notes": "Modeled with @ctrl/tinycolor release dates confirmed from npm registry metadata and broader package scope from StepSecurity/Wiz reporting.",
+    "maintainers": [],
+    "repositories": [],
+    "build_systems": [
+      {
+        "name": "GitHub Actions",
+        "provider": "GitHub",
+        "category": "ci-cd"
+      }
+    ],
+    "distribution_channels": [
+      {
+        "name": "npm registry",
+        "channel_type": "package_registry",
+        "ecosystem": "npm"
+      },
+      {
+        "name": "GitHub Actions workflow",
+        "channel_type": "ci_cd_workflow",
+        "ecosystem": "github-actions"
+      }
+    ],
+    "compromised_accounts": [
+      {
+        "name": "compromised npm maintainer tokens",
+        "provider": "npm",
+        "account_type": "package_registry_account",
+        "role": "maintainer_publish"
+      },
+      {
+        "name": "victim GitHub tokens",
+        "provider": "GitHub",
+        "account_type": "source_control_account",
+        "role": "workflow_secret_access"
+      }
+    ],
+    "threat_actors": [
+      {
+        "id": "actor-shai-hulud-operator",
+        "name": "Shai-Hulud operator",
+        "actor_type": "provisional",
+        "confidence": "suspected",
+        "aliases": [
+          "Shai-Hulud operator"
+        ],
+        "notes": "Provisional operator node for the self-propagating npm campaign; no public APT or nation-state label is asserted.",
+        "source_refs": [
+          "ref-stepsecurity-shai-hulud",
+          "ref-wiz-shai-hulud"
+        ]
+      }
+    ],
+    "attribution_confidence": "suspected",
+    "attribution_evidence": [
+      {
+        "target": "actor-shai-hulud-operator",
+        "relationship_type": "ATTRIBUTED_TO_ACTOR",
+        "source_refs": [
+          "ref-stepsecurity-shai-hulud",
+          "ref-wiz-shai-hulud"
+        ],
+        "summary": "Public reporting supports a coherent Shai-Hulud operator/campaign behavior, but this corpus does not assign a named APT or state sponsor."
+      }
+    ]
+  },
+  {
+    "schema_version": "supply-chain-incident/1",
+    "id": "SC-2025-GO-BOLTDB-TYPOSQUAT",
+    "title": "Go BoltDB typosquat module proxy backdoor",
+    "summary": "Socket researchers disclosed a backdoored Go module typosquatting BoltDB that persisted through Go Module Proxy caching even after the source repository tag was changed.",
+    "status": "confirmed",
+    "first_observed_at": "2021-11-01",
+    "first_public_warning_at": "2025-02-04",
+    "disclosed_at": "2025-02-04",
+    "affected_ecosystems": [
+      "golang",
+      "go-module-proxy",
+      "github"
+    ],
+    "affected_components": [
+      {
+        "component_type": "package",
+        "ecosystem": "golang",
+        "name": "github.com/boltdb-go/bolt",
+        "vendor": "boltdb-go",
+        "package_url": "pkg:golang/github.com/boltdb-go/bolt"
+      }
+    ],
+    "releases": [
+      {
+        "package_name": "github.com/boltdb-go/bolt",
+        "ecosystem": "golang",
+        "purl": "pkg:golang/github.com/boltdb-go/bolt@v1.3.1",
+        "version": "v1.3.1",
+        "published_at": "2021-11-01",
+        "malicious_range": "v1.3.1",
+        "references": [
+          "ref-socket-boltdb-go"
+        ],
+        "disclosed_at": "2025-02-04"
+      }
+    ],
+    "supply_chain_vectors": [
+      "package_repository_compromise",
+      "source_repository_compromise"
+    ],
+    "impact_categories": [
+      "backdoor",
+      "developer_workstation_compromise"
+    ],
+    "references": [
+      {
+        "id": "ref-socket-boltdb-go",
+        "title": "Go Supply Chain Attack: Malicious Package Exploits Go Module Proxy Caching for Persistence",
+        "publisher": "Socket",
+        "url": "https://socket.dev/blog/malicious-package-exploits-go-module-proxy-caching-for-persistence",
+        "published_at": "2025-02-04"
+      },
+      {
+        "id": "ref-go-sum-boltdb-go",
+        "title": "Go checksum database lookup for github.com/boltdb-go/bolt v1.3.1",
+        "publisher": "sum.golang.org",
+        "url": "https://sum.golang.org/lookup/github.com/boltdb-go/bolt@v1.3.1",
+        "published_at": "2025-02-04"
+      }
+    ],
+    "tags": [
+      "golang",
+      "typosquat",
+      "module-proxy",
+      "backdoor"
+    ],
+    "confidence": "high",
+    "evidence_level": "researcher",
+    "attack_stage": "dependency_resolution",
+    "source_artifact_divergence": true,
+    "notes": "Socket reports the malicious v1.3.1 module was uploaded to the Go Module Proxy in November 2021; this record uses 2021-11-01 as a month-level publish anchor for replay rather than asserting day precision.",
+    "maintainers": [],
+    "repositories": [
+      {
+        "name": "boltdb-go/bolt",
+        "host": "github.com",
+        "owner": "boltdb-go",
+        "url": "https://github.com/boltdb-go/bolt"
+      }
+    ],
+    "build_systems": [],
+    "distribution_channels": [
+      {
+        "name": "Go Module Proxy",
+        "channel_type": "package_registry",
+        "ecosystem": "golang"
+      },
+      {
+        "name": "GitHub repository",
+        "channel_type": "source_repository",
+        "ecosystem": "github"
+      }
+    ],
+    "compromised_accounts": [
+      {
+        "name": "boltdb-go GitHub account",
+        "provider": "GitHub",
+        "account_type": "source_control_account",
+        "role": "source_repository_owner"
+      }
+    ],
+    "threat_actors": [
+      {
+        "id": "actor-boltdb-go-operator",
+        "name": "boltdb-go operator",
+        "actor_type": "provisional",
+        "confidence": "suspected",
+        "aliases": [
+          "boltdb-go"
+        ],
+        "notes": "Provisional operator node for the GitHub alias used to distribute the backdoored Go typosquat; no public APT or nation-state label is asserted.",
+        "source_refs": [
+          "ref-socket-boltdb-go"
+        ]
+      }
+    ],
+    "attribution_confidence": "suspected",
+    "attribution_evidence": [
+      {
+        "target": "actor-boltdb-go-operator",
+        "relationship_type": "ATTRIBUTED_TO_ACTOR",
+        "source_refs": [
+          "ref-socket-boltdb-go"
+        ],
+        "summary": "Socket identifies the boltdb-go GitHub alias as the distribution identity for the typosquat; Threatpedia models it as a provisional operator without broader attribution."
+      }
+    ]
   }
 ]

--- a/data/supply-chain-relationships/relationships.json
+++ b/data/supply-chain-relationships/relationships.json
@@ -495,6 +495,116 @@
     "type": "USED_DISTRIBUTION_CHANNEL"
   },
   {
+    "source": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+    "target": "org-boltdb-go",
+    "type": "AFFECTED_ORGANIZATION"
+  },
+  {
+    "source": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+    "target": "pkg-golang-github-com-boltdb-go-bolt",
+    "type": "AFFECTED_PACKAGE"
+  },
+  {
+    "source": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+    "target": "repo-github-com-boltdb-go-bolt",
+    "type": "AFFECTED_REPOSITORY"
+  },
+  {
+    "source": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+    "target": "actor-boltdb-go-operator",
+    "type": "ATTRIBUTED_TO_ACTOR"
+  },
+  {
+    "source": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+    "target": "account-github-boltdb-go-github-account",
+    "type": "COMPROMISED_ACCOUNT"
+  },
+  {
+    "source": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+    "target": "release-golang-github-com-boltdb-go-bolt-v1-3-1",
+    "type": "INCIDENT_AFFECTED_RELEASE"
+  },
+  {
+    "source": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+    "target": "channel-github-source-repository-github-repository",
+    "type": "SOURCE_ARTIFACT_DIVERGENCE"
+  },
+  {
+    "source": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+    "target": "channel-golang-package-registry-go-module-proxy",
+    "type": "SOURCE_ARTIFACT_DIVERGENCE"
+  },
+  {
+    "source": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+    "target": "channel-github-source-repository-github-repository",
+    "type": "USED_DISTRIBUTION_CHANNEL"
+  },
+  {
+    "source": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+    "target": "channel-golang-package-registry-go-module-proxy",
+    "type": "USED_DISTRIBUTION_CHANNEL"
+  },
+  {
+    "source": "incident-SC-2025-NPM-SHAI-HULUD",
+    "target": "org-ctrl",
+    "type": "AFFECTED_ORGANIZATION"
+  },
+  {
+    "source": "incident-SC-2025-NPM-SHAI-HULUD",
+    "target": "org-rxnt",
+    "type": "AFFECTED_ORGANIZATION"
+  },
+  {
+    "source": "incident-SC-2025-NPM-SHAI-HULUD",
+    "target": "pkg-npm-ctrl-tinycolor",
+    "type": "AFFECTED_PACKAGE"
+  },
+  {
+    "source": "incident-SC-2025-NPM-SHAI-HULUD",
+    "target": "pkg-npm-rxnt-authentication",
+    "type": "AFFECTED_PACKAGE"
+  },
+  {
+    "source": "incident-SC-2025-NPM-SHAI-HULUD",
+    "target": "actor-shai-hulud-operator",
+    "type": "ATTRIBUTED_TO_ACTOR"
+  },
+  {
+    "source": "incident-SC-2025-NPM-SHAI-HULUD",
+    "target": "account-github-victim-github-tokens",
+    "type": "COMPROMISED_ACCOUNT"
+  },
+  {
+    "source": "incident-SC-2025-NPM-SHAI-HULUD",
+    "target": "account-npm-compromised-npm-maintainer-tokens",
+    "type": "COMPROMISED_ACCOUNT"
+  },
+  {
+    "source": "incident-SC-2025-NPM-SHAI-HULUD",
+    "target": "release-npm-ctrl-tinycolor-4-1-1",
+    "type": "INCIDENT_AFFECTED_RELEASE"
+  },
+  {
+    "source": "incident-SC-2025-NPM-SHAI-HULUD",
+    "target": "release-npm-ctrl-tinycolor-4-1-2",
+    "type": "INCIDENT_AFFECTED_RELEASE"
+  },
+  {
+    "source": "incident-SC-2025-NPM-SHAI-HULUD",
+    "target": "build-github-github-actions",
+    "type": "USED_BUILD_SYSTEM"
+  },
+  {
+    "source": "incident-SC-2025-NPM-SHAI-HULUD",
+    "target": "channel-github-actions-ci-cd-workflow-github-actions-workflow",
+    "type": "USED_DISTRIBUTION_CHANNEL"
+  },
+  {
+    "source": "incident-SC-2025-NPM-SHAI-HULUD",
+    "target": "channel-npm-package-registry-npm-registry",
+    "type": "USED_DISTRIBUTION_CHANNEL"
+  },
+  {
     "source": "incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
     "target": "org-tj-actions",
     "type": "AFFECTED_ORGANIZATION"
@@ -543,6 +653,21 @@
     "source": "maintainer-riaevangelist",
     "target": "repo-github-com-riaevangelist-node-ipc",
     "type": "MAINTAINS_REPOSITORY"
+  },
+  {
+    "source": "pkg-golang-github-com-boltdb-go-bolt",
+    "target": "release-golang-github-com-boltdb-go-bolt-v1-3-1",
+    "type": "PACKAGE_RELEASE"
+  },
+  {
+    "source": "pkg-npm-ctrl-tinycolor",
+    "target": "release-npm-ctrl-tinycolor-4-1-1",
+    "type": "PACKAGE_RELEASE"
+  },
+  {
+    "source": "pkg-npm-ctrl-tinycolor",
+    "target": "release-npm-ctrl-tinycolor-4-1-2",
+    "type": "PACKAGE_RELEASE"
   },
   {
     "source": "pkg-npm-flatmap-stream",

--- a/data/supply-chain-relationships/relationships.json
+++ b/data/supply-chain-relationships/relationships.json
@@ -496,11 +496,6 @@
   },
   {
     "source": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
-    "target": "org-boltdb-go",
-    "type": "AFFECTED_ORGANIZATION"
-  },
-  {
-    "source": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
     "target": "pkg-golang-github-com-boltdb-go-bolt",
     "type": "AFFECTED_PACKAGE"
   },
@@ -513,11 +508,6 @@
     "source": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
     "target": "actor-boltdb-go-operator",
     "type": "ATTRIBUTED_TO_ACTOR"
-  },
-  {
-    "source": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
-    "target": "account-github-boltdb-go-github-account",
-    "type": "COMPROMISED_ACCOUNT"
   },
   {
     "source": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",

--- a/docs/supply-chain-graph-primitives.md
+++ b/docs/supply-chain-graph-primitives.md
@@ -148,13 +148,13 @@ The Phase 2E pass over 27 incidents currently emits:
 - Packages: 19
 - Releases: 7
 - Repositories: 11
-- Organizations: 20
+- Organizations: 19
 - Build systems: 6
 - Distribution channels: 14
-- Compromised accounts: 11
+- Compromised accounts: 10
 - Actors: 6
 - Campaigns: 3
-- Relationships: 138
+- Relationships: 136
 
 ## Build and Validate
 

--- a/docs/supply-chain-graph-primitives.md
+++ b/docs/supply-chain-graph-primitives.md
@@ -142,19 +142,19 @@ evidence needed to compute future canary primitives.
 
 ## Current Graph Density
 
-The Phase 2D pass over the same 25 incidents currently emits:
+The Phase 2E pass over 27 incidents currently emits:
 
 - Maintainers: 5
-- Packages: 16
-- Releases: 4
-- Repositories: 10
-- Organizations: 17
+- Packages: 19
+- Releases: 7
+- Repositories: 11
+- Organizations: 20
 - Build systems: 6
-- Distribution channels: 11
-- Compromised accounts: 8
-- Actors: 4
+- Distribution channels: 14
+- Compromised accounts: 11
+- Actors: 6
 - Campaigns: 3
-- Relationships: 113
+- Relationships: 138
 
 ## Build and Validate
 

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -37,6 +37,8 @@ const routeUrls = new Set(routes.map(routeUrl));
 assert.ok(routeUrls.has('/supply-chain/'), 'index route should be generated');
 assert.ok(routeUrls.has('/supply-chain/incidents/SC-2021-CODECOV-BASH-UPLOADER/'), 'incident route should be generated');
 assert.ok(routeUrls.has('/supply-chain/packages/pkg-npm-event-stream/'), 'package route should be generated');
+assert.ok(routeUrls.has('/supply-chain/packages/pkg-npm-ctrl-tinycolor/'), 'Shai-Hulud package route should be generated');
+assert.ok(routeUrls.has('/supply-chain/packages/pkg-golang-github-com-boltdb-go-bolt/'), 'Go typosquat package route should be generated');
 assert.ok(routeUrls.has('/supply-chain/repositories/repo-github-com-codecov-codecov-bash/'), 'repository route should be generated');
 assert.ok(routeUrls.has('/supply-chain/organizations/org-codecov/'), 'organization route should be generated');
 assert.ok(routeUrls.has('/supply-chain/maintainers/maintainer-jia-tan/'), 'maintainer route should be generated');

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -31,7 +31,11 @@ def load_json(path: Path):
 
 
 def find_entity(entities: list[dict], entity_id: str) -> dict:
+    if not isinstance(entities, list):
+        raise ValueError("entities must be a list")
     for entity in entities:
+        if not isinstance(entity, dict):
+            continue
         if entity.get("id") == entity_id:
             return entity
     raise ValueError(f"entity not found: {entity_id}")
@@ -276,7 +280,9 @@ class SupplyChainGraphTests(unittest.TestCase):
         entities_by_type["packages"] = copy.deepcopy(entities_by_type["packages"])
         event_stream = find_entity(entities_by_type["packages"], "pkg-npm-event-stream")
         flatmap_stream = find_entity(entities_by_type["packages"], "pkg-npm-flatmap-stream")
-        event_stream["aliases"].append(flatmap_stream["aliases"][0])
+        flatmap_aliases = flatmap_stream.get("aliases") or []
+        self.assertGreater(len(flatmap_aliases), 0)
+        event_stream["aliases"].append(flatmap_aliases[0])
         event_stream["ecosystem"] = flatmap_stream["ecosystem"]
 
         errors = validator.validate_graph(corpus, entities_by_type, relationships)
@@ -365,7 +371,7 @@ class SupplyChainGraphTests(unittest.TestCase):
         tinycolor_release = find_entity(entities_by_type["releases"], "release-npm-ctrl-tinycolor-4-1-1")
         flatmap_release["purl"] = "pkg:npm/flatmap-stream"
         ua_parser_release["published_at"] = "2021-99-99"
-        del tinycolor_release["disclosed_at"]
+        tinycolor_release.pop("disclosed_at", None)
 
         errors = validator.validate_graph(corpus, entities_by_type, relationships)
 
@@ -457,7 +463,7 @@ class SupplyChainGraphTests(unittest.TestCase):
         relationships = copy.deepcopy(load_json(RELATIONSHIP_PATH))
         entities_by_type["maintainers"] = copy.deepcopy(entities_by_type["maintainers"])
         maintainer = find_entity(entities_by_type["maintainers"], "maintainer-dominictarr")
-        del maintainer["onboarding_date"]
+        maintainer.pop("onboarding_date", None)
         maintainer["first_publish_date"] = "2018-99-99"
         maintainer["repositories"] = ["pkg-not-a-repository"]
         maintainer["account_ids"] = ["repo-not-an-account"]

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -55,8 +55,12 @@ class SupplyChainGraphTests(unittest.TestCase):
         self.assertGreaterEqual(len(graph["relationships"]), 100)
         self.assertIn("pkg-npm-event-stream", package_ids)
         self.assertIn("pkg-npm-flatmap-stream", package_ids)
+        self.assertIn("pkg-npm-ctrl-tinycolor", package_ids)
+        self.assertIn("pkg-golang-github-com-boltdb-go-bolt", package_ids)
         self.assertIn("release-npm-flatmap-stream-0-1-1", release_ids)
         self.assertIn("release-npm-ua-parser-js-0-7-29", release_ids)
+        self.assertIn("release-npm-ctrl-tinycolor-4-1-1", release_ids)
+        self.assertIn("release-golang-github-com-boltdb-go-bolt-v1-3-1", release_ids)
         self.assertIn("maintainer-jia-tan", maintainer_ids)
         self.assertIn("maintainer-dominictarr", maintainer_ids)
         self.assertIn("org-codecov", organization_ids)
@@ -67,6 +71,8 @@ class SupplyChainGraphTests(unittest.TestCase):
         self.assertIn("account-npm-eslint-scope-npm-maintainer-account", account_ids)
         self.assertIn("actor-unc-xz-utils-operator", actor_ids)
         self.assertIn("actor-lazarus-group", actor_ids)
+        self.assertIn("actor-shai-hulud-operator", actor_ids)
+        self.assertIn("actor-boltdb-go-operator", actor_ids)
         self.assertIn("campaign-tp-camp-2023-0002", campaign_ids)
         self.assertIn(
             {
@@ -344,9 +350,12 @@ class SupplyChainGraphTests(unittest.TestCase):
         entities_by_type = validator.load_entities(ENTITY_DIR)
         relationships = load_json(RELATIONSHIP_PATH)
         entities_by_type["releases"] = copy.deepcopy(entities_by_type["releases"])
-        entities_by_type["releases"][0]["purl"] = "pkg:npm/flatmap-stream"
-        entities_by_type["releases"][1]["published_at"] = "2021-99-99"
-        del entities_by_type["releases"][2]["disclosed_at"]
+        flatmap_release = next(entity for entity in entities_by_type["releases"] if entity["id"] == "release-npm-flatmap-stream-0-1-1")
+        ua_parser_release = next(entity for entity in entities_by_type["releases"] if entity["id"] == "release-npm-ua-parser-js-0-7-29")
+        tinycolor_release = next(entity for entity in entities_by_type["releases"] if entity["id"] == "release-npm-ctrl-tinycolor-4-1-1")
+        flatmap_release["purl"] = "pkg:npm/flatmap-stream"
+        ua_parser_release["published_at"] = "2021-99-99"
+        del tinycolor_release["disclosed_at"]
 
         errors = validator.validate_graph(corpus, entities_by_type, relationships)
 

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -30,6 +30,10 @@ def load_json(path: Path):
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def find_entity(entities: list[dict], entity_id: str) -> dict:
+    return next(entity for entity in entities if entity["id"] == entity_id)
+
+
 class SupplyChainGraphTests(unittest.TestCase):
     def test_generated_graph_validates(self) -> None:
         corpus = load_json(CORPUS_PATH)
@@ -267,8 +271,10 @@ class SupplyChainGraphTests(unittest.TestCase):
         entities_by_type = validator.load_entities(ENTITY_DIR)
         relationships = load_json(RELATIONSHIP_PATH)
         entities_by_type["packages"] = copy.deepcopy(entities_by_type["packages"])
-        entities_by_type["packages"][0]["aliases"].append(entities_by_type["packages"][1]["aliases"][0])
-        entities_by_type["packages"][0]["ecosystem"] = entities_by_type["packages"][1]["ecosystem"]
+        event_stream = find_entity(entities_by_type["packages"], "pkg-npm-event-stream")
+        flatmap_stream = find_entity(entities_by_type["packages"], "pkg-npm-flatmap-stream")
+        event_stream["aliases"].append(flatmap_stream["aliases"][0])
+        event_stream["ecosystem"] = flatmap_stream["ecosystem"]
 
         errors = validator.validate_graph(corpus, entities_by_type, relationships)
 
@@ -279,7 +285,7 @@ class SupplyChainGraphTests(unittest.TestCase):
         entities_by_type = validator.load_entities(ENTITY_DIR)
         relationships = load_json(RELATIONSHIP_PATH)
         entities_by_type["packages"] = copy.deepcopy(entities_by_type["packages"])
-        first = entities_by_type["packages"][0]
+        first = find_entity(entities_by_type["packages"], "pkg-multiple-internal-dependency-names")
         sibling = copy.deepcopy(first)
         sibling["id"] = "pkg-pypi-internal-dependency-names"
         sibling["ecosystem"] = "pypi"
@@ -303,7 +309,7 @@ class SupplyChainGraphTests(unittest.TestCase):
         entities_by_type = validator.load_entities(ENTITY_DIR)
         relationships = load_json(RELATIONSHIP_PATH)
         entities_by_type["packages"] = copy.deepcopy(entities_by_type["packages"])
-        entities_by_type["packages"][0]["source_incident_ids"] = ["SC-DOES-NOT-EXIST"]
+        find_entity(entities_by_type["packages"], "pkg-npm-event-stream")["source_incident_ids"] = ["SC-DOES-NOT-EXIST"]
 
         errors = validator.validate_graph(corpus, entities_by_type, relationships)
 
@@ -314,7 +320,7 @@ class SupplyChainGraphTests(unittest.TestCase):
         entities_by_type = validator.load_entities(ENTITY_DIR)
         relationships = load_json(RELATIONSHIP_PATH)
         entities_by_type["packages"] = copy.deepcopy(entities_by_type["packages"])
-        entities_by_type["packages"][0]["package_url"] = None
+        find_entity(entities_by_type["packages"], "pkg-npm-event-stream")["package_url"] = None
 
         errors = validator.validate_graph(corpus, entities_by_type, relationships)
 
@@ -325,8 +331,9 @@ class SupplyChainGraphTests(unittest.TestCase):
         entities_by_type = validator.load_entities(ENTITY_DIR)
         relationships = load_json(RELATIONSHIP_PATH)
         entities_by_type["packages"] = copy.deepcopy(entities_by_type["packages"])
-        entities_by_type["packages"][0]["name"] = None
-        entities_by_type["packages"][0]["ecosystem"] = None
+        package = find_entity(entities_by_type["packages"], "pkg-npm-event-stream")
+        package["name"] = None
+        package["ecosystem"] = None
 
         errors = validator.validate_graph(corpus, entities_by_type, relationships)
 

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -31,7 +31,10 @@ def load_json(path: Path):
 
 
 def find_entity(entities: list[dict], entity_id: str) -> dict:
-    return next(entity for entity in entities if entity["id"] == entity_id)
+    for entity in entities:
+        if entity.get("id") == entity_id:
+            return entity
+    raise ValueError(f"entity not found: {entity_id}")
 
 
 class SupplyChainGraphTests(unittest.TestCase):
@@ -192,7 +195,7 @@ class SupplyChainGraphTests(unittest.TestCase):
         second["id"] = "SC-2024-XZ-UTILS-SIBLING"
         second["threat_actors"][0]["confidence"] = "confirmed"
         graph = builder.build_graph([first, second])
-        actor = next(entity for entity in graph["actors"] if entity["id"] == "actor-unc-xz-utils-operator")
+        actor = find_entity(graph["actors"], "actor-unc-xz-utils-operator")
 
         self.assertEqual(actor["attribution_confidence"], "confirmed")
 
@@ -357,9 +360,9 @@ class SupplyChainGraphTests(unittest.TestCase):
         entities_by_type = validator.load_entities(ENTITY_DIR)
         relationships = load_json(RELATIONSHIP_PATH)
         entities_by_type["releases"] = copy.deepcopy(entities_by_type["releases"])
-        flatmap_release = next(entity for entity in entities_by_type["releases"] if entity["id"] == "release-npm-flatmap-stream-0-1-1")
-        ua_parser_release = next(entity for entity in entities_by_type["releases"] if entity["id"] == "release-npm-ua-parser-js-0-7-29")
-        tinycolor_release = next(entity for entity in entities_by_type["releases"] if entity["id"] == "release-npm-ctrl-tinycolor-4-1-1")
+        flatmap_release = find_entity(entities_by_type["releases"], "release-npm-flatmap-stream-0-1-1")
+        ua_parser_release = find_entity(entities_by_type["releases"], "release-npm-ua-parser-js-0-7-29")
+        tinycolor_release = find_entity(entities_by_type["releases"], "release-npm-ctrl-tinycolor-4-1-1")
         flatmap_release["purl"] = "pkg:npm/flatmap-stream"
         ua_parser_release["published_at"] = "2021-99-99"
         del tinycolor_release["disclosed_at"]
@@ -453,7 +456,7 @@ class SupplyChainGraphTests(unittest.TestCase):
         entities_by_type = validator.load_entities(ENTITY_DIR)
         relationships = copy.deepcopy(load_json(RELATIONSHIP_PATH))
         entities_by_type["maintainers"] = copy.deepcopy(entities_by_type["maintainers"])
-        maintainer = next(entity for entity in entities_by_type["maintainers"] if entity["id"] == "maintainer-dominictarr")
+        maintainer = find_entity(entities_by_type["maintainers"], "maintainer-dominictarr")
         del maintainer["onboarding_date"]
         maintainer["first_publish_date"] = "2018-99-99"
         maintainer["repositories"] = ["pkg-not-a-repository"]

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -34,9 +34,25 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
         corpus = load_json(CORPUS_PATH)
         schema = load_json(SCHEMA_PATH)
 
-        self.assertGreaterEqual(len(corpus), 25)
+        self.assertGreaterEqual(len(corpus), 27)
         self.assertEqual(validator.validate_schema_file(schema), [])
         self.assertEqual(validator.validate_corpus(corpus), [])
+
+    def test_phase_2e_mandatory_incidents_are_modeled_end_to_end(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        by_id = {incident["id"]: incident for incident in corpus}
+
+        shai_hulud = by_id["SC-2025-NPM-SHAI-HULUD"]
+        self.assertEqual(shai_hulud["first_public_warning_at"], "2025-09-15")
+        self.assertTrue(any(component["name"] == "@ctrl/tinycolor" for component in shai_hulud["affected_components"]))
+        self.assertTrue(any(release["malicious_range"] == "4.1.1" for release in shai_hulud["releases"]))
+        self.assertEqual(shai_hulud["threat_actors"][0]["actor_type"], "provisional")
+
+        boltdb = by_id["SC-2025-GO-BOLTDB-TYPOSQUAT"]
+        self.assertEqual(boltdb["first_public_warning_at"], "2025-02-04")
+        self.assertTrue(any(component["name"] == "github.com/boltdb-go/bolt" for component in boltdb["affected_components"]))
+        self.assertEqual(boltdb["releases"][0]["malicious_range"], "v1.3.1")
+        self.assertTrue(boltdb["source_artifact_divergence"])
 
     def test_duplicate_ids_fail_validation(self) -> None:
         corpus = load_json(CORPUS_PATH)

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -43,15 +43,22 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
         by_id = {incident["id"]: incident for incident in corpus}
 
         shai_hulud = by_id["SC-2025-NPM-SHAI-HULUD"]
+        shai_actors = shai_hulud.get("threat_actors") or []
+        shai_components = shai_hulud.get("affected_components") or []
+        shai_releases = shai_hulud.get("releases") or []
         self.assertEqual(shai_hulud["first_public_warning_at"], "2025-09-15")
-        self.assertTrue(any(component["name"] == "@ctrl/tinycolor" for component in shai_hulud["affected_components"]))
-        self.assertTrue(any(release["malicious_range"] == "4.1.1" for release in shai_hulud["releases"]))
-        self.assertEqual(shai_hulud["threat_actors"][0]["actor_type"], "provisional")
+        self.assertEqual(shai_hulud["first_observed_at"], "2025-09-14")
+        self.assertTrue(any(component.get("name") == "@ctrl/tinycolor" for component in shai_components))
+        self.assertTrue(any(release.get("malicious_range") == "4.1.1" for release in shai_releases))
+        self.assertTrue(any(actor.get("actor_type") == "provisional" for actor in shai_actors))
 
         boltdb = by_id["SC-2025-GO-BOLTDB-TYPOSQUAT"]
+        boltdb_releases = boltdb.get("releases") or []
         self.assertEqual(boltdb["first_public_warning_at"], "2025-02-04")
         self.assertTrue(any(component["name"] == "github.com/boltdb-go/bolt" for component in boltdb["affected_components"]))
-        self.assertEqual(boltdb["releases"][0]["malicious_range"], "v1.3.1")
+        self.assertTrue(any(release.get("malicious_range") == "v1.3.1" for release in boltdb_releases))
+        self.assertEqual(boltdb["supply_chain_vectors"], ["dependency_confusion", "malicious_dependency"])
+        self.assertEqual(boltdb["compromised_accounts"], [])
         self.assertTrue(boltdb["source_artifact_divergence"])
 
     def test_duplicate_ids_fail_validation(self) -> None:

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -55,7 +55,8 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
         boltdb = by_id["SC-2025-GO-BOLTDB-TYPOSQUAT"]
         boltdb_releases = boltdb.get("releases") or []
         self.assertEqual(boltdb["first_public_warning_at"], "2025-02-04")
-        self.assertTrue(any(component["name"] == "github.com/boltdb-go/bolt" for component in boltdb["affected_components"]))
+        boltdb_components = boltdb.get("affected_components") or []
+        self.assertTrue(any(component.get("name") == "github.com/boltdb-go/bolt" for component in boltdb_components))
         self.assertTrue(any(release.get("malicious_range") == "v1.3.1" for release in boltdb_releases))
         self.assertEqual(boltdb["supply_chain_vectors"], ["dependency_confusion", "malicious_dependency"])
         self.assertEqual(boltdb["compromised_accounts"], [])


### PR DESCRIPTION
## Summary
- add the mandatory Shai-Hulud npm self-propagating package compromise incident
- add the mandatory Go BoltDB typosquat/module-proxy backdoor incident
- preserve precise package/release PURLs, malicious ranges, public-warning/disclosure anchors, provisional operator nodes, and generated graph relationships

## Scope boundaries
- no scoring, risk engine, soak/canary logic, ML, AI inference, or automated attribution
- no UI changes beyond corpus-derived route/page data already supported by earlier phases
- stacked on #1152 / `codex/supply-chain-phase2d`

## Evidence notes
- Shai-Hulud package/version facts use StepSecurity/Wiz reporting plus npm registry metadata for @ctrl/tinycolor release dates
- BoltDB Go typosquat facts use Socket reporting and sum.golang.org lookup; Socket reports November 2021, so the record stores `2021-11-01` as an explicit month-level anchor in notes

## Validation
- `python3 scripts/validate_supply_chain_incidents.py && python3 scripts/validate_supply_chain_graph.py`: PASS
- `python3 -m unittest discover -s tests`: PASS (76 tests)
- `node --check site/src/lib/supplyChainPages.mjs`: PASS
- `node scripts/test-supply-chain-pages.mjs`: PASS (routes=83)
- `node scripts/check_supply_chain_public_readiness.mjs`: PASS
- `git diff --check`: PASS

@dangermouse-bot @ernestpenfold-bot requested for non-author review.

@codex review
/gemini review