### PR TITLE
Supply Chain Phase 2G backtest foundation

### DIFF
--- a/docs/supply-chain-backtest.md
+++ b/docs/supply-chain-backtest.md
@@ -1,0 +1,63 @@
+# Supply Chain Backtest Foundation
+
+Threatpedia's supply-chain backtest is a stored-facts replay model. It exists to show when an incident became observable from the corpus data already modeled in the repository.
+
+It does not score incidents, rank risk, infer actors, run machine learning, or recommend policy. Those are later phases. Phase 2G only bridges the curated incident graph to the release-event spine by replaying stored timestamps.
+
+## Replay Inputs
+
+The replay reads only stored corpus fields:
+
+- `releases[].published_at` when a malicious package release is modeled.
+- `first_observed_at` only when no release entity exists, such as a source-release artifact case.
+- `first_public_warning_at` when the corpus records a warning signal before or at disclosure.
+- `disclosed_at` for the public disclosure date.
+- `references[].published_at` to separate evidence available at replay time from later-discovered evidence.
+
+The replay does not re-research incidents. If a timestamp is missing, the corpus must be updated through the normal evidence-backed incident workflow before the replay can use it.
+
+## Supported Initial Incidents
+
+Phase 2G supports three historical incidents:
+
+- XZ Utils backdoor attempt: modeled as a source-release artifact case, so the replay uses stored `first_observed_at` as the publication/availability anchor.
+- event-stream malicious dependency insertion: modeled with the `flatmap-stream@0.1.1` release and its stored `published_at` value.
+- Go BoltDB typosquat module proxy backdoor: modeled with the `github.com/boltdb-go/bolt@v1.3.1` release and its stored `published_at` value.
+
+## Timeline Output
+
+Run:
+
+```bash
+python3 scripts/supply_chain_backtest.py
+```
+
+The command emits JSON with one timeline per incident:
+
+- `publish_date`
+- `publish_date_source`
+- `first_warning_signal_at`
+- `public_disclosure_at`
+- `discovery_latency_days`
+- `discovery_latency_basis`
+- `available_at_the_time`
+- `later_discovered_evidence`
+- `undated_evidence`
+- `releases`
+
+`discovery_latency_days` is the elapsed days from the publish/availability anchor to `first_public_warning_at` when present, otherwise to `disclosed_at`. This is a measurement only, not a score.
+
+## Evidence Split
+
+The replay preserves the distinction between available-at-the-time evidence and later-discovered evidence.
+
+References with `published_at` on or before the replay date are listed in `available_at_the_time.reference_ids`. References published after the replay date are listed in `later_discovered_evidence.reference_ids`. Undated references are kept separate instead of being silently treated as available.
+
+This split is the foundation for future backtesting. It prevents later knowledge from leaking into a historical replay.
+
+## Current Limits
+
+- The replay only covers the three initial incidents listed above.
+- It reads stored dates and does not fill gaps.
+- It does not join live ingestion data yet.
+- It does not perform scoring, actor attribution, AI inference, or soak/canary logic.

