### PR TITLE
fix(frameworks): clear campaign ATT&CK hard errors

### DIFF
--- a/site/src/content/campaigns/operation-truechaos.md
+++ b/site/src/content/campaigns/operation-truechaos.md
@@ -52,10 +52,10 @@ mitreMappings:
     techniqueName: "Compromise Software Supply Chain"
     tactic: "Initial Access"
     notes: "Adversaries abused the trusted TrueConf on-premises update relationship to distribute a trojanized client package."
-  - techniqueId: "T1574.002"
-    techniqueName: "DLL Side-Loading"
-    tactic: "Defense Evasion"
-    notes: "Malicious updates dropped files used for DLL sideloading through legitimate-looking software paths."
+  - techniqueId: "T1574.001"
+    techniqueName: "DLL"
+    tactic: "Stealth"
+    notes: "Malicious updates dropped legitimate binaries with malicious DLLs to hijack execution through trusted process paths."
   - techniqueId: "T1021.001"
     techniqueName: "Remote Desktop Protocol"
     tactic: "Lateral Movement"
@@ -94,19 +94,11 @@ The actors utilized the initial foothold to conduct hands-on-keyboard reconnaiss
 
 ## MITRE ATT&CK Mapping
 
-### Initial Access
-
 T1195.002 - Supply Chain Compromise: Compromise Software Supply Chain: The campaign's core vector involved hijacking the TrueConf update flow from a compromised on-premises server.
 
-### Defense Evasion
-
-T1574.002 - Hijack Execution Flow: DLL Side-Loading: Attackers used a combination of legitimate binaries and malicious DLLs to execute payloads and evade endpoint detection.
-
-### Lateral Movement
+T1574.001 - DLL: Attackers used a combination of legitimate binaries and malicious DLLs to execute payloads and evade endpoint detection.
 
 T1021.001 - Remote Services: Remote Desktop Protocol: Adversaries were observed using RDP to pivot between agencies within the compromised governmental IT infrastructure.
-
-### Command and Control
 
 T1071.001 - Application Layer Protocol: Web Protocols: The campaign utilized HTTP/S for C2 communications, frequently interacting with the Havoc framework.
 

--- a/site/src/content/campaigns/sandworm-ukraine-power-grid-campaign-2015.md
+++ b/site/src/content/campaigns/sandworm-ukraine-power-grid-campaign-2015.md
@@ -30,7 +30,7 @@ tags:
   - "sabotage"
 sources:
   - url: "https://www.cisa.gov/news-events/alerts/2016/02/25/cyber-attack-against-ukrainian-critical-infrastructure"
-    publisher: "CISA"
+    publisher: "Cybersecurity and Infrastructure Security Agency"
     publisherType: government
     reliability: R1
     publicationDate: "2016-02-25"
@@ -58,22 +58,14 @@ sources:
     accessDate: "2026-04-17"
     archived: false
 mitreMappings:
-  - techniqueId: "T0822"
+  - techniqueId: "T1133"
     techniqueName: "External Remote Services"
-    tactic: "Lateral Movement"
+    tactic: "Initial Access"
     notes: "Sandworm used stolen VPN and remote access paths to reach power utility control environments."
-  - techniqueId: "T0823"
-    techniqueName: "Graphical User Interface"
-    tactic: "Execution"
-    notes: "Operators used SCADA HMIs to interact directly with breaker controls during the 2015 outage."
-  - techniqueId: "T0831"
-    techniqueName: "Manipulation of Control"
+  - techniqueId: "T1485"
+    techniqueName: "Data Destruction"
     tactic: "Impact"
-    notes: "The campaign opened breakers and disrupted electrical service through direct control actions."
-  - techniqueId: "T0814"
-    techniqueName: "Denial of Service"
-    tactic: "Impact"
-    notes: "Telephone denial-of-service activity interfered with outage reporting during the 2015 attack."
+    notes: "KillDisk damaged Windows systems and complicated restoration during the 2015 attack."
 ---
 
 ## Executive Summary
@@ -114,19 +106,9 @@ KillDisk, device tampering, and phone-line disruption were used to slow recovery
 
 ## MITRE ATT&CK Mapping
 
-### Lateral Movement
+T1133 - External Remote Services: Sandworm used stolen remote-access pathways to reach control systems from compromised enterprise environments.
 
