### PR TITLE
Fix issue 547 incident ATT&CK hard errors

### DIFF
--- a/site/src/content/incidents/operation-truechaos-trueconf-zero-day-2026.md
+++ b/site/src/content/incidents/operation-truechaos-trueconf-zero-day-2026.md
@@ -55,12 +55,15 @@ sources:
     archived: false
 mitreMappings:
   - techniqueId: "T1195.002"
-    techniqueName: "Supply Chain Compromise: Compromise Software Supply Chain"
+    techniqueName: "Compromise Software Supply Chain"
     tactic: "Initial Access"
     notes: "Attackers abused the trusted update relationship between an on-premises TrueConf server and downstream clients."
-  - techniqueId: "T1574.002"
-    techniqueName: "Hijack Execution Flow: DLL Side-Loading"
-    tactic: "Defense Evasion"
+  - techniqueId: "T1574.001"
+    techniqueName: "DLL"
+    tactic: "Execution"
+    attack-version: "v19.0"
+    confidence: "confirmed"
+    evidence: "Check Point reported DLL sideloading through PowerISO components dropped by the trojanized update package."
     notes: "Check Point reported DLL sideloading through PowerISO components dropped by the trojanized update package."
 ---
 

--- a/site/src/content/incidents/stuxnet-iran-nuclear-sabotage-2010.md
+++ b/site/src/content/incidents/stuxnet-iran-nuclear-sabotage-2010.md
@@ -67,13 +67,9 @@ mitreMappings:
     techniqueName: Exploitation for Client Execution
     tactic: Execution
     notes: Stuxnet used four zero-day exploits including the Windows Shell LNK vulnerability (CVE-2010-2568) to execute on target systems automatically when a USB drive was browsed.
-  - techniqueId: T0831
-    techniqueName: Manipulation of Control
-    tactic: Impair Process Control
-    notes: Stuxnet modified the frequency converter drives controlling IR-1 centrifuge rotor speeds at Natanz, alternating between speeds that caused mechanical stress and eventual physical destruction of the centrifuges.
 ---
 
-## Executive Summary
+## Summary
 
 Stuxnet was a purpose-built computer worm discovered in June 2010 that targeted Siemens Step 7 industrial control software used in programmable logic controllers (PLCs) managing centrifuge operations at Iran's Natanz uranium enrichment facility. The worm represented the first publicly documented case of a cyberweapon designed to cause physical destruction of industrial equipment.
 
@@ -123,7 +119,7 @@ Beyond the physical damage to centrifuges, Stuxnet's discovery had lasting effec
 
 The worm's uncontrolled propagation beyond the intended target — Stuxnet eventually infected an estimated 100,000 computers in over 100 countries — raised questions about the collateral effects of offensive cyber weapons and the risks of uncontrolled malware proliferation.
 
-## Historical Context
+## Attribution
 
 No government has officially claimed responsibility for Stuxnet. In June 2012, The New York Times reported that the worm was part of a joint U.S.-Israeli covert operation codenamed "Olympic Games," initiated under the George W. Bush administration and continued under the Obama administration. The reporting was based on interviews with current and former U.S., European, and Israeli officials.
 
@@ -131,7 +127,7 @@ Technical analysis by Symantec, Kaspersky Lab, and independent researchers ident
 
 Kaspersky Lab's analysis identified code similarities between Stuxnet and the Equation Group malware toolkit, which was subsequently linked to the U.S. National Security Agency's Tailored Access Operations unit following the Shadow Brokers leaks in 2016-2017.
 
-Attribution confidence is assessed as A2 (probably true, from a reliable source) based on investigative journalism and vendor technical analysis, in the absence of official government confirmation.
+The attribution remains probable based on investigative journalism and vendor technical analysis, in the absence of official government confirmation.
 
 ## Timeline
 

--- a/site/src/content/incidents/ukraine-power-grid-industroyer-2016.md
+++ b/site/src/content/incidents/ukraine-power-grid-industroyer-2016.md
@@ -44,13 +44,16 @@ sources:
     accessDate: "2026-04-19"
     archived: false
 mitreMappings:
-  - techniqueId: "T0831"
-    techniqueName: "Manipulation of Control"
+  - techniqueId: "T1485"
+    techniqueName: "Data Destruction"
     tactic: "Impact"