--- a/scripts/supply_chain_backtest.py
+++ b/scripts/supply_chain_backtest.py
@@ -23,6 +23,19 @@ def load_json(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def error_report(message: str) -> dict[str, Any]:
+    return {
+        "status": "FAIL",
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "model": "stored-fields-only",
+        "non_goals": ["scoring", "risk_engine", "automated_attribution", "ai_inference"],
+        "incident_ids": [],
+        "missing_incident_ids": [],
+        "input_errors": [message],
+        "timelines": [],
+    }
+
+
 def parse_date(value: Any) -> date | None:
     if not isinstance(value, str) or not value.strip():
         return None
@@ -56,8 +69,8 @@ def release_publish_dates(incident: dict[str, Any]) -> list[tuple[date, dict[str
     return sorted(dated_releases, key=lambda item: item[0])
 
 
-def publish_anchor(incident: dict[str, Any]) -> tuple[date | None, str | None, list[str]]:
-    releases = release_publish_dates(incident)
+def publish_anchor(dated_releases: list[tuple[date, dict[str, Any]]], incident: dict[str, Any]) -> tuple[date | None, str | None, list[str]]:
+    releases = dated_releases
     if releases:
         return releases[0][0], "release.published_at", []
 
@@ -87,9 +100,11 @@ def split_references_by_replay_date(
         if not isinstance(reference, dict):
             continue
         reference_id = reference.get("id")
-        if not isinstance(reference_id, str) or not reference_id:
+        if isinstance(reference_id, str) and reference_id.strip():
+            reference_id = reference_id.strip()
+        else:
             url = reference.get("url")
-            reference_id = url if isinstance(url, str) and url.strip() else f"references[{index}]"
+            reference_id = url.strip() if isinstance(url, str) and url.strip() else f"references[{index}]"
         published_at = parse_date(reference.get("published_at"))
         if replay_date is None or published_at is None:
             undated.append(reference_id)
@@ -101,7 +116,8 @@ def split_references_by_replay_date(
 
 
 def build_timeline(incident: dict[str, Any]) -> dict[str, Any]:
-    publish_date, publish_source, notes = publish_anchor(incident)
+    dated_releases = release_publish_dates(incident)
+    publish_date, publish_source, notes = publish_anchor(dated_releases, incident)
     first_warning = parse_date(incident.get("first_public_warning_at"))
     disclosure = parse_date(incident.get("disclosed_at"))
     discovery_date = first_warning or disclosure
@@ -115,7 +131,7 @@ def build_timeline(incident: dict[str, Any]) -> dict[str, Any]:
             "published_at": release.get("published_at"),
             "malicious_range": release.get("malicious_range"),
         }
-        for _, release in release_publish_dates(incident)
+        for _, release in dated_releases
     ]
 
     return {
@@ -176,7 +192,14 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     incident_ids = tuple(args.incident_ids) if args.incident_ids else DEFAULT_INCIDENT_IDS
-    report = build_backtest(load_json(args.corpus), incident_ids)
+    try:
+        corpus = load_json(args.corpus)
+    except OSError as exc:
+        report = error_report(f"corpus: failed to read {args.corpus}: {exc}")
+    except json.JSONDecodeError as exc:
+        report = error_report(f"corpus: invalid JSON in {args.corpus}: {exc}")
+    else:
+        report = build_backtest(corpus, incident_ids)
     print(json.dumps(report, indent=2, sort_keys=True))
     return 0 if report["status"] == "PASS" else 1
 

--- a/scripts/supply_chain_backtest.py
+++ b/scripts/supply_chain_backtest.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Replay stored supply-chain incident dates without scoring or inference."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date, datetime, timezone
+import json
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CORPUS_PATH = REPO_ROOT / "data" / "supply-chain-incidents" / "incidents.json"
+DEFAULT_INCIDENT_IDS = (
+    "SC-2024-XZ-UTILS",
+    "SC-2018-NPM-EVENT-STREAM",
+    "SC-2025-GO-BOLTDB-TYPOSQUAT",
+)
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def parse_date(value: Any) -> date | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def iso(value: date | None) -> str | None:
+    return value.isoformat() if value else None
+
+
+def days_between(start: date | None, end: date | None) -> int | None:
+    if start is None or end is None:
+        return None
+    return (end - start).days
+
+
+def release_publish_dates(incident: dict[str, Any]) -> list[tuple[date, dict[str, Any]]]:
+    releases = incident.get("releases")
+    if not isinstance(releases, list):
+        return []
+    dated_releases = []
+    for release in releases:
+        if not isinstance(release, dict):
+            continue
+        published_at = parse_date(release.get("published_at"))
+        if published_at:
+            dated_releases.append((published_at, release))
+    return sorted(dated_releases, key=lambda item: item[0])
+
+
+def publish_anchor(incident: dict[str, Any]) -> tuple[date | None, str | None, list[str]]:
+    releases = release_publish_dates(incident)
+    if releases:
+        return releases[0][0], "release.published_at", []
+
+    first_observed = parse_date(incident.get("first_observed_at"))
+    if first_observed:
+        return (
+            first_observed,
+            "incident.first_observed_at",
+            ["No release entity is modeled; using stored first_observed_at as the artifact availability anchor."],
+        )
+
+    return None, None, ["No stored release published_at or first_observed_at is available."]
+
+
+def split_references_by_replay_date(
+    incident: dict[str, Any],
+    replay_date: date | None,
+) -> tuple[list[str], list[str], list[str]]:
+    available = []
+    later = []
+    undated = []
+    references = incident.get("references")
+    if not isinstance(references, list):
+        return available, later, undated
+
+    for reference in references:
+        if not isinstance(reference, dict):
+            continue
+        reference_id = reference.get("id")
+        if not isinstance(reference_id, str) or not reference_id:
+            continue
+        published_at = parse_date(reference.get("published_at"))
+        if replay_date is None or published_at is None:
+            undated.append(reference_id)
+        elif published_at <= replay_date:
+            available.append(reference_id)
+        else:
+            later.append(reference_id)
+    return sorted(available), sorted(later), sorted(undated)
+
+
+def build_timeline(incident: dict[str, Any]) -> dict[str, Any]:
+    publish_date, publish_source, notes = publish_anchor(incident)
+    first_warning = parse_date(incident.get("first_public_warning_at"))
+    disclosure = parse_date(incident.get("disclosed_at"))
+    discovery_date = first_warning or disclosure
+    latency_basis = "first_public_warning_at" if first_warning else "disclosed_at"
+    available_refs, later_refs, undated_refs = split_references_by_replay_date(incident, discovery_date)
+
+    releases = [
+        {
+            "purl": release.get("purl"),
+            "version": release.get("version"),
+            "published_at": release.get("published_at"),
+            "malicious_range": release.get("malicious_range"),
+        }
+        for _, release in release_publish_dates(incident)
+    ]
+
+    return {
+        "incident_id": incident.get("id"),
+        "title": incident.get("title"),
+        "publish_date": iso(publish_date),
+        "publish_date_source": publish_source,
+        "first_warning_signal_at": iso(first_warning),
+        "public_disclosure_at": iso(disclosure),
+        "discovery_latency_days": days_between(publish_date, discovery_date),
+        "discovery_latency_basis": latency_basis if discovery_date else None,
+        "available_at_the_time": {
+            "as_of": iso(discovery_date),
+            "reference_ids": available_refs,
+            "release_purls": [release["purl"] for release in releases if release.get("purl")],
+        },
+        "later_discovered_evidence": {
+            "reference_ids": later_refs,
+        },
+        "undated_evidence": {
+            "reference_ids": undated_refs,
+        },
+        "releases": releases,
+        "notes": notes,
+    }
+
+
+def build_backtest(corpus: list[dict[str, Any]], incident_ids: tuple[str, ...] = DEFAULT_INCIDENT_IDS) -> dict[str, Any]:
+    incidents_by_id = {incident.get("id"): incident for incident in corpus if isinstance(incident, dict)}
+    missing_ids = [incident_id for incident_id in incident_ids if incident_id not in incidents_by_id]
+    timelines = [build_timeline(incidents_by_id[incident_id]) for incident_id in incident_ids if incident_id in incidents_by_id]
+
+    return {
+        "status": "PASS" if not missing_ids else "FAIL",
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "model": "stored-fields-only",
+        "non_goals": ["scoring", "risk_engine", "automated_attribution", "ai_inference"],
+        "incident_ids": list(incident_ids),
+        "missing_incident_ids": missing_ids,
+        "timelines": timelines,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS_PATH)
+    parser.add_argument("--incident-id", action="append", dest="incident_ids")
+    args = parser.parse_args(argv)
+
+    incident_ids = tuple(args.incident_ids) if args.incident_ids else DEFAULT_INCIDENT_IDS
+    report = build_backtest(load_json(args.corpus), incident_ids)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["status"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/supply_chain_backtest.py
+++ b/scripts/supply_chain_backtest.py
@@ -88,7 +88,8 @@ def split_references_by_replay_date(
             continue
         reference_id = reference.get("id")
         if not isinstance(reference_id, str) or not reference_id:
-            reference_id = f"references[{index}]"
+            url = reference.get("url")
+            reference_id = url if isinstance(url, str) and url.strip() else f"references[{index}]"
         published_at = parse_date(reference.get("published_at"))
         if replay_date is None or published_at is None:
             undated.append(reference_id)

--- a/scripts/supply_chain_backtest.py
+++ b/scripts/supply_chain_backtest.py
@@ -83,12 +83,12 @@ def split_references_by_replay_date(
     if not isinstance(references, list):
         return available, later, undated
 
-    for reference in references:
+    for index, reference in enumerate(references):
         if not isinstance(reference, dict):
             continue
         reference_id = reference.get("id")
         if not isinstance(reference_id, str) or not reference_id:
-            continue
+            reference_id = f"references[{index}]"
         published_at = parse_date(reference.get("published_at"))
         if replay_date is None or published_at is None:
             undated.append(reference_id)
@@ -142,18 +142,28 @@ def build_timeline(incident: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def build_backtest(corpus: list[dict[str, Any]], incident_ids: tuple[str, ...] = DEFAULT_INCIDENT_IDS) -> dict[str, Any]:
-    incidents_by_id = {incident.get("id"): incident for incident in corpus if isinstance(incident, dict)}
+def build_backtest(corpus: Any, incident_ids: tuple[str, ...] = DEFAULT_INCIDENT_IDS) -> dict[str, Any]:
+    input_errors = []
+    if not isinstance(corpus, list):
+        input_errors.append("corpus: expected array")
+        corpus = []
+
+    incidents_by_id = {
+        incident.get("id"): incident
+        for incident in corpus
+        if isinstance(incident, dict) and isinstance(incident.get("id"), str)
+    }
     missing_ids = [incident_id for incident_id in incident_ids if incident_id not in incidents_by_id]
     timelines = [build_timeline(incidents_by_id[incident_id]) for incident_id in incident_ids if incident_id in incidents_by_id]
 
     return {
-        "status": "PASS" if not missing_ids else "FAIL",
+        "status": "PASS" if not missing_ids and not input_errors else "FAIL",
         "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
         "model": "stored-fields-only",
         "non_goals": ["scoring", "risk_engine", "automated_attribution", "ai_inference"],
         "incident_ids": list(incident_ids),
         "missing_incident_ids": missing_ids,
+        "input_errors": input_errors,
         "timelines": timelines,
     }
 

--- a/tests/test_supply_chain_backtest.py
+++ b/tests/test_supply_chain_backtest.py
@@ -89,7 +89,7 @@ class SupplyChainBacktestTests(unittest.TestCase):
 
         timeline = backtest.build_timeline(event_stream)
 
-        self.assertIn("references[1]", timeline["undated_evidence"]["reference_ids"])
+        self.assertIn("https://example.com/no-id", timeline["undated_evidence"]["reference_ids"])
 
     def test_non_array_corpus_fails_without_crashing(self) -> None:
         report = backtest.build_backtest({"not": "an array"}, ("SC-2024-XZ-UTILS",))

--- a/tests/test_supply_chain_backtest.py
+++ b/tests/test_supply_chain_backtest.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import copy
+import contextlib
+import io
 import json
 from pathlib import Path
 import sys
+import tempfile
 import unittest
 
 
@@ -91,11 +94,53 @@ class SupplyChainBacktestTests(unittest.TestCase):
 
         self.assertIn("https://example.com/no-id", timeline["undated_evidence"]["reference_ids"])
 
+    def test_whitespace_reference_ids_fall_back_to_url(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        event_stream = copy.deepcopy(next(item for item in corpus if item["id"] == "SC-2018-NPM-EVENT-STREAM"))
+        event_stream["references"].append(
+            {
+                "id": "   ",
+                "title": "Reference with blank ID",
+                "publisher": "Researcher",
+                "url": "https://example.com/blank-id",
+                "published_at": None,
+            }
+        )
+
+        timeline = backtest.build_timeline(event_stream)
+
+        self.assertIn("https://example.com/blank-id", timeline["undated_evidence"]["reference_ids"])
+
     def test_non_array_corpus_fails_without_crashing(self) -> None:
         report = backtest.build_backtest({"not": "an array"}, ("SC-2024-XZ-UTILS",))
 
         self.assertEqual(report["status"], "FAIL")
         self.assertEqual(report["input_errors"], ["corpus: expected array"])
+
+    def test_main_reports_missing_corpus_file_without_crashing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing_path = Path(tmpdir) / "missing.json"
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                exit_code = backtest.main(["--corpus", str(missing_path)])
+
+        report = json.loads(output.getvalue())
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(report["status"], "FAIL")
+        self.assertTrue(any("failed to read" in error for error in report["input_errors"]))
+
+    def test_main_reports_malformed_corpus_json_without_crashing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corpus_path = Path(tmpdir) / "incidents.json"
+            corpus_path.write_text("{not-json", encoding="utf-8")
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                exit_code = backtest.main(["--corpus", str(corpus_path)])
+
+        report = json.loads(output.getvalue())
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(report["status"], "FAIL")
+        self.assertTrue(any("invalid JSON" in error for error in report["input_errors"]))
 
     def test_missing_required_replay_incident_fails(self) -> None:
         report = backtest.build_backtest([], ("SC-2024-XZ-UTILS",))

--- a/tests/test_supply_chain_backtest.py
+++ b/tests/test_supply_chain_backtest.py
@@ -1,26 +1,20 @@
 from __future__ import annotations
 
 import copy
-import importlib.util
 import json
 from pathlib import Path
+import sys
 import unittest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CORPUS_PATH = REPO_ROOT / "data" / "supply-chain-incidents" / "incidents.json"
+SCRIPT_DIR = REPO_ROOT / "scripts"
 
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
 
-def load_module(name: str, path: Path):
-    spec = importlib.util.spec_from_file_location(name, path)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"failed to load {path}")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-backtest = load_module("supply_chain_backtest", REPO_ROOT / "scripts" / "supply_chain_backtest.py")
+import supply_chain_backtest as backtest
 
 
 def load_json(path: Path):
@@ -80,6 +74,28 @@ class SupplyChainBacktestTests(unittest.TestCase):
         self.assertEqual(timeline["publish_date"], "2021-11-01")
         self.assertIn("ref-socket-boltdb-go", timeline["available_at_the_time"]["reference_ids"])
         self.assertIn("ref-post-disclosure-analysis", timeline["later_discovered_evidence"]["reference_ids"])
+
+    def test_references_without_ids_are_not_silently_dropped(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        event_stream = copy.deepcopy(next(item for item in corpus if item["id"] == "SC-2018-NPM-EVENT-STREAM"))
+        event_stream["references"].append(
+            {
+                "title": "Undated reference without ID",
+                "publisher": "Researcher",
+                "url": "https://example.com/no-id",
+                "published_at": None,
+            }
+        )
+
+        timeline = backtest.build_timeline(event_stream)
+
+        self.assertIn("references[1]", timeline["undated_evidence"]["reference_ids"])
+
+    def test_non_array_corpus_fails_without_crashing(self) -> None:
+        report = backtest.build_backtest({"not": "an array"}, ("SC-2024-XZ-UTILS",))
+
+        self.assertEqual(report["status"], "FAIL")
+        self.assertEqual(report["input_errors"], ["corpus: expected array"])
 
     def test_missing_required_replay_incident_fails(self) -> None:
         report = backtest.build_backtest([], ("SC-2024-XZ-UTILS",))

--- a/tests/test_supply_chain_backtest.py
+++ b/tests/test_supply_chain_backtest.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CORPUS_PATH = REPO_ROOT / "data" / "supply-chain-incidents" / "incidents.json"
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+backtest = load_module("supply_chain_backtest", REPO_ROOT / "scripts" / "supply_chain_backtest.py")
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class SupplyChainBacktestTests(unittest.TestCase):
+    def test_default_backtest_supports_required_incidents(self) -> None:
+        report = backtest.build_backtest(load_json(CORPUS_PATH))
+
+        self.assertEqual(report["status"], "PASS")
+        self.assertEqual(
+            {timeline["incident_id"] for timeline in report["timelines"]},
+            {"SC-2024-XZ-UTILS", "SC-2018-NPM-EVENT-STREAM", "SC-2025-GO-BOLTDB-TYPOSQUAT"},
+        )
+
+    def test_event_stream_replay_uses_release_publish_date(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        event_stream = next(item for item in corpus if item["id"] == "SC-2018-NPM-EVENT-STREAM")
+
+        timeline = backtest.build_timeline(event_stream)
+
+        self.assertEqual(timeline["publish_date"], "2018-09-09")
+        self.assertEqual(timeline["publish_date_source"], "release.published_at")
+        self.assertEqual(timeline["first_warning_signal_at"], None)
+        self.assertEqual(timeline["public_disclosure_at"], "2018-11-26")
+        self.assertEqual(timeline["discovery_latency_days"], 78)
+        self.assertEqual(timeline["discovery_latency_basis"], "disclosed_at")
+
+    def test_xz_replay_uses_stored_first_observed_anchor_without_release(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        xz_utils = next(item for item in corpus if item["id"] == "SC-2024-XZ-UTILS")
+
+        timeline = backtest.build_timeline(xz_utils)
+
+        self.assertEqual(timeline["publish_date"], "2024-02-24")
+        self.assertEqual(timeline["publish_date_source"], "incident.first_observed_at")
+        self.assertEqual(timeline["first_warning_signal_at"], "2024-03-29")
+        self.assertEqual(timeline["discovery_latency_days"], 34)
+        self.assertTrue(any("No release entity" in note for note in timeline["notes"]))
+
+    def test_later_evidence_is_separated_from_available_at_time_evidence(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        boltdb = copy.deepcopy(next(item for item in corpus if item["id"] == "SC-2025-GO-BOLTDB-TYPOSQUAT"))
+        boltdb["references"].append(
+            {
+                "id": "ref-post-disclosure-analysis",
+                "title": "Later analysis",
+                "publisher": "Researcher",
+                "url": "https://example.com/later-analysis",
+                "published_at": "2025-03-01",
+            }
+        )
+
+        timeline = backtest.build_timeline(boltdb)
+
+        self.assertEqual(timeline["publish_date"], "2021-11-01")
+        self.assertIn("ref-socket-boltdb-go", timeline["available_at_the_time"]["reference_ids"])
+        self.assertIn("ref-post-disclosure-analysis", timeline["later_discovered_evidence"]["reference_ids"])
+
+    def test_missing_required_replay_incident_fails(self) -> None:
+        report = backtest.build_backtest([], ("SC-2024-XZ-UTILS",))
+
+        self.assertEqual(report["status"], "FAIL")
+        self.assertEqual(report["missing_incident_ids"], ["SC-2024-XZ-UTILS"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- adds a stored-fields-only supply-chain backtest helper
- documents the Phase 2G replay model and its non-goals
- supports XZ Utils, event-stream, and Go BoltDB replay timelines without scoring or inference
- separates available-at-the-time references from later-discovered evidence

## Replay sample
- XZ Utils: publish_date=2024-02-24 from incident.first_observed_at, first_warning=2024-03-29, latency=34 days
- event-stream: publish_date=2018-09-09 from release.published_at, disclosure=2018-11-26, latency=78 days
- Go BoltDB typosquat: publish_date=2021-11-01 from release.published_at, first_warning=2025-02-04, latency=1191 days

## Validation
- python3 scripts/supply_chain_backtest.py: PASS
- python3 scripts/validate_supply_chain_incidents.py && python3 scripts/validate_supply_chain_graph.py && python3 scripts/audit_supply_chain_purls_edges.py: PASS
- python3 -m unittest discover -s tests: PASS (84 tests)
- node scripts/test-supply-chain-pages.mjs: PASS (routes=83)
- git diff --check: PASS

@dangermouse-bot @ernestpenfold-bot requested for non-author review.

@codex review
/gemini review