### PR TITLE
Supply Chain G1 landing page shell and theme

### DIFF
--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -69,6 +69,10 @@ index.incidents.forEach((incident) => {
   assert.ok(routeUrls.has(incident.href), `index incident route should resolve: ${incident.href}`);
 });
 assert.ok(index.attackVectorBars.length > 0, 'index should include attack vector controls');
+assert.ok(
+  index.attackVectorBars.some((row) => row.stage === 'ci_cd_compromise' && row.label === 'CI/CD Compromise'),
+  'attack vector labels should preserve CI/CD capitalization'
+);
 assert.equal(
   index.attackVectorBars.reduce((total, row) => total + row.count, 0),
   data.incidents.length,
@@ -87,16 +91,25 @@ index.attributionRows.forEach((row) => {
 const malformedAttributionData = {
   ...data,
   incidentByNodeId: undefined,
+  incidents: [null, ...data.incidents],
+  relationships: [null, ...data.relationships],
   entities: {
     ...data.entities,
-    actors: [{ ...data.entities.actors[0], source_incident_ids: 'not-an-array' }],
+    actors: [null, { ...data.entities.actors[0], name: null, source_incident_ids: 'not-an-array' }],
     campaigns: [
+      null,
       { ...data.entities.campaigns[0], source_incident_ids: 'not-an-array' },
       {
         ...data.entities.campaigns[0],
         id: 'campaign-missing-name',
         name: null,
         source_incident_ids: [data.entities.actors[0].source_incident_ids[0]],
+      },
+      {
+        ...data.entities.campaigns[0],
+        id: 'campaign-unresolved-incident',
+        name: 'Unresolved Incident Campaign',
+        source_incident_ids: ['SC-DOES-NOT-EXIST'],
       },
     ],
   },
@@ -112,16 +125,46 @@ assert.ok(
   ),
   'attribution rows should fall back to campaign ID when a campaign name is missing'
 );
+assert.ok(
+  malformedAttributionIndex.attributionRows.some(
+    (row) => row.id === data.entities.actors[0].id && row.label === data.entities.actors[0].id
+  ),
+  'attribution rows should fall back to actor ID when an actor name is missing'
+);
+assert.ok(
+  malformedAttributionIndex.attributionRows.every((row) =>
+    row.campaigns.every((campaign) => campaign.id !== 'campaign-unresolved-incident')
+  ),
+  'attribution rows should not attach campaigns through unresolved incident IDs'
+);
 assert.ok(index.dwellTimeline.length > 0, 'index should include dwell timeline rows');
 index.dwellTimeline.forEach((row) => {
   assert.equal(row.command.type, 'select-incident', `dwell row should include graph select command: ${row.id}`);
   assert.ok(row.dwellDays >= 0, `dwell row should expose non-negative dwell days: ${row.id}`);
   assert.ok(row.barPercent >= 6 && row.barPercent <= 100, `dwell bar width should be bounded: ${row.id}`);
   assert.ok(row.warningPercent >= 0 && row.warningPercent <= 100, `warning marker should be bounded: ${row.id}`);
+  assert.ok(row.warningPercent <= row.barPercent, `warning marker should not exceed visible dwell bar: ${row.id}`);
   assert.ok(row.disclosedPercent >= 0 && row.disclosedPercent <= 100, `disclosure marker should be bounded: ${row.id}`);
   assert.equal(row.disclosedPercent, row.barPercent, `disclosure marker should align with visible dwell bar: ${row.id}`);
+  if (row.warningDays === row.dwellDays) {
+    assert.equal(row.warningPercent, row.barPercent, `same-day warning marker should align with dwell bar: ${row.id}`);
+  }
   assert.ok(routeUrls.has(row.href), `dwell incident route should resolve: ${row.href}`);
 });
+const isoDwellIncidentId = index.dwellTimeline[0].id;
+const isoDwellData = {
+  ...data,
+  incidents: data.incidents.map((incident) =>
+    incident.id === isoDwellIncidentId
+      ? {
+          ...incident,
+          first_observed_at: `${incident.first_observed_at || incident.first_public_warning_at || incident.disclosed_at}T00:00:00Z`,
+        }
+      : incident
+  ),
+};
+const isoDwellRow = getSupplyChainIndexModel(isoDwellData).dwellTimeline.find((row) => row.id === isoDwellIncidentId);
+assert.ok(isoDwellRow && isoDwellRow.dwellDays >= 0, 'dwell timeline should parse ISO timestamp date anchors');
 assert.equal(index.explanatorySections.length, 4, 'index should include explanatory sections');
 assert.equal(index.featuredIncidents.length, 5, 'index should include five featured incidents');
 assert.deepEqual(

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -60,6 +60,34 @@ assert.equal(index.counts.buildSystems, data.entities.build_systems.length, 'ind
 assert.equal(index.counts.distributionChannels, data.entities.distribution_channels.length, 'index should expose distribution channel count');
 assert.ok(/supply chain/i.test(index.lede), 'index should include polished public copy');
 assert.ok(!JSON.stringify(index).includes('Canary'), 'public page model should not expose the internal codename');
+assert.equal(index.graphHero.status, 'Corpus graph preview', 'index should expose the G1 graph placeholder state');
+assert.ok(index.graphHero.nodeCount > data.incidents.length, 'graph hero should expose corpus node count');
+assert.equal(index.graphHero.relationshipCount, data.relationships.length, 'graph hero should expose relationship count');
+assert.ok(index.attackVectorBars.length > 0, 'index should include attack vector controls');
+assert.equal(
+  index.attackVectorBars.reduce((total, row) => total + row.count, 0),
+  data.incidents.length,
+  'attack vector bars should cover all incidents'
+);
+index.attackVectorBars.forEach((row) => {
+  assert.equal(row.command.type, 'filter-stage', `attack vector should include graph filter command: ${row.stage}`);
+  assert.ok(row.percent >= 8 && row.percent <= 100, `attack vector width should be bounded: ${row.stage}`);
+  assert.ok(row.incidents.length === row.count, `attack vector incident list should match count: ${row.stage}`);
+});
+assert.ok(index.attributionRows.length > 0, 'index should include attribution rows');
+index.attributionRows.forEach((row) => {
+  assert.equal(row.command.type, 'select-actor', `attribution row should include graph select command: ${row.id}`);
+  assert.ok(row.incidentCount > 0, `attribution row should be backed by incidents: ${row.id}`);
+});
+assert.ok(index.dwellTimeline.length > 0, 'index should include dwell timeline rows');
+index.dwellTimeline.forEach((row) => {
+  assert.equal(row.command.type, 'select-incident', `dwell row should include graph select command: ${row.id}`);
+  assert.ok(row.dwellDays >= 0, `dwell row should expose non-negative dwell days: ${row.id}`);
+  assert.ok(row.barPercent >= 6 && row.barPercent <= 100, `dwell bar width should be bounded: ${row.id}`);
+  assert.ok(row.warningPercent >= 0 && row.warningPercent <= 100, `warning marker should be bounded: ${row.id}`);
+  assert.ok(row.disclosedPercent >= 0 && row.disclosedPercent <= 100, `disclosure marker should be bounded: ${row.id}`);
+  assert.ok(routeUrls.has(row.href), `dwell incident route should resolve: ${row.href}`);
+});
 assert.equal(index.explanatorySections.length, 4, 'index should include explanatory sections');
 assert.equal(index.featuredIncidents.length, 5, 'index should include five featured incidents');
 assert.deepEqual(

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -63,6 +63,11 @@ assert.ok(!JSON.stringify(index).includes('Canary'), 'public page model should n
 assert.equal(index.graphHero.status, 'Corpus graph preview', 'index should expose the G1 graph placeholder state');
 assert.ok(index.graphHero.nodeCount > data.incidents.length, 'graph hero should expose corpus node count');
 assert.equal(index.graphHero.relationshipCount, data.relationships.length, 'graph hero should expose relationship count');
+assert.equal(index.incidents.length, data.incidents.length, 'index should expose every incident row');
+assert.ok(index.incidents.every((incident) => incident.summary), 'index incident rows should preserve summaries');
+index.incidents.forEach((incident) => {
+  assert.ok(routeUrls.has(incident.href), `index incident route should resolve: ${incident.href}`);
+});
 assert.ok(index.attackVectorBars.length > 0, 'index should include attack vector controls');
 assert.equal(
   index.attackVectorBars.reduce((total, row) => total + row.count, 0),
@@ -79,6 +84,34 @@ index.attributionRows.forEach((row) => {
   assert.equal(row.command.type, 'select-actor', `attribution row should include graph select command: ${row.id}`);
   assert.ok(row.incidentCount > 0, `attribution row should be backed by incidents: ${row.id}`);
 });
+const malformedAttributionData = {
+  ...data,
+  incidentByNodeId: undefined,
+  entities: {
+    ...data.entities,
+    actors: [{ ...data.entities.actors[0], source_incident_ids: 'not-an-array' }],
+    campaigns: [
+      { ...data.entities.campaigns[0], source_incident_ids: 'not-an-array' },
+      {
+        ...data.entities.campaigns[0],
+        id: 'campaign-missing-name',
+        name: null,
+        source_incident_ids: [data.entities.actors[0].source_incident_ids[0]],
+      },
+    ],
+  },
+};
+const malformedAttributionIndex = getSupplyChainIndexModel(malformedAttributionData);
+assert.ok(
+  malformedAttributionIndex.attributionRows.length > 0,
+  'attribution rows should resolve incident relationships without incidentByNodeId'
+);
+assert.ok(
+  malformedAttributionIndex.attributionRows.some((row) =>
+    row.campaigns.some((campaign) => campaign.id === 'campaign-missing-name' && campaign.label === 'campaign-missing-name')
+  ),
+  'attribution rows should fall back to campaign ID when a campaign name is missing'
+);
 assert.ok(index.dwellTimeline.length > 0, 'index should include dwell timeline rows');
 index.dwellTimeline.forEach((row) => {
   assert.equal(row.command.type, 'select-incident', `dwell row should include graph select command: ${row.id}`);
@@ -86,6 +119,7 @@ index.dwellTimeline.forEach((row) => {
   assert.ok(row.barPercent >= 6 && row.barPercent <= 100, `dwell bar width should be bounded: ${row.id}`);
   assert.ok(row.warningPercent >= 0 && row.warningPercent <= 100, `warning marker should be bounded: ${row.id}`);
   assert.ok(row.disclosedPercent >= 0 && row.disclosedPercent <= 100, `disclosure marker should be bounded: ${row.id}`);
+  assert.equal(row.disclosedPercent, row.barPercent, `disclosure marker should align with visible dwell bar: ${row.id}`);
   assert.ok(routeUrls.has(row.href), `dwell incident route should resolve: ${row.href}`);
 });
 assert.equal(index.explanatorySections.length, 4, 'index should include explanatory sections');

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -264,12 +264,14 @@ function normalizeEntitySlug(value) {
 
 function daysBetween(startDate, endDate) {
   if (!startDate || !endDate) return null;
-  const normalizedStartDate = String(startDate).includes('T') ? startDate : `${startDate}T00:00:00Z`;
-  const normalizedEndDate = String(endDate).includes('T') ? endDate : `${endDate}T00:00:00Z`;
-  const start = Date.parse(normalizedStartDate);
-  const end = Date.parse(normalizedEndDate);
+  const normalize = (value) => {
+    if (value instanceof Date) return value.toISOString().split('T')[0];
+    return String(value).split('T')[0];
+  };
+  const start = Date.parse(`${normalize(startDate)}T00:00:00Z`);
+  const end = Date.parse(`${normalize(endDate)}T00:00:00Z`);
   if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return null;
-  return Math.floor((end - start) / 86400000);
+  return Math.round((end - start) / 86400000);
 }
 
 function displayLabel(value) {

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -264,8 +264,10 @@ function normalizeEntitySlug(value) {
 
 function daysBetween(startDate, endDate) {
   if (!startDate || !endDate) return null;
-  const start = Date.parse(`${startDate}T00:00:00Z`);
-  const end = Date.parse(`${endDate}T00:00:00Z`);
+  const normalizedStartDate = String(startDate).includes('T') ? startDate : `${startDate}T00:00:00Z`;
+  const normalizedEndDate = String(endDate).includes('T') ? endDate : `${endDate}T00:00:00Z`;
+  const start = Date.parse(normalizedStartDate);
+  const end = Date.parse(normalizedEndDate);
   if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return null;
   return Math.floor((end - start) / 86400000);
 }
@@ -508,7 +510,7 @@ function editorialSectionsFor(incident) {
 }
 
 function buildGraphHeroModel(data) {
-  const incidents = Array.isArray(data?.incidents) ? data.incidents : [];
+  const incidents = Array.isArray(data?.incidents) ? data.incidents.filter(Boolean) : [];
   const entities = data?.entities && typeof data.entities === 'object' ? data.entities : {};
   const relationships = Array.isArray(data?.relationships) ? data.relationships : [];
   const nodeCount =
@@ -531,9 +533,9 @@ function buildGraphHeroModel(data) {
 }
 
 function buildAttackVectorBars(data) {
-  const incidents = Array.isArray(data?.incidents) ? data.incidents : [];
+  if (!Array.isArray(data?.incidents)) return [];
   const byStage = new Map();
-  incidents.forEach((incident) => {
+  data.incidents.filter(Boolean).forEach((incident) => {
     const stage = incident.attack_stage || 'unknown';
     const existing = byStage.get(stage) || {
       stage,
@@ -569,16 +571,17 @@ function buildAttributionRows(data) {
     return [];
   }
 
-  const incidentById = new Map(data.incidents.map((incident) => [incident.id, incident]));
+  const incidents = data.incidents.filter(Boolean);
+  const incidentById = new Map(incidents.map((incident) => [incident.id, incident]));
   const attributedRelationshipsByActor = new Map();
-  data.relationships.forEach((relationship) => {
+  data.relationships.filter(Boolean).forEach((relationship) => {
     if (relationship.type !== 'ATTRIBUTED_TO_ACTOR') return;
     const actorRelationships = attributedRelationshipsByActor.get(relationship.target) || [];
     actorRelationships.push(relationship);
     attributedRelationshipsByActor.set(relationship.target, actorRelationships);
   });
   const campaignsByIncidentId = new Map();
-  data.entities.campaigns.forEach((campaign) => {
+  data.entities.campaigns.filter(Boolean).forEach((campaign) => {
     const campaignIncidentIds = Array.isArray(campaign.source_incident_ids) ? campaign.source_incident_ids : [];
     campaignIncidentIds.forEach((incidentId) => {
       const campaigns = campaignsByIncidentId.get(incidentId) || [];
@@ -588,6 +591,7 @@ function buildAttributionRows(data) {
   });
 
   return data.entities.actors
+    .filter(Boolean)
     .map((actor) => {
       const incidentIds = new Set(Array.isArray(actor.source_incident_ids) ? actor.source_incident_ids : []);
       (attributedRelationshipsByActor.get(actor.id) || []).forEach((relationship) => {
@@ -598,14 +602,14 @@ function buildAttributionRows(data) {
             : null);
         if (incident) incidentIds.add(incident.id);
       });
-      const incidents = Array.from(incidentIds)
+      const actorIncidents = Array.from(incidentIds)
         .map((id) => incidentById.get(id))
         .filter(Boolean)
         .map((incident) => incidentLinkRow(incident))
         .sort(compareDateDesc);
       const campaignSet = new Set();
-      incidentIds.forEach((incidentId) => {
-        (campaignsByIncidentId.get(incidentId) || []).forEach((campaign) => {
+      actorIncidents.forEach((incident) => {
+        (campaignsByIncidentId.get(incident.id) || []).forEach((campaign) => {
           campaignSet.add(campaign);
         });
       });
@@ -618,12 +622,12 @@ function buildAttributionRows(data) {
         .sort(compareLabel);
       return {
         id: actor.id,
-        label: actor.name,
+        label: actor.name || actor.id,
         href: actor.href || null,
         confidence: actor.attribution_confidence || 'unknown',
         actorType: actor.actor_type || 'unknown',
-        incidentCount: incidents.length,
-        incidents,
+        incidentCount: actorIncidents.length,
+        incidents: actorIncidents,
         campaigns,
         command: { type: 'select-actor', value: actor.id },
       };
@@ -633,8 +637,9 @@ function buildAttributionRows(data) {
 }
 
 function buildDwellTimeline(data) {
-  const incidents = Array.isArray(data?.incidents) ? data.incidents : [];
-  const rows = incidents
+  if (!Array.isArray(data?.incidents)) return [];
+  const rows = data.incidents
+    .filter(Boolean)
     .map((incident) => {
       const startDate = incident.first_observed_at || incident.first_public_warning_at || incident.disclosed_at;
       const warningDate = incident.first_public_warning_at || incident.disclosed_at;
@@ -659,19 +664,24 @@ function buildDwellTimeline(data) {
   const maxDays = Math.max(...rows.map((row) => row.dwellDays), 1);
   return rows.map((row) => {
     const rawDwellPercent = Math.min(100, Math.max(0, Math.round((row.dwellDays / maxDays) * 100)));
+    const rawWarningPercent = Math.min(100, Math.max(0, Math.round((row.warningDays / maxDays) * 100)));
     const barPercent = Math.max(6, rawDwellPercent);
+    const warningPercent = row.warningDays === row.dwellDays ? barPercent : Math.min(barPercent, rawWarningPercent);
     return {
       ...row,
       barPercent,
-      warningPercent: Math.min(100, Math.max(0, Math.round((row.warningDays / maxDays) * 100))),
+      warningPercent,
       disclosedPercent: barPercent,
     };
   });
 }
 
 export function getSupplyChainIndexModel(data = loadSupplyChainData()) {
+  const incidents = Array.isArray(data?.incidents) ? data.incidents.filter(Boolean) : [];
+  const entities = data?.entities && typeof data.entities === 'object' ? data.entities : {};
+  const relationships = Array.isArray(data?.relationships) ? data.relationships : [];
   const featuredIncidents = SUPPLY_CHAIN_FEATURED_INCIDENT_IDS.map((id) => {
-    const incident = data.incidents.find((item) => item.id === id);
+    const incident = incidents.find((item) => item.id === id);
     if (!incident) throw new Error(`Featured Supply Chain incident not found: ${id}`);
     return {
       id: incident.id,
@@ -683,7 +693,7 @@ export function getSupplyChainIndexModel(data = loadSupplyChainData()) {
       confidence: incident.confidence,
     };
   });
-  const incidents = data.incidents
+  const incidentRows = incidents
     .map((incident) => ({
       ...incidentLinkRow(incident),
       summary: incident.summary,
@@ -702,7 +712,7 @@ export function getSupplyChainIndexModel(data = loadSupplyChainData()) {
     featuredIncidents,
     entitySummaries: entitySummaryDefinitions.map((summary) => ({
       ...summary,
-      count: data.entities[summary.key]?.length || 0,
+      count: Array.isArray(entities[summary.key]) ? entities[summary.key].length : 0,
     })),
     seo: {
       title: 'Supply Chain',
@@ -719,18 +729,18 @@ export function getSupplyChainIndexModel(data = loadSupplyChainData()) {
       },
     },
     counts: {
-      incidents: data.incidents.length,
-      packages: data.entities.packages.length,
-      releases: data.entities.releases.length,
-      repositories: data.entities.repositories.length,
-      organizations: data.entities.organizations.length,
-      maintainers: data.entities.maintainers.length,
-      buildSystems: data.entities.build_systems.length,
-      distributionChannels: data.entities.distribution_channels.length,
-      compromisedAccounts: data.entities.accounts.length,
-      relationships: data.relationships.length,
+      incidents: incidents.length,
+      packages: Array.isArray(entities.packages) ? entities.packages.length : 0,
+      releases: Array.isArray(entities.releases) ? entities.releases.length : 0,
+      repositories: Array.isArray(entities.repositories) ? entities.repositories.length : 0,
+      organizations: Array.isArray(entities.organizations) ? entities.organizations.length : 0,
+      maintainers: Array.isArray(entities.maintainers) ? entities.maintainers.length : 0,
+      buildSystems: Array.isArray(entities.build_systems) ? entities.build_systems.length : 0,
+      distributionChannels: Array.isArray(entities.distribution_channels) ? entities.distribution_channels.length : 0,
+      compromisedAccounts: Array.isArray(entities.accounts) ? entities.accounts.length : 0,
+      relationships: relationships.length,
     },
-    incidents,
+    incidents: incidentRows,
   };
 }
 

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -250,6 +250,10 @@ function compareTitle(a, b) {
   return (a.title || '').localeCompare(b.title || '');
 }
 
+function compareDateDesc(a, b) {
+  return (b.sortDate || '').localeCompare(a.sortDate || '') || compareTitle(a, b);
+}
+
 function normalizeEntitySlug(value) {
   return String(value || '')
     .trim()
@@ -264,6 +268,42 @@ function daysBetween(startDate, endDate) {
   const end = Date.parse(`${endDate}T00:00:00Z`);
   if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return null;
   return Math.floor((end - start) / 86400000);
+}
+
+function displayLabel(value) {
+  if (value === 'ci_cd_compromise') return 'CI/CD Compromise';
+  return String(value || 'unknown')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function severityForAttackStage(stage) {
+  const stageSeverity = {
+    build_compromise: 'critical',
+    ci_cd_compromise: 'critical',
+    source_compromise: 'high',
+    account_compromise: 'high',
+    dependency_resolution: 'high',
+    package_publish: 'medium',
+    distribution_compromise: 'medium',
+  };
+  return stageSeverity[stage] || 'medium';
+}
+
+function incidentSortDate(incident) {
+  return incident.disclosed_at || incident.first_public_warning_at || incident.first_observed_at || '';
+}
+
+function incidentLinkRow(incident) {
+  return {
+    id: incident.id,
+    title: incident.title,
+    href: `/supply-chain/incidents/${incident.id}/`,
+    attackStage: incident.attack_stage,
+    evidenceLevel: incident.evidence_level,
+    confidence: incident.confidence,
+    sortDate: incidentSortDate(incident),
+  };
 }
 
 function incidentLinksFor(data, entityId) {
@@ -467,6 +507,121 @@ function editorialSectionsFor(incident) {
     .filter(Boolean);
 }
 
+function buildGraphHeroModel(data) {
+  const nodeCount =
+    data.incidents.length + Object.values(data.entities).reduce((total, collection) => total + collection.length, 0);
+  const latestIncident = data.incidents
+    .map((incident) => incidentLinkRow(incident))
+    .sort(compareDateDesc)[0];
+  return {
+    title: 'Supply Chain',
+    eyebrow: 'Corpus Graph',
+    summary:
+      'A graph-first view of curated supply chain incidents and the packages, repositories, organizations, maintainers, actors, campaigns, releases, and accounts connected by evidence.',
+    status: 'Corpus graph preview',
+    nodeCount,
+    relationshipCount: data.relationships.length,
+    latestIncident,
+  };
+}
+
+function buildAttackVectorBars(data) {
+  const byStage = new Map();
+  data.incidents.forEach((incident) => {
+    const stage = incident.attack_stage || 'unknown';
+    const existing = byStage.get(stage) || {
+      stage,
+      label: displayLabel(stage),
+      count: 0,
+      incidents: [],
+      severity: severityForAttackStage(stage),
+    };
+    existing.count += 1;
+    existing.incidents.push(incidentLinkRow(incident));
+    byStage.set(stage, existing);
+  });
+  const maxCount = Math.max(...Array.from(byStage.values()).map((row) => row.count), 1);
+  return Array.from(byStage.values())
+    .map((row) => ({
+      ...row,
+      incidents: row.incidents.sort(compareDateDesc),
+      percent: Math.max(8, Math.round((row.count / maxCount) * 100)),
+      command: { type: 'filter-stage', value: row.stage },
+    }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+}
+
+function buildAttributionRows(data) {
+  return data.entities.actors
+    .map((actor) => {
+      const incidentIds = new Set(actor.source_incident_ids || []);
+      data.relationships
+        .filter((relationship) => relationship.type === 'ATTRIBUTED_TO_ACTOR' && relationship.target === actor.id)
+        .forEach((relationship) => {
+          const incident = data.incidentByNodeId.get(relationship.source);
+          if (incident) incidentIds.add(incident.id);
+        });
+      const incidents = Array.from(incidentIds)
+        .map((id) => data.incidents.find((incident) => incident.id === id))
+        .filter(Boolean)
+        .map((incident) => incidentLinkRow(incident))
+        .sort(compareDateDesc);
+      const campaigns = data.entities.campaigns
+        .filter((campaign) => (campaign.source_incident_ids || []).some((id) => incidentIds.has(id)))
+        .map((campaign) => ({
+          id: campaign.id,
+          label: campaign.name,
+          href: campaign.href || (campaign.slug ? `/campaigns/${campaign.slug}/` : null),
+        }))
+        .sort(compareLabel);
+      return {
+        id: actor.id,
+        label: actor.name,
+        href: actor.href || null,
+        confidence: actor.attribution_confidence || 'unknown',
+        actorType: actor.actor_type || 'unknown',
+        incidentCount: incidents.length,
+        incidents,
+        campaigns,
+        command: { type: 'select-actor', value: actor.id },
+      };
+    })
+    .filter((row) => row.incidentCount > 0)
+    .sort((a, b) => b.incidentCount - a.incidentCount || a.label.localeCompare(b.label));
+}
+
+function buildDwellTimeline(data) {
+  const rows = data.incidents
+    .map((incident) => {
+      const startDate = incident.first_observed_at || incident.first_public_warning_at || incident.disclosed_at;
+      const warningDate = incident.first_public_warning_at || incident.disclosed_at;
+      const disclosedDate = incident.disclosed_at;
+      const dwellDays = daysBetween(startDate, disclosedDate);
+      if (!startDate || !disclosedDate || dwellDays === null) return null;
+      const warningDays = daysBetween(startDate, warningDate);
+      return {
+        ...incidentLinkRow(incident),
+        startDate,
+        warningDate,
+        disclosedDate,
+        dwellDays,
+        warningDays: warningDays ?? dwellDays,
+        severity: severityForAttackStage(incident.attack_stage),
+        command: { type: 'select-incident', value: incident.id },
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.dwellDays - a.dwellDays || compareDateDesc(a, b))
+    .slice(0, 12);
+  const maxDays = Math.max(...rows.map((row) => row.dwellDays), 1);
+  return rows.map((row) => ({
+    ...row,
+    barPercent: Math.max(6, Math.round((row.dwellDays / maxDays) * 100)),
+    warningPercent: Math.min(100, Math.max(0, Math.round((row.warningDays / maxDays) * 100))),
+    disclosedPercent: Math.min(100, Math.max(0, Math.round((row.dwellDays / maxDays) * 100))),
+  }));
+}
+
 export function getSupplyChainIndexModel(data = loadSupplyChainData()) {
   const featuredIncidents = SUPPLY_CHAIN_FEATURED_INCIDENT_IDS.map((id) => {
     const incident = data.incidents.find((item) => item.id === id);
@@ -481,12 +636,17 @@ export function getSupplyChainIndexModel(data = loadSupplyChainData()) {
       confidence: incident.confidence,
     };
   });
+  const incidents = data.incidents.map((incident) => incidentLinkRow(incident)).sort(compareTitle);
 
   return {
     kind: 'index',
     title: 'Supply Chain',
+    graphHero: buildGraphHeroModel(data),
     lede: SUPPLY_CHAIN_INDEX_COPY.lede,
     explanatorySections: SUPPLY_CHAIN_INDEX_COPY.sections,
+    attackVectorBars: buildAttackVectorBars(data),
+    attributionRows: buildAttributionRows(data),
+    dwellTimeline: buildDwellTimeline(data),
     featuredIncidents,
     entitySummaries: entitySummaryDefinitions.map((summary) => ({
       ...summary,
@@ -518,16 +678,7 @@ export function getSupplyChainIndexModel(data = loadSupplyChainData()) {
       compromisedAccounts: data.entities.accounts.length,
       relationships: data.relationships.length,
     },
-    incidents: data.incidents
-      .map((incident) => ({
-        id: incident.id,
-        title: incident.title,
-        summary: incident.summary,
-        href: `/supply-chain/incidents/${incident.id}/`,
-        attackStage: incident.attack_stage,
-        evidenceLevel: incident.evidence_level,
-      }))
-      .sort(compareTitle),
+    incidents,
   };
 }
 

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -508,11 +508,16 @@ function editorialSectionsFor(incident) {
 }
 
 function buildGraphHeroModel(data) {
+  const incidents = Array.isArray(data?.incidents) ? data.incidents : [];
+  const entities = data?.entities && typeof data.entities === 'object' ? data.entities : {};
+  const relationships = Array.isArray(data?.relationships) ? data.relationships : [];
   const nodeCount =
-    data.incidents.length + Object.values(data.entities).reduce((total, collection) => total + collection.length, 0);
-  const latestIncident = data.incidents
-    .map((incident) => incidentLinkRow(incident))
-    .sort(compareDateDesc)[0];
+    incidents.length +
+    Object.values(entities).reduce((total, collection) => total + (Array.isArray(collection) ? collection.length : 0), 0);
+  const latestIncident =
+    incidents.length > 0
+      ? incidents.map((incident) => incidentLinkRow(incident)).sort(compareDateDesc)[0] || null
+      : null;
   return {
     title: 'Supply Chain',
     eyebrow: 'Corpus Graph',
@@ -520,14 +525,15 @@ function buildGraphHeroModel(data) {
       'A graph-first view of curated supply chain incidents and the packages, repositories, organizations, maintainers, actors, campaigns, releases, and accounts connected by evidence.',
     status: 'Corpus graph preview',
     nodeCount,
-    relationshipCount: data.relationships.length,
+    relationshipCount: relationships.length,
     latestIncident,
   };
 }
 
 function buildAttackVectorBars(data) {
+  const incidents = Array.isArray(data?.incidents) ? data.incidents : [];
   const byStage = new Map();
-  data.incidents.forEach((incident) => {
+  incidents.forEach((incident) => {
     const stage = incident.attack_stage || 'unknown';
     const existing = byStage.get(stage) || {
       stage,
@@ -548,29 +554,65 @@ function buildAttackVectorBars(data) {
       percent: Math.max(8, Math.round((row.count / maxCount) * 100)),
       command: { type: 'filter-stage', value: row.stage },
     }))
-    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+    .sort((a, b) => b.count - a.count || compareLabel(a, b));
 }
 
 function buildAttributionRows(data) {
+  if (
+    !data ||
+    !Array.isArray(data.relationships) ||
+    !Array.isArray(data.incidents) ||
+    !data.entities ||
+    !Array.isArray(data.entities.actors) ||
+    !Array.isArray(data.entities.campaigns)
+  ) {
+    return [];
+  }
+
+  const incidentById = new Map(data.incidents.map((incident) => [incident.id, incident]));
+  const attributedRelationshipsByActor = new Map();
+  data.relationships.forEach((relationship) => {
+    if (relationship.type !== 'ATTRIBUTED_TO_ACTOR') return;
+    const actorRelationships = attributedRelationshipsByActor.get(relationship.target) || [];
+    actorRelationships.push(relationship);
+    attributedRelationshipsByActor.set(relationship.target, actorRelationships);
+  });
+  const campaignsByIncidentId = new Map();
+  data.entities.campaigns.forEach((campaign) => {
+    const campaignIncidentIds = Array.isArray(campaign.source_incident_ids) ? campaign.source_incident_ids : [];
+    campaignIncidentIds.forEach((incidentId) => {
+      const campaigns = campaignsByIncidentId.get(incidentId) || [];
+      campaigns.push(campaign);
+      campaignsByIncidentId.set(incidentId, campaigns);
+    });
+  });
+
   return data.entities.actors
     .map((actor) => {
-      const incidentIds = new Set(actor.source_incident_ids || []);
-      data.relationships
-        .filter((relationship) => relationship.type === 'ATTRIBUTED_TO_ACTOR' && relationship.target === actor.id)
-        .forEach((relationship) => {
-          const incident = data.incidentByNodeId.get(relationship.source);
-          if (incident) incidentIds.add(incident.id);
-        });
+      const incidentIds = new Set(Array.isArray(actor.source_incident_ids) ? actor.source_incident_ids : []);
+      (attributedRelationshipsByActor.get(actor.id) || []).forEach((relationship) => {
+        const incident =
+          data.incidentByNodeId?.get(relationship.source) ||
+          (typeof relationship.source === 'string' && relationship.source.startsWith('incident-')
+            ? incidentById.get(relationship.source.slice('incident-'.length))
+            : null);
+        if (incident) incidentIds.add(incident.id);
+      });
       const incidents = Array.from(incidentIds)
-        .map((id) => data.incidents.find((incident) => incident.id === id))
+        .map((id) => incidentById.get(id))
         .filter(Boolean)
         .map((incident) => incidentLinkRow(incident))
         .sort(compareDateDesc);
-      const campaigns = data.entities.campaigns
-        .filter((campaign) => (campaign.source_incident_ids || []).some((id) => incidentIds.has(id)))
+      const campaignSet = new Set();
+      incidentIds.forEach((incidentId) => {
+        (campaignsByIncidentId.get(incidentId) || []).forEach((campaign) => {
+          campaignSet.add(campaign);
+        });
+      });
+      const campaigns = Array.from(campaignSet)
         .map((campaign) => ({
           id: campaign.id,
-          label: campaign.name,
+          label: campaign.name || campaign.id,
           href: campaign.href || (campaign.slug ? `/campaigns/${campaign.slug}/` : null),
         }))
         .sort(compareLabel);
@@ -587,11 +629,12 @@ function buildAttributionRows(data) {
       };
     })
     .filter((row) => row.incidentCount > 0)
-    .sort((a, b) => b.incidentCount - a.incidentCount || a.label.localeCompare(b.label));
+    .sort((a, b) => b.incidentCount - a.incidentCount || compareLabel(a, b));
 }
 
 function buildDwellTimeline(data) {
-  const rows = data.incidents
+  const incidents = Array.isArray(data?.incidents) ? data.incidents : [];
+  const rows = incidents
     .map((incident) => {
       const startDate = incident.first_observed_at || incident.first_public_warning_at || incident.disclosed_at;
       const warningDate = incident.first_public_warning_at || incident.disclosed_at;
@@ -614,12 +657,16 @@ function buildDwellTimeline(data) {
     .sort((a, b) => b.dwellDays - a.dwellDays || compareDateDesc(a, b))
     .slice(0, 12);
   const maxDays = Math.max(...rows.map((row) => row.dwellDays), 1);
-  return rows.map((row) => ({
-    ...row,
-    barPercent: Math.max(6, Math.round((row.dwellDays / maxDays) * 100)),
-    warningPercent: Math.min(100, Math.max(0, Math.round((row.warningDays / maxDays) * 100))),
-    disclosedPercent: Math.min(100, Math.max(0, Math.round((row.dwellDays / maxDays) * 100))),
-  }));
+  return rows.map((row) => {
+    const rawDwellPercent = Math.min(100, Math.max(0, Math.round((row.dwellDays / maxDays) * 100)));
+    const barPercent = Math.max(6, rawDwellPercent);
+    return {
+      ...row,
+      barPercent,
+      warningPercent: Math.min(100, Math.max(0, Math.round((row.warningDays / maxDays) * 100))),
+      disclosedPercent: barPercent,
+    };
+  });
 }
 
 export function getSupplyChainIndexModel(data = loadSupplyChainData()) {
@@ -636,7 +683,12 @@ export function getSupplyChainIndexModel(data = loadSupplyChainData()) {
       confidence: incident.confidence,
     };
   });
-  const incidents = data.incidents.map((incident) => incidentLinkRow(incident)).sort(compareTitle);
+  const incidents = data.incidents
+    .map((incident) => ({
+      ...incidentLinkRow(incident),
+      summary: incident.summary,
+    }))
+    .sort(compareTitle);
 
   return {
     kind: 'index',

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -23,6 +23,18 @@ function titleCase(value) {
   return label(value).replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
+function compactNumber(value) {
+  return new Intl.NumberFormat('en-US', { notation: 'compact', maximumFractionDigits: 1 }).format(value || 0);
+}
+
+function percentStyle(value) {
+  return `--bar:${value || 0}%;`;
+}
+
+function severityClass(value) {
+  return `severity-${value || 'medium'}`;
+}
+
 function referenceLabel(reference) {
   return `${reference.publisher}: ${reference.title}`;
 }
@@ -46,16 +58,49 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
   jsonLd={jsonLd}
 >
   {page.kind === 'index' && (
-    <section class="supply-chain-page">
-      <header class="sc-header">
-        <p class="eyebrow">Threatpedia</p>
-        <h1>Supply Chain</h1>
-        <p class="lede">{page.lede}</p>
-      </header>
+    <section class="supply-chain-page supply-chain-index">
+      <section class="graph-hero" aria-labelledby="supply-chain-title">
+        <div class="hero-copy">
+          <p class="eyebrow">{page.graphHero.eyebrow}</p>
+          <h1 id="supply-chain-title">Supply Chain</h1>
+          <p class="lede">{page.graphHero.summary}</p>
+          <div class="hero-meta" aria-label="Supply Chain graph summary">
+            <span>{compactNumber(page.graphHero.nodeCount)} nodes</span>
+            <span>{compactNumber(page.graphHero.relationshipCount)} edges</span>
+            {page.graphHero.latestIncident && <span>Latest: {page.graphHero.latestIncident.sortDate}</span>}
+          </div>
+        </div>
+        <div class="graph-placeholder" role="img" aria-label="Static preview of the Supply Chain corpus graph">
+          <div class="graph-status">
+            <span>{page.graphHero.status}</span>
+            <span>Actors to releases</span>
+          </div>
+          <div class="graph-field" aria-hidden="true">
+            <span class="lane lane-actor"></span>
+            <span class="lane lane-campaign"></span>
+            <span class="lane lane-incident"></span>
+            <span class="lane lane-package"></span>
+            <span class="edge edge-one"></span>
+            <span class="edge edge-two"></span>
+            <span class="edge edge-three"></span>
+            <span class="node node-actor">Actor</span>
+            <span class="node node-campaign">Campaign</span>
+            <span class="node node-incident">Incident</span>
+            <span class="node node-package">Package</span>
+            <span class="node node-release">Release</span>
+            <span class="node node-org">Org</span>
+          </div>
+          <div class="graph-caption">
+            <strong>{page.graphHero.latestIncident?.title}</strong>
+            <span>{page.graphHero.latestIncident ? titleCase(page.graphHero.latestIncident.attackStage) : 'Corpus ready'}</span>
+          </div>
+        </div>
+      </section>
 
-      <section class="metric-grid" aria-label="Supply Chain corpus counts">
+      <section class="metric-grid stat-strip" aria-label="Supply Chain corpus counts">
         <div><span>{page.counts.incidents}</span><p>Incidents</p></div>
         <div><span>{page.counts.packages}</span><p>Packages</p></div>
+        <div><span>{page.counts.releases}</span><p>Releases</p></div>
         <div><span>{page.counts.repositories}</span><p>Repositories</p></div>
         <div><span>{page.counts.organizations}</span><p>Organizations</p></div>
         <div><span>{page.counts.maintainers}</span><p>Maintainers</p></div>
@@ -65,20 +110,87 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
         <div><span>{page.counts.relationships}</span><p>Relationships</p></div>
       </section>
 
-      <section class="copy-grid" aria-label="Supply Chain explanation">
-        {page.explanatorySections.map((section) => (
-          <article class="info-panel">
-            <h2>{section.title}</h2>
-            <p>{section.body}</p>
-          </article>
-        ))}
+      <section class="viz-grid" aria-label="Supply Chain corpus controls">
+        <section class="viz-panel attack-panel">
+          <div class="panel-heading">
+            <p class="eyebrow">How They Got In</p>
+            <h2>Attack Vectors</h2>
+          </div>
+          <div class="attack-bars">
+            {page.attackVectorBars.map((row) => (
+              <button
+                type="button"
+                class={`attack-bar ${severityClass(row.severity)}`}
+                style={percentStyle(row.percent)}
+                data-graph-command={row.command.type}
+                data-graph-value={row.command.value}
+              >
+                <span>{row.label}</span>
+                <strong>{row.count}</strong>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section class="viz-panel attribution-panel">
+          <div class="panel-heading">
+            <p class="eyebrow">Who Is Connected</p>
+            <h2>Attribution</h2>
+          </div>
+          <div class="attribution-list">
+            {page.attributionRows.map((row) => (
+              <a
+                class="attribution-row"
+                href={row.href || '#supply-chain-title'}
+                data-graph-command={row.command.type}
+                data-graph-value={row.command.value}
+              >
+                <span class="confidence-dot" data-confidence={row.confidence}></span>
+                <span>
+                  <strong>{row.label}</strong>
+                  <em>{titleCase(row.confidence)} confidence</em>
+                </span>
+                <b>{row.incidentCount}</b>
+              </a>
+            ))}
+          </div>
+        </section>
+
+        <section class="viz-panel dwell-panel">
+          <div class="panel-heading">
+            <p class="eyebrow">Warning To Disclosure</p>
+            <h2>Dwell Timeline</h2>
+          </div>
+          <div class="dwell-list">
+            {page.dwellTimeline.map((row) => (
+              <a
+                class={`dwell-row ${severityClass(row.severity)}`}
+                href={row.href}
+                style={percentStyle(row.barPercent)}
+                data-graph-command={row.command.type}
+                data-graph-value={row.command.value}
+              >
+                <span class="dwell-title">{row.title}</span>
+                <span class="dwell-track">
+                  <i class="dwell-fill"></i>
+                  <i class="dwell-marker warning" style={`left:${row.warningPercent}%;`}></i>
+                  <i class="dwell-marker disclosed" style={`left:${row.disclosedPercent}%;`}></i>
+                </span>
+                <span class="dwell-days">{row.dwellDays}d</span>
+              </a>
+            ))}
+          </div>
+        </section>
       </section>
 
-      <section class="sc-section">
-        <h2>Featured Incidents</h2>
+      <section class="sc-section featured-section">
+        <div class="section-heading">
+          <p class="eyebrow">Featured Cases</p>
+          <h2>Incident Cards</h2>
+        </div>
         <div class="featured-grid">
           {page.featuredIncidents.map((incident) => (
-            <article class="incident-card">
+            <article class="incident-card" data-graph-command="select-incident" data-graph-value={incident.id}>
               <a href={incident.href}>{incident.title}</a>
               <p>{incident.summary}</p>
               <div class="card-meta">
@@ -91,8 +203,20 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
         </div>
       </section>
 
+      <section class="copy-grid" aria-label="Supply Chain explanation">
+        {page.explanatorySections.map((section) => (
+          <article class="info-panel">
+            <h2>{section.title}</h2>
+            <p>{section.body}</p>
+          </article>
+        ))}
+      </section>
+
       <section class="sc-section">
-        <h2>Entity Summary</h2>
+        <div class="section-heading">
+          <p class="eyebrow">Corpus Shape</p>
+          <h2>Entity Summary</h2>
+        </div>
         <div class="entity-summary-grid">
           {page.entitySummaries.map((entity) => (
             <article class="entity-card">
@@ -101,32 +225,6 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
               <p>{entity.description}</p>
             </article>
           ))}
-        </div>
-      </section>
-
-      <section class="sc-section">
-        <h2>Incidents</h2>
-        <div class="table-wrap">
-          <table>
-            <thead>
-              <tr>
-                <th>ID</th>
-                <th>Name</th>
-                <th>Attack Stage</th>
-                <th>Evidence</th>
-              </tr>
-            </thead>
-            <tbody>
-              {page.incidents.map((incident) => (
-                <tr>
-                  <td><span class="mono">{incident.id}</span></td>
-                  <td><a href={incident.href}>{incident.title}</a></td>
-                  <td>{titleCase(incident.attackStage)}</td>
-                  <td>{titleCase(incident.evidenceLevel)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
         </div>
       </section>
     </section>
@@ -307,6 +405,429 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
     max-width: 1180px;
   }
 
+  .supply-chain-index {
+    max-width: 1240px;
+  }
+
+  .graph-hero {
+    display: grid;
+    grid-template-columns: minmax(280px, 0.72fr) minmax(420px, 1.28fr);
+    gap: 24px;
+    min-height: 520px;
+    align-items: stretch;
+    margin-bottom: 18px;
+  }
+
+  .hero-copy {
+    align-self: center;
+    padding: 24px 0;
+  }
+
+  .hero-copy h1 {
+    margin: 0 0 14px;
+    border-bottom: none;
+    color: var(--white);
+    font-size: clamp(2.6rem, 5vw, 5.4rem);
+    line-height: 0.95;
+    padding-bottom: 0;
+  }
+
+  .hero-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 24px;
+  }
+
+  .hero-meta span,
+  .graph-status span,
+  .graph-caption span {
+    border: 1px solid var(--border);
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.12em;
+    padding: 6px 8px;
+    text-transform: uppercase;
+  }
+
+  .graph-placeholder {
+    position: relative;
+    overflow: hidden;
+    min-height: 500px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background:
+      linear-gradient(rgba(232, 160, 32, 0.06) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(232, 160, 32, 0.05) 1px, transparent 1px),
+      radial-gradient(circle at 28% 32%, rgba(255, 68, 68, 0.11), transparent 22%),
+      radial-gradient(circle at 72% 58%, rgba(232, 160, 32, 0.13), transparent 28%),
+      var(--surface);
+    background-size: 42px 42px, 42px 42px, auto, auto, auto;
+  }
+
+  .graph-status,
+  .graph-caption {
+    position: absolute;
+    z-index: 4;
+    display: flex;
+    gap: 8px;
+  }
+
+  .graph-status {
+    top: 16px;
+    left: 16px;
+  }
+
+  .graph-caption {
+    right: 16px;
+    bottom: 16px;
+    align-items: center;
+    max-width: min(440px, calc(100% - 32px));
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: rgba(8, 11, 16, 0.82);
+    padding: 10px;
+  }
+
+  .graph-caption strong {
+    color: var(--white);
+    font-family: var(--font-serif);
+    font-size: 1rem;
+    line-height: 1.25;
+  }
+
+  .graph-caption span {
+    flex: 0 0 auto;
+  }
+
+  .graph-field {
+    position: absolute;
+    inset: 62px 22px 70px;
+  }
+
+  .lane,
+  .edge,
+  .node {
+    position: absolute;
+    display: block;
+  }
+
+  .lane {
+    left: 2%;
+    right: 2%;
+    height: 1px;
+    background: rgba(90, 106, 126, 0.28);
+  }
+
+  .lane-actor { top: 18%; }
+  .lane-campaign { top: 36%; }
+  .lane-incident { top: 56%; }
+  .lane-package { top: 76%; }
+
+  .edge {
+    height: 1px;
+    transform-origin: left center;
+    background: rgba(232, 160, 32, 0.38);
+  }
+
+  .edge-one {
+    top: 23%;
+    left: 17%;
+    width: 38%;
+    transform: rotate(17deg);
+  }
+
+  .edge-two {
+    top: 49%;
+    left: 40%;
+    width: 31%;
+    transform: rotate(23deg);
+  }
+
+  .edge-three {
+    top: 70%;
+    left: 52%;
+    width: 28%;
+    border-top: 1px dashed rgba(232, 160, 32, 0.42);
+    background: transparent;
+    transform: rotate(-13deg);
+  }
+
+  .node {
+    min-width: 82px;
+    border: 1px solid rgba(232, 160, 32, 0.55);
+    border-radius: 999px;
+    background: rgba(13, 17, 23, 0.92);
+    color: var(--text);
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    letter-spacing: 0.14em;
+    padding: 8px 10px;
+    text-align: center;
+    text-transform: uppercase;
+    box-shadow: 0 0 28px rgba(232, 160, 32, 0.08);
+  }
+
+  .node-actor {
+    top: 11%;
+    left: 8%;
+    border-color: var(--severity-critical);
+  }
+
+  .node-campaign {
+    top: 31%;
+    left: 45%;
+  }
+
+  .node-incident {
+    top: 51%;
+    left: 62%;
+    border-color: var(--severity-high);
+    color: var(--white);
+  }
+
+  .node-package {
+    top: 73%;
+    left: 43%;
+  }
+
+  .node-release {
+    top: 64%;
+    left: 78%;
+    border-color: var(--severity-medium);
+  }
+
+  .node-org {
+    top: 80%;
+    left: 68%;
+    border-color: var(--severity-low);
+  }
+
+  .stat-strip {
+    margin-bottom: 24px;
+  }
+
+  .viz-grid {
+    display: grid;
+    grid-template-columns: minmax(280px, 1.05fr) minmax(250px, 0.75fr);
+    gap: 16px;
+    margin: 24px 0;
+  }
+
+  .viz-panel {
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--surface);
+    padding: 16px;
+  }
+
+  .dwell-panel {
+    grid-column: 1 / -1;
+  }
+
+  .panel-heading,
+  .section-heading {
+    margin-bottom: 14px;
+  }
+
+  .panel-heading h2,
+  .section-heading h2 {
+    margin: 0;
+    border-bottom: none;
+    color: var(--white);
+    font-size: 1rem;
+    letter-spacing: 0.08em;
+    padding-bottom: 0;
+    text-transform: uppercase;
+  }
+
+  .attack-bars,
+  .attribution-list,
+  .dwell-list {
+    display: grid;
+    gap: 10px;
+  }
+
+  .attack-bar,
+  .attribution-row,
+  .dwell-row {
+    position: relative;
+    min-height: 48px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: rgba(8, 11, 16, 0.5);
+    color: var(--text);
+  }
+
+  .attack-bar {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    overflow: hidden;
+    gap: 16px;
+    padding: 10px 12px;
+    cursor: pointer;
+    font: inherit;
+    text-align: left;
+  }
+
+  .attack-bar::before {
+    content: '';
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: var(--bar);
+    opacity: 0.22;
+    background: var(--severity-medium);
+  }
+
+  .attack-bar span,
+  .attack-bar strong {
+    position: relative;
+    z-index: 1;
+  }
+
+  .attack-bar span {
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .attack-bar strong {
+    color: var(--white);
+    font-family: var(--font-mono);
+  }
+
+  .attribution-row {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 12px;
+    padding: 10px;
+    text-decoration: none;
+  }
+
+  .attribution-row strong,
+  .attribution-row em {
+    display: block;
+  }
+
+  .attribution-row strong {
+    color: var(--white);
+    line-height: 1.25;
+  }
+
+  .attribution-row em {
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    font-style: normal;
+    letter-spacing: 0.12em;
+    margin-top: 4px;
+    text-transform: uppercase;
+  }
+
+  .attribution-row b {
+    color: var(--amber);
+    font-family: var(--font-mono);
+  }
+
+  .confidence-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--severity-medium);
+    box-shadow: 0 0 0 4px rgba(232, 160, 32, 0.1);
+  }
+
+  .confidence-dot[data-confidence='confirmed'],
+  .confidence-dot[data-confidence='high'] {
+    background: var(--severity-low);
+  }
+
+  .confidence-dot[data-confidence='likely'],
+  .confidence-dot[data-confidence='medium'] {
+    background: var(--severity-high);
+  }
+
+  .confidence-dot[data-confidence='suspected'],
+  .confidence-dot[data-confidence='low'] {
+    background: var(--severity-medium);
+  }
+
+  .dwell-row {
+    display: grid;
+    grid-template-columns: minmax(160px, 1fr) minmax(180px, 2fr) auto;
+    align-items: center;
+    gap: 12px;
+    padding: 10px;
+    text-decoration: none;
+  }
+
+  .dwell-title {
+    color: var(--white);
+    font-size: 0.9rem;
+    line-height: 1.25;
+  }
+
+  .dwell-track {
+    position: relative;
+    height: 12px;
+    border: 1px solid var(--border);
+    background: rgba(8, 11, 16, 0.7);
+  }
+
+  .dwell-fill {
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: var(--bar);
+    background: var(--severity-medium);
+    opacity: 0.45;
+  }
+
+  .dwell-marker {
+    position: absolute;
+    top: -4px;
+    bottom: -4px;
+    width: 2px;
+    background: var(--white);
+  }
+
+  .dwell-marker.warning {
+    background: var(--amber);
+  }
+
+  .dwell-marker.disclosed {
+    background: var(--severity-critical);
+  }
+
+  .dwell-days {
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+  }
+
+  .severity-critical::before,
+  .severity-critical .dwell-fill {
+    background: var(--severity-critical);
+  }
+
+  .severity-high::before,
+  .severity-high .dwell-fill {
+    background: var(--severity-high);
+  }
+
+  .severity-medium::before,
+  .severity-medium .dwell-fill {
+    background: var(--severity-medium);
+  }
+
+  .severity-low::before,
+  .severity-low .dwell-fill {
+    background: var(--severity-low);
+  }
+
   .sc-header {
     margin-bottom: 30px;
     padding-bottom: 20px;
@@ -359,7 +880,7 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
   .entity-card {
     border: 1px solid var(--border);
     background: var(--surface);
-    border-radius: 6px;
+    border-radius: 4px;
     padding: 16px;
   }
 
@@ -429,7 +950,7 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
   .attack-chain-list li {
     border: 1px solid var(--border);
     background: var(--surface);
-    border-radius: 6px;
+    border-radius: 4px;
     padding: 16px;
   }
 
@@ -592,6 +1113,29 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
   }
 
   @media (max-width: 720px) {
+    .graph-hero,
+    .viz-grid,
+    .dwell-row {
+      grid-template-columns: 1fr;
+    }
+
+    .graph-hero {
+      min-height: auto;
+    }
+
+    .graph-placeholder {
+      min-height: 420px;
+    }
+
+    .graph-caption {
+      display: block;
+    }
+
+    .graph-caption span {
+      display: inline-block;
+      margin-top: 8px;
+    }
+
     .timeline-list li,
     .entity-list li,
     .reference-list li {

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -224,6 +224,24 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
           ))}
         </div>
       </section>
+
+      <section class="sc-section">
+        <div class="section-heading">
+          <p class="eyebrow">Corpus Index</p>
+          <h2>All Incidents</h2>
+        </div>
+        <div class="incident-list-grid">
+          {page.incidents.map((incident) => (
+            <a class="incident-list-row" href={incident.href}>
+              <span>
+                <strong>{incident.title}</strong>
+                <em>{incident.summary}</em>
+              </span>
+              <b>{titleCase(incident.attackStage)}</b>
+            </a>
+          ))}
+        </div>
+      </section>
     </section>
   )}
 
@@ -852,6 +870,7 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
 
   .copy-grid,
   .featured-grid,
+  .incident-list-grid,
   .entity-summary-grid {
     display: grid;
     gap: 16px;
@@ -870,9 +889,14 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
     grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
   }
 
+  .incident-list-grid {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  }
+
   .info-panel,
   .incident-card,
-  .entity-card {
+  .entity-card,
+  .incident-list-row {
     border: 1px solid var(--border);
     background: var(--surface);
     border-radius: 4px;
@@ -892,7 +916,8 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
 
   .info-panel p,
   .incident-card p,
-  .entity-card p {
+  .entity-card p,
+  .incident-list-row em {
     color: var(--muted);
     line-height: 1.6;
     margin: 0;
@@ -904,6 +929,44 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
     font-size: 1.05rem;
     line-height: 1.3;
     margin-bottom: 10px;
+  }
+
+  .incident-list-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .incident-list-row span {
+    display: grid;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  .incident-list-row strong {
+    color: var(--white);
+    line-height: 1.25;
+  }
+
+  .incident-list-row em {
+    display: -webkit-box;
+    overflow: hidden;
+    font-size: 0.9rem;
+    font-style: normal;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+
+  .incident-list-row b {
+    flex: 0 0 auto;
+    color: var(--amber);
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
   }
 
   .card-meta {
@@ -1107,7 +1170,7 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
     font-style: normal;
   }
 
-  @media (max-width: 720px) {
+  @media (max-width: 820px) {
     .graph-hero,
     .viz-grid,
     .dwell-row {

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -155,7 +155,7 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
 
         <section class="viz-panel dwell-panel">
           <div class="panel-heading">
-            <p class="eyebrow">Warning To Disclosure</p>
+            <p class="eyebrow">Observed To Disclosure</p>
             <h2>Dwell Timeline</h2>
           </div>
           <div class="dwell-list">

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -118,16 +118,13 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
           </div>
           <div class="attack-bars">
             {page.attackVectorBars.map((row) => (
-              <button
-                type="button"
+              <div
                 class={`attack-bar ${severityClass(row.severity)}`}
                 style={percentStyle(row.percent)}
-                data-graph-command={row.command.type}
-                data-graph-value={row.command.value}
               >
                 <span>{row.label}</span>
                 <strong>{row.count}</strong>
-              </button>
+              </div>
             ))}
           </div>
         </section>
@@ -667,8 +664,6 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
     overflow: hidden;
     gap: 16px;
     padding: 10px 12px;
-    cursor: pointer;
-    font: inherit;
     text-align: left;
   }
 


### PR DESCRIPTION
## Summary

Implements Supply Chain visualization surface G1: page shell + live Threatpedia dark theme + static corpus-driven drill-in panels with a placeholder hero graph.

This PR intentionally does not implement the WebGL graph renderer, graph payload build step, focus reflow, dive-and-bloom, labels/a11y graph traversal, or page-to-graph runtime binding. Those are later G2-G7 slices.

## Scope

- Replaces the Supply Chain index with a graph-first hero placeholder using live Threatpedia tokens.
- Adds compact corpus stat strip below the hero.
- Adds live-derived panel models and markup for:
  - attack-vector bars by `attack_stage`
  - attribution rows from actor relationships/source incident IDs
  - dwell timeline rows from stored first-observed, first-warning, and disclosed dates
  - featured incident cards
- Keeps incident/entity page behavior unchanged.
- Keeps `ENABLE_SUPPLY_CHAIN_PAGES` default-disabled behavior unchanged.

## Stack

Base: #1162 / `codex/supply-chain-s0-seeded-by`

Note: #1162 has its S0 code fixes pushed at `1dbe8a3`, but the live review decision still reflects the earlier DM change-request review pending re-review.

## Validation

- `node scripts/test-supply-chain-pages.mjs` - PASS (`routes=83`)
- `ENABLE_SUPPLY_CHAIN_PAGES=true npm run build` - PASS; pre-existing campaign relation warnings only
- `ENABLE_SUPPLY_CHAIN_PAGES=false npm run build` - PASS; no Supply Chain routes generated
- `node --check site/src/lib/supplyChainPages.mjs && node --check scripts/test-supply-chain-pages.mjs && git diff --check` - PASS
- Browser desktop check at `/supply-chain/` - PASS: hero present, 7 attack bars, 6 attribution rows, 12 dwell rows, 5 incident cards, no `Canary`, no horizontal overflow
- Browser mobile check at 390px - PASS: stacked hero/panels, graph placeholder visible, no horizontal overflow

## Non-goals honored

- No scoring
- No live feeds
- No graph database
- No ML or automated attribution
- No fabricated nodes
- No public enablement by default

@dangermouse-bot @ernestpenfold-bot please review.