-    notes: "Industroyer was designed to directly manipulate industrial control processes."
+    attack-version: "v19.0"
+    confidence: "confirmed"
+    evidence: "The malware triggered a protective wiper routine to destroy local operating systems and configuration data."
+    notes: "Industroyer's wiper component destroyed operational systems and configuration data after the outage."
 ---
 
-## Executive Summary
+## Summary
 
 On December 17, 2016, a cyberattack on a transmission substation near Kyiv, Ukraine, caused a blackout affecting approximately one-fifth of the capital. The attack was carried out by the Russian GRU-associated group Sandworm, the same actor responsible for the earlier 2015 Ukrainian power grid attack. This event is exceptionally notable for the deployment of "Industroyer" (also known as CrashOverride), a purpose-built industrial control system (ICS) malware framework capable of directly speaking electric-sector protocols.
 
@@ -78,12 +81,7 @@ The malware triggered a protective wiper routine to destroy the local operating 
 
 The incident resulted in a loss of power for roughly 20% of Kyiv's electrical footprint for approximately an hour. While the outage duration was relatively short due to human intervention and physical manual overrides, the use of automated ICS-specific malware demonstrated a dangerous escalation in capability and intent by state-sponsored actors targeting civilian infrastructure.
 
-## MITRE ATT&CK Mapping
-
-### Impact
-T0831 - Manipulation of Control: Industroyer directly manipulated circuit breakers via automated ICS protocol payloads.
-
-## Historical Context
+## Attribution
 
 The U.S. Department of Justice fully attributed the 2016 Industroyer incident, alongside the 2015 BlackEnergy grid incident and the 2017 NotPetya wiper, to the Russian GRU Unit 74455 (Sandworm). The 2016 incident represents the second pillar of the overarching Sandworm Ukraine Power Grid Campaign.
 
@@ -106,4 +104,4 @@ The incident solidifies the necessity of stringent architectural segmentation be
 
 - [ESET: Industroyer - The Biggest Threat to Industrial Control Systems Since Stuxnet](https://www.welivesecurity.com/2017/06/12/industroyer-biggest-threat-industrial-control-systems-since-stuxnet/) — ESET, 2017-06-12
 - [U.S. Department of Justice: Six Russian GRU Officers Charged in Connection with Worldwide Deployment of Destructive Malware and Other Disruptive Actions in Cyberspace](https://www.justice.gov/opa/pr/six-russian-gru-officers-charged-connection-worldwide-deployment-destructive-malware-and-other) — U.S. Department of Justice, 2020-10-19
-- [MITRE ATT&CK: 2016 Ukraine Electric Power Attack](https://attack.mitre.org/campaigns/C0028/) — MITRE, 2025-04-16
+- [MITRE ATT&CK: 2016 Ukraine Electric Power Attack](https://attack.mitre.org/campaigns/C0028/) — MITRE ATT&CK, 2025-04-16


### PR DESCRIPTION
## Summary

- Clears the issue #547 incident hard-error slice from the current ATT&CK Enterprise v19 audit.
- Replaces the revoked TrueChaos `T1574.002` mapping with pinned v19 `T1574.001` (`DLL`) using the article-supported DLL sideloading evidence.
- Removes unsupported Enterprise `T0831` ICS mappings from Stuxnet and Industroyer; adds an article-supported Enterprise `T1485` Data Destruction mapping for Industroyer so the incident keeps a valid mapping.
- Applies only validator-required canonical heading/source/name cleanup in the touched legacy files.

## Validation

- `node scripts/validate-content-corpus.mjs --files-file /tmp/issue-547-changed-files.txt --json-out /tmp/issue-547-validate.json`
- `node scripts/audit-framework-mappings.mjs --json-out /tmp/issue-547-incidents-audit2.json --markdown-out /tmp/issue-547-incidents-audit2.md`
- `git diff --check`
- `npm --prefix site run build`

Audit delta for this slice: hard errors drop from 11 to 8; incident revoked/unknown hard errors are cleared. Remaining hard errors are outside this PR scope (threat-actors and zero-days).

Closes no umbrella issue; contributes to #547.
