### PR TITLE
Supply Chain Phase 2D maintainer intelligence expansion

### DIFF
--- a/data/supply-chain-entities/maintainers.json
+++ b/data/supply-chain-entities/maintainers.json
@@ -1,54 +1,82 @@
 [
   {
+    "account_ids": [],
     "aliases": [
       "Dominic Tarr",
       "dominictarr"
     ],
+    "first_publish_date": null,
     "id": "maintainer-dominictarr",
     "name": "Dominic Tarr",
+    "onboarding_date": null,
+    "repositories": [
+      "repo-github-com-dominictarr-event-stream"
+    ],
     "source_incident_ids": [
       "SC-2018-NPM-EVENT-STREAM"
     ]
   },
   {
+    "account_ids": [],
     "aliases": [
       "Jia Tan",
       "JiaT75"
     ],
+    "first_publish_date": null,
     "id": "maintainer-jia-tan",
     "name": "Jia Tan",
+    "onboarding_date": null,
+    "repositories": [
+      "repo-github-com-tukaani-project-xz"
+    ],
     "source_incident_ids": [
       "SC-2024-XZ-UTILS"
     ]
   },
   {
+    "account_ids": [],
     "aliases": [
       "Marak",
       "Marak Squires"
     ],
+    "first_publish_date": null,
     "id": "maintainer-marak-squires",
     "name": "Marak Squires",
+    "onboarding_date": null,
+    "repositories": [
+      "repo-github-com-marak-colors-js"
+    ],
     "source_incident_ids": [
       "SC-2022-COLORS-FAKER"
     ]
   },
   {
+    "account_ids": [],
     "aliases": [
       "Brandon Nozaki Miller",
       "RIAEvangelist"
     ],
+    "first_publish_date": null,
     "id": "maintainer-riaevangelist",
     "name": "RIAEvangelist",
+    "onboarding_date": null,
+    "repositories": [
+      "repo-github-com-riaevangelist-node-ipc"
+    ],
     "source_incident_ids": [
       "SC-2022-NODE-IPC"
     ]
   },
   {
+    "account_ids": [],
     "aliases": [
       "right9ctrl"
     ],
+    "first_publish_date": "2018-09-09",
     "id": "maintainer-right9ctrl",
     "name": "right9ctrl",
+    "onboarding_date": null,
+    "repositories": [],
     "source_incident_ids": [
       "SC-2018-NPM-EVENT-STREAM"
     ]

--- a/data/supply-chain-incidents/incidents.json
+++ b/data/supply-chain-incidents/incidents.json
@@ -470,12 +470,22 @@
         "aliases": [
           "dominictarr"
         ],
-        "id_slug": "dominictarr"
+        "id_slug": "dominictarr",
+        "onboarding_date": null,
+        "first_publish_date": null,
+        "repositories": [
+          "repo-github-com-dominictarr-event-stream"
+        ],
+        "account_ids": []
       },
       {
         "name": "right9ctrl",
         "aliases": [],
-        "id_slug": "right9ctrl"
+        "id_slug": "right9ctrl",
+        "onboarding_date": null,
+        "first_publish_date": "2018-09-09",
+        "repositories": [],
+        "account_ids": []
       }
     ],
     "repositories": [
@@ -1403,7 +1413,13 @@
         "aliases": [
           "Marak"
         ],
-        "id_slug": "marak-squires"
+        "id_slug": "marak-squires",
+        "onboarding_date": null,
+        "first_publish_date": null,
+        "repositories": [
+          "repo-github-com-marak-colors-js"
+        ],
+        "account_ids": []
       }
     ],
     "repositories": [
@@ -1481,7 +1497,13 @@
         "aliases": [
           "Brandon Nozaki Miller"
         ],
-        "id_slug": "riaevangelist"
+        "id_slug": "riaevangelist",
+        "onboarding_date": null,
+        "first_publish_date": null,
+        "repositories": [
+          "repo-github-com-riaevangelist-node-ipc"
+        ],
+        "account_ids": []
       }
     ],
     "repositories": [
@@ -2099,7 +2121,13 @@
         "aliases": [
           "JiaT75"
         ],
-        "id_slug": "jia-tan"
+        "id_slug": "jia-tan",
+        "onboarding_date": null,
+        "first_publish_date": null,
+        "repositories": [
+          "repo-github-com-tukaani-project-xz"
+        ],
+        "account_ids": []
       }
     ],
     "repositories": [

--- a/data/supply-chain-incidents/schema.json
+++ b/data/supply-chain-incidents/schema.json
@@ -476,7 +476,11 @@
       "required": [
         "name",
         "aliases",
-        "id_slug"
+        "id_slug",
+        "onboarding_date",
+        "first_publish_date",
+        "repositories",
+        "account_ids"
       ],
       "properties": {
         "name": {
@@ -490,6 +494,34 @@
         },
         "id_slug": {
           "type": "string"
+        },
+        "onboarding_date": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+        },
+        "first_publish_date": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+        },
+        "repositories": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^repo-[a-z0-9][a-z0-9-]*$"
+          }
+        },
+        "account_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^account-[a-z0-9][a-z0-9-]*$"
+          }
         }
       }
     },