-T0822 - External Remote Services: Sandworm used stolen remote-access pathways to reach control systems from compromised enterprise environments.
-
-### Execution
-
-T0823 - Graphical User Interface: The 2015 phase depended on direct operator use of SCADA HMIs to manipulate live infrastructure.
-
-### Impact
-
-T0831 - Manipulation of Control: The campaign's core effect came from opening breakers and disrupting electric service.
-
-T0814 - Denial of Service: Call-center disruption compounded the operational impact and hindered outage reporting.
+T1485 - Data Destruction: KillDisk damaged Windows systems and complicated restoration during the 2015 attack.
 
 ## Timeline
 
@@ -158,7 +140,7 @@ The 2015 and 2016 cases also show why defenders should prepare for multi-layered
 
 ## Sources & References
 
-1. [CISA: Cyber Attack Against Ukrainian Critical Infrastructure](https://www.cisa.gov/news-events/alerts/2016/02/25/cyber-attack-against-ukrainian-critical-infrastructure) - CISA, 2016-02-25
-2. [U.S. Department of Justice: Six Russian GRU Officers Charged in Connection with Worldwide Deployment of Destructive Malware and Other Disruptive Actions in Cyberspace](https://www.justice.gov/opa/pr/six-russian-gru-officers-charged-connection-worldwide-deployment-destructive-malware-and-other) - U.S. Department of Justice, 2020-10-19
-3. [ESET: Industroyer - The Biggest Threat to Industrial Control Systems Since Stuxnet](https://www.welivesecurity.com/2017/06/12/industroyer-biggest-threat-industrial-control-systems-since-stuxnet/) - ESET, 2017-06-12
-4. [MITRE ATT&CK: 2015 Ukraine Electric Power Attack (C0028)](https://attack.mitre.org/campaigns/C0028/) - MITRE ATT&CK, 2025-04-16
+- [Cybersecurity and Infrastructure Security Agency: Cyber Attack Against Ukrainian Critical Infrastructure](https://www.cisa.gov/news-events/alerts/2016/02/25/cyber-attack-against-ukrainian-critical-infrastructure) — Cybersecurity and Infrastructure Security Agency, 2016-02-25
+- [U.S. Department of Justice: Six Russian GRU Officers Charged in Connection with Worldwide Deployment of Destructive Malware and Other Disruptive Actions in Cyberspace](https://www.justice.gov/opa/pr/six-russian-gru-officers-charged-connection-worldwide-deployment-destructive-malware-and-other) — U.S. Department of Justice, 2020-10-19
+- [ESET: Industroyer - The Biggest Threat to Industrial Control Systems Since Stuxnet](https://www.welivesecurity.com/2017/06/12/industroyer-biggest-threat-industrial-control-systems-since-stuxnet/) — ESET, 2017-06-12
+- [MITRE ATT&CK: 2015 Ukraine Electric Power Attack (C0028)](https://attack.mitre.org/campaigns/C0028/) — MITRE ATT&CK, 2025-04-16


### PR DESCRIPTION
## Summary

Resolves the campaign hard-error slice of #547.

- Replaces revoked TrueChaos `T1574.002` with current ATT&CK Enterprise v19 `T1574.001` / `Stealth`, matching the article evidence for DLL hijack execution through malicious DLLs.
- Removes ICS-only Sandworm campaign mappings from the Enterprise `mitreMappings` field where no safe Enterprise equivalent exists.
- Keeps the Sandworm campaign mapped to article-supported Enterprise techniques for remote services and KillDisk data destruction.
- Normalizes Sandworm source-reference body formatting because changed-file validation requires frontmatter/body URL parity.

## Scope Control

This PR intentionally does not touch metadata enrichment, Defense Evasion split candidates outside the campaign hard-error slice, or the remaining NotPetya campaign tactic mismatch. Those stay in #547 for later bounded PRs.

## Validation

- `node scripts/audit-framework-mappings.mjs --markdown-out /tmp/issue547-campaign-fix-audit.md --json-out /tmp/issue547-campaign-fix-audit.json`
  - Campaign revoked/unknown technique ID errors are cleared.
  - Remaining campaign warning is pre-existing `notpetya-destructive-campaign-2017.md` tactic mismatch, outside this PR scope.
- `node scripts/validate-content-corpus.mjs --files-file /tmp/issue547-changed-files.txt --json-out /tmp/issue547-content-validation.json`
- `git diff --check origin/main...HEAD`
- `cd site && npm ci --no-audit --no-fund && npm run build`

Review requested from non-author reviewers: @dangermouse-bot @ernestpenfold-bot.