### PR TITLE
Supply Chain G2 graph core

### DIFF
--- a/docs/supply-chain-pages.md
+++ b/docs/supply-chain-pages.md
@@ -36,6 +36,24 @@ data/supply-chain-entities/*.json
 data/supply-chain-relationships/relationships.json
 ```
 
+The graph hero does not parse those raw corpus files at runtime. The site build
+compiles them into one browser-facing payload:
+
+```text
+site/public/supply-chain-graph.json
+```
+
+Generate or check the payload with:
+
+```bash
+node scripts/build-supply-chain-graph.mjs
+node scripts/build-supply-chain-graph.mjs --check
+```
+
+The Phase 1.0 G2 renderer draws only the actor, campaign, and incident tiers.
+Package and release nodes are preserved in the payload for later level-of-detail
+slices, but they remain payload-only until the dive-and-bloom work lands.
+
 ## Local Build
 
 Disabled/default build:

--- a/scripts/build-supply-chain-graph.mjs
+++ b/scripts/build-supply-chain-graph.mjs
@@ -1,0 +1,315 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(moduleDir, '..');
+const dataRoot = path.join(repoRoot, 'data');
+const outputPath = path.join(repoRoot, 'site/public/supply-chain-graph.json');
+
+const entityFiles = {
+  accounts: 'accounts.json',
+  actors: 'actors.json',
+  build_systems: 'build_systems.json',
+  campaigns: 'campaigns.json',
+  distribution_channels: 'distribution_channels.json',
+  maintainers: 'maintainers.json',
+  organizations: 'organizations.json',
+  packages: 'packages.json',
+  releases: 'releases.json',
+  repositories: 'repositories.json',
+};
+
+const entityTypeByCollection = {
+  accounts: 'account',
+  actors: 'actor',
+  build_systems: 'build_system',
+  campaigns: 'campaign',
+  distribution_channels: 'distribution_channel',
+  maintainers: 'maintainer',
+  organizations: 'organization',
+  packages: 'package',
+  releases: 'release',
+  repositories: 'repository',
+};
+
+const tierByType = {
+  account: 'account',
+  actor: 'actor',
+  build_system: 'supporting',
+  campaign: 'campaign',
+  distribution_channel: 'supporting',
+  incident: 'incident',
+  maintainer: 'maintainer',
+  organization: 'organization',
+  package: 'package',
+  release: 'release',
+  repository: 'repository',
+};
+
+const severityByAttackStage = {
+  account_compromise: 'high',
+  build_compromise: 'critical',
+  ci_cd_compromise: 'critical',
+  dependency_resolution: 'high',
+  distribution_compromise: 'medium',
+  package_publish: 'medium',
+  source_compromise: 'high',
+};
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+function displayLabel(value) {
+  return String(value || 'unknown')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase())
+    .replace('Ci/Cd', 'CI/CD');
+}
+
+function nodeHref(type, id, entity = {}) {
+  if (entity.href) return entity.href;
+  if (type === 'incident') return `/supply-chain/incidents/${id.replace(/^incident-/, '')}/`;
+  const routeSegments = {
+    maintainer: 'maintainers',
+    organization: 'organizations',
+    package: 'packages',
+    repository: 'repositories',
+  };
+  return routeSegments[type] ? `/supply-chain/${routeSegments[type]}/${id}/` : null;
+}
+
+function incidentTime(incident) {
+  return incident.disclosed_at || incident.first_public_warning_at || incident.first_observed_at || null;
+}
+
+function incidentTechniques(incident) {
+  return [
+    ...(Array.isArray(incident.supply_chain_vectors) ? incident.supply_chain_vectors : []),
+    ...(Array.isArray(incident.impact_categories) ? incident.impact_categories : []),
+    ...(Array.isArray(incident.tags) ? incident.tags : []),
+  ]
+    .filter(Boolean)
+    .map((item) => String(item));
+}
+
+function loadCorpus() {
+  const incidents = readJson(path.join(dataRoot, 'supply-chain-incidents/incidents.json'));
+  const relationships = readJson(path.join(dataRoot, 'supply-chain-relationships/relationships.json'));
+  const entities = Object.fromEntries(
+    Object.entries(entityFiles).map(([key, filename]) => [
+      key,
+      readJson(path.join(dataRoot, 'supply-chain-entities', filename)),
+    ])
+  );
+  return { incidents, relationships, entities };
+}
+
+function uniqueEdges(edges) {
+  const seen = new Set();
+  return edges.filter((edge) => {
+    const key = `${edge.source}\0${edge.target}\0${edge.type}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function normalizeRelationshipEdge(relationship, nodeIds) {
+  if (!relationship?.source || !relationship?.target || !relationship?.type) return null;
+  if (!nodeIds.has(relationship.source) || !nodeIds.has(relationship.target)) return null;
+
+  const directionOverrides = {
+    ATTRIBUTED_TO_ACTOR: { source: relationship.target, target: relationship.source },
+    RELATED_CAMPAIGN: { source: relationship.target, target: relationship.source },
+    PACKAGE_RELEASE: { source: relationship.source, target: relationship.target },
+    INCIDENT_AFFECTED_RELEASE: { source: relationship.source, target: relationship.target },
+    AFFECTED_PACKAGE: { source: relationship.source, target: relationship.target },
+  };
+  const directed = directionOverrides[relationship.type] || {
+    source: relationship.source,
+    target: relationship.target,
+  };
+
+  return {
+    id: `${relationship.type}:${directed.source}->${directed.target}`,
+    source: directed.source,
+    target: directed.target,
+    type: relationship.type,
+    evidence_tier: relationship.evidence_tier || null,
+    source_refs: Array.isArray(relationship.source_refs) ? relationship.source_refs : [],
+  };
+}
+
+function deriveIncidentContextEdges(nodes, incidents, entities) {
+  const edges = [];
+  const actorIds = new Set((entities.actors || []).map((actor) => actor.id));
+  const campaignIds = new Set((entities.campaigns || []).map((campaign) => campaign.id));
+  const nodeIds = new Set(nodes.map((node) => node.id));
+
+  incidents.forEach((incident) => {
+    const incidentNodeId = `incident-${incident.id}`;
+    (incident.threat_actors || []).forEach((actor) => {
+      if (actor?.id && actorIds.has(actor.id) && nodeIds.has(incidentNodeId)) {
+        edges.push({
+          id: `INCIDENT_ACTOR_CONTEXT:${actor.id}->${incidentNodeId}`,
+          source: actor.id,
+          target: incidentNodeId,
+          type: 'ATTRIBUTED_TO_ACTOR',
+          derived: true,
+        });
+      }
+    });
+    (incident.campaigns || []).forEach((campaign) => {
+      if (campaign?.id && campaignIds.has(campaign.id) && nodeIds.has(incidentNodeId)) {
+        edges.push({
+          id: `INCIDENT_CAMPAIGN_CONTEXT:${campaign.id}->${incidentNodeId}`,
+          source: campaign.id,
+          target: incidentNodeId,
+          type: 'RELATED_CAMPAIGN',
+          derived: true,
+        });
+      }
+    });
+  });
+
+  return edges;
+}
+
+export function buildSupplyChainGraphData(corpus = loadCorpus()) {
+  const { incidents, relationships, entities } = corpus;
+  const nodes = [];
+
+  incidents.forEach((incident) => {
+    const id = `incident-${incident.id}`;
+    const time = incidentTime(incident);
+    nodes.push({
+      id,
+      entity_id: incident.id,
+      type: 'incident',
+      label: incident.title,
+      tier: 'incident',
+      sev: severityByAttackStage[incident.attack_stage] || 'medium',
+      time,
+      parent: null,
+      techniques: incidentTechniques(incident),
+      purl: null,
+      href: nodeHref('incident', id),
+      attack_stage: incident.attack_stage || null,
+      evidence_level: incident.evidence_level || null,
+      confidence: incident.confidence || null,
+      summary: incident.summary || '',
+    });
+  });
+
+  Object.entries(entities).forEach(([collection, collectionItems]) => {
+    const type = entityTypeByCollection[collection];
+    if (!type || !Array.isArray(collectionItems)) return;
+    collectionItems.forEach((entity) => {
+      nodes.push({
+        id: entity.id,
+        entity_id: entity.id,
+        type,
+        label: entity.name || entity.id,
+        tier: tierByType[type] || type,
+        sev: null,
+        time: entity.published_at || null,
+        parent: null,
+        techniques: [],
+        purl: entity.purl || entity.package_url || null,
+        href: nodeHref(type, entity.id, entity),
+        ecosystem: entity.ecosystem || null,
+        aliases: Array.isArray(entity.aliases) ? entity.aliases : [],
+        source_incident_ids: Array.isArray(entity.source_incident_ids) ? entity.source_incident_ids : [],
+      });
+    });
+  });
+
+  const nodeIds = new Set(nodes.map((node) => node.id));
+  const corpusEdges = relationships
+    .map((relationship) => normalizeRelationshipEdge(relationship, nodeIds))
+    .filter(Boolean);
+  const derivedEdges = deriveIncidentContextEdges(nodes, incidents, entities);
+  const edges = uniqueEdges([...corpusEdges, ...derivedEdges]);
+
+  const parentByIncident = new Map();
+  edges.forEach((edge) => {
+    if (edge.type === 'RELATED_CAMPAIGN' && edge.target.startsWith('incident-')) {
+      parentByIncident.set(edge.target, edge.source);
+    }
+  });
+  edges.forEach((edge) => {
+    if (edge.type === 'ATTRIBUTED_TO_ACTOR' && edge.target.startsWith('incident-') && !parentByIncident.has(edge.target)) {
+      parentByIncident.set(edge.target, edge.source);
+    }
+  });
+  nodes.forEach((node) => {
+    if (node.type === 'incident') node.parent = parentByIncident.get(node.id) || null;
+  });
+
+  const counts = nodes.reduce((acc, node) => {
+    acc[node.type] = (acc[node.type] || 0) + 1;
+    return acc;
+  }, {});
+  const attackStages = Array.from(
+    new Set(incidents.map((incident) => incident.attack_stage).filter(Boolean))
+  )
+    .sort()
+    .map((stage) => ({ id: stage, label: displayLabel(stage) }));
+
+  return {
+    schema_version: 'threatpedia-supply-chain-graph/1',
+    generated_at: new Date().toISOString(),
+    source: {
+      incidents: 'data/supply-chain-incidents/incidents.json',
+      relationships: 'data/supply-chain-relationships/relationships.json',
+      entities: 'data/supply-chain-entities/*.json',
+    },
+    renderer_contract: {
+      g2_drawable_tiers: ['actor', 'campaign', 'incident'],
+      package_release_lod: 'payload-only-until-G4',
+      layout: 'time-anchored-actor-lanes',
+    },
+    counts,
+    attack_stages: attackStages,
+    nodes: nodes.sort((a, b) => a.id.localeCompare(b.id)),
+    edges: edges.sort((a, b) => a.id.localeCompare(b.id)),
+  };
+}
+
+function stableStringify(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+export function writeSupplyChainGraphData(options = {}) {
+  const graph = buildSupplyChainGraphData();
+  const current = existsSync(outputPath) ? readFileSync(outputPath, 'utf8') : '';
+  if (current) {
+    try {
+      const currentGraph = JSON.parse(current);
+      if (typeof currentGraph.generated_at === 'string') graph.generated_at = currentGraph.generated_at;
+    } catch {
+      // Fall through and overwrite malformed generated payloads.
+    }
+  }
+  const serialized = stableStringify(graph);
+  if (options.check) {
+    if (current !== serialized) {
+      throw new Error(`${path.relative(repoRoot, outputPath)} is out of date; run node scripts/build-supply-chain-graph.mjs`);
+    }
+    return { graph, outputPath, changed: false };
+  }
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, serialized);
+  return { graph, outputPath, changed: true };
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const check = process.argv.includes('--check');
+  const { graph } = writeSupplyChainGraphData({ check });
+  console.log(
+    `Supply Chain graph ${check ? 'checked' : 'written'}: nodes=${graph.nodes.length} edges=${graph.edges.length}`
+  );
+}

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -10,10 +10,15 @@ import {
   loadSupplyChainData,
   validateSupplyChainPageData,
 } from '../site/src/lib/supplyChainPages.mjs';
+import { buildSupplyChainGraphData } from './build-supply-chain-graph.mjs';
 
 const data = loadSupplyChainData();
 const baseLayoutSource = readFileSync(new URL('../site/src/layouts/Base.astro', import.meta.url), 'utf-8');
 const supplyChainRouteSource = readFileSync(new URL('../site/src/pages/supply-chain/[...slug].astro', import.meta.url), 'utf-8');
+const supplyChainGraphSource = readFileSync(new URL('../site/public/js/supply-chain-graph-core.js', import.meta.url), 'utf-8');
+const supplyChainGraphPayload = JSON.parse(
+  readFileSync(new URL('../site/public/supply-chain-graph.json', import.meta.url), 'utf-8')
+);
 
 function routeUrl(route) {
   return route.slug ? `/supply-chain/${route.slug}/` : '/supply-chain/';
@@ -48,6 +53,12 @@ assert.ok(routeUrls.has('/supply-chain/maintainers/maintainer-jia-tan/'), 'maint
 assert.ok(
   supplyChainRouteSource.includes('transition:persist="supply-chain-graph-hero"'),
   'route should persist graph hero across Supply Chain navigation'
+);
+assert.ok(
+  supplyChainRouteSource.includes('data-supply-chain-graph-root') &&
+    supplyChainRouteSource.includes('data-sc-graph-canvas') &&
+    supplyChainRouteSource.includes('/js/supply-chain-graph-core.js'),
+  'route should mount the persisted WebGL graph island'
 );
 assert.ok(
   !supplyChainRouteSource.includes('class="graph-hero graph-hero-persistent"\n    transition:persist='),
@@ -181,7 +192,7 @@ assert.equal(index.counts.buildSystems, data.entities.build_systems.length, 'ind
 assert.equal(index.counts.distributionChannels, data.entities.distribution_channels.length, 'index should expose distribution channel count');
 assert.ok(/supply chain/i.test(index.lede), 'index should include polished public copy');
 assert.ok(!JSON.stringify(index).includes('Canary'), 'public page model should not expose the internal codename');
-assert.equal(index.graphHero.status, 'Corpus graph preview', 'index should expose the G1 graph placeholder state');
+assert.equal(index.graphHero.status, 'WebGL graph loading', 'index should expose the G2 graph loading state');
 assert.ok(index.graphHero.nodeCount > data.incidents.length, 'graph hero should expose corpus node count');
 assert.equal(index.graphHero.relationshipCount, data.relationships.length, 'graph hero should expose relationship count');
 assert.equal(index.incidents.length, data.incidents.length, 'index should expose every incident row');
@@ -314,6 +325,67 @@ assert.equal(index.seo.canonicalPath, '/supply-chain/', 'index should include ca
 assert.ok(index.seo.ogTitle, 'index should include Open Graph title');
 assert.ok(index.seo.ogDescription, 'index should include Open Graph description');
 assert.ok(index.seo.jsonLd, 'index should include JSON-LD');
+
+const builtGraph = buildSupplyChainGraphData(data);
+assert.equal(
+  supplyChainGraphPayload.schema_version,
+  'threatpedia-supply-chain-graph/1',
+  'graph payload should expose the G2 schema version'
+);
+assert.equal(
+  supplyChainGraphPayload.nodes.length,
+  builtGraph.nodes.length,
+  'checked graph payload should match builder node count'
+);
+assert.equal(
+  supplyChainGraphPayload.edges.length,
+  builtGraph.edges.length,
+  'checked graph payload should match builder edge count'
+);
+assert.ok(
+  supplyChainGraphPayload.renderer_contract.g2_drawable_tiers.includes('incident'),
+  'graph payload should declare G2 drawable tiers'
+);
+assert.equal(
+  supplyChainGraphPayload.renderer_contract.package_release_lod,
+  'payload-only-until-G4',
+  'graph payload should keep package and release tiers payload-only until G4'
+);
+assert.ok(
+  supplyChainGraphPayload.nodes.some((node) => node.type === 'package') &&
+    supplyChainGraphPayload.nodes.some((node) => node.type === 'release'),
+  'graph payload should preserve package and release nodes for later LOD slices'
+);
+assert.ok(
+  supplyChainGraphPayload.nodes.some((node) => node.type === 'actor') &&
+    supplyChainGraphPayload.nodes.some((node) => node.type === 'campaign') &&
+    supplyChainGraphPayload.nodes.some((node) => node.type === 'incident'),
+  'graph payload should include actor, campaign, and incident tiers'
+);
+assert.ok(
+  supplyChainGraphPayload.edges.some((edge) => edge.type === 'ATTRIBUTED_TO_ACTOR') &&
+    supplyChainGraphPayload.edges.some((edge) => edge.type === 'RELATED_CAMPAIGN'),
+  'graph payload should include actor and campaign graph edges'
+);
+assert.ok(
+  supplyChainGraphSource.includes("getContext('webgl2'") &&
+    supplyChainGraphSource.includes("getContext('webgl'") &&
+    supplyChainGraphSource.includes('class SupplyChainQuadtree') &&
+    supplyChainGraphSource.includes('function isG2DrawableNode') &&
+    supplyChainGraphSource.includes("const DRAWABLE_TIERS = new Set(['actor', 'campaign', 'incident'])") &&
+    supplyChainGraphSource.includes('const layoutNodes = Array.from(nodeById.values())') &&
+    supplyChainGraphSource.includes("layoutNodes.filter((node) => node.tier === 'incident')") &&
+    supplyChainGraphSource.includes('selectEntityContext') &&
+    supplyChainGraphSource.includes('source_incident_ids') &&
+    supplyChainGraphSource.includes('connected incident') &&
+    supplyChainGraphSource.includes("laneIndex.get(actorId) ?? laneIndex.get('actor-unattributed') ?? 0") &&
+    supplyChainGraphSource.includes('setCameraTarget') &&
+    supplyChainGraphSource.includes('clamp(') &&
+    supplyChainGraphSource.includes('this.lastLabelKey') &&
+    supplyChainGraphSource.includes('this.payload.nodes.length') &&
+    supplyChainGraphSource.includes('corpus nodes and'),
+  'graph client should use WebGL, quadtree picking, G2 LOD culling, clone-backed layout, clamped camera targets, cached labels, and ready status'
+);
 
 const codecov = getSupplyChainIncidentPage('SC-2021-CODECOV-BASH-UPLOADER', data);
 assert.ok(codecov.graphHero, 'incident pages should expose graph hero data');

--- a/site/package.json
+++ b/site/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "astro dev",
     "validate:campaigns": "node ../scripts/validate-campaign-corpus.mjs",
-    "build": "npm run validate:campaigns && astro build",
+    "build": "node ../scripts/build-supply-chain-graph.mjs && npm run validate:campaigns && astro build",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/site/public/js/supply-chain-graph-core.js
+++ b/site/public/js/supply-chain-graph-core.js
@@ -1,0 +1,658 @@
+const GRAPH_DATA_URL = '/supply-chain-graph.json';
+const DRAWABLE_TIERS = new Set(['actor', 'campaign', 'incident']);
+const SEVERITY_COLORS = {
+  critical: [1.0, 0.267, 0.267, 1],
+  high: [1.0, 0.647, 0.0, 1],
+  medium: [0.91, 0.627, 0.125, 1],
+  low: [0.318, 0.812, 0.4, 1],
+  actor: [1.0, 0.267, 0.267, 1],
+  campaign: [0.91, 0.627, 0.125, 1],
+  default: [0.804, 0.835, 0.878, 1],
+  muted: [0.353, 0.416, 0.494, 0.32],
+};
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function clampAxis(value, min, max) {
+  return min > max ? (min + max) / 2 : clamp(value, min, max);
+}
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+function dateNumber(value) {
+  const parsed = Date.parse(value || '');
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function tierRank(tier) {
+  if (tier === 'actor') return 0;
+  if (tier === 'campaign') return 1;
+  if (tier === 'incident') return 2;
+  return 3;
+}
+
+function isG2DrawableNode(node) {
+  return DRAWABLE_TIERS.has(node?.tier);
+}
+
+class SupplyChainQuadtree {
+  constructor(bounds, depth = 0) {
+    this.bounds = bounds;
+    this.depth = depth;
+    this.points = [];
+    this.children = null;
+  }
+
+  contains(point) {
+    const { x, y } = point;
+    const { x0, y0, x1, y1 } = this.bounds;
+    return x >= x0 && x <= x1 && y >= y0 && y <= y1;
+  }
+
+  subdivide() {
+    const { x0, y0, x1, y1 } = this.bounds;
+    const mx = (x0 + x1) / 2;
+    const my = (y0 + y1) / 2;
+    this.children = [
+      new SupplyChainQuadtree({ x0, y0, x1: mx, y1: my }, this.depth + 1),
+      new SupplyChainQuadtree({ x0: mx, y0, x1, y1: my }, this.depth + 1),
+      new SupplyChainQuadtree({ x0, y0: my, x1: mx, y1 }, this.depth + 1),
+      new SupplyChainQuadtree({ x0: mx, y0: my, x1, y1 }, this.depth + 1),
+    ];
+  }
+
+  insert(point) {
+    if (!this.contains(point)) return false;
+    if (!this.children && (this.points.length < 6 || this.depth >= 8)) {
+      this.points.push(point);
+      return true;
+    }
+    if (!this.children) {
+      const existing = this.points;
+      this.points = [];
+      this.subdivide();
+      existing.forEach((item) => this.insert(item));
+    }
+    return this.children.some((child) => child.insert(point));
+  }
+
+  nearest(x, y, radius, best = null) {
+    const { x0, y0, x1, y1 } = this.bounds;
+    const dx = x < x0 ? x0 - x : x > x1 ? x - x1 : 0;
+    const dy = y < y0 ? y0 - y : y > y1 ? y - y1 : 0;
+    const boundaryDistance = Math.hypot(dx, dy);
+    const currentRadius = best ? Math.min(radius, best.distance) : radius;
+    if (boundaryDistance > currentRadius) return best;
+
+    for (const point of this.points) {
+      const distance = Math.hypot(point.x - x, point.y - y);
+      if (distance <= currentRadius && (!best || distance < best.distance)) {
+        best = { point, distance };
+      }
+    }
+    if (this.children) {
+      for (const child of this.children) best = child.nearest(x, y, radius, best);
+    }
+    return best;
+  }
+}
+
+function compileShader(gl, type, source) {
+  const shader = gl.createShader(type);
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    throw new Error(gl.getShaderInfoLog(shader) || 'WebGL shader compile failed');
+  }
+  return shader;
+}
+
+function createProgram(gl, vertexSource, fragmentSource) {
+  const program = gl.createProgram();
+  gl.attachShader(program, compileShader(gl, gl.VERTEX_SHADER, vertexSource));
+  gl.attachShader(program, compileShader(gl, gl.FRAGMENT_SHADER, fragmentSource));
+  gl.linkProgram(program);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    throw new Error(gl.getProgramInfoLog(program) || 'WebGL program link failed');
+  }
+  return program;
+}
+
+function fitBounds(nodes, viewport, padding = 120) {
+  if (!nodes.length) return { cx: 0, cy: 0, z: 1.2 };
+  const bounds = nodes.reduce(
+    (acc, node) => ({
+      x0: Math.min(acc.x0, node.x),
+      y0: Math.min(acc.y0, node.y),
+      x1: Math.max(acc.x1, node.x),
+      y1: Math.max(acc.y1, node.y),
+    }),
+    { x0: Infinity, y0: Infinity, x1: -Infinity, y1: -Infinity }
+  );
+  const width = Math.max(1, bounds.x1 - bounds.x0 + padding * 2);
+  const height = Math.max(1, bounds.y1 - bounds.y0 + padding * 2);
+  const z = Math.min(viewport.width / width, viewport.height / height);
+  return {
+    cx: (bounds.x0 + bounds.x1) / 2,
+    cy: (bounds.y0 + bounds.y1) / 2,
+    z: clamp(z, 0.22, 2.8),
+  };
+}
+
+function buildLayout(payload) {
+  const drawableNodes = payload.nodes.filter(isG2DrawableNode);
+  const nodeById = new Map(drawableNodes.map((node) => [node.id, { ...node }]));
+  const layoutNodes = Array.from(nodeById.values());
+  const incidentNodes = layoutNodes.filter((node) => node.tier === 'incident');
+  const actorNodes = layoutNodes.filter((node) => node.tier === 'actor');
+  const campaignNodes = layoutNodes.filter((node) => node.tier === 'campaign');
+  const actorIds = new Set(actorNodes.map((node) => node.id));
+  const campaignIds = new Set(campaignNodes.map((node) => node.id));
+  const incidentActor = new Map();
+  const incidentCampaign = new Map();
+
+  payload.edges.forEach((edge) => {
+    if (edge.type === 'ATTRIBUTED_TO_ACTOR' && actorIds.has(edge.source) && nodeById.has(edge.target)) {
+      incidentActor.set(edge.target, edge.source);
+    }
+    if (edge.type === 'RELATED_CAMPAIGN' && campaignIds.has(edge.source) && nodeById.has(edge.target)) {
+      incidentCampaign.set(edge.target, edge.source);
+    }
+  });
+
+  const laneIds = Array.from(new Set([...actorNodes.map((node) => node.id), 'actor-unattributed']));
+  const laneIndex = new Map(laneIds.map((id, index) => [id, index]));
+  const minTime = Math.min(...incidentNodes.map((node) => dateNumber(node.time)).filter(Number.isFinite));
+  const maxTime = Math.max(...incidentNodes.map((node) => dateNumber(node.time)).filter(Number.isFinite));
+  const timeSpan = Math.max(1, maxTime - minTime);
+  const xForTime = (value) => {
+    const parsed = dateNumber(value);
+    if (!Number.isFinite(parsed)) return 0;
+    return ((parsed - minTime) / timeSpan) * 1600 - 800;
+  };
+
+  actorNodes.forEach((node) => {
+    const lane = laneIndex.get(node.id) || 0;
+    node.x = -980;
+    node.y = lane * 190;
+    node.radius = 18;
+  });
+
+  incidentNodes.forEach((node, index) => {
+    const actorId = incidentActor.get(node.id) || 'actor-unattributed';
+    const lane = laneIndex.get(actorId) ?? laneIndex.get('actor-unattributed') ?? 0;
+    node.x = xForTime(node.time);
+    node.y = lane * 190 + 72 + ((index % 3) - 1) * 18;
+    node.radius = 10;
+  });
+
+  campaignNodes.forEach((node, index) => {
+    const incidentChildren = incidentNodes.filter((incident) => incidentCampaign.get(incident.id) === node.id);
+    if (incidentChildren.length > 0) {
+      const actorId = incidentActor.get(incidentChildren[0].id) || 'actor-unattributed';
+      const lane = laneIndex.get(actorId) || 0;
+      node.x = incidentChildren.reduce((sum, child) => sum + child.x, 0) / incidentChildren.length;
+      node.y = lane * 190 + 34;
+    } else {
+      node.x = -620 + index * 160;
+      node.y = -120;
+    }
+    node.radius = 13;
+  });
+
+  const laidOutNodes = Array.from(nodeById.values()).sort((a, b) => tierRank(a.tier) - tierRank(b.tier));
+  const laidOutById = new Map(laidOutNodes.map((node) => [node.id, node]));
+  const edges = payload.edges
+    .filter((edge) => laidOutById.has(edge.source) && laidOutById.has(edge.target))
+    .map((edge) => ({ ...edge, sourceNode: laidOutById.get(edge.source), targetNode: laidOutById.get(edge.target) }));
+  const bounds = laidOutNodes.reduce(
+    (acc, node) => ({
+      x0: Math.min(acc.x0, node.x - 180),
+      y0: Math.min(acc.y0, node.y - 120),
+      x1: Math.max(acc.x1, node.x + 180),
+      y1: Math.max(acc.y1, node.y + 120),
+    }),
+    { x0: -1200, y0: -240, x1: 1200, y1: 720 }
+  );
+
+  const quadtree = new SupplyChainQuadtree(bounds);
+  laidOutNodes.forEach((node) => quadtree.insert(node));
+  return { nodes: laidOutNodes, nodeById: laidOutById, edges, bounds, quadtree };
+}
+
+class SupplyChainGraph {
+  constructor(root, payload) {
+    this.root = root;
+    this.payload = payload;
+    this.canvas = root.querySelector('[data-sc-graph-canvas]');
+    this.labelLayer = root.querySelector('[data-sc-graph-labels]');
+    this.status = root.querySelector('[data-sc-graph-status]');
+    this.captionTitle = root.querySelector('[data-sc-graph-caption-title]');
+    this.captionBody = root.querySelector('[data-sc-graph-caption-body]');
+    this.viewport = { width: 1, height: 1, dpr: 1 };
+    this.layout = buildLayout(payload);
+    this.camera = { cx: 0, cy: 0, z: 1 };
+    this.targetCamera = { cx: 0, cy: 0, z: 1 };
+    this.selection = null;
+    this.drag = null;
+    this.reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    this.gl = this.canvas.getContext('webgl2', { antialias: true }) || this.canvas.getContext('webgl', { antialias: true });
+    if (!this.gl) throw new Error('WebGL is not available');
+    this.initWebGL();
+    this.bind();
+    this.resize();
+    this.selectFromRoute();
+    requestAnimationFrame(() => this.frame());
+  }
+
+  initWebGL() {
+    const gl = this.gl;
+    this.nodeProgram = createProgram(
+      gl,
+      `
+        attribute vec2 a_position;
+        attribute vec4 a_color;
+        attribute float a_size;
+        uniform vec2 u_resolution;
+        uniform vec3 u_camera;
+        varying vec4 v_color;
+        void main() {
+          vec2 screen = (a_position - u_camera.xy) * u_camera.z + u_resolution * 0.5;
+          vec2 clip = (screen / u_resolution) * 2.0 - 1.0;
+          gl_Position = vec4(clip * vec2(1.0, -1.0), 0.0, 1.0);
+          gl_PointSize = a_size * u_camera.z;
+          v_color = a_color;
+        }
+      `,
+      `
+        precision mediump float;
+        varying vec4 v_color;
+        void main() {
+          vec2 center = gl_PointCoord - vec2(0.5);
+          float d = length(center);
+          if (d > 0.5) discard;
+          float ring = smoothstep(0.47, 0.5, d);
+          vec4 fill = vec4(v_color.rgb, v_color.a * 0.72);
+          vec4 edge = vec4(v_color.rgb, 1.0);
+          gl_FragColor = mix(fill, edge, ring);
+        }
+      `
+    );
+    this.edgeProgram = createProgram(
+      gl,
+      `
+        attribute vec2 a_position;
+        attribute vec4 a_color;
+        uniform vec2 u_resolution;
+        uniform vec3 u_camera;
+        varying vec4 v_color;
+        void main() {
+          vec2 screen = (a_position - u_camera.xy) * u_camera.z + u_resolution * 0.5;
+          vec2 clip = (screen / u_resolution) * 2.0 - 1.0;
+          gl_Position = vec4(clip * vec2(1.0, -1.0), 0.0, 1.0);
+          v_color = a_color;
+        }
+      `,
+      `
+        precision mediump float;
+        varying vec4 v_color;
+        void main() {
+          gl_FragColor = v_color;
+        }
+      `
+    );
+    this.nodeBuffer = gl.createBuffer();
+    this.edgeBuffer = gl.createBuffer();
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+  }
+
+  bind() {
+    const resizeObserver = new ResizeObserver(() => this.resize());
+    resizeObserver.observe(this.root);
+    this.canvas.addEventListener('pointerdown', (event) => {
+      this.canvas.setPointerCapture(event.pointerId);
+      this.drag = {
+        pointerId: event.pointerId,
+        x: event.clientX,
+        y: event.clientY,
+        startCx: this.targetCamera.cx,
+        startCy: this.targetCamera.cy,
+        moved: false,
+      };
+    });
+    this.canvas.addEventListener('pointermove', (event) => {
+      if (!this.drag) return;
+      const dx = event.clientX - this.drag.x;
+      const dy = event.clientY - this.drag.y;
+      if (Math.hypot(dx, dy) > 3) this.drag.moved = true;
+      this.setCameraTarget({
+        ...this.targetCamera,
+        cx: this.drag.startCx - dx / this.targetCamera.z,
+        cy: this.drag.startCy - dy / this.targetCamera.z,
+      });
+    });
+    this.canvas.addEventListener('pointerup', (event) => {
+      const drag = this.drag;
+      this.drag = null;
+      if (!drag || drag.moved) return;
+      const node = this.pick(event.clientX, event.clientY);
+      if (node) this.selectNode(node);
+    });
+    this.canvas.addEventListener('wheel', (event) => {
+      event.preventDefault();
+      const zoomFactor = Math.exp(-event.deltaY * 0.001);
+      this.setCameraTarget({ ...this.targetCamera, z: clamp(this.targetCamera.z * zoomFactor, 0.22, 3.4) });
+    }, { passive: false });
+    document.addEventListener('click', (event) => {
+      const commandTarget = event.target.closest('[data-graph-command][data-graph-value]');
+      if (!commandTarget) return;
+      const command = commandTarget.dataset.graphCommand;
+      const value = commandTarget.dataset.graphValue;
+      if (command === 'select-incident') this.selectByEntityId('incident', value);
+      if (command === 'select-actor') this.selectByEntityId('actor', value);
+      if (command === 'filter-stage') this.filterStage(value);
+    });
+    document.addEventListener('astro:page-load', () => this.selectFromRoute());
+  }
+
+  resize() {
+    const rect = this.root.getBoundingClientRect();
+    const dpr = Math.min(2, window.devicePixelRatio || 1);
+    this.viewport = { width: Math.max(1, rect.width), height: Math.max(1, rect.height), dpr };
+    this.canvas.width = Math.floor(this.viewport.width * dpr);
+    this.canvas.height = Math.floor(this.viewport.height * dpr);
+    this.canvas.style.width = `${this.viewport.width}px`;
+    this.canvas.style.height = `${this.viewport.height}px`;
+    this.gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+    if (!this.hasInitialFrame) {
+      this.setCameraTarget(fitBounds(this.recentNodes(), this.viewport), true);
+      this.hasInitialFrame = true;
+    }
+  }
+
+  recentNodes() {
+    const incidents = this.layout.nodes
+      .filter((node) => node.tier === 'incident')
+      .sort((a, b) => String(b.time || '').localeCompare(String(a.time || '')))
+      .slice(0, 16);
+    const relatedIds = new Set(incidents.map((node) => node.id));
+    this.layout.edges.forEach((edge) => {
+      if (relatedIds.has(edge.target)) relatedIds.add(edge.source);
+      if (relatedIds.has(edge.source)) relatedIds.add(edge.target);
+    });
+    return this.layout.nodes.filter((node) => relatedIds.has(node.id));
+  }
+
+  setCameraTarget(target, immediate = false) {
+    const z = clamp(target.z, 0.22, 3.4);
+    const halfWidth = this.viewport.width / z / 2;
+    const halfHeight = this.viewport.height / z / 2;
+    const bounds = this.layout.bounds;
+    this.targetCamera = {
+      cx: clampAxis(target.cx, bounds.x0 + halfWidth, bounds.x1 - halfWidth),
+      cy: clampAxis(target.cy, bounds.y0 + halfHeight, bounds.y1 - halfHeight),
+      z,
+    };
+    if (immediate || this.reduceMotion) this.camera = { ...this.targetCamera };
+  }
+
+  screenToWorld(clientX, clientY) {
+    const rect = this.canvas.getBoundingClientRect();
+    return {
+      x: (clientX - rect.left - this.viewport.width / 2) / this.camera.z + this.camera.cx,
+      y: (clientY - rect.top - this.viewport.height / 2) / this.camera.z + this.camera.cy,
+    };
+  }
+
+  worldToScreen(node) {
+    return {
+      x: (node.x - this.camera.cx) * this.camera.z + this.viewport.width / 2,
+      y: (node.y - this.camera.cy) * this.camera.z + this.viewport.height / 2,
+    };
+  }
+
+  pick(clientX, clientY) {
+    const world = this.screenToWorld(clientX, clientY);
+    const radius = 24 / this.camera.z;
+    const nearest = this.layout.quadtree.nearest(world.x, world.y, radius);
+    return nearest?.point || null;
+  }
+
+  selectFromRoute() {
+    const hero = document.querySelector('[data-graph-selection-type][data-graph-selection-value]');
+    const type = hero?.dataset.graphSelectionType;
+    const value = hero?.dataset.graphSelectionValue;
+    if (type === 'incident') {
+      if (!this.selectByEntityId('incident', value)) this.showOverview();
+    } else if (type && type !== 'overview') {
+      const normalizedType = type.replace(/\s+/g, '_');
+      if (!this.selectByEntityId(normalizedType, value)) this.selectEntityContext(normalizedType, value);
+    } else {
+      this.showOverview();
+    }
+  }
+
+  selectByEntityId(type, value) {
+    const normalizedType = type === 'threat actor' || type === 'threat_actor' ? 'actor' : type;
+    const node = this.layout.nodes.find(
+      (item) => item.type === normalizedType && (item.id === value || item.entity_id === value)
+    );
+    if (!node) return false;
+    this.selectNode(node);
+    return true;
+  }
+
+  selectEntityContext(type, value) {
+    const entity = this.payload.nodes.find((node) => node.type === type && (node.id === value || node.entity_id === value));
+    const incidentIds = new Set(
+      (Array.isArray(entity?.source_incident_ids) ? entity.source_incident_ids : []).map((id) => `incident-${id}`)
+    );
+    this.payload.edges.forEach((edge) => {
+      if (edge.source === value && edge.target?.startsWith('incident-')) incidentIds.add(edge.target);
+      if (edge.target === value && edge.source?.startsWith('incident-')) incidentIds.add(edge.source);
+    });
+    const incidentNodes = this.layout.nodes.filter((node) => node.tier === 'incident' && incidentIds.has(node.id));
+    if (!incidentNodes.length) {
+      this.showOverview();
+      return;
+    }
+    this.selection = { type, value, nodes: new Set(incidentNodes.map((node) => node.id)) };
+    this.setCameraTarget(fitBounds(incidentNodes, this.viewport, 180));
+    this.updateCaption(
+      entity?.label || value,
+      `${incidentNodes.length} connected incident${incidentNodes.length === 1 ? '' : 's'} framed for this entity.`
+    );
+  }
+
+  showOverview() {
+    this.selection = null;
+    this.setCameraTarget(fitBounds(this.recentNodes(), this.viewport));
+    this.updateCaption(
+      'Supply Chain Graph',
+      `${this.payload.nodes.length} corpus nodes and ${this.payload.edges.length} typed edges loaded.`
+    );
+  }
+
+  filterStage(stage) {
+    const nodes = this.layout.nodes.filter((node) => node.tier === 'incident' && node.attack_stage === stage);
+    if (nodes.length === 0) return;
+    this.selection = { type: 'stage', value: stage, nodes: new Set(nodes.map((node) => node.id)) };
+    this.setCameraTarget(fitBounds(nodes, this.viewport));
+    this.updateCaption(`Attack stage: ${stage.replace(/_/g, ' ')}`, `${nodes.length} incident${nodes.length === 1 ? '' : 's'} selected.`);
+  }
+
+  selectNode(node) {
+    this.selection = { type: node.type, value: node.id, nodes: new Set([node.id]) };
+    const cluster = this.clusterFor(node);
+    this.setCameraTarget(fitBounds(cluster, this.viewport, node.tier === 'incident' ? 170 : 140));
+    this.updateCaption(node.label, node.summary || `${node.type.replace(/_/g, ' ')} node selected.`);
+  }
+
+  clusterFor(node) {
+    const clusterIds = new Set([node.id]);
+    if (node.tier === 'actor') {
+      this.layout.edges.forEach((edge) => {
+        if (edge.source === node.id) clusterIds.add(edge.target);
+      });
+    } else if (node.tier === 'campaign') {
+      this.layout.edges.forEach((edge) => {
+        if (edge.source === node.id) clusterIds.add(edge.target);
+      });
+    } else if (node.tier === 'incident') {
+      this.layout.edges.forEach((edge) => {
+        if (edge.target === node.id) clusterIds.add(edge.source);
+        if (edge.source === node.id) clusterIds.add(edge.target);
+      });
+    }
+    return this.layout.nodes.filter((item) => clusterIds.has(item.id));
+  }
+
+  updateCaption(title, body) {
+    if (this.captionTitle) this.captionTitle.textContent = title;
+    if (this.captionBody) this.captionBody.textContent = body;
+    if (this.status) this.status.textContent = title;
+  }
+
+  colorForNode(node) {
+    if (this.selection?.type === 'stage' && node.tier === 'incident') {
+      return this.selection.nodes.has(node.id) ? SEVERITY_COLORS[node.sev] || SEVERITY_COLORS.default : SEVERITY_COLORS.muted;
+    }
+    if (node.tier === 'actor') return SEVERITY_COLORS.actor;
+    if (node.tier === 'campaign') return SEVERITY_COLORS.campaign;
+    return SEVERITY_COLORS[node.sev] || SEVERITY_COLORS.default;
+  }
+
+  edgeAlpha(edge) {
+    if (!this.selection) return 0.28;
+    if (this.selection.nodes?.has(edge.source) || this.selection.nodes?.has(edge.target)) return 0.64;
+    return 0.1;
+  }
+
+  drawEdges() {
+    const gl = this.gl;
+    const values = [];
+    this.layout.edges.forEach((edge) => {
+      const alpha = this.edgeAlpha(edge);
+      const color = edge.type === 'ATTRIBUTED_TO_ACTOR' ? SEVERITY_COLORS.high : SEVERITY_COLORS.medium;
+      values.push(edge.sourceNode.x, edge.sourceNode.y, color[0], color[1], color[2], alpha);
+      values.push(edge.targetNode.x, edge.targetNode.y, color[0], color[1], color[2], alpha);
+    });
+    gl.useProgram(this.edgeProgram);
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.edgeBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(values), gl.DYNAMIC_DRAW);
+    const stride = 6 * 4;
+    const position = gl.getAttribLocation(this.edgeProgram, 'a_position');
+    const color = gl.getAttribLocation(this.edgeProgram, 'a_color');
+    gl.enableVertexAttribArray(position);
+    gl.vertexAttribPointer(position, 2, gl.FLOAT, false, stride, 0);
+    gl.enableVertexAttribArray(color);
+    gl.vertexAttribPointer(color, 4, gl.FLOAT, false, stride, 2 * 4);
+    gl.uniform2f(gl.getUniformLocation(this.edgeProgram, 'u_resolution'), this.canvas.width, this.canvas.height);
+    gl.uniform3f(
+      gl.getUniformLocation(this.edgeProgram, 'u_camera'),
+      this.camera.cx,
+      this.camera.cy,
+      this.camera.z * this.viewport.dpr
+    );
+    gl.drawArrays(gl.LINES, 0, values.length / 6);
+  }
+
+  drawNodes() {
+    const gl = this.gl;
+    const values = [];
+    this.layout.nodes.forEach((node) => {
+      const color = this.colorForNode(node);
+      const selected = this.selection?.nodes?.has(node.id);
+      values.push(node.x, node.y, color[0], color[1], color[2], color[3], selected ? node.radius * 2.5 : node.radius * 2);
+    });
+    gl.useProgram(this.nodeProgram);
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.nodeBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(values), gl.DYNAMIC_DRAW);
+    const stride = 7 * 4;
+    const position = gl.getAttribLocation(this.nodeProgram, 'a_position');
+    const color = gl.getAttribLocation(this.nodeProgram, 'a_color');
+    const size = gl.getAttribLocation(this.nodeProgram, 'a_size');
+    gl.enableVertexAttribArray(position);
+    gl.vertexAttribPointer(position, 2, gl.FLOAT, false, stride, 0);
+    gl.enableVertexAttribArray(color);
+    gl.vertexAttribPointer(color, 4, gl.FLOAT, false, stride, 2 * 4);
+    gl.enableVertexAttribArray(size);
+    gl.vertexAttribPointer(size, 1, gl.FLOAT, false, stride, 6 * 4);
+    gl.uniform2f(gl.getUniformLocation(this.nodeProgram, 'u_resolution'), this.canvas.width, this.canvas.height);
+    gl.uniform3f(
+      gl.getUniformLocation(this.nodeProgram, 'u_camera'),
+      this.camera.cx,
+      this.camera.cy,
+      this.camera.z * this.viewport.dpr
+    );
+    gl.drawArrays(gl.POINTS, 0, values.length / 7);
+  }
+
+  drawLabels() {
+    const labelNodes = this.layout.nodes.filter(
+      (node) => node.tier === 'actor' || node.tier === 'campaign' || this.selection?.nodes?.has(node.id)
+    );
+    const labels = labelNodes.slice(0, 24).map((node) => {
+      const position = this.worldToScreen(node);
+      return {
+        node,
+        x: Math.round(position.x + 12),
+        y: Math.round(position.y - 10),
+      };
+    });
+    const labelKey = labels.map((item) => `${item.node.id}:${item.x}:${item.y}`).join('|');
+    if (labelKey === this.lastLabelKey) return;
+    this.lastLabelKey = labelKey;
+    this.labelLayer.replaceChildren(
+      ...labels.map((item) => {
+        const label = document.createElement('span');
+        label.className = `sc-graph-label sc-graph-label-${item.node.tier}`;
+        label.textContent = item.node.label;
+        label.style.transform = `translate(${item.x}px, ${item.y}px)`;
+        return label;
+      })
+    );
+  }
+
+  frame() {
+    this.camera = {
+      cx: lerp(this.camera.cx, this.targetCamera.cx, this.reduceMotion ? 1 : 0.14),
+      cy: lerp(this.camera.cy, this.targetCamera.cy, this.reduceMotion ? 1 : 0.14),
+      z: lerp(this.camera.z, this.targetCamera.z, this.reduceMotion ? 1 : 0.16),
+    };
+    const gl = this.gl;
+    gl.clearColor(0.031, 0.043, 0.063, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    this.drawEdges();
+    this.drawNodes();
+    this.drawLabels();
+    requestAnimationFrame(() => this.frame());
+  }
+}
+
+async function bootSupplyChainGraph() {
+  const root = document.querySelector('[data-supply-chain-graph-root]');
+  if (!root || root.dataset.graphBooted === 'true') return;
+  root.dataset.graphBooted = 'true';
+  try {
+    const response = await fetch(GRAPH_DATA_URL, { credentials: 'same-origin' });
+    if (!response.ok) throw new Error(`Graph payload fetch failed: ${response.status}`);
+    const payload = await response.json();
+    const graph = new SupplyChainGraph(root, payload);
+    window.__threatpediaSupplyChainGraph = graph;
+    root.dataset.graphStatus = 'ready';
+  } catch (error) {
+    root.dataset.graphStatus = 'failed';
+    const status = root.querySelector('[data-sc-graph-status]');
+    if (status) status.textContent = 'Graph unavailable';
+    console.error(error);
+  }
+}
+
+bootSupplyChainGraph();
+document.addEventListener('astro:page-load', bootSupplyChainGraph);

--- a/site/public/supply-chain-graph.json
+++ b/site/public/supply-chain-graph.json
@@ -1,0 +1,3902 @@
+{
+  "schema_version": "threatpedia-supply-chain-graph/1",
+  "generated_at": "2026-06-17T16:55:00.513Z",
+  "source": {
+    "incidents": "data/supply-chain-incidents/incidents.json",
+    "relationships": "data/supply-chain-relationships/relationships.json",
+    "entities": "data/supply-chain-entities/*.json"
+  },
+  "renderer_contract": {
+    "g2_drawable_tiers": [
+      "actor",
+      "campaign",
+      "incident"
+    ],
+    "package_release_lod": "payload-only-until-G4",
+    "layout": "time-anchored-actor-lanes"
+  },
+  "counts": {
+    "incident": 27,
+    "account": 10,
+    "actor": 6,
+    "build_system": 6,
+    "campaign": 3,
+    "distribution_channel": 14,
+    "maintainer": 5,
+    "organization": 19,
+    "package": 21,
+    "release": 7,
+    "repository": 11
+  },
+  "attack_stages": [
+    {
+      "id": "account_compromise",
+      "label": "Account Compromise"
+    },
+    {
+      "id": "build_compromise",
+      "label": "Build Compromise"
+    },
+    {
+      "id": "ci_cd_compromise",
+      "label": "Ci Cd Compromise"
+    },
+    {
+      "id": "dependency_resolution",
+      "label": "Dependency Resolution"
+    },
+    {
+      "id": "distribution_compromise",
+      "label": "Distribution Compromise"
+    },
+    {
+      "id": "package_publish",
+      "label": "Package Publish"
+    },
+    {
+      "id": "source_compromise",
+      "label": "Source Compromise"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "account-github-tj-actions-github-action-release-path",
+      "entity_id": "account-github-tj-actions-github-action-release-path",
+      "type": "account",
+      "label": "tj-actions GitHub Action release path",
+      "tier": "account",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": null,
+      "aliases": [
+        "tj-actions GitHub Action release path"
+      ],
+      "source_incident_ids": [
+        "SC-2025-TJ-ACTIONS-CHANGED-FILES"
+      ]
+    },
+    {
+      "id": "account-github-victim-github-tokens",
+      "entity_id": "account-github-victim-github-tokens",
+      "type": "account",
+      "label": "victim GitHub tokens",
+      "tier": "account",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": null,
+      "aliases": [
+        "victim GitHub tokens"
+      ],
+      "source_incident_ids": [
+        "SC-2025-NPM-SHAI-HULUD"
+      ]
+    },
+    {
+      "id": "account-npm-compromised-npm-maintainer-tokens",
+      "entity_id": "account-npm-compromised-npm-maintainer-tokens",
+      "type": "account",
+      "label": "compromised npm maintainer tokens",
+      "tier": "account",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": null,
+      "aliases": [
+        "compromised npm maintainer tokens"
+      ],
+      "source_incident_ids": [
+        "SC-2025-NPM-SHAI-HULUD"
+      ]
+    },
+    {
+      "id": "account-npm-eslint-scope-npm-maintainer-account",
+      "entity_id": "account-npm-eslint-scope-npm-maintainer-account",
+      "type": "account",
+      "label": "eslint-scope npm maintainer account",
+      "tier": "account",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": null,
+      "aliases": [
+        "eslint-scope npm maintainer account"
+      ],
+      "source_incident_ids": [
+        "SC-2018-ESLINT-SCOPE"
+      ]
+    },
+    {
+      "id": "account-npm-ledgerhq-connect-kit-npm-publish-account",
+      "entity_id": "account-npm-ledgerhq-connect-kit-npm-publish-account",
+      "type": "account",
+      "label": "@ledgerhq/connect-kit npm publish account",
+      "tier": "account",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": null,
+      "aliases": [
+        "@ledgerhq/connect-kit npm publish account"
+      ],
+      "source_incident_ids": [
+        "SC-2023-LEDGER-CONNECT-KIT"
+      ]
+    },
+    {
+      "id": "account-npm-lottiefiles-lottie-player-npm-publish-account",
+      "entity_id": "account-npm-lottiefiles-lottie-player-npm-publish-account",
+      "type": "account",
+      "label": "@lottiefiles/lottie-player npm publish account",
+      "tier": "account",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": null,
+      "aliases": [
+        "@lottiefiles/lottie-player npm publish account"
+      ],
+      "source_incident_ids": [
+        "SC-2024-LOTTIE-PLAYER"
+      ]
+    },
+    {
+      "id": "account-npm-ua-parser-js-npm-maintainer-account",
+      "entity_id": "account-npm-ua-parser-js-npm-maintainer-account",
+      "type": "account",
+      "label": "ua-parser-js npm maintainer account",
+      "tier": "account",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": null,
+      "aliases": [
+        "ua-parser-js npm maintainer account"
+      ],
+      "source_incident_ids": [
+        "SC-2021-UA-PARSER-JS"
+      ]
+    },
+    {
+      "id": "account-php-git-php-git-server-commit-identity",
+      "entity_id": "account-php-git-php-git-server-commit-identity",
+      "type": "account",
+      "label": "PHP git server commit identity",
+      "tier": "account",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": null,
+      "aliases": [
+        "PHP git server commit identity"
+      ],
+      "source_incident_ids": [
+        "SC-2021-PHP-GIT-SERVER"
+      ]
+    },
+    {
+      "id": "account-pypi-ctx-pypi-project-account",
+      "entity_id": "account-pypi-ctx-pypi-project-account",
+      "type": "account",
+      "label": "ctx PyPI project account",
+      "tier": "account",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": null,
+      "aliases": [
+        "ctx PyPI project account"
+      ],
+      "source_incident_ids": [
+        "SC-2022-PYPI-CTX"
+      ]
+    },
+    {
+      "id": "account-pypi-ultralytics-pypi-publishing-token",
+      "entity_id": "account-pypi-ultralytics-pypi-publishing-token",
+      "type": "account",
+      "label": "Ultralytics PyPI publishing token",
+      "tier": "account",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": null,
+      "aliases": [
+        "Ultralytics PyPI publishing token"
+      ],
+      "source_incident_ids": [
+        "SC-2024-ULTRALYTICS-PYPI"
+      ]
+    },
+    {
+      "id": "actor-apt29",
+      "entity_id": "actor-apt29",
+      "type": "actor",
+      "label": "APT29",
+      "tier": "actor",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/threat-actors/apt29/",
+      "ecosystem": null,
+      "aliases": [
+        "APT29",
+        "Cozy Bear",
+        "SVR"
+      ],
+      "source_incident_ids": [
+        "SC-2020-SOLARWINDS-ORION"
+      ]
+    },
+    {
+      "id": "actor-boltdb-go-operator",
+      "entity_id": "actor-boltdb-go-operator",
+      "type": "actor",
+      "label": "boltdb-go operator",
+      "tier": "actor",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": null,
+      "aliases": [
+        "boltdb-go",
+        "boltdb-go operator"
+      ],
+      "source_incident_ids": [
+        "SC-2025-GO-BOLTDB-TYPOSQUAT"
+      ]
+    },
+    {
+      "id": "actor-lazarus-group",
+      "entity_id": "actor-lazarus-group",
+      "type": "actor",
+      "label": "Lazarus Group",
+      "tier": "actor",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/threat-actors/lazarus-group/",
+      "ecosystem": null,
+      "aliases": [
+        "Lazarus Group",
+        "UNC4736"
+      ],
+      "source_incident_ids": [
+        "SC-2023-THREE-CX-DESKTOP"
+      ]
+    },
+    {
+      "id": "actor-sandworm",
+      "entity_id": "actor-sandworm",
+      "type": "actor",
+      "label": "Sandworm",
+      "tier": "actor",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/threat-actors/sandworm/",
+      "ecosystem": null,
+      "aliases": [
+        "GRU Unit 74455",
+        "Sandworm"
+      ],
+      "source_incident_ids": [
+        "SC-2017-NOTPETYA-MEDOC"
+      ]
+    },
+    {
+      "id": "actor-shai-hulud-operator",
+      "entity_id": "actor-shai-hulud-operator",
+      "type": "actor",
+      "label": "Shai-Hulud operator",
+      "tier": "actor",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": null,
+      "aliases": [
+        "Shai-Hulud operator"
+      ],
+      "source_incident_ids": [
+        "SC-2025-NPM-SHAI-HULUD"
+      ]
+    },
+    {
+      "id": "actor-unc-xz-utils-operator",
+      "entity_id": "actor-unc-xz-utils-operator",
+      "type": "actor",
+      "label": "UNC-XZ-UTILS",
+      "tier": "actor",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": null,
+      "aliases": [
+        "Jia Tan operator cluster",
+        "UNC-XZ-UTILS"
+      ],
+      "source_incident_ids": [
+        "SC-2024-XZ-UTILS"
+      ]
+    },
+    {
+      "id": "build-3cx-3cx-desktopapp-build-pipeline",
+      "entity_id": "build-3cx-3cx-desktopapp-build-pipeline",
+      "type": "build_system",
+      "label": "3CX DesktopApp build pipeline",
+      "tier": "supporting",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": null,
+      "aliases": [
+        "3CX DesktopApp build pipeline"
+      ],
+      "source_incident_ids": [
+        "SC-2023-THREE-CX-DESKTOP"
+      ]
+    },
+    {
+      "id": "build-codecov-codecov-bash-uploader-distribution-pipeline",
+      "entity_id": "build-codecov-codecov-bash-uploader-distribution-pipeline",
+      "type": "build_system",
+      "label": "Codecov Bash Uploader distribution pipeline",
+      "tier": "supporting",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": null,
+      "aliases": [
+        "Codecov Bash Uploader distribution pipeline"
+      ],
+      "source_incident_ids": [
+        "SC-2021-CODECOV-BASH-UPLOADER"
+      ]
+    },
+    {
+      "id": "build-github-github-actions",
+      "entity_id": "build-github-github-actions",
+      "type": "build_system",
+      "label": "GitHub Actions",
+      "tier": "supporting",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": null,
+      "aliases": [
+        "GitHub Actions"
+      ],
+      "source_incident_ids": [
+        "SC-2024-ULTRALYTICS-PYPI",
+        "SC-2025-NPM-SHAI-HULUD",
+        "SC-2025-TJ-ACTIONS-CHANGED-FILES"
+      ]
+    },
+    {
+      "id": "build-netbeans-netbeans-project-build-process",
+      "entity_id": "build-netbeans-netbeans-project-build-process",
+      "type": "build_system",
+      "label": "NetBeans project build process",
+      "tier": "supporting",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": null,
+      "aliases": [
+        "NetBeans project build process"
+      ],
+      "source_incident_ids": [
+        "SC-2020-OCTOPUS-SCANNER"
+      ]
+    },
+    {
+      "id": "build-pytorch-pytorch-nightly-build-pipeline",
+      "entity_id": "build-pytorch-pytorch-nightly-build-pipeline",
+      "type": "build_system",
+      "label": "PyTorch nightly build pipeline",
+      "tier": "supporting",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": null,
+      "aliases": [
+        "PyTorch nightly build pipeline"
+      ],
+      "source_incident_ids": [
+        "SC-2022-PYTORCH-NIGHTLY"
+      ]
+    },
+    {
+      "id": "build-solarwinds-solarwinds-orion-build-system",
+      "entity_id": "build-solarwinds-solarwinds-orion-build-system",
+      "type": "build_system",
+      "label": "SolarWinds Orion build system",
+      "tier": "supporting",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": null,
+      "aliases": [
+        "SolarWinds Orion build system"
+      ],
+      "source_incident_ids": [
+        "SC-2020-SOLARWINDS-ORION"
+      ]
+    },
+    {
+      "id": "campaign-tp-camp-2017-0002",
+      "entity_id": "campaign-tp-camp-2017-0002",
+      "type": "campaign",
+      "label": "NotPetya Destructive Campaign: Sandworm Global Wiper Operation (2017)",
+      "tier": "campaign",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/campaigns/notpetya-destructive-campaign-2017/",
+      "ecosystem": null,
+      "aliases": [
+        "NotPetya Destructive Campaign: Sandworm Global Wiper Operation (2017)",
+        "TP-CAMP-2017-0002"
+      ],
+      "source_incident_ids": [
+        "SC-2017-NOTPETYA-MEDOC"
+      ]
+    },
+    {
+      "id": "campaign-tp-camp-2020-0001",
+      "entity_id": "campaign-tp-camp-2020-0001",
+      "type": "campaign",
+      "label": "SolarWinds Supply Chain Espionage Campaign",
+      "tier": "campaign",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/campaigns/solarwinds-supply-chain-campaign/",
+      "ecosystem": null,
+      "aliases": [
+        "SolarWinds Supply Chain Espionage Campaign",
+        "TP-CAMP-2020-0001"
+      ],
+      "source_incident_ids": [
+        "SC-2020-SOLARWINDS-ORION"
+      ]
+    },
+    {
+      "id": "campaign-tp-camp-2023-0002",
+      "entity_id": "campaign-tp-camp-2023-0002",
+      "type": "campaign",
+      "label": "Lazarus Group Operation SmoothOperator - 3CX Software Supply Chain Compromise",
+      "tier": "campaign",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/campaigns/lazarus-3cx-supply-chain-compromise-2023/",
+      "ecosystem": null,
+      "aliases": [
+        "Lazarus Group Operation SmoothOperator - 3CX Software Supply Chain Compromise",
+        "TP-CAMP-2023-0002"
+      ],
+      "source_incident_ids": [
+        "SC-2023-THREE-CX-DESKTOP"
+      ]
+    },
+    {
+      "id": "channel-ci-cd-script-download-codecov-bash-uploader-download-path",
+      "entity_id": "channel-ci-cd-script-download-codecov-bash-uploader-download-path",
+      "type": "distribution_channel",
+      "label": "Codecov Bash Uploader download path",
+      "tier": "supporting",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": "ci-cd",
+      "aliases": [
+        "Codecov Bash Uploader download path"
+      ],
+      "source_incident_ids": [
+        "SC-2021-CODECOV-BASH-UPLOADER"
+      ]
+    },
+    {
+      "id": "channel-github-actions-ci-cd-marketplace-github-actions-marketplace",
+      "entity_id": "channel-github-actions-ci-cd-marketplace-github-actions-marketplace",
+      "type": "distribution_channel",
+      "label": "GitHub Actions Marketplace",
+      "tier": "supporting",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": "github-actions",
+      "aliases": [
+        "GitHub Actions Marketplace"
+      ],
+      "source_incident_ids": [
+        "SC-2025-TJ-ACTIONS-CHANGED-FILES"
+      ]
+    },
+    {
+      "id": "channel-github-actions-ci-cd-workflow-github-actions-workflow",
+      "entity_id": "channel-github-actions-ci-cd-workflow-github-actions-workflow",
+      "type": "distribution_channel",
+      "label": "GitHub Actions workflow",
+      "tier": "supporting",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": "github-actions",
+      "aliases": [
+        "GitHub Actions workflow"
+      ],
+      "source_incident_ids": [
+        "SC-2025-NPM-SHAI-HULUD"
+      ]
+    },
+    {
+      "id": "channel-github-source-repository-github-repository",
+      "entity_id": "channel-github-source-repository-github-repository",
+      "type": "distribution_channel",
+      "label": "GitHub repository",
+      "tier": "supporting",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": "github",
+      "aliases": [
+        "GitHub repository"
+      ],
+      "source_incident_ids": [
+        "SC-2025-GO-BOLTDB-TYPOSQUAT"
+      ]
+    },
+    {
+      "id": "channel-golang-package-registry-go-module-proxy",
+      "entity_id": "channel-golang-package-registry-go-module-proxy",
+      "type": "distribution_channel",
+      "label": "Go Module Proxy",
+      "tier": "supporting",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": "golang",
+      "aliases": [
+        "Go Module Proxy"
+      ],
+      "source_incident_ids": [
+        "SC-2025-GO-BOLTDB-TYPOSQUAT"
+      ]
+    },
+    {
+      "id": "channel-linux-source-release-upstream-source-release-tarball",
+      "entity_id": "channel-linux-source-release-upstream-source-release-tarball",
+      "type": "distribution_channel",
+      "label": "Upstream source release tarball",
+      "tier": "supporting",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": "linux",
+      "aliases": [
+        "Upstream source release tarball"
+      ],
+      "source_incident_ids": [
+        "SC-2024-XZ-UTILS"
+      ]
+    },
+    {
+      "id": "channel-linux-website-download-linux-mint-download-site",
+      "entity_id": "channel-linux-website-download-linux-mint-download-site",
+      "type": "distribution_channel",
+      "label": "Linux Mint download site",
+      "tier": "supporting",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": "linux",
+      "aliases": [
+        "Linux Mint download site"
+      ],
+      "source_incident_ids": [
+        "SC-2016-LINUX-MINT-ISO"
+      ]
+    },
+    {
+      "id": "channel-npm-package-registry-npm-registry",
+      "entity_id": "channel-npm-package-registry-npm-registry",
+      "type": "distribution_channel",
+      "label": "npm registry",
+      "tier": "supporting",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": "npm",
+      "aliases": [
+        "npm registry"
+      ],
+      "source_incident_ids": [
+        "SC-2018-ESLINT-SCOPE",
+        "SC-2018-NPM-EVENT-STREAM",
+        "SC-2021-DEPENDENCY-CONFUSION",
+        "SC-2021-NPM-RC",
+        "SC-2021-UA-PARSER-JS",
+        "SC-2022-COLORS-FAKER",
+        "SC-2022-NODE-IPC",
+        "SC-2023-LEDGER-CONNECT-KIT",
+        "SC-2024-LOTTIE-PLAYER",
+        "SC-2025-NPM-SHAI-HULUD"
+      ]
+    },
+    {
+      "id": "channel-pypi-package-registry-pypi",
+      "entity_id": "channel-pypi-package-registry-pypi",
+      "type": "distribution_channel",
+      "label": "PyPI",
+      "tier": "supporting",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": "pypi",
+      "aliases": [
+        "PyPI"
+      ],
+      "source_incident_ids": [
+        "SC-2021-DEPENDENCY-CONFUSION",
+        "SC-2022-PYPI-CTX",
+        "SC-2022-PYTORCH-NIGHTLY",
+        "SC-2024-ULTRALYTICS-PYPI"
+      ]
+    },
+    {
+      "id": "channel-rubygems-package-registry-rubygems",
+      "entity_id": "channel-rubygems-package-registry-rubygems",
+      "type": "distribution_channel",
+      "label": "RubyGems",
+      "tier": "supporting",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": "rubygems",
+      "aliases": [
+        "RubyGems"
+      ],
+      "source_incident_ids": [
+        "SC-2021-DEPENDENCY-CONFUSION"
+      ]
+    },
+    {
+      "id": "channel-source-control-source-repository-source-repository",
+      "entity_id": "channel-source-control-source-repository-source-repository",
+      "type": "distribution_channel",
+      "label": "Source repository",
+      "tier": "supporting",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": "source-control",
+      "aliases": [
+        "Source repository"
+      ],
+      "source_incident_ids": [
+        "SC-2020-OCTOPUS-SCANNER",
+        "SC-2021-PHP-GIT-SERVER"
+      ]
+    },
+    {
+      "id": "channel-vendor-update-signed-update-signed-software-installer-update-channel",
+      "entity_id": "channel-vendor-update-signed-update-signed-software-installer-update-channel",
+      "type": "distribution_channel",
+      "label": "Signed software installer/update channel",
+      "tier": "supporting",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": "vendor-update",
+      "aliases": [
+        "Signed software installer/update channel"
+      ],
+      "source_incident_ids": [
+        "SC-2017-CCLEANER",
+        "SC-2019-ASUS-SHADOWHAMMER",
+        "SC-2020-SOLARWINDS-ORION",
+        "SC-2023-THREE-CX-DESKTOP"
+      ]
+    },
+    {
+      "id": "channel-vendor-update-software-update-vendor-software-update-channel",
+      "entity_id": "channel-vendor-update-software-update-vendor-software-update-channel",
+      "type": "distribution_channel",
+      "label": "Vendor software update channel",
+      "tier": "supporting",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": "vendor-update",
+      "aliases": [
+        "Vendor software update channel"
+      ],
+      "source_incident_ids": [
+        "SC-2017-NOTPETYA-MEDOC",
+        "SC-2021-KASEYA-VSA"
+      ]
+    },
+    {
+      "id": "channel-web-cdn-script-third-party-cdn-script",
+      "entity_id": "channel-web-cdn-script-third-party-cdn-script",
+      "type": "distribution_channel",
+      "label": "Third-party CDN script",
+      "tier": "supporting",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": null,
+      "ecosystem": "web",
+      "aliases": [
+        "Third-party CDN script"
+      ],
+      "source_incident_ids": [
+        "SC-2024-POLYFILL-IO"
+      ]
+    },
+    {
+      "id": "incident-SC-2016-LINUX-MINT-ISO",
+      "entity_id": "SC-2016-LINUX-MINT-ISO",
+      "type": "incident",
+      "label": "Linux Mint ISO distribution site compromise",
+      "tier": "incident",
+      "sev": "medium",
+      "time": "2016-02-21",
+      "parent": null,
+      "techniques": [
+        "distribution_site_compromise",
+        "malware_distribution",
+        "backdoor",
+        "iso",
+        "distribution"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2016-LINUX-MINT-ISO/",
+      "attack_stage": "distribution_compromise",
+      "evidence_level": "vendor",
+      "confidence": "high",
+      "summary": "Attackers modified Linux Mint download infrastructure so some users received a backdoored ISO image instead of the legitimate distribution image."
+    },
+    {
+      "id": "incident-SC-2017-CCLEANER",
+      "entity_id": "SC-2017-CCLEANER",
+      "type": "incident",
+      "label": "CCleaner signed installer compromise",
+      "tier": "incident",
+      "sev": "medium",
+      "time": "2017-09-18",
+      "parent": null,
+      "techniques": [
+        "signed_update_compromise",
+        "malware_distribution",
+        "backdoor",
+        "signed-update",
+        "windows"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2017-CCLEANER/",
+      "attack_stage": "distribution_compromise",
+      "evidence_level": "researcher",
+      "confidence": "high",
+      "summary": "A legitimate CCleaner release was modified and signed, distributing malware to downstream users through the normal software update and download path."
+    },
+    {
+      "id": "incident-SC-2017-NOTPETYA-MEDOC",
+      "entity_id": "SC-2017-NOTPETYA-MEDOC",
+      "type": "incident",
+      "label": "NotPetya distributed through M.E.Doc update channel",
+      "tier": "incident",
+      "sev": "medium",
+      "time": "2017-07-01",
+      "parent": "campaign-tp-camp-2017-0002",
+      "techniques": [
+        "vendor_update_compromise",
+        "destructive_payload",
+        "ransomware_delivery",
+        "downstream_customer_compromise",
+        "notpetya",
+        "software-update"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2017-NOTPETYA-MEDOC/",
+      "attack_stage": "distribution_compromise",
+      "evidence_level": "vendor",
+      "confidence": "high",
+      "summary": "The NotPetya destructive malware outbreak was seeded through a compromised Ukrainian accounting software update mechanism used by M.E.Doc customers."
+    },
+    {
+      "id": "incident-SC-2018-ESLINT-SCOPE",
+      "entity_id": "SC-2018-ESLINT-SCOPE",
+      "type": "incident",
+      "label": "eslint-scope npm package credential-stealing release",
+      "tier": "incident",
+      "sev": "high",
+      "time": "2018-07-12",
+      "parent": null,
+      "techniques": [
+        "maintainer_account_compromise",
+        "package_repository_compromise",
+        "credential_theft",
+        "developer_workstation_compromise",
+        "npm",
+        "maintainer-account"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2018-ESLINT-SCOPE/",
+      "attack_stage": "account_compromise",
+      "evidence_level": "vendor",
+      "confidence": "high",
+      "summary": "An attacker used compromised npm maintainer credentials to publish malicious eslint-scope and eslint-config-eslint releases that attempted to steal npm tokens."
+    },
+    {
+      "id": "incident-SC-2018-NPM-EVENT-STREAM",
+      "entity_id": "SC-2018-NPM-EVENT-STREAM",
+      "type": "incident",
+      "label": "event-stream malicious dependency insertion",
+      "tier": "incident",
+      "sev": "medium",
+      "time": "2018-11-26",
+      "parent": null,
+      "techniques": [
+        "malicious_dependency",
+        "credential_theft",
+        "crypto_theft",
+        "npm",
+        "dependency"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2018-NPM-EVENT-STREAM/",
+      "attack_stage": "package_publish",
+      "evidence_level": "primary",
+      "confidence": "high",
+      "summary": "A maintainer transfer enabled a malicious dependency to be added to the event-stream npm package dependency tree, targeting downstream cryptocurrency wallet software."
+    },
+    {
+      "id": "incident-SC-2019-ASUS-SHADOWHAMMER",
+      "entity_id": "SC-2019-ASUS-SHADOWHAMMER",
+      "type": "incident",
+      "label": "ASUS Live Update Operation ShadowHammer",
+      "tier": "incident",
+      "sev": "medium",
+      "time": "2019-03-25",
+      "parent": null,
+      "techniques": [
+        "signed_update_compromise",
+        "malware_distribution",
+        "backdoor",
+        "signed-update",
+        "targeted"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2019-ASUS-SHADOWHAMMER/",
+      "attack_stage": "distribution_compromise",
+      "evidence_level": "researcher",
+      "confidence": "high",
+      "summary": "Attackers compromised the ASUS Live Update utility and distributed signed malicious updates to selected downstream systems."
+    },
+    {
+      "id": "incident-SC-2020-OCTOPUS-SCANNER",
+      "entity_id": "SC-2020-OCTOPUS-SCANNER",
+      "type": "incident",
+      "label": "Octopus Scanner malicious NetBeans project campaign",
+      "tier": "incident",
+      "sev": "high",
+      "time": "2020-03-09",
+      "parent": null,
+      "techniques": [
+        "source_repository_compromise",
+        "build_system_compromise",
+        "developer_workstation_compromise",
+        "malware_distribution",
+        "github",
+        "java"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2020-OCTOPUS-SCANNER/",
+      "attack_stage": "source_compromise",
+      "evidence_level": "researcher",
+      "confidence": "high",
+      "summary": "Malicious code planted in open source NetBeans projects propagated through developer builds and attempted to infect additional projects."
+    },
+    {
+      "id": "incident-SC-2020-SOLARWINDS-ORION",
+      "entity_id": "SC-2020-SOLARWINDS-ORION",
+      "type": "incident",
+      "label": "SolarWinds Orion software build compromise",
+      "tier": "incident",
+      "sev": "critical",
+      "time": "2020-12-13",
+      "parent": "campaign-tp-camp-2020-0001",
+      "techniques": [
+        "build_system_compromise",
+        "signed_update_compromise",
+        "backdoor",
+        "downstream_customer_compromise",
+        "build-system",
+        "sunburst"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2020-SOLARWINDS-ORION/",
+      "attack_stage": "build_compromise",
+      "evidence_level": "vendor",
+      "confidence": "high",
+      "summary": "Attackers compromised the SolarWinds Orion build process and inserted the SUNBURST backdoor into signed software updates delivered to customers."
+    },
+    {
+      "id": "incident-SC-2021-CODECOV-BASH-UPLOADER",
+      "entity_id": "SC-2021-CODECOV-BASH-UPLOADER",
+      "type": "incident",
+      "label": "Codecov Bash Uploader credential exfiltration",
+      "tier": "incident",
+      "sev": "critical",
+      "time": "2021-04-15",
+      "parent": null,
+      "techniques": [
+        "build_system_compromise",
+        "credential_theft",
+        "data_exfiltration",
+        "ci-cd",
+        "credentials"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2021-CODECOV-BASH-UPLOADER/",
+      "attack_stage": "ci_cd_compromise",
+      "evidence_level": "vendor",
+      "confidence": "high",
+      "summary": "The Codecov Bash Uploader was modified by an attacker, enabling environment variable and credential exfiltration from affected CI environments."
+    },
+    {
+      "id": "incident-SC-2021-DEPENDENCY-CONFUSION",
+      "entity_id": "SC-2021-DEPENDENCY-CONFUSION",
+      "type": "incident",
+      "label": "Dependency confusion proof-of-concept campaign",
+      "tier": "incident",
+      "sev": "high",
+      "time": "2021-02-09",
+      "parent": null,
+      "techniques": [
+        "dependency_confusion",
+        "developer_workstation_compromise",
+        "data_exfiltration",
+        "dependency-confusion",
+        "research"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2021-DEPENDENCY-CONFUSION/",
+      "attack_stage": "dependency_resolution",
+      "evidence_level": "researcher",
+      "confidence": "high",
+      "summary": "Researchers demonstrated that public package registries could be abused to satisfy internal dependency names and execute code in downstream build environments."
+    },
+    {
+      "id": "incident-SC-2021-KASEYA-VSA",
+      "entity_id": "SC-2021-KASEYA-VSA",
+      "type": "incident",
+      "label": "Kaseya VSA ransomware supply-chain attack",
+      "tier": "incident",
+      "sev": "medium",
+      "time": "2021-07-02",
+      "parent": null,
+      "techniques": [
+        "vendor_update_compromise",
+        "ransomware_delivery",
+        "downstream_customer_compromise",
+        "ransomware",
+        "msp"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2021-KASEYA-VSA/",
+      "attack_stage": "distribution_compromise",
+      "evidence_level": "vendor",
+      "confidence": "high",
+      "summary": "Attackers abused Kaseya VSA management software to distribute ransomware through managed service provider environments to downstream customers."
+    },
+    {
+      "id": "incident-SC-2021-NPM-RC",
+      "entity_id": "SC-2021-NPM-RC",
+      "type": "incident",
+      "label": "rc npm package malicious release",
+      "tier": "incident",
+      "sev": "medium",
+      "time": "2021-11-04",
+      "parent": null,
+      "techniques": [
+        "package_repository_compromise",
+        "malware_distribution",
+        "npm",
+        "malicious-package"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2021-NPM-RC/",
+      "attack_stage": "package_publish",
+      "evidence_level": "vendor",
+      "confidence": "high",
+      "summary": "The rc npm package had malicious versions published that required users to downgrade and inspect systems for suspicious activity."
+    },
+    {
+      "id": "incident-SC-2021-PHP-GIT-SERVER",
+      "entity_id": "SC-2021-PHP-GIT-SERVER",
+      "type": "incident",
+      "label": "PHP source repository backdoor attempt",
+      "tier": "incident",
+      "sev": "high",
+      "time": "2021-03-28",
+      "parent": null,
+      "techniques": [
+        "source_repository_compromise",
+        "backdoor",
+        "source-control",
+        "php"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2021-PHP-GIT-SERVER/",
+      "attack_stage": "source_compromise",
+      "evidence_level": "vendor",
+      "confidence": "high",
+      "summary": "Attackers pushed malicious commits to the PHP source repository that would have introduced a backdoor if accepted into releases."
+    },
+    {
+      "id": "incident-SC-2021-UA-PARSER-JS",
+      "entity_id": "SC-2021-UA-PARSER-JS",
+      "type": "incident",
+      "label": "ua-parser-js npm package account compromise",
+      "tier": "incident",
+      "sev": "high",
+      "time": "2021-10-22",
+      "parent": null,
+      "techniques": [
+        "maintainer_account_compromise",
+        "package_repository_compromise",
+        "credential_theft",
+        "cryptomining",
+        "npm",
+        "account-compromise"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2021-UA-PARSER-JS/",
+      "attack_stage": "account_compromise",
+      "evidence_level": "vendor",
+      "confidence": "high",
+      "summary": "Malicious versions of ua-parser-js were published to npm after maintainer account compromise, delivering credential-stealing and cryptomining payloads."
+    },
+    {
+      "id": "incident-SC-2022-COLORS-FAKER",
+      "entity_id": "SC-2022-COLORS-FAKER",
+      "type": "incident",
+      "label": "colors and faker npm protestware releases",
+      "tier": "incident",
+      "sev": "medium",
+      "time": "2022-01-09",
+      "parent": null,
+      "techniques": [
+        "protestware",
+        "destructive_payload",
+        "protest_payload",
+        "npm",
+        "protestware"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2022-COLORS-FAKER/",
+      "attack_stage": "package_publish",
+      "evidence_level": "primary",
+      "confidence": "high",
+      "summary": "The maintainer of colors and faker published intentionally disruptive releases that broke downstream consumers and demonstrated maintainer-driven supply-chain risk."
+    },
+    {
+      "id": "incident-SC-2022-NODE-IPC",
+      "entity_id": "SC-2022-NODE-IPC",
+      "type": "incident",
+      "label": "node-ipc peacenotwar protestware release",
+      "tier": "incident",
+      "sev": "medium",
+      "time": "2022-03-16",
+      "parent": null,
+      "techniques": [
+        "protestware",
+        "destructive_payload",
+        "protest_payload",
+        "npm",
+        "protestware"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2022-NODE-IPC/",
+      "attack_stage": "package_publish",
+      "evidence_level": "researcher",
+      "confidence": "high",
+      "summary": "The node-ipc npm package included protestware behavior that modified files for users in certain geographies, creating downstream integrity and availability risk."
+    },
+    {
+      "id": "incident-SC-2022-PYPI-CTX",
+      "entity_id": "SC-2022-PYPI-CTX",
+      "type": "incident",
+      "label": "ctx PyPI project account takeover",
+      "tier": "incident",
+      "sev": "high",
+      "time": "2022-05-24",
+      "parent": null,
+      "techniques": [
+        "maintainer_account_compromise",
+        "package_repository_compromise",
+        "credential_theft",
+        "data_exfiltration",
+        "pypi",
+        "account-takeover"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2022-PYPI-CTX/",
+      "attack_stage": "account_compromise",
+      "evidence_level": "researcher",
+      "confidence": "high",
+      "summary": "The ctx project on PyPI was taken over and replaced with malicious code that collected environment variables from affected users."
+    },
+    {
+      "id": "incident-SC-2022-PYTORCH-NIGHTLY",
+      "entity_id": "SC-2022-PYTORCH-NIGHTLY",
+      "type": "incident",
+      "label": "PyTorch nightly dependency confusion compromise",
+      "tier": "incident",
+      "sev": "high",
+      "time": "2022-12-31",
+      "parent": null,
+      "techniques": [
+        "dependency_confusion",
+        "credential_theft",
+        "developer_workstation_compromise",
+        "pypi",
+        "dependency-confusion"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2022-PYTORCH-NIGHTLY/",
+      "attack_stage": "dependency_resolution",
+      "evidence_level": "vendor",
+      "confidence": "high",
+      "summary": "A malicious torchtriton package on PyPI was installed by some PyTorch nightly users because it shadowed an expected dependency name."
+    },
+    {
+      "id": "incident-SC-2023-LEDGER-CONNECT-KIT",
+      "entity_id": "SC-2023-LEDGER-CONNECT-KIT",
+      "type": "incident",
+      "label": "Ledger Connect Kit npm package compromise",
+      "tier": "incident",
+      "sev": "high",
+      "time": "2023-12-14",
+      "parent": null,
+      "techniques": [
+        "maintainer_account_compromise",
+        "package_repository_compromise",
+        "crypto_theft",
+        "downstream_customer_compromise",
+        "npm",
+        "web3"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2023-LEDGER-CONNECT-KIT/",
+      "attack_stage": "account_compromise",
+      "evidence_level": "vendor",
+      "confidence": "high",
+      "summary": "A compromised Ledger Connect Kit npm release injected malicious code into downstream web applications and targeted cryptocurrency wallet transactions."
+    },
+    {
+      "id": "incident-SC-2023-THREE-CX-DESKTOP",
+      "entity_id": "SC-2023-THREE-CX-DESKTOP",
+      "type": "incident",
+      "label": "3CX desktop application software supply-chain compromise",
+      "tier": "incident",
+      "sev": "critical",
+      "time": "2023-03-29",
+      "parent": "campaign-tp-camp-2023-0002",
+      "techniques": [
+        "build_system_compromise",
+        "signed_update_compromise",
+        "malware_distribution",
+        "backdoor",
+        "downstream_customer_compromise",
+        "desktop",
+        "signed-update"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2023-THREE-CX-DESKTOP/",
+      "attack_stage": "build_compromise",
+      "evidence_level": "researcher",
+      "confidence": "high",
+      "summary": "Attackers compromised 3CX desktop application builds, causing trojanized installers and updates to reach downstream customers."
+    },
+    {
+      "id": "incident-SC-2024-LOTTIE-PLAYER",
+      "entity_id": "SC-2024-LOTTIE-PLAYER",
+      "type": "incident",
+      "label": "LottieFiles lottie-player npm package compromise",
+      "tier": "incident",
+      "sev": "high",
+      "time": "2024-10-31",
+      "parent": null,
+      "techniques": [
+        "maintainer_account_compromise",
+        "package_repository_compromise",
+        "crypto_theft",
+        "downstream_customer_compromise",
+        "npm",
+        "web3"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2024-LOTTIE-PLAYER/",
+      "attack_stage": "account_compromise",
+      "evidence_level": "vendor",
+      "confidence": "high",
+      "summary": "Compromised releases of the @lottiefiles/lottie-player npm package injected malicious wallet-draining code into downstream web applications."
+    },
+    {
+      "id": "incident-SC-2024-POLYFILL-IO",
+      "entity_id": "SC-2024-POLYFILL-IO",
+      "type": "incident",
+      "label": "Polyfill.io CDN script supply-chain compromise",
+      "tier": "incident",
+      "sev": "medium",
+      "time": "2024-06-25",
+      "parent": null,
+      "techniques": [
+        "cdn_script_compromise",
+        "malware_distribution",
+        "downstream_customer_compromise",
+        "cdn",
+        "javascript"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2024-POLYFILL-IO/",
+      "attack_stage": "distribution_compromise",
+      "evidence_level": "researcher",
+      "confidence": "high",
+      "summary": "The Polyfill.io service began serving malicious JavaScript to downstream websites that embedded the third-party CDN script."
+    },
+    {
+      "id": "incident-SC-2024-ULTRALYTICS-PYPI",
+      "entity_id": "SC-2024-ULTRALYTICS-PYPI",
+      "type": "incident",
+      "label": "Ultralytics PyPI package compromise",
+      "tier": "incident",
+      "sev": "critical",
+      "time": "2024-12-11",
+      "parent": null,
+      "techniques": [
+        "build_system_compromise",
+        "package_repository_compromise",
+        "cryptomining",
+        "developer_workstation_compromise",
+        "pypi",
+        "github-actions"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2024-ULTRALYTICS-PYPI/",
+      "attack_stage": "ci_cd_compromise",
+      "evidence_level": "vendor",
+      "confidence": "high",
+      "summary": "The ultralytics Python project suffered a supply-chain attack through compromised GitHub Actions workflows and PyPI publishing, resulting in malicious package releases."
+    },
+    {
+      "id": "incident-SC-2024-XZ-UTILS",
+      "entity_id": "SC-2024-XZ-UTILS",
+      "type": "incident",
+      "label": "XZ Utils backdoor attempt",
+      "tier": "incident",
+      "sev": "high",
+      "time": "2024-03-29",
+      "parent": "actor-unc-xz-utils-operator",
+      "techniques": [
+        "source_repository_compromise",
+        "malicious_dependency",
+        "backdoor",
+        "linux",
+        "backdoor"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2024-XZ-UTILS/",
+      "attack_stage": "source_compromise",
+      "evidence_level": "primary",
+      "confidence": "high",
+      "summary": "A backdoor was inserted into upstream XZ Utils release tarballs, affecting some downstream Linux distribution packaging before broad removal."
+    },
+    {
+      "id": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "entity_id": "SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "type": "incident",
+      "label": "Go BoltDB typosquat module proxy backdoor",
+      "tier": "incident",
+      "sev": "high",
+      "time": "2025-02-04",
+      "parent": "actor-boltdb-go-operator",
+      "techniques": [
+        "dependency_confusion",
+        "malicious_dependency",
+        "backdoor",
+        "developer_workstation_compromise",
+        "golang",
+        "typosquat",
+        "module-proxy",
+        "backdoor"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2025-GO-BOLTDB-TYPOSQUAT/",
+      "attack_stage": "dependency_resolution",
+      "evidence_level": "researcher",
+      "confidence": "high",
+      "summary": "Socket researchers disclosed a backdoored Go module typosquatting BoltDB that persisted through Go Module Proxy caching even after the source repository tag was changed."
+    },
+    {
+      "id": "incident-SC-2025-NPM-SHAI-HULUD",
+      "entity_id": "SC-2025-NPM-SHAI-HULUD",
+      "type": "incident",
+      "label": "Shai-Hulud npm self-propagating package compromise",
+      "tier": "incident",
+      "sev": "medium",
+      "time": "2025-09-16",
+      "parent": "actor-shai-hulud-operator",
+      "techniques": [
+        "maintainer_account_compromise",
+        "package_repository_compromise",
+        "ci_cd_action_compromise",
+        "credential_theft",
+        "developer_workstation_compromise",
+        "downstream_customer_compromise",
+        "npm",
+        "self-propagating",
+        "credential-theft",
+        "github-actions"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2025-NPM-SHAI-HULUD/",
+      "attack_stage": "package_publish",
+      "evidence_level": "researcher",
+      "confidence": "high",
+      "summary": "The Shai-Hulud campaign compromised npm packages with credential-harvesting malware that used stolen npm tokens to publish malicious versions of additional packages."
+    },
+    {
+      "id": "incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
+      "entity_id": "SC-2025-TJ-ACTIONS-CHANGED-FILES",
+      "type": "incident",
+      "label": "tj-actions changed-files GitHub Action compromise",
+      "tier": "incident",
+      "sev": "critical",
+      "time": "2025-03-15",
+      "parent": null,
+      "techniques": [
+        "ci_cd_action_compromise",
+        "credential_theft",
+        "developer_workstation_compromise",
+        "github-actions",
+        "ci-cd"
+      ],
+      "purl": null,
+      "href": "/supply-chain/incidents/SC-2025-TJ-ACTIONS-CHANGED-FILES/",
+      "attack_stage": "ci_cd_compromise",
+      "evidence_level": "researcher",
+      "confidence": "high",
+      "summary": "The tj-actions/changed-files GitHub Action was compromised, exposing secrets from affected workflow runs through malicious action behavior."
+    },
+    {
+      "id": "maintainer-dominictarr",
+      "entity_id": "maintainer-dominictarr",
+      "type": "maintainer",
+      "label": "Dominic Tarr",
+      "tier": "maintainer",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/maintainers/maintainer-dominictarr/",
+      "ecosystem": null,
+      "aliases": [
+        "Dominic Tarr",
+        "dominictarr"
+      ],
+      "source_incident_ids": [
+        "SC-2018-NPM-EVENT-STREAM"
+      ]
+    },
+    {
+      "id": "maintainer-jia-tan",
+      "entity_id": "maintainer-jia-tan",
+      "type": "maintainer",
+      "label": "Jia Tan",
+      "tier": "maintainer",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/maintainers/maintainer-jia-tan/",
+      "ecosystem": null,
+      "aliases": [
+        "Jia Tan",
+        "JiaT75"
+      ],
+      "source_incident_ids": [
+        "SC-2024-XZ-UTILS"
+      ]
+    },
+    {
+      "id": "maintainer-marak-squires",
+      "entity_id": "maintainer-marak-squires",
+      "type": "maintainer",
+      "label": "Marak Squires",
+      "tier": "maintainer",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/maintainers/maintainer-marak-squires/",
+      "ecosystem": null,
+      "aliases": [
+        "Marak",
+        "Marak Squires"
+      ],
+      "source_incident_ids": [
+        "SC-2022-COLORS-FAKER"
+      ]
+    },
+    {
+      "id": "maintainer-riaevangelist",
+      "entity_id": "maintainer-riaevangelist",
+      "type": "maintainer",
+      "label": "RIAEvangelist",
+      "tier": "maintainer",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/maintainers/maintainer-riaevangelist/",
+      "ecosystem": null,
+      "aliases": [
+        "Brandon Nozaki Miller",
+        "RIAEvangelist"
+      ],
+      "source_incident_ids": [
+        "SC-2022-NODE-IPC"
+      ]
+    },
+    {
+      "id": "maintainer-right9ctrl",
+      "entity_id": "maintainer-right9ctrl",
+      "type": "maintainer",
+      "label": "right9ctrl",
+      "tier": "maintainer",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/maintainers/maintainer-right9ctrl/",
+      "ecosystem": null,
+      "aliases": [
+        "right9ctrl"
+      ],
+      "source_incident_ids": [
+        "SC-2018-NPM-EVENT-STREAM"
+      ]
+    },
+    {
+      "id": "org-3cx",
+      "entity_id": "org-3cx",
+      "type": "organization",
+      "label": "3CX",
+      "tier": "organization",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/organizations/org-3cx/",
+      "ecosystem": null,
+      "aliases": [
+        "3CX"
+      ],
+      "source_incident_ids": [
+        "SC-2023-THREE-CX-DESKTOP"
+      ]
+    },
+    {
+      "id": "org-asus",
+      "entity_id": "org-asus",
+      "type": "organization",
+      "label": "ASUS",
+      "tier": "organization",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/organizations/org-asus/",
+      "ecosystem": null,
+      "aliases": [
+        "ASUS"
+      ],
+      "source_incident_ids": [
+        "SC-2019-ASUS-SHADOWHAMMER"
+      ]
+    },
+    {
+      "id": "org-codecov",
+      "entity_id": "org-codecov",
+      "type": "organization",
+      "label": "Codecov",
+      "tier": "organization",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/organizations/org-codecov/",
+      "ecosystem": null,
+      "aliases": [
+        "Codecov"
+      ],
+      "source_incident_ids": [
+        "SC-2021-CODECOV-BASH-UPLOADER"
+      ]
+    },
+    {
+      "id": "org-ctrl",
+      "entity_id": "org-ctrl",
+      "type": "organization",
+      "label": "ctrl",
+      "tier": "organization",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/organizations/org-ctrl/",
+      "ecosystem": null,
+      "aliases": [
+        "ctrl"
+      ],
+      "source_incident_ids": [
+        "SC-2025-NPM-SHAI-HULUD"
+      ]
+    },
+    {
+      "id": "org-eslint",
+      "entity_id": "org-eslint",
+      "type": "organization",
+      "label": "ESLint",
+      "tier": "organization",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/organizations/org-eslint/",
+      "ecosystem": null,
+      "aliases": [
+        "ESLint"
+      ],
+      "source_incident_ids": [
+        "SC-2018-ESLINT-SCOPE"
+      ]
+    },
+    {
+      "id": "org-intellect-service",
+      "entity_id": "org-intellect-service",
+      "type": "organization",
+      "label": "Intellect Service",
+      "tier": "organization",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/organizations/org-intellect-service/",
+      "ecosystem": null,
+      "aliases": [
+        "Intellect Service"
+      ],
+      "source_incident_ids": [
+        "SC-2017-NOTPETYA-MEDOC"
+      ]
+    },
+    {
+      "id": "org-kaseya",
+      "entity_id": "org-kaseya",
+      "type": "organization",
+      "label": "Kaseya",
+      "tier": "organization",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/organizations/org-kaseya/",
+      "ecosystem": null,
+      "aliases": [
+        "Kaseya"
+      ],
+      "source_incident_ids": [
+        "SC-2021-KASEYA-VSA"
+      ]
+    },
+    {
+      "id": "org-ledger",
+      "entity_id": "org-ledger",
+      "type": "organization",
+      "label": "Ledger",
+      "tier": "organization",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/organizations/org-ledger/",
+      "ecosystem": null,
+      "aliases": [
+        "Ledger"
+      ],
+      "source_incident_ids": [
+        "SC-2023-LEDGER-CONNECT-KIT"
+      ]
+    },
+    {
+      "id": "org-linux-mint",
+      "entity_id": "org-linux-mint",
+      "type": "organization",
+      "label": "Linux Mint",
+      "tier": "organization",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/organizations/org-linux-mint/",
+      "ecosystem": null,
+      "aliases": [
+        "Linux Mint"
+      ],
+      "source_incident_ids": [
+        "SC-2016-LINUX-MINT-ISO"
+      ]
+    },
+    {
+      "id": "org-lottiefiles",
+      "entity_id": "org-lottiefiles",
+      "type": "organization",
+      "label": "LottieFiles",
+      "tier": "organization",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/organizations/org-lottiefiles/",
+      "ecosystem": null,
+      "aliases": [
+        "LottieFiles"
+      ],
+      "source_incident_ids": [
+        "SC-2024-LOTTIE-PLAYER"
+      ]
+    },
+    {
+      "id": "org-php-project",
+      "entity_id": "org-php-project",
+      "type": "organization",
+      "label": "PHP project",
+      "tier": "organization",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/organizations/org-php-project/",
+      "ecosystem": null,
+      "aliases": [
+        "PHP project"
+      ],
+      "source_incident_ids": [
+        "SC-2021-PHP-GIT-SERVER"
+      ]
+    },
+    {
+      "id": "org-piriform",
+      "entity_id": "org-piriform",
+      "type": "organization",
+      "label": "Piriform",
+      "tier": "organization",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/organizations/org-piriform/",
+      "ecosystem": null,
+      "aliases": [
+        "Piriform"
+      ],
+      "source_incident_ids": [
+        "SC-2017-CCLEANER"
+      ]
+    },
+    {
+      "id": "org-polyfill-io",
+      "entity_id": "org-polyfill-io",
+      "type": "organization",
+      "label": "Polyfill.io",
+      "tier": "organization",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/organizations/org-polyfill-io/",
+      "ecosystem": null,
+      "aliases": [
+        "Polyfill.io"
+      ],
+      "source_incident_ids": [
+        "SC-2024-POLYFILL-IO"
+      ]
+    },
+    {
+      "id": "org-pytorch",
+      "entity_id": "org-pytorch",
+      "type": "organization",
+      "label": "PyTorch",
+      "tier": "organization",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/organizations/org-pytorch/",
+      "ecosystem": null,
+      "aliases": [
+        "PyTorch"
+      ],
+      "source_incident_ids": [
+        "SC-2022-PYTORCH-NIGHTLY"
+      ]
+    },
+    {
+      "id": "org-rxnt",
+      "entity_id": "org-rxnt",
+      "type": "organization",
+      "label": "rxnt",
+      "tier": "organization",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/organizations/org-rxnt/",
+      "ecosystem": null,
+      "aliases": [
+        "rxnt"
+      ],
+      "source_incident_ids": [
+        "SC-2025-NPM-SHAI-HULUD"
+      ]
+    },
+    {
+      "id": "org-solarwinds",
+      "entity_id": "org-solarwinds",
+      "type": "organization",
+      "label": "SolarWinds",
+      "tier": "organization",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/organizations/org-solarwinds/",
+      "ecosystem": null,
+      "aliases": [
+        "SolarWinds"
+      ],
+      "source_incident_ids": [
+        "SC-2020-SOLARWINDS-ORION"
+      ]
+    },
+    {
+      "id": "org-tj-actions",
+      "entity_id": "org-tj-actions",
+      "type": "organization",
+      "label": "tj-actions",
+      "tier": "organization",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/organizations/org-tj-actions/",
+      "ecosystem": null,
+      "aliases": [
+        "tj-actions"
+      ],
+      "source_incident_ids": [
+        "SC-2025-TJ-ACTIONS-CHANGED-FILES"
+      ]
+    },
+    {
+      "id": "org-tukaani-project",
+      "entity_id": "org-tukaani-project",
+      "type": "organization",
+      "label": "Tukaani Project",
+      "tier": "organization",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/organizations/org-tukaani-project/",
+      "ecosystem": null,
+      "aliases": [
+        "Tukaani Project"
+      ],
+      "source_incident_ids": [
+        "SC-2024-XZ-UTILS"
+      ]
+    },
+    {
+      "id": "org-ultralytics",
+      "entity_id": "org-ultralytics",
+      "type": "organization",
+      "label": "Ultralytics",
+      "tier": "organization",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/organizations/org-ultralytics/",
+      "ecosystem": null,
+      "aliases": [
+        "Ultralytics"
+      ],
+      "source_incident_ids": [
+        "SC-2024-ULTRALYTICS-PYPI"
+      ]
+    },
+    {
+      "id": "pkg-generic-3cx-desktopapp",
+      "entity_id": "pkg-generic-3cx-desktopapp",
+      "type": "package",
+      "label": "3CX DesktopApp",
+      "tier": "package",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:generic/3cx-desktopapp",
+      "href": "/supply-chain/packages/pkg-generic-3cx-desktopapp/",
+      "ecosystem": "generic",
+      "aliases": [
+        "3CX DesktopApp"
+      ],
+      "source_incident_ids": [
+        "SC-2023-THREE-CX-DESKTOP"
+      ]
+    },
+    {
+      "id": "pkg-generic-x-trader",
+      "entity_id": "pkg-generic-x-trader",
+      "type": "package",
+      "label": "X_TRADER",
+      "tier": "package",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:generic/x-trader",
+      "href": "/supply-chain/packages/pkg-generic-x-trader/",
+      "ecosystem": "generic",
+      "aliases": [
+        "X_TRADER"
+      ],
+      "source_incident_ids": [
+        "SC-2023-THREE-CX-DESKTOP"
+      ]
+    },
+    {
+      "id": "pkg-golang-github-com-boltdb-go-bolt",
+      "entity_id": "pkg-golang-github-com-boltdb-go-bolt",
+      "type": "package",
+      "label": "github.com/boltdb-go/bolt",
+      "tier": "package",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:golang/github.com/boltdb-go/bolt",
+      "href": "/supply-chain/packages/pkg-golang-github-com-boltdb-go-bolt/",
+      "ecosystem": "golang",
+      "aliases": [
+        "github.com/boltdb-go/bolt"
+      ],
+      "source_incident_ids": [
+        "SC-2025-GO-BOLTDB-TYPOSQUAT"
+      ]
+    },
+    {
+      "id": "pkg-multiple-internal-dependency-names",
+      "entity_id": "pkg-multiple-internal-dependency-names",
+      "type": "package",
+      "label": "internal dependency names",
+      "tier": "package",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:generic/internal-dependency-names",
+      "href": "/supply-chain/packages/pkg-multiple-internal-dependency-names/",
+      "ecosystem": "multiple",
+      "aliases": [
+        "internal dependency names"
+      ],
+      "source_incident_ids": [
+        "SC-2021-DEPENDENCY-CONFUSION"
+      ]
+    },
+    {
+      "id": "pkg-npm-colors",
+      "entity_id": "pkg-npm-colors",
+      "type": "package",
+      "label": "colors",
+      "tier": "package",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:npm/colors",
+      "href": "/supply-chain/packages/pkg-npm-colors/",
+      "ecosystem": "npm",
+      "aliases": [
+        "colors"
+      ],
+      "source_incident_ids": [
+        "SC-2022-COLORS-FAKER"
+      ]
+    },
+    {
+      "id": "pkg-npm-ctrl-tinycolor",
+      "entity_id": "pkg-npm-ctrl-tinycolor",
+      "type": "package",
+      "label": "@ctrl/tinycolor",
+      "tier": "package",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:npm/%40ctrl/tinycolor",
+      "href": "/supply-chain/packages/pkg-npm-ctrl-tinycolor/",
+      "ecosystem": "npm",
+      "aliases": [
+        "@ctrl/tinycolor"
+      ],
+      "source_incident_ids": [
+        "SC-2025-NPM-SHAI-HULUD"
+      ]
+    },
+    {
+      "id": "pkg-npm-eslint-config-eslint",
+      "entity_id": "pkg-npm-eslint-config-eslint",
+      "type": "package",
+      "label": "eslint-config-eslint",
+      "tier": "package",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:npm/eslint-config-eslint",
+      "href": "/supply-chain/packages/pkg-npm-eslint-config-eslint/",
+      "ecosystem": "npm",
+      "aliases": [
+        "eslint-config-eslint"
+      ],
+      "source_incident_ids": [
+        "SC-2018-ESLINT-SCOPE"
+      ]
+    },
+    {
+      "id": "pkg-npm-eslint-scope",
+      "entity_id": "pkg-npm-eslint-scope",
+      "type": "package",
+      "label": "eslint-scope",
+      "tier": "package",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:npm/eslint-scope",
+      "href": "/supply-chain/packages/pkg-npm-eslint-scope/",
+      "ecosystem": "npm",
+      "aliases": [
+        "eslint-scope"
+      ],
+      "source_incident_ids": [
+        "SC-2018-ESLINT-SCOPE"
+      ]
+    },
+    {
+      "id": "pkg-npm-event-stream",
+      "entity_id": "pkg-npm-event-stream",
+      "type": "package",
+      "label": "event-stream",
+      "tier": "package",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:npm/event-stream",
+      "href": "/supply-chain/packages/pkg-npm-event-stream/",
+      "ecosystem": "npm",
+      "aliases": [
+        "event-stream"
+      ],
+      "source_incident_ids": [
+        "SC-2018-NPM-EVENT-STREAM"
+      ]
+    },
+    {
+      "id": "pkg-npm-faker",
+      "entity_id": "pkg-npm-faker",
+      "type": "package",
+      "label": "faker",
+      "tier": "package",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:npm/faker",
+      "href": "/supply-chain/packages/pkg-npm-faker/",
+      "ecosystem": "npm",
+      "aliases": [
+        "faker"
+      ],
+      "source_incident_ids": [
+        "SC-2022-COLORS-FAKER"
+      ]
+    },
+    {
+      "id": "pkg-npm-flatmap-stream",
+      "entity_id": "pkg-npm-flatmap-stream",
+      "type": "package",
+      "label": "flatmap-stream",
+      "tier": "package",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:npm/flatmap-stream",
+      "href": "/supply-chain/packages/pkg-npm-flatmap-stream/",
+      "ecosystem": "npm",
+      "aliases": [
+        "flatmap-stream"
+      ],
+      "source_incident_ids": [
+        "SC-2018-NPM-EVENT-STREAM"
+      ]
+    },
+    {
+      "id": "pkg-npm-ledgerhq-connect-kit",
+      "entity_id": "pkg-npm-ledgerhq-connect-kit",
+      "type": "package",
+      "label": "@ledgerhq/connect-kit",
+      "tier": "package",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:npm/%40ledgerhq/connect-kit",
+      "href": "/supply-chain/packages/pkg-npm-ledgerhq-connect-kit/",
+      "ecosystem": "npm",
+      "aliases": [
+        "@ledgerhq/connect-kit"
+      ],
+      "source_incident_ids": [
+        "SC-2023-LEDGER-CONNECT-KIT"
+      ]
+    },
+    {
+      "id": "pkg-npm-lottiefiles-lottie-player",
+      "entity_id": "pkg-npm-lottiefiles-lottie-player",
+      "type": "package",
+      "label": "@lottiefiles/lottie-player",
+      "tier": "package",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:npm/%40lottiefiles/lottie-player",
+      "href": "/supply-chain/packages/pkg-npm-lottiefiles-lottie-player/",
+      "ecosystem": "npm",
+      "aliases": [
+        "@lottiefiles/lottie-player"
+      ],
+      "source_incident_ids": [
+        "SC-2024-LOTTIE-PLAYER"
+      ]
+    },
+    {
+      "id": "pkg-npm-node-ipc",
+      "entity_id": "pkg-npm-node-ipc",
+      "type": "package",
+      "label": "node-ipc",
+      "tier": "package",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:npm/node-ipc",
+      "href": "/supply-chain/packages/pkg-npm-node-ipc/",
+      "ecosystem": "npm",
+      "aliases": [
+        "node-ipc"
+      ],
+      "source_incident_ids": [
+        "SC-2022-NODE-IPC"
+      ]
+    },
+    {
+      "id": "pkg-npm-peacenotwar",
+      "entity_id": "pkg-npm-peacenotwar",
+      "type": "package",
+      "label": "peacenotwar",
+      "tier": "package",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:npm/peacenotwar",
+      "href": "/supply-chain/packages/pkg-npm-peacenotwar/",
+      "ecosystem": "npm",
+      "aliases": [
+        "peacenotwar"
+      ],
+      "source_incident_ids": [
+        "SC-2022-NODE-IPC"
+      ]
+    },
+    {
+      "id": "pkg-npm-rc",
+      "entity_id": "pkg-npm-rc",
+      "type": "package",
+      "label": "rc",
+      "tier": "package",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:npm/rc",
+      "href": "/supply-chain/packages/pkg-npm-rc/",
+      "ecosystem": "npm",
+      "aliases": [
+        "rc"
+      ],
+      "source_incident_ids": [
+        "SC-2021-NPM-RC"
+      ]
+    },
+    {
+      "id": "pkg-npm-rxnt-authentication",
+      "entity_id": "pkg-npm-rxnt-authentication",
+      "type": "package",
+      "label": "rxnt-authentication",
+      "tier": "package",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:npm/rxnt-authentication",
+      "href": "/supply-chain/packages/pkg-npm-rxnt-authentication/",
+      "ecosystem": "npm",
+      "aliases": [
+        "rxnt-authentication"
+      ],
+      "source_incident_ids": [
+        "SC-2025-NPM-SHAI-HULUD"
+      ]
+    },
+    {
+      "id": "pkg-npm-ua-parser-js",
+      "entity_id": "pkg-npm-ua-parser-js",
+      "type": "package",
+      "label": "ua-parser-js",
+      "tier": "package",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:npm/ua-parser-js",
+      "href": "/supply-chain/packages/pkg-npm-ua-parser-js/",
+      "ecosystem": "npm",
+      "aliases": [
+        "ua-parser-js"
+      ],
+      "source_incident_ids": [
+        "SC-2021-UA-PARSER-JS"
+      ]
+    },
+    {
+      "id": "pkg-pypi-ctx",
+      "entity_id": "pkg-pypi-ctx",
+      "type": "package",
+      "label": "ctx",
+      "tier": "package",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:pypi/ctx",
+      "href": "/supply-chain/packages/pkg-pypi-ctx/",
+      "ecosystem": "pypi",
+      "aliases": [
+        "ctx"
+      ],
+      "source_incident_ids": [
+        "SC-2022-PYPI-CTX"
+      ]
+    },
+    {
+      "id": "pkg-pypi-torchtriton",
+      "entity_id": "pkg-pypi-torchtriton",
+      "type": "package",
+      "label": "torchtriton",
+      "tier": "package",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:pypi/torchtriton",
+      "href": "/supply-chain/packages/pkg-pypi-torchtriton/",
+      "ecosystem": "pypi",
+      "aliases": [
+        "torchtriton"
+      ],
+      "source_incident_ids": [
+        "SC-2022-PYTORCH-NIGHTLY"
+      ]
+    },
+    {
+      "id": "pkg-pypi-ultralytics",
+      "entity_id": "pkg-pypi-ultralytics",
+      "type": "package",
+      "label": "ultralytics",
+      "tier": "package",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:pypi/ultralytics",
+      "href": "/supply-chain/packages/pkg-pypi-ultralytics/",
+      "ecosystem": "pypi",
+      "aliases": [
+        "ultralytics"
+      ],
+      "source_incident_ids": [
+        "SC-2024-ULTRALYTICS-PYPI"
+      ]
+    },
+    {
+      "id": "release-golang-github-com-boltdb-go-bolt-v1-3-1",
+      "entity_id": "release-golang-github-com-boltdb-go-bolt-v1-3-1",
+      "type": "release",
+      "label": "github.com/boltdb-go/bolt@v1.3.1",
+      "tier": "release",
+      "sev": null,
+      "time": "2021-11-01",
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:golang/github.com/boltdb-go/bolt@v1.3.1",
+      "href": null,
+      "ecosystem": "golang",
+      "aliases": [
+        "github.com/boltdb-go/bolt@v1.3.1",
+        "pkg:golang/github.com/boltdb-go/bolt@v1.3.1"
+      ],
+      "source_incident_ids": [
+        "SC-2025-GO-BOLTDB-TYPOSQUAT"
+      ]
+    },
+    {
+      "id": "release-npm-ctrl-tinycolor-4-1-1",
+      "entity_id": "release-npm-ctrl-tinycolor-4-1-1",
+      "type": "release",
+      "label": "@ctrl/tinycolor@4.1.1",
+      "tier": "release",
+      "sev": null,
+      "time": "2025-09-15",
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:npm/%40ctrl/tinycolor@4.1.1",
+      "href": null,
+      "ecosystem": "npm",
+      "aliases": [
+        "@ctrl/tinycolor@4.1.1",
+        "pkg:npm/%40ctrl/tinycolor@4.1.1"
+      ],
+      "source_incident_ids": [
+        "SC-2025-NPM-SHAI-HULUD"
+      ]
+    },
+    {
+      "id": "release-npm-ctrl-tinycolor-4-1-2",
+      "entity_id": "release-npm-ctrl-tinycolor-4-1-2",
+      "type": "release",
+      "label": "@ctrl/tinycolor@4.1.2",
+      "tier": "release",
+      "sev": null,
+      "time": "2025-09-15",
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:npm/%40ctrl/tinycolor@4.1.2",
+      "href": null,
+      "ecosystem": "npm",
+      "aliases": [
+        "@ctrl/tinycolor@4.1.2",
+        "pkg:npm/%40ctrl/tinycolor@4.1.2"
+      ],
+      "source_incident_ids": [
+        "SC-2025-NPM-SHAI-HULUD"
+      ]
+    },
+    {
+      "id": "release-npm-flatmap-stream-0-1-1",
+      "entity_id": "release-npm-flatmap-stream-0-1-1",
+      "type": "release",
+      "label": "flatmap-stream@0.1.1",
+      "tier": "release",
+      "sev": null,
+      "time": "2018-09-09",
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:npm/flatmap-stream@0.1.1",
+      "href": null,
+      "ecosystem": "npm",
+      "aliases": [
+        "flatmap-stream@0.1.1",
+        "pkg:npm/flatmap-stream@0.1.1"
+      ],
+      "source_incident_ids": [
+        "SC-2018-NPM-EVENT-STREAM"
+      ]
+    },
+    {
+      "id": "release-npm-ua-parser-js-0-7-29",
+      "entity_id": "release-npm-ua-parser-js-0-7-29",
+      "type": "release",
+      "label": "ua-parser-js@0.7.29",
+      "tier": "release",
+      "sev": null,
+      "time": "2021-10-22",
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:npm/ua-parser-js@0.7.29",
+      "href": null,
+      "ecosystem": "npm",
+      "aliases": [
+        "pkg:npm/ua-parser-js@0.7.29",
+        "ua-parser-js@0.7.29"
+      ],
+      "source_incident_ids": [
+        "SC-2021-UA-PARSER-JS"
+      ]
+    },
+    {
+      "id": "release-npm-ua-parser-js-0-8-0",
+      "entity_id": "release-npm-ua-parser-js-0-8-0",
+      "type": "release",
+      "label": "ua-parser-js@0.8.0",
+      "tier": "release",
+      "sev": null,
+      "time": "2021-10-22",
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:npm/ua-parser-js@0.8.0",
+      "href": null,
+      "ecosystem": "npm",
+      "aliases": [
+        "pkg:npm/ua-parser-js@0.8.0",
+        "ua-parser-js@0.8.0"
+      ],
+      "source_incident_ids": [
+        "SC-2021-UA-PARSER-JS"
+      ]
+    },
+    {
+      "id": "release-npm-ua-parser-js-1-0-0",
+      "entity_id": "release-npm-ua-parser-js-1-0-0",
+      "type": "release",
+      "label": "ua-parser-js@1.0.0",
+      "tier": "release",
+      "sev": null,
+      "time": "2021-10-22",
+      "parent": null,
+      "techniques": [],
+      "purl": "pkg:npm/ua-parser-js@1.0.0",
+      "href": null,
+      "ecosystem": "npm",
+      "aliases": [
+        "pkg:npm/ua-parser-js@1.0.0",
+        "ua-parser-js@1.0.0"
+      ],
+      "source_incident_ids": [
+        "SC-2021-UA-PARSER-JS"
+      ]
+    },
+    {
+      "id": "repo-github-com-boltdb-go-bolt",
+      "entity_id": "repo-github-com-boltdb-go-bolt",
+      "type": "repository",
+      "label": "boltdb-go/bolt",
+      "tier": "repository",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/repositories/repo-github-com-boltdb-go-bolt/",
+      "ecosystem": null,
+      "aliases": [
+        "boltdb-go/bolt"
+      ],
+      "source_incident_ids": [
+        "SC-2025-GO-BOLTDB-TYPOSQUAT"
+      ]
+    },
+    {
+      "id": "repo-github-com-codecov-codecov-bash",
+      "entity_id": "repo-github-com-codecov-codecov-bash",
+      "type": "repository",
+      "label": "codecov/codecov-bash",
+      "tier": "repository",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/repositories/repo-github-com-codecov-codecov-bash/",
+      "ecosystem": null,
+      "aliases": [
+        "codecov/codecov-bash"
+      ],
+      "source_incident_ids": [
+        "SC-2021-CODECOV-BASH-UPLOADER"
+      ]
+    },
+    {
+      "id": "repo-github-com-dominictarr-event-stream",
+      "entity_id": "repo-github-com-dominictarr-event-stream",
+      "type": "repository",
+      "label": "dominictarr/event-stream",
+      "tier": "repository",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/repositories/repo-github-com-dominictarr-event-stream/",
+      "ecosystem": null,
+      "aliases": [
+        "dominictarr/event-stream"
+      ],
+      "source_incident_ids": [
+        "SC-2018-NPM-EVENT-STREAM"
+      ]
+    },
+    {
+      "id": "repo-github-com-eslint-eslint-scope",
+      "entity_id": "repo-github-com-eslint-eslint-scope",
+      "type": "repository",
+      "label": "eslint/eslint-scope",
+      "tier": "repository",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/repositories/repo-github-com-eslint-eslint-scope/",
+      "ecosystem": null,
+      "aliases": [
+        "eslint/eslint-scope"
+      ],
+      "source_incident_ids": [
+        "SC-2018-ESLINT-SCOPE"
+      ]
+    },
+    {
+      "id": "repo-github-com-marak-colors-js",
+      "entity_id": "repo-github-com-marak-colors-js",
+      "type": "repository",
+      "label": "Marak/colors.js",
+      "tier": "repository",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/repositories/repo-github-com-marak-colors-js/",
+      "ecosystem": null,
+      "aliases": [
+        "Marak/colors.js"
+      ],
+      "source_incident_ids": [
+        "SC-2022-COLORS-FAKER"
+      ]
+    },
+    {
+      "id": "repo-github-com-php-php-src",
+      "entity_id": "repo-github-com-php-php-src",
+      "type": "repository",
+      "label": "php/php-src",
+      "tier": "repository",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/repositories/repo-github-com-php-php-src/",
+      "ecosystem": null,
+      "aliases": [
+        "php/php-src"
+      ],
+      "source_incident_ids": [
+        "SC-2021-PHP-GIT-SERVER"
+      ]
+    },
+    {
+      "id": "repo-github-com-pytorch-pytorch",
+      "entity_id": "repo-github-com-pytorch-pytorch",
+      "type": "repository",
+      "label": "pytorch/pytorch",
+      "tier": "repository",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/repositories/repo-github-com-pytorch-pytorch/",
+      "ecosystem": null,
+      "aliases": [
+        "pytorch/pytorch"
+      ],
+      "source_incident_ids": [
+        "SC-2022-PYTORCH-NIGHTLY"
+      ]
+    },
+    {
+      "id": "repo-github-com-riaevangelist-node-ipc",
+      "entity_id": "repo-github-com-riaevangelist-node-ipc",
+      "type": "repository",
+      "label": "RIAEvangelist/node-ipc",
+      "tier": "repository",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/repositories/repo-github-com-riaevangelist-node-ipc/",
+      "ecosystem": null,
+      "aliases": [
+        "RIAEvangelist/node-ipc"
+      ],
+      "source_incident_ids": [
+        "SC-2022-NODE-IPC"
+      ]
+    },
+    {
+      "id": "repo-github-com-tj-actions-changed-files",
+      "entity_id": "repo-github-com-tj-actions-changed-files",
+      "type": "repository",
+      "label": "tj-actions/changed-files",
+      "tier": "repository",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/repositories/repo-github-com-tj-actions-changed-files/",
+      "ecosystem": null,
+      "aliases": [
+        "tj-actions/changed-files"
+      ],
+      "source_incident_ids": [
+        "SC-2025-TJ-ACTIONS-CHANGED-FILES"
+      ]
+    },
+    {
+      "id": "repo-github-com-tukaani-project-xz",
+      "entity_id": "repo-github-com-tukaani-project-xz",
+      "type": "repository",
+      "label": "tukaani-project/xz",
+      "tier": "repository",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/repositories/repo-github-com-tukaani-project-xz/",
+      "ecosystem": null,
+      "aliases": [
+        "tukaani-project/xz"
+      ],
+      "source_incident_ids": [
+        "SC-2024-XZ-UTILS"
+      ]
+    },
+    {
+      "id": "repo-github-com-ultralytics-ultralytics",
+      "entity_id": "repo-github-com-ultralytics-ultralytics",
+      "type": "repository",
+      "label": "ultralytics/ultralytics",
+      "tier": "repository",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/repositories/repo-github-com-ultralytics-ultralytics/",
+      "ecosystem": null,
+      "aliases": [
+        "ultralytics/ultralytics"
+      ],
+      "source_incident_ids": [
+        "SC-2024-ULTRALYTICS-PYPI"
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "id": "AFFECTED_MAINTAINER:incident-SC-2018-NPM-EVENT-STREAM->maintainer-dominictarr",
+      "source": "incident-SC-2018-NPM-EVENT-STREAM",
+      "target": "maintainer-dominictarr",
+      "type": "AFFECTED_MAINTAINER",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_MAINTAINER:incident-SC-2018-NPM-EVENT-STREAM->maintainer-right9ctrl",
+      "source": "incident-SC-2018-NPM-EVENT-STREAM",
+      "target": "maintainer-right9ctrl",
+      "type": "AFFECTED_MAINTAINER",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_MAINTAINER:incident-SC-2022-COLORS-FAKER->maintainer-marak-squires",
+      "source": "incident-SC-2022-COLORS-FAKER",
+      "target": "maintainer-marak-squires",
+      "type": "AFFECTED_MAINTAINER",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_MAINTAINER:incident-SC-2022-NODE-IPC->maintainer-riaevangelist",
+      "source": "incident-SC-2022-NODE-IPC",
+      "target": "maintainer-riaevangelist",
+      "type": "AFFECTED_MAINTAINER",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_MAINTAINER:incident-SC-2024-XZ-UTILS->maintainer-jia-tan",
+      "source": "incident-SC-2024-XZ-UTILS",
+      "target": "maintainer-jia-tan",
+      "type": "AFFECTED_MAINTAINER",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_ORGANIZATION:incident-SC-2016-LINUX-MINT-ISO->org-linux-mint",
+      "source": "incident-SC-2016-LINUX-MINT-ISO",
+      "target": "org-linux-mint",
+      "type": "AFFECTED_ORGANIZATION",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_ORGANIZATION:incident-SC-2017-CCLEANER->org-piriform",
+      "source": "incident-SC-2017-CCLEANER",
+      "target": "org-piriform",
+      "type": "AFFECTED_ORGANIZATION",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_ORGANIZATION:incident-SC-2017-NOTPETYA-MEDOC->org-intellect-service",
+      "source": "incident-SC-2017-NOTPETYA-MEDOC",
+      "target": "org-intellect-service",
+      "type": "AFFECTED_ORGANIZATION",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_ORGANIZATION:incident-SC-2018-ESLINT-SCOPE->org-eslint",
+      "source": "incident-SC-2018-ESLINT-SCOPE",
+      "target": "org-eslint",
+      "type": "AFFECTED_ORGANIZATION",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_ORGANIZATION:incident-SC-2019-ASUS-SHADOWHAMMER->org-asus",
+      "source": "incident-SC-2019-ASUS-SHADOWHAMMER",
+      "target": "org-asus",
+      "type": "AFFECTED_ORGANIZATION",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_ORGANIZATION:incident-SC-2020-SOLARWINDS-ORION->org-solarwinds",
+      "source": "incident-SC-2020-SOLARWINDS-ORION",
+      "target": "org-solarwinds",
+      "type": "AFFECTED_ORGANIZATION",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_ORGANIZATION:incident-SC-2021-CODECOV-BASH-UPLOADER->org-codecov",
+      "source": "incident-SC-2021-CODECOV-BASH-UPLOADER",
+      "target": "org-codecov",
+      "type": "AFFECTED_ORGANIZATION",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_ORGANIZATION:incident-SC-2021-KASEYA-VSA->org-kaseya",
+      "source": "incident-SC-2021-KASEYA-VSA",
+      "target": "org-kaseya",
+      "type": "AFFECTED_ORGANIZATION",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_ORGANIZATION:incident-SC-2021-PHP-GIT-SERVER->org-php-project",
+      "source": "incident-SC-2021-PHP-GIT-SERVER",
+      "target": "org-php-project",
+      "type": "AFFECTED_ORGANIZATION",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_ORGANIZATION:incident-SC-2022-PYTORCH-NIGHTLY->org-pytorch",
+      "source": "incident-SC-2022-PYTORCH-NIGHTLY",
+      "target": "org-pytorch",
+      "type": "AFFECTED_ORGANIZATION",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_ORGANIZATION:incident-SC-2023-LEDGER-CONNECT-KIT->org-ledger",
+      "source": "incident-SC-2023-LEDGER-CONNECT-KIT",
+      "target": "org-ledger",
+      "type": "AFFECTED_ORGANIZATION",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_ORGANIZATION:incident-SC-2023-THREE-CX-DESKTOP->org-3cx",
+      "source": "incident-SC-2023-THREE-CX-DESKTOP",
+      "target": "org-3cx",
+      "type": "AFFECTED_ORGANIZATION",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_ORGANIZATION:incident-SC-2024-LOTTIE-PLAYER->org-lottiefiles",
+      "source": "incident-SC-2024-LOTTIE-PLAYER",
+      "target": "org-lottiefiles",
+      "type": "AFFECTED_ORGANIZATION",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_ORGANIZATION:incident-SC-2024-POLYFILL-IO->org-polyfill-io",
+      "source": "incident-SC-2024-POLYFILL-IO",
+      "target": "org-polyfill-io",
+      "type": "AFFECTED_ORGANIZATION",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_ORGANIZATION:incident-SC-2024-ULTRALYTICS-PYPI->org-ultralytics",
+      "source": "incident-SC-2024-ULTRALYTICS-PYPI",
+      "target": "org-ultralytics",
+      "type": "AFFECTED_ORGANIZATION",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_ORGANIZATION:incident-SC-2024-XZ-UTILS->org-tukaani-project",
+      "source": "incident-SC-2024-XZ-UTILS",
+      "target": "org-tukaani-project",
+      "type": "AFFECTED_ORGANIZATION",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_ORGANIZATION:incident-SC-2025-NPM-SHAI-HULUD->org-ctrl",
+      "source": "incident-SC-2025-NPM-SHAI-HULUD",
+      "target": "org-ctrl",
+      "type": "AFFECTED_ORGANIZATION",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_ORGANIZATION:incident-SC-2025-NPM-SHAI-HULUD->org-rxnt",
+      "source": "incident-SC-2025-NPM-SHAI-HULUD",
+      "target": "org-rxnt",
+      "type": "AFFECTED_ORGANIZATION",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_ORGANIZATION:incident-SC-2025-TJ-ACTIONS-CHANGED-FILES->org-tj-actions",
+      "source": "incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
+      "target": "org-tj-actions",
+      "type": "AFFECTED_ORGANIZATION",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_PACKAGE:incident-SC-2018-ESLINT-SCOPE->pkg-npm-eslint-config-eslint",
+      "source": "incident-SC-2018-ESLINT-SCOPE",
+      "target": "pkg-npm-eslint-config-eslint",
+      "type": "AFFECTED_PACKAGE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_PACKAGE:incident-SC-2018-ESLINT-SCOPE->pkg-npm-eslint-scope",
+      "source": "incident-SC-2018-ESLINT-SCOPE",
+      "target": "pkg-npm-eslint-scope",
+      "type": "AFFECTED_PACKAGE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_PACKAGE:incident-SC-2018-NPM-EVENT-STREAM->pkg-npm-event-stream",
+      "source": "incident-SC-2018-NPM-EVENT-STREAM",
+      "target": "pkg-npm-event-stream",
+      "type": "AFFECTED_PACKAGE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_PACKAGE:incident-SC-2018-NPM-EVENT-STREAM->pkg-npm-flatmap-stream",
+      "source": "incident-SC-2018-NPM-EVENT-STREAM",
+      "target": "pkg-npm-flatmap-stream",
+      "type": "AFFECTED_PACKAGE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_PACKAGE:incident-SC-2021-DEPENDENCY-CONFUSION->pkg-multiple-internal-dependency-names",
+      "source": "incident-SC-2021-DEPENDENCY-CONFUSION",
+      "target": "pkg-multiple-internal-dependency-names",
+      "type": "AFFECTED_PACKAGE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_PACKAGE:incident-SC-2021-NPM-RC->pkg-npm-rc",
+      "source": "incident-SC-2021-NPM-RC",
+      "target": "pkg-npm-rc",
+      "type": "AFFECTED_PACKAGE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_PACKAGE:incident-SC-2021-UA-PARSER-JS->pkg-npm-ua-parser-js",
+      "source": "incident-SC-2021-UA-PARSER-JS",
+      "target": "pkg-npm-ua-parser-js",
+      "type": "AFFECTED_PACKAGE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_PACKAGE:incident-SC-2022-COLORS-FAKER->pkg-npm-colors",
+      "source": "incident-SC-2022-COLORS-FAKER",
+      "target": "pkg-npm-colors",
+      "type": "AFFECTED_PACKAGE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_PACKAGE:incident-SC-2022-COLORS-FAKER->pkg-npm-faker",
+      "source": "incident-SC-2022-COLORS-FAKER",
+      "target": "pkg-npm-faker",
+      "type": "AFFECTED_PACKAGE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_PACKAGE:incident-SC-2022-NODE-IPC->pkg-npm-node-ipc",
+      "source": "incident-SC-2022-NODE-IPC",
+      "target": "pkg-npm-node-ipc",
+      "type": "AFFECTED_PACKAGE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_PACKAGE:incident-SC-2022-NODE-IPC->pkg-npm-peacenotwar",
+      "source": "incident-SC-2022-NODE-IPC",
+      "target": "pkg-npm-peacenotwar",
+      "type": "AFFECTED_PACKAGE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_PACKAGE:incident-SC-2022-PYPI-CTX->pkg-pypi-ctx",
+      "source": "incident-SC-2022-PYPI-CTX",
+      "target": "pkg-pypi-ctx",
+      "type": "AFFECTED_PACKAGE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_PACKAGE:incident-SC-2022-PYTORCH-NIGHTLY->pkg-pypi-torchtriton",
+      "source": "incident-SC-2022-PYTORCH-NIGHTLY",
+      "target": "pkg-pypi-torchtriton",
+      "type": "AFFECTED_PACKAGE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_PACKAGE:incident-SC-2023-LEDGER-CONNECT-KIT->pkg-npm-ledgerhq-connect-kit",
+      "source": "incident-SC-2023-LEDGER-CONNECT-KIT",
+      "target": "pkg-npm-ledgerhq-connect-kit",
+      "type": "AFFECTED_PACKAGE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_PACKAGE:incident-SC-2023-THREE-CX-DESKTOP->pkg-generic-3cx-desktopapp",
+      "source": "incident-SC-2023-THREE-CX-DESKTOP",
+      "target": "pkg-generic-3cx-desktopapp",
+      "type": "AFFECTED_PACKAGE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_PACKAGE:incident-SC-2024-LOTTIE-PLAYER->pkg-npm-lottiefiles-lottie-player",
+      "source": "incident-SC-2024-LOTTIE-PLAYER",
+      "target": "pkg-npm-lottiefiles-lottie-player",
+      "type": "AFFECTED_PACKAGE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_PACKAGE:incident-SC-2024-ULTRALYTICS-PYPI->pkg-pypi-ultralytics",
+      "source": "incident-SC-2024-ULTRALYTICS-PYPI",
+      "target": "pkg-pypi-ultralytics",
+      "type": "AFFECTED_PACKAGE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_PACKAGE:incident-SC-2025-GO-BOLTDB-TYPOSQUAT->pkg-golang-github-com-boltdb-go-bolt",
+      "source": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "target": "pkg-golang-github-com-boltdb-go-bolt",
+      "type": "AFFECTED_PACKAGE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_PACKAGE:incident-SC-2025-NPM-SHAI-HULUD->pkg-npm-ctrl-tinycolor",
+      "source": "incident-SC-2025-NPM-SHAI-HULUD",
+      "target": "pkg-npm-ctrl-tinycolor",
+      "type": "AFFECTED_PACKAGE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_PACKAGE:incident-SC-2025-NPM-SHAI-HULUD->pkg-npm-rxnt-authentication",
+      "source": "incident-SC-2025-NPM-SHAI-HULUD",
+      "target": "pkg-npm-rxnt-authentication",
+      "type": "AFFECTED_PACKAGE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_REPOSITORY:incident-SC-2018-ESLINT-SCOPE->repo-github-com-eslint-eslint-scope",
+      "source": "incident-SC-2018-ESLINT-SCOPE",
+      "target": "repo-github-com-eslint-eslint-scope",
+      "type": "AFFECTED_REPOSITORY",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_REPOSITORY:incident-SC-2018-NPM-EVENT-STREAM->repo-github-com-dominictarr-event-stream",
+      "source": "incident-SC-2018-NPM-EVENT-STREAM",
+      "target": "repo-github-com-dominictarr-event-stream",
+      "type": "AFFECTED_REPOSITORY",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_REPOSITORY:incident-SC-2021-CODECOV-BASH-UPLOADER->repo-github-com-codecov-codecov-bash",
+      "source": "incident-SC-2021-CODECOV-BASH-UPLOADER",
+      "target": "repo-github-com-codecov-codecov-bash",
+      "type": "AFFECTED_REPOSITORY",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_REPOSITORY:incident-SC-2021-PHP-GIT-SERVER->repo-github-com-php-php-src",
+      "source": "incident-SC-2021-PHP-GIT-SERVER",
+      "target": "repo-github-com-php-php-src",
+      "type": "AFFECTED_REPOSITORY",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_REPOSITORY:incident-SC-2022-COLORS-FAKER->repo-github-com-marak-colors-js",
+      "source": "incident-SC-2022-COLORS-FAKER",
+      "target": "repo-github-com-marak-colors-js",
+      "type": "AFFECTED_REPOSITORY",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_REPOSITORY:incident-SC-2022-NODE-IPC->repo-github-com-riaevangelist-node-ipc",
+      "source": "incident-SC-2022-NODE-IPC",
+      "target": "repo-github-com-riaevangelist-node-ipc",
+      "type": "AFFECTED_REPOSITORY",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_REPOSITORY:incident-SC-2022-PYTORCH-NIGHTLY->repo-github-com-pytorch-pytorch",
+      "source": "incident-SC-2022-PYTORCH-NIGHTLY",
+      "target": "repo-github-com-pytorch-pytorch",
+      "type": "AFFECTED_REPOSITORY",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_REPOSITORY:incident-SC-2024-ULTRALYTICS-PYPI->repo-github-com-ultralytics-ultralytics",
+      "source": "incident-SC-2024-ULTRALYTICS-PYPI",
+      "target": "repo-github-com-ultralytics-ultralytics",
+      "type": "AFFECTED_REPOSITORY",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_REPOSITORY:incident-SC-2024-XZ-UTILS->repo-github-com-tukaani-project-xz",
+      "source": "incident-SC-2024-XZ-UTILS",
+      "target": "repo-github-com-tukaani-project-xz",
+      "type": "AFFECTED_REPOSITORY",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_REPOSITORY:incident-SC-2025-GO-BOLTDB-TYPOSQUAT->repo-github-com-boltdb-go-bolt",
+      "source": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "target": "repo-github-com-boltdb-go-bolt",
+      "type": "AFFECTED_REPOSITORY",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "AFFECTED_REPOSITORY:incident-SC-2025-TJ-ACTIONS-CHANGED-FILES->repo-github-com-tj-actions-changed-files",
+      "source": "incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
+      "target": "repo-github-com-tj-actions-changed-files",
+      "type": "AFFECTED_REPOSITORY",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "ATTRIBUTED_TO_ACTOR:actor-apt29->incident-SC-2020-SOLARWINDS-ORION",
+      "source": "actor-apt29",
+      "target": "incident-SC-2020-SOLARWINDS-ORION",
+      "type": "ATTRIBUTED_TO_ACTOR",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "ATTRIBUTED_TO_ACTOR:actor-boltdb-go-operator->incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "source": "actor-boltdb-go-operator",
+      "target": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "type": "ATTRIBUTED_TO_ACTOR",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "ATTRIBUTED_TO_ACTOR:actor-lazarus-group->incident-SC-2023-THREE-CX-DESKTOP",
+      "source": "actor-lazarus-group",
+      "target": "incident-SC-2023-THREE-CX-DESKTOP",
+      "type": "ATTRIBUTED_TO_ACTOR",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "ATTRIBUTED_TO_ACTOR:actor-sandworm->incident-SC-2017-NOTPETYA-MEDOC",
+      "source": "actor-sandworm",
+      "target": "incident-SC-2017-NOTPETYA-MEDOC",
+      "type": "ATTRIBUTED_TO_ACTOR",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "ATTRIBUTED_TO_ACTOR:actor-shai-hulud-operator->incident-SC-2025-NPM-SHAI-HULUD",
+      "source": "actor-shai-hulud-operator",
+      "target": "incident-SC-2025-NPM-SHAI-HULUD",
+      "type": "ATTRIBUTED_TO_ACTOR",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "ATTRIBUTED_TO_ACTOR:actor-unc-xz-utils-operator->incident-SC-2024-XZ-UTILS",
+      "source": "actor-unc-xz-utils-operator",
+      "target": "incident-SC-2024-XZ-UTILS",
+      "type": "ATTRIBUTED_TO_ACTOR",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "ATTRIBUTED_TO_ACTOR:actor-unc-xz-utils-operator->maintainer-jia-tan",
+      "source": "actor-unc-xz-utils-operator",
+      "target": "maintainer-jia-tan",
+      "type": "ATTRIBUTED_TO_ACTOR",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "COMPROMISED_ACCOUNT:incident-SC-2018-ESLINT-SCOPE->account-npm-eslint-scope-npm-maintainer-account",
+      "source": "incident-SC-2018-ESLINT-SCOPE",
+      "target": "account-npm-eslint-scope-npm-maintainer-account",
+      "type": "COMPROMISED_ACCOUNT",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "COMPROMISED_ACCOUNT:incident-SC-2021-PHP-GIT-SERVER->account-php-git-php-git-server-commit-identity",
+      "source": "incident-SC-2021-PHP-GIT-SERVER",
+      "target": "account-php-git-php-git-server-commit-identity",
+      "type": "COMPROMISED_ACCOUNT",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "COMPROMISED_ACCOUNT:incident-SC-2021-UA-PARSER-JS->account-npm-ua-parser-js-npm-maintainer-account",
+      "source": "incident-SC-2021-UA-PARSER-JS",
+      "target": "account-npm-ua-parser-js-npm-maintainer-account",
+      "type": "COMPROMISED_ACCOUNT",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "COMPROMISED_ACCOUNT:incident-SC-2022-PYPI-CTX->account-pypi-ctx-pypi-project-account",
+      "source": "incident-SC-2022-PYPI-CTX",
+      "target": "account-pypi-ctx-pypi-project-account",
+      "type": "COMPROMISED_ACCOUNT",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "COMPROMISED_ACCOUNT:incident-SC-2023-LEDGER-CONNECT-KIT->account-npm-ledgerhq-connect-kit-npm-publish-account",
+      "source": "incident-SC-2023-LEDGER-CONNECT-KIT",
+      "target": "account-npm-ledgerhq-connect-kit-npm-publish-account",
+      "type": "COMPROMISED_ACCOUNT",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "COMPROMISED_ACCOUNT:incident-SC-2024-LOTTIE-PLAYER->account-npm-lottiefiles-lottie-player-npm-publish-account",
+      "source": "incident-SC-2024-LOTTIE-PLAYER",
+      "target": "account-npm-lottiefiles-lottie-player-npm-publish-account",
+      "type": "COMPROMISED_ACCOUNT",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "COMPROMISED_ACCOUNT:incident-SC-2024-ULTRALYTICS-PYPI->account-pypi-ultralytics-pypi-publishing-token",
+      "source": "incident-SC-2024-ULTRALYTICS-PYPI",
+      "target": "account-pypi-ultralytics-pypi-publishing-token",
+      "type": "COMPROMISED_ACCOUNT",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "COMPROMISED_ACCOUNT:incident-SC-2025-NPM-SHAI-HULUD->account-github-victim-github-tokens",
+      "source": "incident-SC-2025-NPM-SHAI-HULUD",
+      "target": "account-github-victim-github-tokens",
+      "type": "COMPROMISED_ACCOUNT",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "COMPROMISED_ACCOUNT:incident-SC-2025-NPM-SHAI-HULUD->account-npm-compromised-npm-maintainer-tokens",
+      "source": "incident-SC-2025-NPM-SHAI-HULUD",
+      "target": "account-npm-compromised-npm-maintainer-tokens",
+      "type": "COMPROMISED_ACCOUNT",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "COMPROMISED_ACCOUNT:incident-SC-2025-TJ-ACTIONS-CHANGED-FILES->account-github-tj-actions-github-action-release-path",
+      "source": "incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
+      "target": "account-github-tj-actions-github-action-release-path",
+      "type": "COMPROMISED_ACCOUNT",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "INCIDENT_AFFECTED_RELEASE:incident-SC-2018-NPM-EVENT-STREAM->release-npm-flatmap-stream-0-1-1",
+      "source": "incident-SC-2018-NPM-EVENT-STREAM",
+      "target": "release-npm-flatmap-stream-0-1-1",
+      "type": "INCIDENT_AFFECTED_RELEASE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "INCIDENT_AFFECTED_RELEASE:incident-SC-2021-UA-PARSER-JS->release-npm-ua-parser-js-0-7-29",
+      "source": "incident-SC-2021-UA-PARSER-JS",
+      "target": "release-npm-ua-parser-js-0-7-29",
+      "type": "INCIDENT_AFFECTED_RELEASE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "INCIDENT_AFFECTED_RELEASE:incident-SC-2021-UA-PARSER-JS->release-npm-ua-parser-js-0-8-0",
+      "source": "incident-SC-2021-UA-PARSER-JS",
+      "target": "release-npm-ua-parser-js-0-8-0",
+      "type": "INCIDENT_AFFECTED_RELEASE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "INCIDENT_AFFECTED_RELEASE:incident-SC-2021-UA-PARSER-JS->release-npm-ua-parser-js-1-0-0",
+      "source": "incident-SC-2021-UA-PARSER-JS",
+      "target": "release-npm-ua-parser-js-1-0-0",
+      "type": "INCIDENT_AFFECTED_RELEASE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "INCIDENT_AFFECTED_RELEASE:incident-SC-2025-GO-BOLTDB-TYPOSQUAT->release-golang-github-com-boltdb-go-bolt-v1-3-1",
+      "source": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "target": "release-golang-github-com-boltdb-go-bolt-v1-3-1",
+      "type": "INCIDENT_AFFECTED_RELEASE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "INCIDENT_AFFECTED_RELEASE:incident-SC-2025-NPM-SHAI-HULUD->release-npm-ctrl-tinycolor-4-1-1",
+      "source": "incident-SC-2025-NPM-SHAI-HULUD",
+      "target": "release-npm-ctrl-tinycolor-4-1-1",
+      "type": "INCIDENT_AFFECTED_RELEASE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "INCIDENT_AFFECTED_RELEASE:incident-SC-2025-NPM-SHAI-HULUD->release-npm-ctrl-tinycolor-4-1-2",
+      "source": "incident-SC-2025-NPM-SHAI-HULUD",
+      "target": "release-npm-ctrl-tinycolor-4-1-2",
+      "type": "INCIDENT_AFFECTED_RELEASE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "MAINTAINS_REPOSITORY:maintainer-dominictarr->repo-github-com-dominictarr-event-stream",
+      "source": "maintainer-dominictarr",
+      "target": "repo-github-com-dominictarr-event-stream",
+      "type": "MAINTAINS_REPOSITORY",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "MAINTAINS_REPOSITORY:maintainer-jia-tan->repo-github-com-tukaani-project-xz",
+      "source": "maintainer-jia-tan",
+      "target": "repo-github-com-tukaani-project-xz",
+      "type": "MAINTAINS_REPOSITORY",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "MAINTAINS_REPOSITORY:maintainer-marak-squires->repo-github-com-marak-colors-js",
+      "source": "maintainer-marak-squires",
+      "target": "repo-github-com-marak-colors-js",
+      "type": "MAINTAINS_REPOSITORY",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "MAINTAINS_REPOSITORY:maintainer-riaevangelist->repo-github-com-riaevangelist-node-ipc",
+      "source": "maintainer-riaevangelist",
+      "target": "repo-github-com-riaevangelist-node-ipc",
+      "type": "MAINTAINS_REPOSITORY",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "PACKAGE_RELEASE:pkg-golang-github-com-boltdb-go-bolt->release-golang-github-com-boltdb-go-bolt-v1-3-1",
+      "source": "pkg-golang-github-com-boltdb-go-bolt",
+      "target": "release-golang-github-com-boltdb-go-bolt-v1-3-1",
+      "type": "PACKAGE_RELEASE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "PACKAGE_RELEASE:pkg-npm-ctrl-tinycolor->release-npm-ctrl-tinycolor-4-1-1",
+      "source": "pkg-npm-ctrl-tinycolor",
+      "target": "release-npm-ctrl-tinycolor-4-1-1",
+      "type": "PACKAGE_RELEASE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "PACKAGE_RELEASE:pkg-npm-ctrl-tinycolor->release-npm-ctrl-tinycolor-4-1-2",
+      "source": "pkg-npm-ctrl-tinycolor",
+      "target": "release-npm-ctrl-tinycolor-4-1-2",
+      "type": "PACKAGE_RELEASE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "PACKAGE_RELEASE:pkg-npm-flatmap-stream->release-npm-flatmap-stream-0-1-1",
+      "source": "pkg-npm-flatmap-stream",
+      "target": "release-npm-flatmap-stream-0-1-1",
+      "type": "PACKAGE_RELEASE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "PACKAGE_RELEASE:pkg-npm-ua-parser-js->release-npm-ua-parser-js-0-7-29",
+      "source": "pkg-npm-ua-parser-js",
+      "target": "release-npm-ua-parser-js-0-7-29",
+      "type": "PACKAGE_RELEASE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "PACKAGE_RELEASE:pkg-npm-ua-parser-js->release-npm-ua-parser-js-0-8-0",
+      "source": "pkg-npm-ua-parser-js",
+      "target": "release-npm-ua-parser-js-0-8-0",
+      "type": "PACKAGE_RELEASE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "PACKAGE_RELEASE:pkg-npm-ua-parser-js->release-npm-ua-parser-js-1-0-0",
+      "source": "pkg-npm-ua-parser-js",
+      "target": "release-npm-ua-parser-js-1-0-0",
+      "type": "PACKAGE_RELEASE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "RELATED_CAMPAIGN:campaign-tp-camp-2017-0002->incident-SC-2017-NOTPETYA-MEDOC",
+      "source": "campaign-tp-camp-2017-0002",
+      "target": "incident-SC-2017-NOTPETYA-MEDOC",
+      "type": "RELATED_CAMPAIGN",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "RELATED_CAMPAIGN:campaign-tp-camp-2020-0001->incident-SC-2020-SOLARWINDS-ORION",
+      "source": "campaign-tp-camp-2020-0001",
+      "target": "incident-SC-2020-SOLARWINDS-ORION",
+      "type": "RELATED_CAMPAIGN",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "RELATED_CAMPAIGN:campaign-tp-camp-2023-0002->incident-SC-2023-THREE-CX-DESKTOP",
+      "source": "campaign-tp-camp-2023-0002",
+      "target": "incident-SC-2023-THREE-CX-DESKTOP",
+      "type": "RELATED_CAMPAIGN",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "SEEDED_BY:pkg-generic-x-trader->pkg-generic-3cx-desktopapp",
+      "source": "pkg-generic-x-trader",
+      "target": "pkg-generic-3cx-desktopapp",
+      "type": "SEEDED_BY",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "SEEDED_BY:pkg-npm-rxnt-authentication->release-npm-ctrl-tinycolor-4-1-1",
+      "source": "pkg-npm-rxnt-authentication",
+      "target": "release-npm-ctrl-tinycolor-4-1-1",
+      "type": "SEEDED_BY",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "SEEDED_BY:release-npm-ctrl-tinycolor-4-1-1->release-npm-ctrl-tinycolor-4-1-2",
+      "source": "release-npm-ctrl-tinycolor-4-1-1",
+      "target": "release-npm-ctrl-tinycolor-4-1-2",
+      "type": "SEEDED_BY",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "SOURCE_ARTIFACT_DIVERGENCE:incident-SC-2016-LINUX-MINT-ISO->channel-linux-website-download-linux-mint-download-site",
+      "source": "incident-SC-2016-LINUX-MINT-ISO",
+      "target": "channel-linux-website-download-linux-mint-download-site",
+      "type": "SOURCE_ARTIFACT_DIVERGENCE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "SOURCE_ARTIFACT_DIVERGENCE:incident-SC-2021-CODECOV-BASH-UPLOADER->channel-ci-cd-script-download-codecov-bash-uploader-download-path",
+      "source": "incident-SC-2021-CODECOV-BASH-UPLOADER",
+      "target": "channel-ci-cd-script-download-codecov-bash-uploader-download-path",
+      "type": "SOURCE_ARTIFACT_DIVERGENCE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "SOURCE_ARTIFACT_DIVERGENCE:incident-SC-2024-XZ-UTILS->channel-linux-source-release-upstream-source-release-tarball",
+      "source": "incident-SC-2024-XZ-UTILS",
+      "target": "channel-linux-source-release-upstream-source-release-tarball",
+      "type": "SOURCE_ARTIFACT_DIVERGENCE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "SOURCE_ARTIFACT_DIVERGENCE:incident-SC-2025-GO-BOLTDB-TYPOSQUAT->channel-github-source-repository-github-repository",
+      "source": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "target": "channel-github-source-repository-github-repository",
+      "type": "SOURCE_ARTIFACT_DIVERGENCE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "SOURCE_ARTIFACT_DIVERGENCE:incident-SC-2025-GO-BOLTDB-TYPOSQUAT->channel-golang-package-registry-go-module-proxy",
+      "source": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "target": "channel-golang-package-registry-go-module-proxy",
+      "type": "SOURCE_ARTIFACT_DIVERGENCE",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_BUILD_SYSTEM:incident-SC-2020-OCTOPUS-SCANNER->build-netbeans-netbeans-project-build-process",
+      "source": "incident-SC-2020-OCTOPUS-SCANNER",
+      "target": "build-netbeans-netbeans-project-build-process",
+      "type": "USED_BUILD_SYSTEM",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_BUILD_SYSTEM:incident-SC-2020-SOLARWINDS-ORION->build-solarwinds-solarwinds-orion-build-system",
+      "source": "incident-SC-2020-SOLARWINDS-ORION",
+      "target": "build-solarwinds-solarwinds-orion-build-system",
+      "type": "USED_BUILD_SYSTEM",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_BUILD_SYSTEM:incident-SC-2021-CODECOV-BASH-UPLOADER->build-codecov-codecov-bash-uploader-distribution-pipeline",
+      "source": "incident-SC-2021-CODECOV-BASH-UPLOADER",
+      "target": "build-codecov-codecov-bash-uploader-distribution-pipeline",
+      "type": "USED_BUILD_SYSTEM",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_BUILD_SYSTEM:incident-SC-2022-PYTORCH-NIGHTLY->build-pytorch-pytorch-nightly-build-pipeline",
+      "source": "incident-SC-2022-PYTORCH-NIGHTLY",
+      "target": "build-pytorch-pytorch-nightly-build-pipeline",
+      "type": "USED_BUILD_SYSTEM",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_BUILD_SYSTEM:incident-SC-2023-THREE-CX-DESKTOP->build-3cx-3cx-desktopapp-build-pipeline",
+      "source": "incident-SC-2023-THREE-CX-DESKTOP",
+      "target": "build-3cx-3cx-desktopapp-build-pipeline",
+      "type": "USED_BUILD_SYSTEM",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_BUILD_SYSTEM:incident-SC-2024-ULTRALYTICS-PYPI->build-github-github-actions",
+      "source": "incident-SC-2024-ULTRALYTICS-PYPI",
+      "target": "build-github-github-actions",
+      "type": "USED_BUILD_SYSTEM",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_BUILD_SYSTEM:incident-SC-2025-NPM-SHAI-HULUD->build-github-github-actions",
+      "source": "incident-SC-2025-NPM-SHAI-HULUD",
+      "target": "build-github-github-actions",
+      "type": "USED_BUILD_SYSTEM",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_BUILD_SYSTEM:incident-SC-2025-TJ-ACTIONS-CHANGED-FILES->build-github-github-actions",
+      "source": "incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
+      "target": "build-github-github-actions",
+      "type": "USED_BUILD_SYSTEM",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2016-LINUX-MINT-ISO->channel-linux-website-download-linux-mint-download-site",
+      "source": "incident-SC-2016-LINUX-MINT-ISO",
+      "target": "channel-linux-website-download-linux-mint-download-site",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2017-CCLEANER->channel-vendor-update-signed-update-signed-software-installer-update-channel",
+      "source": "incident-SC-2017-CCLEANER",
+      "target": "channel-vendor-update-signed-update-signed-software-installer-update-channel",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2017-NOTPETYA-MEDOC->channel-vendor-update-software-update-vendor-software-update-channel",
+      "source": "incident-SC-2017-NOTPETYA-MEDOC",
+      "target": "channel-vendor-update-software-update-vendor-software-update-channel",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2018-ESLINT-SCOPE->channel-npm-package-registry-npm-registry",
+      "source": "incident-SC-2018-ESLINT-SCOPE",
+      "target": "channel-npm-package-registry-npm-registry",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2018-NPM-EVENT-STREAM->channel-npm-package-registry-npm-registry",
+      "source": "incident-SC-2018-NPM-EVENT-STREAM",
+      "target": "channel-npm-package-registry-npm-registry",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2019-ASUS-SHADOWHAMMER->channel-vendor-update-signed-update-signed-software-installer-update-channel",
+      "source": "incident-SC-2019-ASUS-SHADOWHAMMER",
+      "target": "channel-vendor-update-signed-update-signed-software-installer-update-channel",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2020-OCTOPUS-SCANNER->channel-source-control-source-repository-source-repository",
+      "source": "incident-SC-2020-OCTOPUS-SCANNER",
+      "target": "channel-source-control-source-repository-source-repository",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2020-SOLARWINDS-ORION->channel-vendor-update-signed-update-signed-software-installer-update-channel",
+      "source": "incident-SC-2020-SOLARWINDS-ORION",
+      "target": "channel-vendor-update-signed-update-signed-software-installer-update-channel",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2021-CODECOV-BASH-UPLOADER->channel-ci-cd-script-download-codecov-bash-uploader-download-path",
+      "source": "incident-SC-2021-CODECOV-BASH-UPLOADER",
+      "target": "channel-ci-cd-script-download-codecov-bash-uploader-download-path",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2021-DEPENDENCY-CONFUSION->channel-npm-package-registry-npm-registry",
+      "source": "incident-SC-2021-DEPENDENCY-CONFUSION",
+      "target": "channel-npm-package-registry-npm-registry",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2021-DEPENDENCY-CONFUSION->channel-pypi-package-registry-pypi",
+      "source": "incident-SC-2021-DEPENDENCY-CONFUSION",
+      "target": "channel-pypi-package-registry-pypi",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2021-DEPENDENCY-CONFUSION->channel-rubygems-package-registry-rubygems",
+      "source": "incident-SC-2021-DEPENDENCY-CONFUSION",
+      "target": "channel-rubygems-package-registry-rubygems",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2021-KASEYA-VSA->channel-vendor-update-software-update-vendor-software-update-channel",
+      "source": "incident-SC-2021-KASEYA-VSA",
+      "target": "channel-vendor-update-software-update-vendor-software-update-channel",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2021-NPM-RC->channel-npm-package-registry-npm-registry",
+      "source": "incident-SC-2021-NPM-RC",
+      "target": "channel-npm-package-registry-npm-registry",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2021-PHP-GIT-SERVER->channel-source-control-source-repository-source-repository",
+      "source": "incident-SC-2021-PHP-GIT-SERVER",
+      "target": "channel-source-control-source-repository-source-repository",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2021-UA-PARSER-JS->channel-npm-package-registry-npm-registry",
+      "source": "incident-SC-2021-UA-PARSER-JS",
+      "target": "channel-npm-package-registry-npm-registry",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2022-COLORS-FAKER->channel-npm-package-registry-npm-registry",
+      "source": "incident-SC-2022-COLORS-FAKER",
+      "target": "channel-npm-package-registry-npm-registry",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2022-NODE-IPC->channel-npm-package-registry-npm-registry",
+      "source": "incident-SC-2022-NODE-IPC",
+      "target": "channel-npm-package-registry-npm-registry",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2022-PYPI-CTX->channel-pypi-package-registry-pypi",
+      "source": "incident-SC-2022-PYPI-CTX",
+      "target": "channel-pypi-package-registry-pypi",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2022-PYTORCH-NIGHTLY->channel-pypi-package-registry-pypi",
+      "source": "incident-SC-2022-PYTORCH-NIGHTLY",
+      "target": "channel-pypi-package-registry-pypi",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2023-LEDGER-CONNECT-KIT->channel-npm-package-registry-npm-registry",
+      "source": "incident-SC-2023-LEDGER-CONNECT-KIT",
+      "target": "channel-npm-package-registry-npm-registry",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2023-THREE-CX-DESKTOP->channel-vendor-update-signed-update-signed-software-installer-update-channel",
+      "source": "incident-SC-2023-THREE-CX-DESKTOP",
+      "target": "channel-vendor-update-signed-update-signed-software-installer-update-channel",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2024-LOTTIE-PLAYER->channel-npm-package-registry-npm-registry",
+      "source": "incident-SC-2024-LOTTIE-PLAYER",
+      "target": "channel-npm-package-registry-npm-registry",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2024-POLYFILL-IO->channel-web-cdn-script-third-party-cdn-script",
+      "source": "incident-SC-2024-POLYFILL-IO",
+      "target": "channel-web-cdn-script-third-party-cdn-script",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2024-ULTRALYTICS-PYPI->channel-pypi-package-registry-pypi",
+      "source": "incident-SC-2024-ULTRALYTICS-PYPI",
+      "target": "channel-pypi-package-registry-pypi",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2024-XZ-UTILS->channel-linux-source-release-upstream-source-release-tarball",
+      "source": "incident-SC-2024-XZ-UTILS",
+      "target": "channel-linux-source-release-upstream-source-release-tarball",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2025-GO-BOLTDB-TYPOSQUAT->channel-github-source-repository-github-repository",
+      "source": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "target": "channel-github-source-repository-github-repository",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2025-GO-BOLTDB-TYPOSQUAT->channel-golang-package-registry-go-module-proxy",
+      "source": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "target": "channel-golang-package-registry-go-module-proxy",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2025-NPM-SHAI-HULUD->channel-github-actions-ci-cd-workflow-github-actions-workflow",
+      "source": "incident-SC-2025-NPM-SHAI-HULUD",
+      "target": "channel-github-actions-ci-cd-workflow-github-actions-workflow",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2025-NPM-SHAI-HULUD->channel-npm-package-registry-npm-registry",
+      "source": "incident-SC-2025-NPM-SHAI-HULUD",
+      "target": "channel-npm-package-registry-npm-registry",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    },
+    {
+      "id": "USED_DISTRIBUTION_CHANNEL:incident-SC-2025-TJ-ACTIONS-CHANGED-FILES->channel-github-actions-ci-cd-marketplace-github-actions-marketplace",
+      "source": "incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
+      "target": "channel-github-actions-ci-cd-marketplace-github-actions-marketplace",
+      "type": "USED_DISTRIBUTION_CHANNEL",
+      "evidence_tier": null,
+      "source_refs": []
+    }
+  ]
+}

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -538,7 +538,7 @@ function buildEmptyGraphHeroModel() {
     eyebrow: 'Corpus Graph',
     summary:
       'A graph-first view of curated supply chain incidents and the packages, repositories, organizations, maintainers, actors, campaigns, releases, and accounts connected by evidence.',
-    status: 'Corpus graph preview',
+    status: 'WebGL graph loading',
     nodeCount: 0,
     relationshipCount: 0,
     latestIncident: null,
@@ -568,7 +568,7 @@ function buildGraphHeroModel(data) {
     eyebrow: 'Corpus Graph',
     summary:
       'A graph-first view of curated supply chain incidents and the packages, repositories, organizations, maintainers, actors, campaigns, releases, and accounts connected by evidence.',
-    status: 'Corpus graph preview',
+    status: 'WebGL graph loading',
     nodeCount,
     relationshipCount: relationships.length,
     latestIncident,

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -80,33 +80,36 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
     data-graph-selection-value={graphSelectionValue}
   >
     <div
-      class="graph-placeholder"
+      class="graph-placeholder sc-graph-root"
       transition:persist="supply-chain-graph-hero"
-      role="img"
+      data-supply-chain-graph-root
+      data-graph-status="loading"
+      role="application"
       aria-label="Persistent preview of the Supply Chain corpus graph"
     >
       <div class="graph-status">
-        <span>{graphHero.status}</span>
-        <span>Actor → Release</span>
+        <span data-sc-graph-status>{graphHero.status}</span>
+        <span>Actor to Incident</span>
       </div>
-      <div class="graph-field" aria-hidden="true">
+      <canvas
+        class="sc-graph-canvas"
+        data-sc-graph-canvas
+        aria-hidden="true"
+      ></canvas>
+      <div class="sc-graph-label-layer" data-sc-graph-labels aria-hidden="true"></div>
+      <div class="graph-field sc-graph-fallback" aria-hidden="true">
         <span class="lane lane-actor"></span>
         <span class="lane lane-campaign"></span>
         <span class="lane lane-incident"></span>
-        <span class="lane lane-package"></span>
         <span class="edge edge-one"></span>
         <span class="edge edge-two"></span>
-        <span class="edge edge-three"></span>
         <span class="node node-actor">Actor</span>
         <span class="node node-campaign">Campaign</span>
         <span class="node node-incident">Incident</span>
-        <span class="node node-package">Package</span>
-        <span class="node node-release">Release</span>
-        <span class="node node-org">Org</span>
       </div>
       <div class="graph-caption">
-        <strong>Supply Chain Graph</strong>
-        <span>Persistent corpus surface</span>
+        <strong data-sc-graph-caption-title>Supply Chain Graph</strong>
+        <span data-sc-graph-caption-body>Pan, zoom, and select actor, campaign, and incident tiers.</span>
       </div>
     </div>
     <div class="hero-copy">
@@ -450,6 +453,8 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
   )}
 </Base>
 
+<script type="module" src="/js/supply-chain-graph-core.js"></script>
+
 <style>
   .supply-chain-page {
     max-width: 1180px;
@@ -538,6 +543,59 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
       radial-gradient(circle at 72% 58%, rgba(232, 160, 32, 0.13), transparent 28%),
       var(--surface);
     background-size: 42px 42px, 42px 42px, auto, auto, auto;
+  }
+
+  .sc-graph-canvas {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    display: block;
+    width: 100%;
+    height: 100%;
+    cursor: grab;
+    touch-action: none;
+  }
+
+  .sc-graph-canvas:active {
+    cursor: grabbing;
+  }
+
+  .sc-graph-label-layer {
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    pointer-events: none;
+  }
+
+  .sc-graph-label {
+    position: absolute;
+    max-width: 220px;
+    border: 1px solid rgba(30, 39, 51, 0.9);
+    border-radius: 4px;
+    background: rgba(8, 11, 16, 0.78);
+    color: var(--text);
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    letter-spacing: 0.12em;
+    line-height: 1.3;
+    padding: 5px 7px;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .sc-graph-label-actor {
+    border-color: rgba(255, 68, 68, 0.58);
+    color: var(--white);
+  }
+
+  .sc-graph-label-campaign {
+    border-color: rgba(232, 160, 32, 0.58);
+  }
+
+  .sc-graph-root[data-graph-status='ready'] .sc-graph-fallback,
+  .sc-graph-root[data-graph-status='failed'] .sc-graph-canvas,
+  .sc-graph-root[data-graph-status='failed'] .sc-graph-label-layer {
+    display: none;
   }
 
   .graph-status,


### PR DESCRIPTION
Replacement for closed stacked PR #1189 after #1184 merged and its base branch was deleted.

Scope:
- Adds the compiled supply-chain graph payload build step.
- Adds the G2 WebGL graph core with actor/campaign/incident tiers, quadtree picking, camera pan/zoom/clamping, route selection, and panel commands.
- Keeps package/release tiers payload-only until later LOD slices.

Validation run locally on current branch:
- node --check scripts/build-supply-chain-graph.mjs
- node --check site/public/js/supply-chain-graph-core.js
- node --check scripts/test-supply-chain-pages.mjs
- node scripts/build-supply-chain-graph.mjs --check
- node scripts/test-supply-chain-pages.mjs
- python3 scripts/validate_supply_chain_incidents.py
- python3 scripts/validate_supply_chain_graph.py
- git diff --check

Review notes:
- Prior #1189 review feedback was addressed before recreating this PR.
- Recreated against main to avoid merging into the deleted G1 stack branch.