--- a/data/supply-chain-relationships/relationships.json
+++ b/data/supply-chain-relationships/relationships.json
@@ -520,9 +520,29 @@
     "type": "USED_DISTRIBUTION_CHANNEL"
   },
   {
+    "source": "maintainer-dominictarr",
+    "target": "repo-github-com-dominictarr-event-stream",
+    "type": "MAINTAINS_REPOSITORY"
+  },
+  {
     "source": "maintainer-jia-tan",
     "target": "actor-unc-xz-utils-operator",
     "type": "ATTRIBUTED_TO_ACTOR"
+  },
+  {
+    "source": "maintainer-jia-tan",
+    "target": "repo-github-com-tukaani-project-xz",
+    "type": "MAINTAINS_REPOSITORY"
+  },
+  {
+    "source": "maintainer-marak-squires",
+    "target": "repo-github-com-marak-colors-js",
+    "type": "MAINTAINS_REPOSITORY"
+  },
+  {
+    "source": "maintainer-riaevangelist",
+    "target": "repo-github-com-riaevangelist-node-ipc",
+    "type": "MAINTAINS_REPOSITORY"
   },
   {
     "source": "pkg-npm-flatmap-stream",

--- a/docs/supply-chain-graph-primitives.md
+++ b/docs/supply-chain-graph-primitives.md
@@ -6,7 +6,8 @@ and compromised accounts from the curated incident corpus. Phase 2B connects
 the supply-chain corpus to existing Threatpedia actor and campaign entities
 where public evidence supports the edge.
 Phase 2C adds version-addressable release entities for package incidents with
-precise public release evidence.
+precise public release evidence. Phase 2D strengthens maintainer entities with
+dated anchors and explicit repository/account links.
 
 This is a lightweight relationship layer, not a graph database.
 
@@ -46,6 +47,10 @@ Release entities carry `purl`, `package_name`, `version`, `published_at`,
 `ecosystem`, `malicious_range`, `references`, and nullable `disclosed_at`.
 Release PURLs are versioned canonical PURLs and must remain joinable to the
 release-event spine.
+Maintainer entities also carry `onboarding_date`, `first_publish_date`,
+`repositories`, and `account_ids`. The graph does not store `tenure`; pages can
+derive tenure-at-malicious-release from those anchors and release
+`published_at` values.
 Repository entities also carry `host`, `url`, and `owner`.
 Build-system, distribution-channel, and account entities carry type-specific
 fields copied from the incident corpus.
@@ -71,6 +76,8 @@ Allowed relationship types are intentionally narrow:
 - `RELATED_CAMPAIGN`
 - `PACKAGE_RELEASE`
 - `INCIDENT_AFFECTED_RELEASE`
+- `MAINTAINS_REPOSITORY`
+- `USES_ACCOUNT`
 - `USED_BUILD_SYSTEM`
 - `USED_DISTRIBUTION_CHANNEL`
 - `COMPROMISED_ACCOUNT`
@@ -118,9 +125,24 @@ Release edges make specific malicious or affected versions graph-addressable:
 release entity. Release nodes are not public-routed entity pages in Phase 2C,
 but incident pages can display them as affected releases.
 
+Maintainer intelligence edges connect maintainer identities to supported
+repository/account primitives:
+
+```json
+{
+  "source": "maintainer-dominictarr",
+  "target": "repo-github-com-dominictarr-event-stream",
+  "type": "MAINTAINS_REPOSITORY"
+}
+```
+
+`MAINTAINS_REPOSITORY` and `USES_ACCOUNT` start from maintainer nodes. These
+edges are not trust or behavior scores; they only preserve structured public
+evidence needed to compute future canary primitives.
+
 ## Current Graph Density
 
-The Phase 2C pass over the same 25 incidents currently emits:
+The Phase 2D pass over the same 25 incidents currently emits:
 
 - Maintainers: 5
 - Packages: 16
@@ -132,7 +154,7 @@ The Phase 2C pass over the same 25 incidents currently emits:
 - Compromised accounts: 8
 - Actors: 4
 - Campaigns: 3
-- Relationships: 109
+- Relationships: 113
 
 ## Build and Validate
 
@@ -161,6 +183,7 @@ This phase supports lookup questions such as:
 - incidents involving a package
 - incidents involving a specific package release
 - incidents involving a maintainer
+- maintained repositories or accounts connected to a maintainer
 - incidents involving a repository
 - incidents involving an organization
 - incidents involving a build system

--- a/docs/supply-chain-incident-schema.md
+++ b/docs/supply-chain-incident-schema.md
@@ -58,7 +58,9 @@ The core fields are:
   entered or propagated
 - `source_artifact_divergence`: `true`, `false`, or `null` when unknown
 - `maintainers`: named maintainers or maintainership handles when directly
-  supported
+  supported. Maintainer records include aliases, dated anchors
+  (`onboarding_date`, `first_publish_date`), and explicit repository/account
+  entity IDs where public evidence supports those links.
 - `repositories`: source repositories tied to the incident
 - `build_systems`: build or CI/CD systems tied to the incident
 - `distribution_channels`: registries, update channels, CDN scripts, source
@@ -69,6 +71,11 @@ The core fields are:
 - `campaigns`: optional evidence-backed campaign links
 - `attribution_confidence`: optional incident-level attribution confidence
 - `attribution_evidence`: local evidence records for each actor/campaign edge
+
+Maintainer records deliberately store dated anchors, not a mutable `tenure`
+field. Page generation derives tenure-at-malicious-release from
+`onboarding_date` or `first_publish_date` and the affected release
+`published_at` value when both are known.
 
 Featured incident pages may also carry editorial fields:
 

--- a/docs/supply-chain-pages.md
+++ b/docs/supply-chain-pages.md
@@ -111,6 +111,9 @@ stage, source-artifact divergence, affected packages, affected releases,
 structured supply-chain primitives, compromised accounts, connected entities,
 and references. Release rows are generated from `releases.json` and show the
 versioned PURL plus publish date when modeled. When
+maintainer date anchors and release publish dates are both present, incident
+pages derive a tenure-at-malicious-release row. The corpus stores the dated
+anchors only; it does not store a stale tenure field or score. When
 Phase 2B actor or campaign links are present, incident pages also show threat
 actor links, campaign links, attribution confidence, and the local evidence
 basis for those edges. These links are corpus-driven convergence edges; they do

--- a/scripts/build_supply_chain_entities.py
+++ b/scripts/build_supply_chain_entities.py
@@ -50,6 +50,8 @@ RELATIONSHIP_TYPES = {
     "USED_DISTRIBUTION_CHANNEL",
     "PACKAGE_RELEASE",
     "INCIDENT_AFFECTED_RELEASE",
+    "MAINTAINS_REPOSITORY",
+    "USES_ACCOUNT",
 }
 GENERIC_VENDOR_NAMES = {
     "malicious publisher",
@@ -169,6 +171,14 @@ def add_source(entity: dict[str, Any], incident_id: str) -> None:
     sources = set(entity.get("source_incident_ids", []))
     sources.add(incident_id)
     entity["source_incident_ids"] = sorted(sources)
+
+
+def earliest_date(current: Any, candidate: Any) -> Any:
+    if not isinstance(candidate, str) or not candidate:
+        return current
+    if not isinstance(current, str) or not current:
+        return candidate
+    return min(current, candidate)
 
 
 def upsert_package(packages: dict[str, dict[str, Any]], component: dict[str, Any], incident_id: str) -> str:
@@ -295,16 +305,26 @@ def upsert_maintainer(maintainers: dict[str, dict[str, Any]], hint: dict[str, An
     name = hint["name"]
     aliases = sorted(set((hint.get("aliases") or []) + [name]))
     entity_id = stable_id("maintainer", hint["id_slug"])
+    repositories = sorted(set(hint.get("repositories") or []))
+    account_ids = sorted(set(hint.get("account_ids") or []))
     entity = maintainers.setdefault(
         entity_id,
         {
             "id": entity_id,
             "name": name,
             "aliases": aliases,
+            "onboarding_date": hint.get("onboarding_date"),
+            "first_publish_date": hint.get("first_publish_date"),
+            "repositories": repositories,
+            "account_ids": account_ids,
             "source_incident_ids": [],
         },
     )
     entity["aliases"] = sorted(set(entity.get("aliases", []) + aliases))
+    entity["onboarding_date"] = earliest_date(entity.get("onboarding_date"), hint.get("onboarding_date"))
+    entity["first_publish_date"] = earliest_date(entity.get("first_publish_date"), hint.get("first_publish_date"))
+    entity["repositories"] = sorted(set(entity.get("repositories", []) + repositories))
+    entity["account_ids"] = sorted(set(entity.get("account_ids", []) + account_ids))
     add_source(entity, incident_id)
     return entity_id
 
@@ -454,6 +474,10 @@ def build_graph(corpus: list[dict[str, Any]]) -> dict[str, Any]:
         for maintainer in incident.get("maintainers") or []:
             maintainer_id = upsert_maintainer(maintainers, maintainer, incident_id)
             add_relationship(relationship(source, maintainer_id, "AFFECTED_MAINTAINER"))
+            for repo_id in maintainer.get("repositories") or []:
+                add_relationship(relationship(maintainer_id, repo_id, "MAINTAINS_REPOSITORY"))
+            for account_id in maintainer.get("account_ids") or []:
+                add_relationship(relationship(maintainer_id, account_id, "USES_ACCOUNT"))
 
         for repo in incident.get("repositories") or []:
             repo_id = upsert_repository(repositories, repo, incident_id)

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -186,6 +186,17 @@ assert.ok(
   'release rows should expose versioned PURL context'
 );
 
+const eventStream = getSupplyChainIncidentPage('SC-2018-NPM-EVENT-STREAM', data);
+assert.ok(
+  eventStream.sections.maintainerTenureAtMaliciousRelease.some(
+    (row) =>
+      row.maintainer.id === 'maintainer-right9ctrl' &&
+      row.release.id === 'release-npm-flatmap-stream-0-1-1' &&
+      row.days === 0
+  ),
+  'event-stream page should derive maintainer tenure at malicious release from stored anchors'
+);
+
 const threeCx = getSupplyChainIncidentPage('SC-2023-THREE-CX-DESKTOP', data);
 assert.ok(
   threeCx.sections.actors.some((actor) => actor.href === '/threat-actors/lazarus-group/'),
@@ -227,6 +238,10 @@ assert.ok(eventStreamPackage.seo.ogTitle, 'entity page should include Open Graph
 assert.ok(eventStreamPackage.seo.jsonLd, 'entity page should include JSON-LD');
 
 const jiaTanMaintainer = getSupplyChainEntityPage('maintainers', 'maintainer-jia-tan', data);
+assert.ok(
+  jiaTanMaintainer.connectedEntities.some((entity) => entity.id === 'repo-github-com-tukaani-project-xz'),
+  'maintainer page should surface maintained repository connections'
+);
 assert.ok(
   jiaTanMaintainer.connectedEntities.some(
     (entity) => entity.id === 'actor-unc-xz-utils-operator' && entity.entityType === 'Threat Actor' && entity.href === null

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -50,6 +50,8 @@ VALID_RELATIONSHIP_TYPES = {
     "USED_DISTRIBUTION_CHANNEL",
     "PACKAGE_RELEASE",
     "INCIDENT_AFFECTED_RELEASE",
+    "MAINTAINS_REPOSITORY",
+    "USES_ACCOUNT",
 }
 ENTITY_ID_PATTERN = re.compile(r"^(account|actor|build|campaign|channel|maintainer|pkg|release|repo|org)-[a-z0-9][a-z0-9-]*$")
 RELATIONSHIP_TARGET_PREFIXES = {
@@ -66,6 +68,8 @@ RELATIONSHIP_TARGET_PREFIXES = {
     "USED_DISTRIBUTION_CHANNEL": "channel-",
     "PACKAGE_RELEASE": "release-",
     "INCIDENT_AFFECTED_RELEASE": "release-",
+    "MAINTAINS_REPOSITORY": "repo-",
+    "USES_ACCOUNT": "account-",
 }
 ENTITY_TYPE_REQUIRED_FIELDS = {
     "accounts": ["provider", "account_type", "role"],
@@ -242,6 +246,26 @@ def validate_entity_file(errors: list[str], entity_type: str, entities: Any, inc
                 errors.append(f"{entity_id}.references: expected non-empty list")
             elif not all(isinstance(ref, str) and ref.strip() for ref in references):
                 errors.append(f"{entity_id}.references: expected non-empty string references")
+        if entity_type == "maintainers":
+            for field in ["onboarding_date", "first_publish_date"]:
+                if field not in entity:
+                    errors.append(f"{entity_id}.{field}: missing required field")
+                elif entity.get(field) is not None and parse_date(entity.get(field)) is None:
+                    errors.append(f"{entity_id}.{field}: expected YYYY-MM-DD date or null")
+            repositories = entity.get("repositories")
+            if not isinstance(repositories, list):
+                errors.append(f"{entity_id}.repositories: expected list")
+                repositories = []
+            for repo_index, repo_id in enumerate(repositories):
+                if not isinstance(repo_id, str) or not repo_id.startswith("repo-"):
+                    errors.append(f"{entity_id}.repositories[{repo_index}]: expected repo-* entity id")
+            account_ids = entity.get("account_ids")
+            if not isinstance(account_ids, list):
+                errors.append(f"{entity_id}.account_ids: expected list")
+                account_ids = []
+            for account_index, account_id in enumerate(account_ids):
+                if not isinstance(account_id, str) or not account_id.startswith("account-"):
+                    errors.append(f"{entity_id}.account_ids[{account_index}]: expected account-* entity id")
         source_incident_ids = entity.get("source_incident_ids")
         if not isinstance(source_incident_ids, list) or not source_incident_ids:
             errors.append(f"{entity_id}.source_incident_ids: expected non-empty list")
@@ -341,6 +365,10 @@ def validate_relationships(
                 errors.append(f"{path}.source: PACKAGE_RELEASE must start from a package node")
             if rel_type == "INCIDENT_AFFECTED_RELEASE" and not source.startswith("incident-"):
                 errors.append(f"{path}.source: INCIDENT_AFFECTED_RELEASE must start from an incident node")
+            if rel_type == "MAINTAINS_REPOSITORY" and not source.startswith("maintainer-"):
+                errors.append(f"{path}.source: MAINTAINS_REPOSITORY must start from a maintainer node")
+            if rel_type == "USES_ACCOUNT" and not source.startswith("maintainer-"):
+                errors.append(f"{path}.source: USES_ACCOUNT must start from a maintainer node")
         if source not in valid_nodes:
             errors.append(f"{path}.source: unknown source {source!r}")
         if target not in valid_nodes:
@@ -396,6 +424,16 @@ def validate_corpus_implied_relationships(corpus: list[dict[str, Any]], relation
                 key = (source, campaign["id"], "RELATED_CAMPAIGN")
                 if key not in relationship_keys:
                     errors.append(f"{source}: missing RELATED_CAMPAIGN relationship for {campaign['id']}")
+        for maintainer in incident.get("maintainers") or []:
+            if not isinstance(maintainer, dict) or not isinstance(maintainer.get("id_slug"), str):
+                continue
+            maintainer_id = f"maintainer-{normalize_alias(maintainer['id_slug'])}"
+            for repo_id in maintainer.get("repositories") or []:
+                if isinstance(repo_id, str) and (maintainer_id, repo_id, "MAINTAINS_REPOSITORY") not in relationship_keys:
+                    errors.append(f"{source}: missing MAINTAINS_REPOSITORY relationship from {maintainer_id} to {repo_id}")
+            for account_id in maintainer.get("account_ids") or []:
+                if isinstance(account_id, str) and (maintainer_id, account_id, "USES_ACCOUNT") not in relationship_keys:
+                    errors.append(f"{source}: missing USES_ACCOUNT relationship from {maintainer_id} to {account_id}")
         for release in incident.get("releases") or []:
             if not isinstance(release, dict):
                 continue

--- a/scripts/validate_supply_chain_incidents.py
+++ b/scripts/validate_supply_chain_incidents.py
@@ -441,32 +441,45 @@ def validate_maintainer(errors: list[str], incident_id: str, index: int, maintai
     if not isinstance(maintainer, dict):
         errors.append(f"{path}: expected object")
         return
-    required_fields = ["name", "aliases", "id_slug", "onboarding_date", "first_publish_date", "repositories", "account_ids"]
+    required_fields = [
+        "name",
+        "aliases",
+        "id_slug",
+        "onboarding_date",
+        "first_publish_date",
+        "repositories",
+        "account_ids",
+    ]
     for field in required_fields:
         if field not in maintainer:
             errors.append(f"{path}.{field}: missing required field")
-    require_string(errors, f"{path}.name", maintainer.get("name"))
-    require_string(errors, f"{path}.id_slug", maintainer.get("id_slug"))
-    aliases = maintainer.get("aliases")
-    if not isinstance(aliases, list):
-        errors.append(f"{path}.aliases: expected list")
-    else:
-        for alias_index, alias in enumerate(aliases):
-            if not isinstance(alias, str) or not alias.strip():
-                errors.append(f"{path}.aliases[{alias_index}]: expected non-empty string")
+    if "name" in maintainer:
+        require_string(errors, f"{path}.name", maintainer.get("name"))
+    if "id_slug" in maintainer:
+        require_string(errors, f"{path}.id_slug", maintainer.get("id_slug"))
+    if "aliases" in maintainer:
+        aliases = maintainer.get("aliases")
+        if not isinstance(aliases, list):
+            errors.append(f"{path}.aliases: expected list")
+        else:
+            for alias_index, alias in enumerate(aliases):
+                if not isinstance(alias, str) or not alias.strip():
+                    errors.append(f"{path}.aliases[{alias_index}]: expected non-empty string")
     for field in ["onboarding_date", "first_publish_date"]:
-        if maintainer.get(field) is not None and parse_date(maintainer.get(field)) is None:
+        if field in maintainer and maintainer.get(field) is not None and parse_date(maintainer.get(field)) is None:
             errors.append(f"{path}.{field}: expected YYYY-MM-DD date or null")
-    require_string_list(errors, f"{path}.repositories", maintainer.get("repositories"), allow_empty=True)
-    if isinstance(maintainer.get("repositories"), list):
-        for repo_index, repo_id in enumerate(maintainer["repositories"]):
-            if isinstance(repo_id, str) and not repo_id.startswith("repo-"):
-                errors.append(f"{path}.repositories[{repo_index}]: expected repo-* entity id")
-    require_string_list(errors, f"{path}.account_ids", maintainer.get("account_ids"), allow_empty=True)
-    if isinstance(maintainer.get("account_ids"), list):
-        for account_index, account_id in enumerate(maintainer["account_ids"]):
-            if isinstance(account_id, str) and not account_id.startswith("account-"):
-                errors.append(f"{path}.account_ids[{account_index}]: expected account-* entity id")
+    if "repositories" in maintainer:
+        require_string_list(errors, f"{path}.repositories", maintainer.get("repositories"), allow_empty=True)
+        if isinstance(maintainer.get("repositories"), list):
+            for repo_index, repo_id in enumerate(maintainer["repositories"]):
+                if isinstance(repo_id, str) and not repo_id.startswith("repo-"):
+                    errors.append(f"{path}.repositories[{repo_index}]: expected repo-* entity id")
+    if "account_ids" in maintainer:
+        require_string_list(errors, f"{path}.account_ids", maintainer.get("account_ids"), allow_empty=True)
+        if isinstance(maintainer.get("account_ids"), list):
+            for account_index, account_id in enumerate(maintainer["account_ids"]):
+                if isinstance(account_id, str) and not account_id.startswith("account-"):
+                    errors.append(f"{path}.account_ids[{account_index}]: expected account-* entity id")
 
 
 def validate_repository(errors: list[str], incident_id: str, index: int, repository: Any) -> None:

--- a/scripts/validate_supply_chain_incidents.py
+++ b/scripts/validate_supply_chain_incidents.py
@@ -441,15 +441,33 @@ def validate_maintainer(errors: list[str], incident_id: str, index: int, maintai
     if not isinstance(maintainer, dict):
         errors.append(f"{path}: expected object")
         return
+    required_fields = ["name", "aliases", "id_slug", "onboarding_date", "first_publish_date", "repositories", "account_ids"]
+    for field in required_fields:
+        if field not in maintainer:
+            errors.append(f"{path}.{field}: missing required field")
     require_string(errors, f"{path}.name", maintainer.get("name"))
     require_string(errors, f"{path}.id_slug", maintainer.get("id_slug"))
     aliases = maintainer.get("aliases")
     if not isinstance(aliases, list):
         errors.append(f"{path}.aliases: expected list")
-        return
-    for alias_index, alias in enumerate(aliases):
-        if not isinstance(alias, str) or not alias.strip():
-            errors.append(f"{path}.aliases[{alias_index}]: expected non-empty string")
+    else:
+        for alias_index, alias in enumerate(aliases):
+            if not isinstance(alias, str) or not alias.strip():
+                errors.append(f"{path}.aliases[{alias_index}]: expected non-empty string")
+    for field in ["onboarding_date", "first_publish_date"]:
+        if maintainer.get(field) is not None and parse_date(maintainer.get(field)) is None:
+            errors.append(f"{path}.{field}: expected YYYY-MM-DD date or null")
+    require_string_list(errors, f"{path}.repositories", maintainer.get("repositories"), allow_empty=True)
+    if isinstance(maintainer.get("repositories"), list):
+        for repo_index, repo_id in enumerate(maintainer["repositories"]):
+            if isinstance(repo_id, str) and not repo_id.startswith("repo-"):
+                errors.append(f"{path}.repositories[{repo_index}]: expected repo-* entity id")
+    require_string_list(errors, f"{path}.account_ids", maintainer.get("account_ids"), allow_empty=True)
+    if isinstance(maintainer.get("account_ids"), list):
+        for account_index, account_id in enumerate(maintainer["account_ids"]):
+            if isinstance(account_id, str) and not account_id.startswith("account-"):
+                errors.append(f"{path}.account_ids[{account_index}]: expected account-* entity id")
+
 
 def validate_repository(errors: list[str], incident_id: str, index: int, repository: Any) -> None:
     path = f"{incident_id}.repositories[{index}]"

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -250,6 +250,14 @@ function compareTitle(a, b) {
   return (a.title || '').localeCompare(b.title || '');
 }
 
+function normalizeEntitySlug(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
 function daysBetween(startDate, endDate) {
   if (!startDate || !endDate) return null;
   const start = Date.parse(`${startDate}T00:00:00Z`);
@@ -385,7 +393,7 @@ function maintainerTenureAtMaliciousRelease(data, incidentId) {
     const anchorDate = maintainer.onboarding_date || maintainer.first_publish_date;
     if (!anchorDate) return [];
     const anchorLabel = maintainer.onboarding_date ? 'onboarding' : 'first publish';
-    const maintainerId = `maintainer-${maintainer.id_slug}`;
+    const maintainerId = `maintainer-${normalizeEntitySlug(maintainer.id_slug)}`;
     const maintainerLink = entityLink(data, maintainerId) || { href: null, label: maintainer.name, id: maintainerId };
     return releases
       .map((release) => {

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -250,6 +250,14 @@ function compareTitle(a, b) {
   return (a.title || '').localeCompare(b.title || '');
 }
 
+function daysBetween(startDate, endDate) {
+  if (!startDate || !endDate) return null;
+  const start = Date.parse(`${startDate}T00:00:00Z`);
+  const end = Date.parse(`${endDate}T00:00:00Z`);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return null;
+  return Math.floor((end - start) / 86400000);
+}
+
 function incidentLinksFor(data, entityId) {
   return relationshipRows(data, entityId)
     .filter((row) => row.incident)
@@ -357,6 +365,47 @@ function incidentReleaseLinks(data, incidentId) {
     })
     .filter(Boolean)
     .sort(compareLabel);
+}
+
+function incidentReleaseEntities(data, incidentId) {
+  const nodeId = `incident-${incidentId}`;
+  return data.relationships
+    .filter((relationship) => relationship.source === nodeId && relationship.type === 'INCIDENT_AFFECTED_RELEASE')
+    .map((relationship) => data.entityById.get(relationship.target))
+    .filter(Boolean)
+    .sort((a, b) => (a.published_at || '').localeCompare(b.published_at || '') || (a.name || '').localeCompare(b.name || ''));
+}
+
+function maintainerTenureAtMaliciousRelease(data, incidentId) {
+  const incident = data.incidents.find((item) => item.id === incidentId);
+  if (!incident) return [];
+  const releases = incidentReleaseEntities(data, incidentId);
+  if (releases.length === 0) return [];
+  return (incident.maintainers || []).flatMap((maintainer) => {
+    const anchorDate = maintainer.onboarding_date || maintainer.first_publish_date;
+    if (!anchorDate) return [];
+    const anchorLabel = maintainer.onboarding_date ? 'onboarding' : 'first publish';
+    const maintainerId = `maintainer-${maintainer.id_slug}`;
+    const maintainerLink = entityLink(data, maintainerId) || { href: null, label: maintainer.name, id: maintainerId };
+    return releases
+      .map((release) => {
+        const days = daysBetween(anchorDate, release.published_at);
+        if (days === null) return null;
+        return {
+          maintainer: maintainerLink,
+          anchorDate,
+          anchorLabel,
+          release: {
+            label: release.name,
+            id: release.id,
+            purl: release.purl,
+            publishedAt: release.published_at,
+          },
+          days,
+        };
+      })
+      .filter(Boolean);
+  });
 }
 
 function incidentAttributionLinks(data, incidentId, relationshipType, collectionKey) {
@@ -525,6 +574,7 @@ export function getSupplyChainIncidentPage(id, data = loadSupplyChainData()) {
       distributionChannels: incidentEntities(data, id, 'distribution_channels', 'USED_DISTRIBUTION_CHANNEL'),
       compromisedAccounts: incidentEntities(data, id, 'compromised_accounts', 'COMPROMISED_ACCOUNT'),
       attributionEvidence: attributionEvidenceFor(incident),
+      maintainerTenureAtMaliciousRelease: maintainerTenureAtMaliciousRelease(data, id),
     },
   };
 }

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -217,6 +217,40 @@ const robots = supplyChainPagesEnabled ? undefined : 'noindex, nofollow';
       <EntityList title="Compromised Accounts" items={page.sections.compromisedAccounts} />
       <EntityList title="Connected Entities" items={page.connectedEntities} />
 
+      {page.sections.maintainerTenureAtMaliciousRelease.length > 0 && (
+        <section class="sc-section">
+          <h2>Tenure At Malicious Release</h2>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Maintainer</th>
+                  <th>Anchor</th>
+                  <th>Release</th>
+                  <th>Elapsed</th>
+                </tr>
+              </thead>
+              <tbody>
+                {page.sections.maintainerTenureAtMaliciousRelease.map((row) => (
+                  <tr>
+                    <td>
+                      {row.maintainer.href ? (
+                        <a href={row.maintainer.href}>{row.maintainer.label}</a>
+                      ) : (
+                        row.maintainer.label
+                      )}
+                    </td>
+                    <td>{titleCase(row.anchorLabel)} · {row.anchorDate}</td>
+                    <td><span class="mono">{row.release.purl}</span><br />published {row.release.publishedAt}</td>
+                    <td>{row.days} days</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
       {page.sections.attributionEvidence.length > 0 && (
         <section class="sc-section">
           <h2>Attribution Evidence</h2>

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -68,6 +68,14 @@ class SupplyChainGraphTests(unittest.TestCase):
         self.assertIn("actor-unc-xz-utils-operator", actor_ids)
         self.assertIn("actor-lazarus-group", actor_ids)
         self.assertIn("campaign-tp-camp-2023-0002", campaign_ids)
+        self.assertIn(
+            {
+                "source": "maintainer-dominictarr",
+                "target": "repo-github-com-dominictarr-event-stream",
+                "type": "MAINTAINS_REPOSITORY",
+            },
+            graph["relationships"],
+        )
 
     def test_builder_preserves_exact_release_versions_when_normalized_slugs_collide(self) -> None:
         corpus = [
@@ -399,6 +407,58 @@ class SupplyChainGraphTests(unittest.TestCase):
 
         self.assertTrue(any("PACKAGE_RELEASE must start from a package node" in error for error in errors))
         self.assertTrue(any("INCIDENT_AFFECTED_RELEASE must start from an incident node" in error for error in errors))
+
+    def test_maintainer_relationship_sources_are_bounded(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        entities_by_type = validator.load_entities(ENTITY_DIR)
+        relationships = copy.deepcopy(load_json(RELATIONSHIP_PATH))
+        relationships.append(
+            {
+                "source": "incident-SC-2018-NPM-EVENT-STREAM",
+                "target": "repo-github-com-dominictarr-event-stream",
+                "type": "MAINTAINS_REPOSITORY",
+            }
+        )
+        relationships.append(
+            {
+                "source": "incident-SC-2018-NPM-EVENT-STREAM",
+                "target": "account-npm-eslint-scope-npm-maintainer-account",
+                "type": "USES_ACCOUNT",
+            }
+        )
+
+        errors = validator.validate_graph(corpus, entities_by_type, relationships)
+
+        self.assertTrue(any("MAINTAINS_REPOSITORY must start from a maintainer node" in error for error in errors))
+        self.assertTrue(any("USES_ACCOUNT must start from a maintainer node" in error for error in errors))
+
+    def test_maintainer_entities_require_anchor_fields_and_implied_edges(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        entities_by_type = validator.load_entities(ENTITY_DIR)
+        relationships = copy.deepcopy(load_json(RELATIONSHIP_PATH))
+        entities_by_type["maintainers"] = copy.deepcopy(entities_by_type["maintainers"])
+        maintainer = next(entity for entity in entities_by_type["maintainers"] if entity["id"] == "maintainer-dominictarr")
+        del maintainer["onboarding_date"]
+        maintainer["first_publish_date"] = "2018-99-99"
+        maintainer["repositories"] = ["pkg-not-a-repository"]
+        maintainer["account_ids"] = ["repo-not-an-account"]
+        relationships = [
+            relationship
+            for relationship in relationships
+            if not (
+                relationship["source"] == "maintainer-dominictarr"
+                and relationship["target"] == "repo-github-com-dominictarr-event-stream"
+                and relationship["type"] == "MAINTAINS_REPOSITORY"
+            )
+        ]
+
+        errors = validator.validate_graph(corpus, entities_by_type, relationships)
+
+        self.assertTrue(any(".onboarding_date: missing required field" in error for error in errors))
+        self.assertTrue(any(".first_publish_date: expected YYYY-MM-DD date or null" in error for error in errors))
+        self.assertTrue(any(".repositories[0]: expected repo-* entity id" in error for error in errors))
+        self.assertTrue(any(".account_ids[0]: expected account-* entity id" in error for error in errors))
+        self.assertTrue(any("missing MAINTAINS_REPOSITORY relationship" in error for error in errors))
 
     def test_relationship_type_must_target_expected_entity_class(self) -> None:
         corpus = load_json(CORPUS_PATH)

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -218,12 +218,18 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
         incident["distribution_channels"][0]["name"] = ""
         incident["source_artifact_divergence"] = "yes"
         del incident["maintainers"][0]["id_slug"]
+        incident["maintainers"][1]["first_publish_date"] = "2018-99-99"
+        incident["maintainers"][1]["repositories"] = ["pkg-not-a-repository"]
+        incident["maintainers"][1]["account_ids"] = ["repo-not-an-account"]
 
         errors = validator.validate_incident(incident)
 
         self.assertTrue(any(".distribution_channels[0].name: expected non-empty string" in error for error in errors))
         self.assertTrue(any(".source_artifact_divergence: expected boolean or null" in error for error in errors))
         self.assertTrue(any(".maintainers[0].id_slug: expected non-empty string" in error for error in errors))
+        self.assertTrue(any(".maintainers[1].first_publish_date: expected YYYY-MM-DD date or null" in error for error in errors))
+        self.assertTrue(any(".maintainers[1].repositories[0]: expected repo-* entity id" in error for error in errors))
+        self.assertTrue(any(".maintainers[1].account_ids[0]: expected account-* entity id" in error for error in errors))
 
     def test_unhashable_enum_items_do_not_crash_validation(self) -> None:
         incident = copy.deepcopy(load_json(CORPUS_PATH)[0])

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -226,7 +226,10 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
 
         self.assertTrue(any(".distribution_channels[0].name: expected non-empty string" in error for error in errors))
         self.assertTrue(any(".source_artifact_divergence: expected boolean or null" in error for error in errors))
-        self.assertTrue(any(".maintainers[0].id_slug: expected non-empty string" in error for error in errors))
+        self.assertEqual(
+            [error for error in errors if ".maintainers[0].id_slug" in error],
+            [f"{incident['id']}.maintainers[0].id_slug: missing required field"],
+        )
         self.assertTrue(any(".maintainers[1].first_publish_date: expected YYYY-MM-DD date or null" in error for error in errors))
         self.assertTrue(any(".maintainers[1].repositories[0]: expected repo-* entity id" in error for error in errors))
         self.assertTrue(any(".maintainers[1].account_ids[0]: expected account-* entity id" in error for error in errors))

--- a/tests/test_supply_chain_incidents.py
+++ b/tests/test_supply_chain_incidents.py
@@ -215,6 +215,18 @@ class SupplyChainIncidentValidationTests(unittest.TestCase):
 
     def test_structured_depth_fields_are_enforced(self) -> None:
         incident = copy.deepcopy(next(item for item in load_json(CORPUS_PATH) if item["maintainers"]))
+        if len(incident["maintainers"]) < 2:
+            incident["maintainers"].append(
+                {
+                    "name": "Temporary maintainer",
+                    "id_slug": "temporary-maintainer",
+                    "aliases": [],
+                    "onboarding_date": None,
+                    "first_publish_date": None,
+                    "repositories": [],
+                    "account_ids": [],
+                }
+            )
         incident["distribution_channels"][0]["name"] = ""
         incident["source_artifact_divergence"] = "yes"
         del incident["maintainers"][0]["id_slug"]


### PR DESCRIPTION
Replacement for closed/unmerged #1152, rebased onto main as part of stack collapse.

Scope: Phase 2D maintainer intelligence expansion only.

Validation run locally:
- python3 scripts/validate_supply_chain_incidents.py: PASS
- python3 scripts/validate_supply_chain_graph.py: PASS
- python3 -m unittest tests.test_supply_chain_incidents tests.test_supply_chain_graph tests.test_supply_chain_purl: PASS (69 tests)
- node --check site/src/lib/supplyChainPages.mjs: PASS
- node --check scripts/test-supply-chain-pages.mjs: PASS
- node scripts/test-supply-chain-pages.mjs: PASS (routes=74)
- git diff --check origin/main...HEAD: PASS

Reviewers requested: @dangermouse-bot @ernestpenfold-bot

Automated review requested after PR creation.