### PR TITLE
Fix issue 547 threat actor ATT&CK hard errors

### DIFF
--- a/site/src/content/threat-actors/apt27.md
+++ b/site/src/content/threat-actors/apt27.md
@@ -120,11 +120,13 @@ CISA advisory AA21-200B identified Chinese state-sponsored actors (including act
 
 **Initial Access**: Exploitation of public-facing applications (T1190) is the primary vector, targeting Exchange, SharePoint, and database servers. Spearphishing attachments (T1566.001) serve as a secondary vector.
 
-**Persistence**: Web shells (T1505.003), scheduled tasks (T1053), and DLL side-loading (T1574.001) maintain persistent access. HyperBro and SysUpdate install as services or scheduled tasks.
+**Execution**: DLL side-loading with signed legitimate executables (T1574.001) loads HyperBro and other backdoors during operations.
+
+**Persistence**: Web shells (T1505.003) and scheduled tasks (T1053) maintain persistent access. HyperBro and SysUpdate install as services or scheduled tasks.
 
 **Credential Access**: The group uses OS credential dumping (T1003) via Mimikatz, ProcDump, and custom tools to harvest domain credentials.
 
-**Defense Evasion**: DLL side-loading with signed binaries (T1574.001), process injection (T1055), and indicator removal (T1070) are used to evade security controls.
+**Defense Evasion**: Signed-binary abuse, process injection (T1055), and indicator removal (T1070) are used to evade security controls.
 
 **Exfiltration**: Data is compressed (T1560) and exfiltrated over C2 channels (T1041) using encrypted HTTPS communications.
 

--- a/site/src/content/threat-actors/apt27.md
+++ b/site/src/content/threat-actors/apt27.md
@@ -37,12 +37,15 @@ mitreMappings:
     tactic: "Initial Access"
     notes: "APT27 exploits web-facing applications including SharePoint, Exchange, and MySQL servers."
   - techniqueId: "T1505.003"
-    techniqueName: "Server Software Component: Web Shell"
+    techniqueName: "Web Shell"
     tactic: "Persistence"
     notes: "Deploys China Chopper and custom web shells on compromised web servers."
-  - techniqueId: "T1574.002"
-    techniqueName: "Hijack Execution Flow: DLL Side-Loading"
-    tactic: "Defense Evasion"
+  - techniqueId: "T1574.001"
+    techniqueName: "DLL"
+    tactic: "Execution"
+    attack-version: "v19.0"
+    confidence: "confirmed"
+    evidence: "APT27 uses DLL side-loading with legitimate signed executables to load HyperBro and other backdoors."
     notes: "Uses DLL side-loading with legitimate signed executables to load HyperBro and other backdoors."
 attributionConfidence: A3
 attributionRationale: "Attributed to China-nexus actors by multiple cybersecurity vendors including Secureworks, Trend Micro, and Mandiant, based on infrastructure, tooling, and targeting analysis. No government indictment to date."
@@ -117,16 +120,16 @@ CISA advisory AA21-200B identified Chinese state-sponsored actors (including act
 
 **Initial Access**: Exploitation of public-facing applications (T1190) is the primary vector, targeting Exchange, SharePoint, and database servers. Spearphishing attachments (T1566.001) serve as a secondary vector.
 
-**Persistence**: Web shells (T1505.003), scheduled tasks (T1053), and DLL side-loading (T1574.002) maintain persistent access. HyperBro and SysUpdate install as services or scheduled tasks.
+**Persistence**: Web shells (T1505.003), scheduled tasks (T1053), and DLL side-loading (T1574.001) maintain persistent access. HyperBro and SysUpdate install as services or scheduled tasks.
 
 **Credential Access**: The group uses OS credential dumping (T1003) via Mimikatz, ProcDump, and custom tools to harvest domain credentials.
 
-**Defense Evasion**: DLL side-loading with signed binaries (T1574.002), process injection (T1055), and indicator removal (T1070) are used to evade security controls.
+**Defense Evasion**: DLL side-loading with signed binaries (T1574.001), process injection (T1055), and indicator removal (T1070) are used to evade security controls.
 
 **Exfiltration**: Data is compressed (T1560) and exfiltrated over C2 channels (T1041) using encrypted HTTPS communications.
 
 ## Sources & References
 
-- [MITRE ATT&CK: APT27](https://attack.mitre.org/groups/G0027/) -- MITRE ATT&CK
-- [CISA: Advisory AA21-200B](https://www.cisa.gov/news-events/cybersecurity-advisories/aa21-200b) -- CISA, 2021-07-19
-- [Secureworks: Bronze Union](https://www.secureworks.com/research/bronze-union) -- Secureworks, 2017-06-27
+- [MITRE ATT&CK: APT27](https://attack.mitre.org/groups/G0027/) — MITRE ATT&CK, 2025-10-17
+- [CISA: Advisory AA21-200B](https://www.cisa.gov/news-events/cybersecurity-advisories/aa21-200b) — CISA, 2021-07-19
+- [Secureworks: Bronze Union](https://www.secureworks.com/research/bronze-union) — Secureworks, 2017-06-27

--- a/site/src/content/threat-actors/apt41.md
+++ b/site/src/content/threat-actors/apt41.md
@@ -34,16 +34,19 @@ tools:
   - "DUSTPAN"
 mitreMappings:
   - techniqueId: "T1195.002"
-    techniqueName: "Supply Chain Compromise: Compromise Software Supply Chain"
+    techniqueName: "Compromise Software Supply Chain"
     tactic: "Initial Access"
     notes: "APT41 has conducted multiple supply chain compromises of legitimate software vendors."
   - techniqueId: "T1059.001"
-    techniqueName: "Command and Scripting Interpreter: PowerShell"
+    techniqueName: "PowerShell"
     tactic: "Execution"
     notes: "Uses PowerShell scripts for payload delivery and post-compromise operations."
-  - techniqueId: "T1574.002"
-    techniqueName: "Hijack Execution Flow: DLL Side-Loading"
-    tactic: "Defense Evasion"
+  - techniqueId: "T1574.001"
+    techniqueName: "DLL"
+    tactic: "Execution"
+    attack-version: "v19.0"
+    confidence: "confirmed"
+    evidence: "DLL side-loading with signed legitimate binaries is a hallmark of APT41 operations."
     notes: "DLL side-loading with signed legitimate binaries is a hallmark of APT41 operations."
 attributionConfidence: A1
 attributionRationale: "Attributed to Chinese MSS-affiliated actors by a September 2020 DOJ indictment of five Chinese nationals and two Malaysian nationals."
@@ -67,7 +70,7 @@ sources:
     accessDate: "2026-04-16"
     archived: false
   - url: "https://www.justice.gov/opa/pr/seven-international-cyber-defendants-including-apt41-actors-charged-connection-computer"
-    publisher: "US Department of Justice"
+    publisher: "U.S. Department of Justice"
     publisherType: government
     reliability: R1
     publicationDate: "2020-09-16"
@@ -127,7 +130,7 @@ CISA advisory AA20-258A detailed APT41 exploitation of public-facing application
 
 **Initial Access**: Supply chain compromise (T1195.002), exploitation of public-facing applications (T1190), and spearphishing (T1566.001) are primary vectors.
 
-**Execution**: DLL side-loading (T1574.002), PowerShell (T1059.001), and custom loaders deploy backdoors while evading detection.
+**Execution**: DLL side-loading (T1574.001), PowerShell (T1059.001), and custom loaders deploy backdoors while evading detection.
 
 **Persistence**: ShadowPad and KEYPLUG install as services (T1543.003) or scheduled tasks (T1053). Bootkit-level persistence has been observed in some operations.
 
@@ -137,7 +140,7 @@ CISA advisory AA20-258A detailed APT41 exploitation of public-facing application
 
 ## Sources & References
 
-- [MITRE ATT&CK: APT41](https://attack.mitre.org/groups/G0096/) -- MITRE ATT&CK
-- [US DOJ: APT41 Actors Charged](https://www.justice.gov/opa/pr/seven-international-cyber-defendants-including-apt41-actors-charged-connection-computer) -- US Department of Justice, 2020-09-16
-- [CISA: Advisory AA20-258A](https://www.cisa.gov/news-events/cybersecurity-advisories/aa20-258a) -- CISA, 2020-09-14
-- [Mandiant: APT41 Dual Espionage and Cybercrime](https://www.mandiant.com/resources/blog/apt41-dual-espionage-and-cyber-crime-operation) -- Mandiant, 2019-08-07
+- [MITRE ATT&CK: APT41](https://attack.mitre.org/groups/G0096/) — MITRE ATT&CK, 2025-10-17
+- [U.S. Department of Justice: APT41 Actors Charged](https://www.justice.gov/opa/pr/seven-international-cyber-defendants-including-apt41-actors-charged-connection-computer) — U.S. Department of Justice, 2020-09-16
+- [CISA: Advisory AA20-258A](https://www.cisa.gov/news-events/cybersecurity-advisories/aa20-258a) — CISA, 2020-09-14
+- [Mandiant: APT41 Dual Espionage and Cybercrime](https://www.mandiant.com/resources/blog/apt41-dual-espionage-and-cyber-crime-operation) — Mandiant, 2019-08-07

--- a/site/src/content/threat-actors/ransomhouse.md
+++ b/site/src/content/threat-actors/ransomhouse.md
@@ -118,9 +118,11 @@ Public attribution remains moderate rather than confirmed at the individual-oper
 
 **Lateral Movement**: Remote Services: SSH (T1021.004), especially against virtualization infrastructure.
 
+**Defense Impairment**: Disable or Modify System Firewall (T1686) covers firewall manipulation used to ease ransomware deployment.
+
 **Exfiltration**: Exfiltration Over Web Service (T1567) before extortion.
 
-**Impact**: Data Encrypted for Impact (T1486) and disable-or-modify defensive controls such as firewalls (T1686).
+**Impact**: Data Encrypted for Impact (T1486).
 
 ## Sources & References
 

--- a/site/src/content/threat-actors/ransomhouse.md
+++ b/site/src/content/threat-actors/ransomhouse.md
@@ -29,12 +29,15 @@ mitreMappings:
     tactic: "Initial Access"
     notes: "RansomHouse operations frequently leverage compromised credentials and access-brokered footholds."
   - techniqueId: "T1021.004"
-    techniqueName: "Remote Services: SSH"
+    techniqueName: "SSH"
     tactic: "Lateral Movement"
     notes: "Recent RansomHouse tooling has targeted VMware ESXi environments over SSH for post-compromise operations."
-  - techniqueId: "T1562.004"
-    techniqueName: "Impair Defenses: Disable or Modify System Firewall"
-    tactic: "Defense Evasion"
+  - techniqueId: "T1686"
+    techniqueName: "Disable or Modify System Firewall"
+    tactic: "Defense Impairment"
+    attack-version: "v19.0"
+    confidence: "confirmed"
+    evidence: "MrAgent capability descriptions include ESXi firewall manipulation to ease ransomware deployment."
     notes: "MrAgent capability descriptions include ESXi firewall manipulation to ease ransomware deployment."
   - techniqueId: "T1567"
     techniqueName: "Exfiltration Over Web Service"
@@ -103,7 +106,7 @@ Recent reporting ties RansomHouse activity to a combination of data-extortion tr
 
 RansomHouse does not appear to rely on a single stable initial-access method across all cases. Instead, reporting and victim patterns are more consistent with an affiliate or access-broker model in which footholds are obtained through compromised credentials, vulnerable public-facing services, phishing, or third-party access. That ambiguity is why the group is best understood as an extortion operation with a recognizable post-compromise toolkit, rather than as a cluster defined by one exploit chain.
 
-## Historical Context
+## Attribution
 
 RansomHouse publicly styled itself as a group exposing weak security, but the operational pattern is extortion, not benevolent disclosure. The operation’s history shows an evolution from leak-site coercion toward broader ransomware enablement while preserving the same core pressure model: steal data, disrupt recovery, and use controlled disclosure to force negotiations.
 
@@ -117,10 +120,10 @@ Public attribution remains moderate rather than confirmed at the individual-oper
 
 **Exfiltration**: Exfiltration Over Web Service (T1567) before extortion.
 
-**Impact**: Data Encrypted for Impact (T1486) and disable-or-modify defensive controls such as firewalls (T1562.004).
+**Impact**: Data Encrypted for Impact (T1486) and disable-or-modify defensive controls such as firewalls (T1686).
 
 ## Sources & References
 
-- [Palo Alto Unit 42: From Linear to Complex -- An Upgrade in RansomHouse Encryption](https://unit42.paloaltonetworks.com/ransomhouse-encryption-upgrade/) -- Palo Alto Unit 42, 2025-12-17
-- [BleepingComputer: RansomHouse upgrades encryption with multi-layered data processing](https://www.bleepingcomputer.com/news/security/ransomhouse-upgrades-encryption-with-multi-layered-data-processing/) -- BleepingComputer, 2025-12-20
-- [TechRadar: Top museums hit by apparent cyberattack on Vivaticket](https://www.techradar.com/pro/security/top-museums-hit-by-apparent-cyberattack-on-vivaticket-louvre-and-other-institutions-affected) -- TechRadar, 2026-04-06
+- [Palo Alto Unit 42: From Linear to Complex — An Upgrade in RansomHouse Encryption](https://unit42.paloaltonetworks.com/ransomhouse-encryption-upgrade/) — Palo Alto Unit 42, 2025-12-17
+- [BleepingComputer: RansomHouse upgrades encryption with multi-layered data processing](https://www.bleepingcomputer.com/news/security/ransomhouse-upgrades-encryption-with-multi-layered-data-processing/) — BleepingComputer, 2025-12-20
+- [TechRadar: Top museums hit by apparent cyberattack on Vivaticket](https://www.techradar.com/pro/security/top-museums-hit-by-apparent-cyberattack-on-vivaticket-louvre-and-other-institutions-affected) — TechRadar, 2026-04-06

--- a/site/src/content/threat-actors/sandworm.md
+++ b/site/src/content/threat-actors/sandworm.md
@@ -39,17 +39,13 @@ mitreMappings:
     tactic: "Impact"
     notes: "NotPetya and CaddyWiper were designed to irreversibly destroy data on targeted systems."
   - techniqueId: "T1059.001"
-    techniqueName: "Command and Scripting Interpreter: PowerShell"
+    techniqueName: "PowerShell"
     tactic: "Execution"
     notes: "PowerShell scripts used in multiple campaigns for lateral movement and payload delivery."
   - techniqueId: "T1195.002"
-    techniqueName: "Supply Chain Compromise: Compromise Software Supply Chain"
+    techniqueName: "Compromise Software Supply Chain"
     tactic: "Initial Access"
     notes: "NotPetya distributed via compromised M.E.Doc Ukrainian accounting software."
-  - techniqueId: "T1562.001"
-    techniqueName: "Impair Defenses: Disable or Modify Tools"
-    tactic: "Defense Evasion"
-    notes: "Industroyer manipulated ICS protocols to disable safety systems during power grid attacks."
 attributionConfidence: A1
 attributionRationale: "Attributed to GRU Unit 74455 by a 2020 U.S. DOJ indictment of six officers, corroborated by Five Eyes intelligence agencies and private-sector research from ESET, Mandiant, and Dragos."
 reviewStatus: "under_review"
@@ -79,7 +75,7 @@ sources:
     accessDate: "2026-04-16"
     archived: false
   - url: "https://www.justice.gov/opa/pr/six-russian-gru-officers-charged-connection-worldwide-deployment-destructive-malware-and"
-    publisher: "US Department of Justice"
+    publisher: "U.S. Department of Justice"
     publisherType: government
     reliability: R1
     publicationDate: "2020-10-19"
@@ -157,8 +153,8 @@ CISA advisory AA22-110A (April 2022) and joint advisories from Five Eyes intelli
 
 ## Sources & References
 
-- [MITRE ATT&CK: Sandworm Team](https://attack.mitre.org/groups/G0034/) -- MITRE ATT&CK
-- [CISA: Advisory AA22-110A](https://www.cisa.gov/news-events/cybersecurity-advisories/aa22-110a) -- CISA, 2022-04-20
-- [US DOJ: Six Russian GRU Officers Charged](https://www.justice.gov/opa/pr/six-russian-gru-officers-charged-connection-worldwide-deployment-destructive-malware-and) -- US Department of Justice, 2020-10-19
-- [Mandiant: Sandworm Disrupts Power in Ukraine](https://www.mandiant.com/resources/blog/sandworm-disrupts-power-ukraine-operational-technology) -- Mandiant, 2023-11-09
-- [ESET: TeleBots Supply Chain Attacks Against Ukraine](https://www.welivesecurity.com/2017/06/30/telebots-back-supply-chain-attacks-against-ukraine/) -- ESET, 2017-06-30
+- [MITRE ATT&CK: Sandworm Team](https://attack.mitre.org/groups/G0034/) — MITRE ATT&CK, 2025-10-17
+- [CISA: Advisory AA22-110A](https://www.cisa.gov/news-events/cybersecurity-advisories/aa22-110a) — CISA, 2022-04-20
+- [U.S. Department of Justice: Six Russian GRU Officers Charged](https://www.justice.gov/opa/pr/six-russian-gru-officers-charged-connection-worldwide-deployment-destructive-malware-and) — U.S. Department of Justice, 2020-10-19
+- [Mandiant: Sandworm Disrupts Power in Ukraine](https://www.mandiant.com/resources/blog/sandworm-disrupts-power-ukraine-operational-technology) — Mandiant, 2023-11-09
+- [ESET: TeleBots Supply Chain Attacks Against Ukraine](https://www.welivesecurity.com/2017/06/30/telebots-back-supply-chain-attacks-against-ukraine/) — ESET, 2017-06-30

--- a/site/src/content/threat-actors/scattered-spider.md
+++ b/site/src/content/threat-actors/scattered-spider.md
@@ -31,16 +31,19 @@ tools:
   - "Cobalt Strike"
 mitreMappings:
   - techniqueId: "T1566.002"
-    techniqueName: "Phishing: Spearphishing Link"
+    techniqueName: "Spearphishing Link"
     tactic: "Initial Access"
     notes: "Phishes employees with fake SSO login pages to harvest MFA-protected credentials."
   - techniqueId: "T1621"
     techniqueName: "Multi-Factor Authentication Request Generation"
     tactic: "Credential Access"
     notes: "Conducts MFA fatigue attacks by sending repeated push notifications."
-  - techniqueId: "T1656"
+  - techniqueId: "T1684.001"
     techniqueName: "Impersonation"
-    tactic: "Defense Evasion"
+    tactic: "Stealth"
+    attack-version: "v19.0"
+    confidence: "confirmed"
+    evidence: "Scattered Spider social engineers IT help desks by impersonating employees to reset credentials."
     notes: "Social engineers IT help desks by impersonating employees to reset credentials."
 attributionConfidence: A1
 attributionRationale: "Multiple members arrested and charged by FBI in 2024, including a UK national extradited to the U.S. CISA advisory AA23-320A documented group TTPs."
@@ -63,7 +66,7 @@ sources:
     accessDate: "2026-04-16"
     archived: false
   - url: "https://www.justice.gov/usao-cdca/pr/five-defendants-charged-multi-year-hacking-scheme-targeting-dozens-companies-and"
-    publisher: "US Department of Justice"
+    publisher: "U.S. Department of Justice"
     publisherType: government
     reliability: R1
     publicationDate: "2024-11-20"
@@ -110,7 +113,7 @@ In November 2024, the DOJ charged five individuals associated with Scattered Spi
 
 ## MITRE ATT&CK Profile
 
-**Initial Access**: Phishing for credentials (T1566.002), social engineering of help desks (T1656), and SIM swapping for MFA bypass.
+**Initial Access**: Phishing for credentials (T1566.002), social engineering of help desks (T1684.001), and SIM swapping for MFA bypass.
 
 **Credential Access**: MFA fatigue attacks (T1621), credential phishing with fake SSO pages, and SIM swapping.
 
@@ -120,6 +123,6 @@ In November 2024, the DOJ charged five individuals associated with Scattered Spi
 
 ## Sources & References
 
-- [CISA: Advisory AA23-320A - Scattered Spider](https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-320a) -- CISA, 2023-11-16
-- [US DOJ: Five Defendants Charged in Multi-Year Hacking Scheme](https://www.justice.gov/usao-cdca/pr/five-defendants-charged-multi-year-hacking-scheme-targeting-dozens-companies-and) -- US Department of Justice, 2024-11-20
-- [Microsoft: Octo Tempest Analysis](https://www.microsoft.com/en-us/security/blog/2023/10/25/octo-tempest-crosses-boundaries-to-facilitate-extortion-encryption-and-destruction/) -- Microsoft Security, 2023-10-25
+- [CISA: Advisory AA23-320A — Scattered Spider](https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-320a) — CISA, 2023-11-16
+- [U.S. Department of Justice: Five Defendants Charged in Multi-Year Hacking Scheme](https://www.justice.gov/usao-cdca/pr/five-defendants-charged-multi-year-hacking-scheme-targeting-dozens-companies-and) — U.S. Department of Justice, 2024-11-20
+- [Microsoft Security: Octo Tempest Analysis](https://www.microsoft.com/en-us/security/blog/2023/10/25/octo-tempest-crosses-boundaries-to-facilitate-extortion-encryption-and-destruction/) — Microsoft Security, 2023-10-25

--- a/site/src/content/threat-actors/scattered-spider.md
+++ b/site/src/content/threat-actors/scattered-spider.md
@@ -113,11 +113,13 @@ In November 2024, the DOJ charged five individuals associated with Scattered Spi
 
 ## MITRE ATT&CK Profile
 
-**Initial Access**: Phishing for credentials (T1566.002), social engineering of help desks (T1684.001), and SIM swapping for MFA bypass.
+**Initial Access**: Phishing for credentials (T1566.002), social engineering of help desks, and SIM swapping for MFA bypass.
 
 **Credential Access**: MFA fatigue attacks (T1621), credential phishing with fake SSO pages, and SIM swapping.
 
 **Persistence**: Creation of new user accounts (T1136), enrollment of new MFA devices, and OAuth application registration in cloud environments.
+
+**Stealth**: Impersonation of help desk targets (T1684.001) supports credential reset and MFA enrollment abuse.
 
 **Impact**: Ransomware deployment (T1486) as BlackCat affiliates, data theft, and extortion.
 


### PR DESCRIPTION
## Summary

- Clears the issue #547 threat-actor revoked-ID slice from the current ATT&CK Enterprise v19 audit.
- Replaces article-supported revoked mappings: APT27/APT41 DLL side-loading to pinned v19 `T1574.001`, RansomHouse firewall manipulation to `T1686`, and Scattered Spider impersonation to `T1684.001`.
- Removes Sandworm `T1562.001` because the article evidence describes ICS safety-system disruption, not disabling security tools; existing valid Sandworm impact/supply-chain mappings remain.
- Applies validator-required canonical ATT&CK names, publisher aliases, headings, and source-line formatting only in the touched files.

## Validation

- `node scripts/validate-content-corpus.mjs --files-file /tmp/issue-547-threatactors-files.txt --json-out /tmp/issue-547-threatactors-validate.json`
- `node scripts/audit-framework-mappings.mjs --json-out /tmp/issue-547-threatactors-audit2.json --markdown-out /tmp/issue-547-threatactors-audit2.md`
- `git diff --check`
- `npm --prefix site run build`

Audit delta for this slice: hard errors drop from 8 to 3; the remaining hard errors are all zero-day files and stay outside this PR scope.

Contributes to #547.
