### PR TITLE
Supply Chain G3 technique focus

### DIFF
--- a/docs/supply-chain-pages.md
+++ b/docs/supply-chain-pages.md
@@ -50,9 +50,14 @@ node scripts/build-supply-chain-graph.mjs
 node scripts/build-supply-chain-graph.mjs --check
 ```
 
-The Phase 1.0 G2 renderer draws only the actor, campaign, and incident tiers.
-Package and release nodes are preserved in the payload for later level-of-detail
-slices, but they remain payload-only until the dive-and-bloom work lands.
+The Phase 1.0 G2 renderer draws the actor, campaign, and incident tiers. G3
+adds cross-cutting technique/exploit nodes derived from incident vectors, tags,
+and impact categories. Selecting a technique highlights its incidents across
+actor lanes and pulls the camera back to a stable wide shot. The optional
+`Focus reflow` control clusters those incidents around the selected technique
+node and can be toggled back to the wide shot. Package and release nodes are
+preserved in the payload for later level-of-detail slices, but they remain
+payload-only until the dive-and-bloom work lands.
 
 ## Local Build
 

--- a/scripts/build-supply-chain-graph.mjs
+++ b/scripts/build-supply-chain-graph.mjs
@@ -46,6 +46,7 @@ const tierByType = {
   package: 'package',
   release: 'release',
   repository: 'repository',
+  technique: 'technique',
 };
 
 const severityByAttackStage = {
@@ -67,6 +68,14 @@ function displayLabel(value) {
     .replace(/[_-]+/g, ' ')
     .replace(/\b\w/g, (char) => char.toUpperCase())
     .replace('Ci/Cd', 'CI/CD');
+}
+
+function slugify(value) {
+  return String(value || 'unknown')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
 }
 
 function nodeHref(type, id, entity = {}) {
@@ -204,6 +213,34 @@ export function buildSupplyChainGraphData(corpus = loadCorpus()) {
     });
   });
 
+  const techniqueById = new Map();
+  incidents.forEach((incident) => {
+    incidentTechniques(incident).forEach((technique) => {
+      const id = `technique-${slugify(technique)}`;
+      if (!techniqueById.has(id)) {
+        techniqueById.set(id, {
+          id,
+          entity_id: technique,
+          type: 'technique',
+          label: displayLabel(technique),
+          tier: 'technique',
+          sev: null,
+          time: null,
+          parent: null,
+          techniques: [technique],
+          purl: null,
+          href: null,
+          source_incident_ids: [],
+        });
+      }
+      techniqueById.get(id).source_incident_ids.push(incident.id);
+    });
+  });
+  nodes.push(...Array.from(techniqueById.values()).map((node) => ({
+    ...node,
+    source_incident_ids: Array.from(new Set(node.source_incident_ids)).sort(),
+  })));
+
   Object.entries(entities).forEach(([collection, collectionItems]) => {
     const type = entityTypeByCollection[collection];
     if (!type || !Array.isArray(collectionItems)) return;
@@ -232,7 +269,20 @@ export function buildSupplyChainGraphData(corpus = loadCorpus()) {
     .map((relationship) => normalizeRelationshipEdge(relationship, nodeIds))
     .filter(Boolean);
   const derivedEdges = deriveIncidentContextEdges(nodes, incidents, entities);
-  const edges = uniqueEdges([...corpusEdges, ...derivedEdges]);
+  const techniqueEdges = incidents.flatMap((incident) =>
+    incidentTechniques(incident).map((technique) => {
+      const source = `technique-${slugify(technique)}`;
+      const target = `incident-${incident.id}`;
+      return {
+        id: `INCIDENT_TECHNIQUE:${source}->${target}`,
+        source,
+        target,
+        type: 'INCIDENT_TECHNIQUE',
+        derived: true,
+      };
+    })
+  );
+  const edges = uniqueEdges([...corpusEdges, ...derivedEdges, ...techniqueEdges]);
 
   const parentByIncident = new Map();
   edges.forEach((edge) => {
@@ -269,6 +319,8 @@ export function buildSupplyChainGraphData(corpus = loadCorpus()) {
     },
     renderer_contract: {
       g2_drawable_tiers: ['actor', 'campaign', 'incident'],
+      g3_drawable_tiers: ['actor', 'campaign', 'incident', 'technique'],
+      technique_focus: 'wide-shot-default-with-operator-reflow',
       package_release_lod: 'payload-only-until-G4',
       layout: 'time-anchored-actor-lanes',
     },

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -57,6 +57,7 @@ assert.ok(
 assert.ok(
   supplyChainRouteSource.includes('data-supply-chain-graph-root') &&
     supplyChainRouteSource.includes('data-sc-graph-canvas') &&
+    supplyChainRouteSource.includes('data-sc-graph-focus-reflow') &&
     supplyChainRouteSource.includes('/js/supply-chain-graph-core.js'),
   'route should mount the persisted WebGL graph island'
 );
@@ -193,8 +194,8 @@ assert.equal(index.counts.distributionChannels, data.entities.distribution_chann
 assert.ok(/supply chain/i.test(index.lede), 'index should include polished public copy');
 assert.ok(!JSON.stringify(index).includes('Canary'), 'public page model should not expose the internal codename');
 assert.equal(index.graphHero.status, 'WebGL graph loading', 'index should expose the G2 graph loading state');
-assert.ok(index.graphHero.nodeCount > data.incidents.length, 'graph hero should expose corpus node count');
-assert.equal(index.graphHero.relationshipCount, data.relationships.length, 'graph hero should expose relationship count');
+assert.equal(index.graphHero.nodeCount, supplyChainGraphPayload.nodes.length, 'graph hero should expose rendered graph node count');
+assert.equal(index.graphHero.relationshipCount, supplyChainGraphPayload.edges.length, 'graph hero should expose rendered graph edge count');
 assert.equal(index.incidents.length, data.incidents.length, 'index should expose every incident row');
 assert.ok(index.incidents.every((incident) => incident.summary), 'index incident rows should preserve summaries');
 index.incidents.forEach((incident) => {
@@ -346,6 +347,11 @@ assert.ok(
   supplyChainGraphPayload.renderer_contract.g2_drawable_tiers.includes('incident'),
   'graph payload should declare G2 drawable tiers'
 );
+assert.ok(
+  supplyChainGraphPayload.renderer_contract.g3_drawable_tiers.includes('technique') &&
+    supplyChainGraphPayload.renderer_contract.technique_focus === 'wide-shot-default-with-operator-reflow',
+  'graph payload should declare G3 technique focus behavior'
+);
 assert.equal(
   supplyChainGraphPayload.renderer_contract.package_release_lod,
   'payload-only-until-G4',
@@ -359,22 +365,25 @@ assert.ok(
 assert.ok(
   supplyChainGraphPayload.nodes.some((node) => node.type === 'actor') &&
     supplyChainGraphPayload.nodes.some((node) => node.type === 'campaign') &&
-    supplyChainGraphPayload.nodes.some((node) => node.type === 'incident'),
-  'graph payload should include actor, campaign, and incident tiers'
+    supplyChainGraphPayload.nodes.some((node) => node.type === 'incident') &&
+    supplyChainGraphPayload.nodes.some((node) => node.type === 'technique'),
+  'graph payload should include actor, campaign, incident, and technique tiers'
 );
 assert.ok(
   supplyChainGraphPayload.edges.some((edge) => edge.type === 'ATTRIBUTED_TO_ACTOR') &&
-    supplyChainGraphPayload.edges.some((edge) => edge.type === 'RELATED_CAMPAIGN'),
-  'graph payload should include actor and campaign graph edges'
+    supplyChainGraphPayload.edges.some((edge) => edge.type === 'RELATED_CAMPAIGN') &&
+    supplyChainGraphPayload.edges.some((edge) => edge.type === 'INCIDENT_TECHNIQUE'),
+  'graph payload should include actor, campaign, and technique graph edges'
 );
 assert.ok(
   supplyChainGraphSource.includes("getContext('webgl2'") &&
     supplyChainGraphSource.includes("getContext('webgl'") &&
     supplyChainGraphSource.includes('class SupplyChainQuadtree') &&
     supplyChainGraphSource.includes('function isG2DrawableNode') &&
-    supplyChainGraphSource.includes("const DRAWABLE_TIERS = new Set(['actor', 'campaign', 'incident'])") &&
+    supplyChainGraphSource.includes("const DRAWABLE_TIERS = new Set(['actor', 'campaign', 'incident', 'technique'])") &&
     supplyChainGraphSource.includes('const layoutNodes = Array.from(nodeById.values())') &&
     supplyChainGraphSource.includes("layoutNodes.filter((node) => node.tier === 'incident')") &&
+    supplyChainGraphSource.includes("layoutNodes.filter((node) => node.tier === 'technique')") &&
     supplyChainGraphSource.includes('selectEntityContext') &&
     supplyChainGraphSource.includes('source_incident_ids') &&
     supplyChainGraphSource.includes('connected incident') &&
@@ -384,7 +393,21 @@ assert.ok(
     supplyChainGraphSource.includes('this.lastLabelKey') &&
     supplyChainGraphSource.includes('this.payload.nodes.length') &&
     supplyChainGraphSource.includes('corpus nodes and'),
-  'graph client should use WebGL, quadtree picking, G2 LOD culling, clone-backed layout, clamped camera targets, cached labels, and ready status'
+  'graph client should use WebGL, quadtree picking, G2/G3 LOD culling, clone-backed layout, clamped camera targets, cached labels, and ready status'
+);
+assert.ok(
+  supplyChainGraphSource.includes('this.focusReflow') &&
+    supplyChainGraphSource.includes('Focus reflow') &&
+    supplyChainGraphSource.includes("edge.type === 'INCIDENT_TECHNIQUE'") &&
+    supplyChainGraphSource.includes("this.selection?.type === 'technique'") &&
+    supplyChainGraphSource.includes('frameSelectedTechniqueWideShot') &&
+    supplyChainGraphSource.includes("if (edge.type === 'INCIDENT_TECHNIQUE') return;") &&
+    supplyChainGraphSource.includes('z: Math.min(fit.z, 0.82)') &&
+    supplyChainGraphSource.includes("contextEdge.type === 'ATTRIBUTED_TO_ACTOR' || contextEdge.type === 'RELATED_CAMPAIGN'") &&
+    supplyChainGraphSource.includes("this.focusReflow && this.selection?.type === 'technique'") &&
+    supplyChainGraphSource.includes("node.tier === 'campaign'") &&
+    supplyChainGraphSource.includes("node.tier === 'technique' && this.selection?.value === node.id"),
+  'graph client should implement bounded technique focus, reflow hit testing, and campaign-preserving labels'
 );
 
 const codecov = getSupplyChainIncidentPage('SC-2021-CODECOV-BASH-UPLOADER', data);

--- a/site/public/js/supply-chain-graph-core.js
+++ b/site/public/js/supply-chain-graph-core.js
@@ -1,5 +1,5 @@
 const GRAPH_DATA_URL = '/supply-chain-graph.json';
-const DRAWABLE_TIERS = new Set(['actor', 'campaign', 'incident']);
+const DRAWABLE_TIERS = new Set(['actor', 'campaign', 'incident', 'technique']);
 const SEVERITY_COLORS = {
   critical: [1.0, 0.267, 0.267, 1],
   high: [1.0, 0.647, 0.0, 1],
@@ -7,6 +7,7 @@ const SEVERITY_COLORS = {
   low: [0.318, 0.812, 0.4, 1],
   actor: [1.0, 0.267, 0.267, 1],
   campaign: [0.91, 0.627, 0.125, 1],
+  technique: [0.804, 0.835, 0.878, 1],
   default: [0.804, 0.835, 0.878, 1],
   muted: [0.353, 0.416, 0.494, 0.32],
 };
@@ -30,8 +31,9 @@ function dateNumber(value) {
 
 function tierRank(tier) {
   if (tier === 'actor') return 0;
-  if (tier === 'campaign') return 1;
-  if (tier === 'incident') return 2;
+  if (tier === 'technique') return 1;
+  if (tier === 'campaign') return 2;
+  if (tier === 'incident') return 3;
   return 3;
 }
 
@@ -150,6 +152,7 @@ function buildLayout(payload) {
   const incidentNodes = layoutNodes.filter((node) => node.tier === 'incident');
   const actorNodes = layoutNodes.filter((node) => node.tier === 'actor');
   const campaignNodes = layoutNodes.filter((node) => node.tier === 'campaign');
+  const techniqueNodes = layoutNodes.filter((node) => node.tier === 'technique');
   const actorIds = new Set(actorNodes.map((node) => node.id));
   const campaignIds = new Set(campaignNodes.map((node) => node.id));
   const incidentActor = new Map();
@@ -204,6 +207,21 @@ function buildLayout(payload) {
     node.radius = 13;
   });
 
+  techniqueNodes.forEach((node, index) => {
+    const incidentChildren = payload.edges
+      .filter((edge) => edge.type === 'INCIDENT_TECHNIQUE' && edge.source === node.id)
+      .map((edge) => nodeById.get(edge.target))
+      .filter(Boolean);
+    if (incidentChildren.length > 0) {
+      node.x = incidentChildren.reduce((sum, child) => sum + child.x, 0) / incidentChildren.length;
+      node.y = -150 - (index % 3) * 36;
+    } else {
+      node.x = -760 + index * 120;
+      node.y = -180;
+    }
+    node.radius = 12;
+  });
+
   const laidOutNodes = Array.from(nodeById.values()).sort((a, b) => tierRank(a.tier) - tierRank(b.tier));
   const laidOutById = new Map(laidOutNodes.map((node) => [node.id, node]));
   const edges = payload.edges
@@ -233,11 +251,13 @@ class SupplyChainGraph {
     this.status = root.querySelector('[data-sc-graph-status]');
     this.captionTitle = root.querySelector('[data-sc-graph-caption-title]');
     this.captionBody = root.querySelector('[data-sc-graph-caption-body]');
+    this.reflowButton = root.querySelector('[data-sc-graph-focus-reflow]');
     this.viewport = { width: 1, height: 1, dpr: 1 };
     this.layout = buildLayout(payload);
     this.camera = { cx: 0, cy: 0, z: 1 };
     this.targetCamera = { cx: 0, cy: 0, z: 1 };
     this.selection = null;
+    this.focusReflow = false;
     this.drag = null;
     this.reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     this.gl = this.canvas.getContext('webgl2', { antialias: true }) || this.canvas.getContext('webgl', { antialias: true });
@@ -348,6 +368,13 @@ class SupplyChainGraph {
       const zoomFactor = Math.exp(-event.deltaY * 0.001);
       this.setCameraTarget({ ...this.targetCamera, z: clamp(this.targetCamera.z * zoomFactor, 0.22, 3.4) });
     }, { passive: false });
+    this.reflowButton?.addEventListener('click', () => {
+      if (this.selection?.type !== 'technique') return;
+      this.focusReflow = !this.focusReflow;
+      if (!this.focusReflow) this.frameSelectedTechniqueWideShot();
+      this.reflowButton.setAttribute('aria-pressed', String(this.focusReflow));
+      this.reflowButton.textContent = this.focusReflow ? 'Restore wide shot' : 'Focus reflow';
+    });
     document.addEventListener('click', (event) => {
       const commandTarget = event.target.closest('[data-graph-command][data-graph-value]');
       if (!commandTarget) return;
@@ -419,6 +446,15 @@ class SupplyChainGraph {
   pick(clientX, clientY) {
     const world = this.screenToWorld(clientX, clientY);
     const radius = 24 / this.camera.z;
+    if (this.focusReflow && this.selection?.type === 'technique') {
+      const nearest = this.layout.nodes.reduce((best, node) => {
+        const displayNode = this.displayNode(node);
+        const distance = Math.hypot(displayNode.x - world.x, displayNode.y - world.y);
+        if (distance > radius || (best && best.distance <= distance)) return best;
+        return { point: node, distance };
+      }, null);
+      return nearest?.point || null;
+    }
     const nearest = this.layout.quadtree.nearest(world.x, world.y, radius);
     return nearest?.point || null;
   }
@@ -482,15 +518,36 @@ class SupplyChainGraph {
     const nodes = this.layout.nodes.filter((node) => node.tier === 'incident' && node.attack_stage === stage);
     if (nodes.length === 0) return;
     this.selection = { type: 'stage', value: stage, nodes: new Set(nodes.map((node) => node.id)) };
+    this.focusReflow = false;
+    this.updateReflowControl();
     this.setCameraTarget(fitBounds(nodes, this.viewport));
     this.updateCaption(`Attack stage: ${stage.replace(/_/g, ' ')}`, `${nodes.length} incident${nodes.length === 1 ? '' : 's'} selected.`);
   }
 
   selectNode(node) {
-    this.selection = { type: node.type, value: node.id, nodes: new Set([node.id]) };
+    this.focusReflow = false;
     const cluster = this.clusterFor(node);
-    this.setCameraTarget(fitBounds(cluster, this.viewport, node.tier === 'incident' ? 170 : 140));
+    const selectionNodes =
+      node.tier === 'technique'
+        ? cluster.filter((item) => item.tier === 'technique' || item.tier === 'incident').map((item) => item.id)
+        : [node.id];
+    this.selection = { type: node.type, value: node.id, nodes: new Set(selectionNodes) };
+    if (node.tier === 'technique') {
+      this.frameSelectedTechniqueWideShot(cluster);
+    } else {
+      this.setCameraTarget(fitBounds(cluster, this.viewport, node.tier === 'incident' ? 170 : 140));
+    }
     this.updateCaption(node.label, node.summary || `${node.type.replace(/_/g, ' ')} node selected.`);
+    this.updateReflowControl();
+  }
+
+  frameSelectedTechniqueWideShot(cluster = null) {
+    if (this.selection?.type !== 'technique') return;
+    const selectedNode = this.layout.nodeById.get(this.selection.value);
+    const techniqueCluster = cluster || (selectedNode ? this.clusterFor(selectedNode) : []);
+    if (!techniqueCluster.length) return;
+    const fit = fitBounds(techniqueCluster, this.viewport, 300);
+    this.setCameraTarget({ ...fit, z: Math.min(fit.z, 0.82) });
   }
 
   clusterFor(node) {
@@ -505,11 +562,35 @@ class SupplyChainGraph {
       });
     } else if (node.tier === 'incident') {
       this.layout.edges.forEach((edge) => {
+        if (edge.type === 'INCIDENT_TECHNIQUE') return;
         if (edge.target === node.id) clusterIds.add(edge.source);
         if (edge.source === node.id) clusterIds.add(edge.target);
       });
+    } else if (node.tier === 'technique') {
+      this.layout.edges.forEach((edge) => {
+        if (edge.source === node.id && edge.type === 'INCIDENT_TECHNIQUE') {
+          clusterIds.add(edge.target);
+          this.layout.edges.forEach((contextEdge) => {
+            if (
+              contextEdge.target === edge.target &&
+              (contextEdge.type === 'ATTRIBUTED_TO_ACTOR' || contextEdge.type === 'RELATED_CAMPAIGN')
+            ) {
+              clusterIds.add(contextEdge.source);
+            }
+          });
+        }
+      });
     }
     return this.layout.nodes.filter((item) => clusterIds.has(item.id));
+  }
+
+  updateReflowControl() {
+    if (!this.reflowButton) return;
+    const isTechnique = this.selection?.type === 'technique';
+    this.reflowButton.disabled = !isTechnique;
+    this.reflowButton.hidden = !isTechnique;
+    this.reflowButton.setAttribute('aria-pressed', String(isTechnique && this.focusReflow));
+    this.reflowButton.textContent = isTechnique && this.focusReflow ? 'Restore wide shot' : 'Focus reflow';
   }
 
   updateCaption(title, body) {
@@ -519,7 +600,11 @@ class SupplyChainGraph {
   }
 
   colorForNode(node) {
+    if (node.tier === 'technique') return SEVERITY_COLORS.technique;
     if (this.selection?.type === 'stage' && node.tier === 'incident') {
+      return this.selection.nodes.has(node.id) ? SEVERITY_COLORS[node.sev] || SEVERITY_COLORS.default : SEVERITY_COLORS.muted;
+    }
+    if (this.selection?.type === 'technique' && node.tier === 'incident') {
       return this.selection.nodes.has(node.id) ? SEVERITY_COLORS[node.sev] || SEVERITY_COLORS.default : SEVERITY_COLORS.muted;
     }
     if (node.tier === 'actor') return SEVERITY_COLORS.actor;
@@ -533,14 +618,36 @@ class SupplyChainGraph {
     return 0.1;
   }
 
+  displayNode(node) {
+    if (!this.focusReflow || this.selection?.type !== 'technique') return node;
+    if (node.id === this.selection.value) return { ...node, x: this.camera.cx, y: this.camera.cy - 40 };
+    if (!this.selection.nodes?.has(node.id) || node.tier !== 'incident') return node;
+    const incidents = this.layout.nodes.filter((item) => this.selection.nodes.has(item.id) && item.tier === 'incident');
+    const index = incidents.findIndex((item) => item.id === node.id);
+    const angle = (index / Math.max(1, incidents.length)) * Math.PI * 2 - Math.PI / 2;
+    const radius = 150 + Math.floor(index / 12) * 72;
+    return {
+      ...node,
+      x: this.camera.cx + Math.cos(angle) * radius,
+      y: this.camera.cy - 40 + Math.sin(angle) * radius,
+    };
+  }
+
   drawEdges() {
     const gl = this.gl;
     const values = [];
     this.layout.edges.forEach((edge) => {
       const alpha = this.edgeAlpha(edge);
-      const color = edge.type === 'ATTRIBUTED_TO_ACTOR' ? SEVERITY_COLORS.high : SEVERITY_COLORS.medium;
-      values.push(edge.sourceNode.x, edge.sourceNode.y, color[0], color[1], color[2], alpha);
-      values.push(edge.targetNode.x, edge.targetNode.y, color[0], color[1], color[2], alpha);
+      const color =
+        edge.type === 'ATTRIBUTED_TO_ACTOR'
+          ? SEVERITY_COLORS.high
+          : edge.type === 'INCIDENT_TECHNIQUE'
+            ? SEVERITY_COLORS.technique
+            : SEVERITY_COLORS.medium;
+      const sourceNode = this.displayNode(edge.sourceNode);
+      const targetNode = this.displayNode(edge.targetNode);
+      values.push(sourceNode.x, sourceNode.y, color[0], color[1], color[2], alpha);
+      values.push(targetNode.x, targetNode.y, color[0], color[1], color[2], alpha);
     });
     gl.useProgram(this.edgeProgram);
     gl.bindBuffer(gl.ARRAY_BUFFER, this.edgeBuffer);
@@ -566,9 +673,18 @@ class SupplyChainGraph {
     const gl = this.gl;
     const values = [];
     this.layout.nodes.forEach((node) => {
+      const displayNode = this.displayNode(node);
       const color = this.colorForNode(node);
       const selected = this.selection?.nodes?.has(node.id);
-      values.push(node.x, node.y, color[0], color[1], color[2], color[3], selected ? node.radius * 2.5 : node.radius * 2);
+      values.push(
+        displayNode.x,
+        displayNode.y,
+        color[0],
+        color[1],
+        color[2],
+        color[3],
+        selected ? node.radius * 2.5 : node.radius * 2
+      );
     });
     gl.useProgram(this.nodeProgram);
     gl.bindBuffer(gl.ARRAY_BUFFER, this.nodeBuffer);
@@ -595,10 +711,14 @@ class SupplyChainGraph {
 
   drawLabels() {
     const labelNodes = this.layout.nodes.filter(
-      (node) => node.tier === 'actor' || node.tier === 'campaign' || this.selection?.nodes?.has(node.id)
+      (node) =>
+        node.tier === 'actor' ||
+        node.tier === 'campaign' ||
+        (node.tier === 'technique' && this.selection?.value === node.id) ||
+        this.selection?.nodes?.has(node.id)
     );
     const labels = labelNodes.slice(0, 24).map((node) => {
-      const position = this.worldToScreen(node);
+      const position = this.worldToScreen(this.displayNode(node));
       return {
         node,
         x: Math.round(position.x + 12),

--- a/site/public/supply-chain-graph.json
+++ b/site/public/supply-chain-graph.json
@@ -12,11 +12,19 @@
       "campaign",
       "incident"
     ],
+    "g3_drawable_tiers": [
+      "actor",
+      "campaign",
+      "incident",
+      "technique"
+    ],
+    "technique_focus": "wide-shot-default-with-operator-reflow",
     "package_release_lod": "payload-only-until-G4",
     "layout": "time-anchored-actor-lanes"
   },
   "counts": {
     "incident": 27,
+    "technique": 58,
     "account": 10,
     "actor": 6,
     "build_system": 6,
@@ -2775,6 +2783,1137 @@
       "source_incident_ids": [
         "SC-2024-ULTRALYTICS-PYPI"
       ]
+    },
+    {
+      "id": "technique-account-compromise",
+      "entity_id": "account-compromise",
+      "type": "technique",
+      "label": "Account Compromise",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "account-compromise"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2021-UA-PARSER-JS"
+      ]
+    },
+    {
+      "id": "technique-account-takeover",
+      "entity_id": "account-takeover",
+      "type": "technique",
+      "label": "Account Takeover",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "account-takeover"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2022-PYPI-CTX"
+      ]
+    },
+    {
+      "id": "technique-backdoor",
+      "entity_id": "backdoor",
+      "type": "technique",
+      "label": "Backdoor",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "backdoor"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2016-LINUX-MINT-ISO",
+        "SC-2017-CCLEANER",
+        "SC-2019-ASUS-SHADOWHAMMER",
+        "SC-2020-SOLARWINDS-ORION",
+        "SC-2021-PHP-GIT-SERVER",
+        "SC-2023-THREE-CX-DESKTOP",
+        "SC-2024-XZ-UTILS",
+        "SC-2025-GO-BOLTDB-TYPOSQUAT"
+      ]
+    },
+    {
+      "id": "technique-build-system",
+      "entity_id": "build-system",
+      "type": "technique",
+      "label": "Build System",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "build-system"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2020-SOLARWINDS-ORION"
+      ]
+    },
+    {
+      "id": "technique-build-system-compromise",
+      "entity_id": "build_system_compromise",
+      "type": "technique",
+      "label": "Build System Compromise",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "build_system_compromise"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2020-OCTOPUS-SCANNER",
+        "SC-2020-SOLARWINDS-ORION",
+        "SC-2021-CODECOV-BASH-UPLOADER",
+        "SC-2023-THREE-CX-DESKTOP",
+        "SC-2024-ULTRALYTICS-PYPI"
+      ]
+    },
+    {
+      "id": "technique-cdn",
+      "entity_id": "cdn",
+      "type": "technique",
+      "label": "Cdn",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "cdn"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2024-POLYFILL-IO"
+      ]
+    },
+    {
+      "id": "technique-cdn-script-compromise",
+      "entity_id": "cdn_script_compromise",
+      "type": "technique",
+      "label": "Cdn Script Compromise",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "cdn_script_compromise"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2024-POLYFILL-IO"
+      ]
+    },
+    {
+      "id": "technique-ci-cd",
+      "entity_id": "ci-cd",
+      "type": "technique",
+      "label": "Ci Cd",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "ci-cd"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2021-CODECOV-BASH-UPLOADER",
+        "SC-2025-TJ-ACTIONS-CHANGED-FILES"
+      ]
+    },
+    {
+      "id": "technique-ci-cd-action-compromise",
+      "entity_id": "ci_cd_action_compromise",
+      "type": "technique",
+      "label": "Ci Cd Action Compromise",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "ci_cd_action_compromise"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2025-NPM-SHAI-HULUD",
+        "SC-2025-TJ-ACTIONS-CHANGED-FILES"
+      ]
+    },
+    {
+      "id": "technique-credential-theft",
+      "entity_id": "credential_theft",
+      "type": "technique",
+      "label": "Credential Theft",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "credential_theft"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2018-ESLINT-SCOPE",
+        "SC-2018-NPM-EVENT-STREAM",
+        "SC-2021-CODECOV-BASH-UPLOADER",
+        "SC-2021-UA-PARSER-JS",
+        "SC-2022-PYPI-CTX",
+        "SC-2022-PYTORCH-NIGHTLY",
+        "SC-2025-NPM-SHAI-HULUD",
+        "SC-2025-TJ-ACTIONS-CHANGED-FILES"
+      ]
+    },
+    {
+      "id": "technique-credentials",
+      "entity_id": "credentials",
+      "type": "technique",
+      "label": "Credentials",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "credentials"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2021-CODECOV-BASH-UPLOADER"
+      ]
+    },
+    {
+      "id": "technique-crypto-theft",
+      "entity_id": "crypto_theft",
+      "type": "technique",
+      "label": "Crypto Theft",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "crypto_theft"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2018-NPM-EVENT-STREAM",
+        "SC-2023-LEDGER-CONNECT-KIT",
+        "SC-2024-LOTTIE-PLAYER"
+      ]
+    },
+    {
+      "id": "technique-cryptomining",
+      "entity_id": "cryptomining",
+      "type": "technique",
+      "label": "Cryptomining",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "cryptomining"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2021-UA-PARSER-JS",
+        "SC-2024-ULTRALYTICS-PYPI"
+      ]
+    },
+    {
+      "id": "technique-data-exfiltration",
+      "entity_id": "data_exfiltration",
+      "type": "technique",
+      "label": "Data Exfiltration",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "data_exfiltration"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2021-CODECOV-BASH-UPLOADER",
+        "SC-2021-DEPENDENCY-CONFUSION",
+        "SC-2022-PYPI-CTX"
+      ]
+    },
+    {
+      "id": "technique-dependency",
+      "entity_id": "dependency",
+      "type": "technique",
+      "label": "Dependency",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "dependency"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2018-NPM-EVENT-STREAM"
+      ]
+    },
+    {
+      "id": "technique-dependency-confusion",
+      "entity_id": "dependency_confusion",
+      "type": "technique",
+      "label": "Dependency Confusion",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "dependency_confusion"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2021-DEPENDENCY-CONFUSION",
+        "SC-2022-PYTORCH-NIGHTLY",
+        "SC-2025-GO-BOLTDB-TYPOSQUAT"
+      ]
+    },
+    {
+      "id": "technique-desktop",
+      "entity_id": "desktop",
+      "type": "technique",
+      "label": "Desktop",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "desktop"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2023-THREE-CX-DESKTOP"
+      ]
+    },
+    {
+      "id": "technique-destructive-payload",
+      "entity_id": "destructive_payload",
+      "type": "technique",
+      "label": "Destructive Payload",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "destructive_payload"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2017-NOTPETYA-MEDOC",
+        "SC-2022-COLORS-FAKER",
+        "SC-2022-NODE-IPC"
+      ]
+    },
+    {
+      "id": "technique-developer-workstation-compromise",
+      "entity_id": "developer_workstation_compromise",
+      "type": "technique",
+      "label": "Developer Workstation Compromise",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "developer_workstation_compromise"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2018-ESLINT-SCOPE",
+        "SC-2020-OCTOPUS-SCANNER",
+        "SC-2021-DEPENDENCY-CONFUSION",
+        "SC-2022-PYTORCH-NIGHTLY",
+        "SC-2024-ULTRALYTICS-PYPI",
+        "SC-2025-GO-BOLTDB-TYPOSQUAT",
+        "SC-2025-NPM-SHAI-HULUD",
+        "SC-2025-TJ-ACTIONS-CHANGED-FILES"
+      ]
+    },
+    {
+      "id": "technique-distribution",
+      "entity_id": "distribution",
+      "type": "technique",
+      "label": "Distribution",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "distribution"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2016-LINUX-MINT-ISO"
+      ]
+    },
+    {
+      "id": "technique-distribution-site-compromise",
+      "entity_id": "distribution_site_compromise",
+      "type": "technique",
+      "label": "Distribution Site Compromise",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "distribution_site_compromise"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2016-LINUX-MINT-ISO"
+      ]
+    },
+    {
+      "id": "technique-downstream-customer-compromise",
+      "entity_id": "downstream_customer_compromise",
+      "type": "technique",
+      "label": "Downstream Customer Compromise",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "downstream_customer_compromise"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2017-NOTPETYA-MEDOC",
+        "SC-2020-SOLARWINDS-ORION",
+        "SC-2021-KASEYA-VSA",
+        "SC-2023-LEDGER-CONNECT-KIT",
+        "SC-2023-THREE-CX-DESKTOP",
+        "SC-2024-LOTTIE-PLAYER",
+        "SC-2024-POLYFILL-IO",
+        "SC-2025-NPM-SHAI-HULUD"
+      ]
+    },
+    {
+      "id": "technique-github",
+      "entity_id": "github",
+      "type": "technique",
+      "label": "Github",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "github"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2020-OCTOPUS-SCANNER"
+      ]
+    },
+    {
+      "id": "technique-github-actions",
+      "entity_id": "github-actions",
+      "type": "technique",
+      "label": "Github Actions",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "github-actions"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2024-ULTRALYTICS-PYPI",
+        "SC-2025-NPM-SHAI-HULUD",
+        "SC-2025-TJ-ACTIONS-CHANGED-FILES"
+      ]
+    },
+    {
+      "id": "technique-golang",
+      "entity_id": "golang",
+      "type": "technique",
+      "label": "Golang",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "golang"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2025-GO-BOLTDB-TYPOSQUAT"
+      ]
+    },
+    {
+      "id": "technique-iso",
+      "entity_id": "iso",
+      "type": "technique",
+      "label": "Iso",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "iso"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2016-LINUX-MINT-ISO"
+      ]
+    },
+    {
+      "id": "technique-java",
+      "entity_id": "java",
+      "type": "technique",
+      "label": "Java",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "java"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2020-OCTOPUS-SCANNER"
+      ]
+    },
+    {
+      "id": "technique-javascript",
+      "entity_id": "javascript",
+      "type": "technique",
+      "label": "Javascript",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "javascript"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2024-POLYFILL-IO"
+      ]
+    },
+    {
+      "id": "technique-linux",
+      "entity_id": "linux",
+      "type": "technique",
+      "label": "Linux",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "linux"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2024-XZ-UTILS"
+      ]
+    },
+    {
+      "id": "technique-maintainer-account",
+      "entity_id": "maintainer-account",
+      "type": "technique",
+      "label": "Maintainer Account",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "maintainer-account"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2018-ESLINT-SCOPE"
+      ]
+    },
+    {
+      "id": "technique-maintainer-account-compromise",
+      "entity_id": "maintainer_account_compromise",
+      "type": "technique",
+      "label": "Maintainer Account Compromise",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "maintainer_account_compromise"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2018-ESLINT-SCOPE",
+        "SC-2021-UA-PARSER-JS",
+        "SC-2022-PYPI-CTX",
+        "SC-2023-LEDGER-CONNECT-KIT",
+        "SC-2024-LOTTIE-PLAYER",
+        "SC-2025-NPM-SHAI-HULUD"
+      ]
+    },
+    {
+      "id": "technique-malicious-dependency",
+      "entity_id": "malicious_dependency",
+      "type": "technique",
+      "label": "Malicious Dependency",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "malicious_dependency"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2018-NPM-EVENT-STREAM",
+        "SC-2024-XZ-UTILS",
+        "SC-2025-GO-BOLTDB-TYPOSQUAT"
+      ]
+    },
+    {
+      "id": "technique-malicious-package",
+      "entity_id": "malicious-package",
+      "type": "technique",
+      "label": "Malicious Package",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "malicious-package"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2021-NPM-RC"
+      ]
+    },
+    {
+      "id": "technique-malware-distribution",
+      "entity_id": "malware_distribution",
+      "type": "technique",
+      "label": "Malware Distribution",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "malware_distribution"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2016-LINUX-MINT-ISO",
+        "SC-2017-CCLEANER",
+        "SC-2019-ASUS-SHADOWHAMMER",
+        "SC-2020-OCTOPUS-SCANNER",
+        "SC-2021-NPM-RC",
+        "SC-2023-THREE-CX-DESKTOP",
+        "SC-2024-POLYFILL-IO"
+      ]
+    },
+    {
+      "id": "technique-module-proxy",
+      "entity_id": "module-proxy",
+      "type": "technique",
+      "label": "Module Proxy",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "module-proxy"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2025-GO-BOLTDB-TYPOSQUAT"
+      ]
+    },
+    {
+      "id": "technique-msp",
+      "entity_id": "msp",
+      "type": "technique",
+      "label": "Msp",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "msp"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2021-KASEYA-VSA"
+      ]
+    },
+    {
+      "id": "technique-notpetya",
+      "entity_id": "notpetya",
+      "type": "technique",
+      "label": "Notpetya",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "notpetya"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2017-NOTPETYA-MEDOC"
+      ]
+    },
+    {
+      "id": "technique-npm",
+      "entity_id": "npm",
+      "type": "technique",
+      "label": "Npm",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "npm"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2018-ESLINT-SCOPE",
+        "SC-2018-NPM-EVENT-STREAM",
+        "SC-2021-NPM-RC",
+        "SC-2021-UA-PARSER-JS",
+        "SC-2022-COLORS-FAKER",
+        "SC-2022-NODE-IPC",
+        "SC-2023-LEDGER-CONNECT-KIT",
+        "SC-2024-LOTTIE-PLAYER",
+        "SC-2025-NPM-SHAI-HULUD"
+      ]
+    },
+    {
+      "id": "technique-package-repository-compromise",
+      "entity_id": "package_repository_compromise",
+      "type": "technique",
+      "label": "Package Repository Compromise",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "package_repository_compromise"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2018-ESLINT-SCOPE",
+        "SC-2021-NPM-RC",
+        "SC-2021-UA-PARSER-JS",
+        "SC-2022-PYPI-CTX",
+        "SC-2023-LEDGER-CONNECT-KIT",
+        "SC-2024-LOTTIE-PLAYER",
+        "SC-2024-ULTRALYTICS-PYPI",
+        "SC-2025-NPM-SHAI-HULUD"
+      ]
+    },
+    {
+      "id": "technique-php",
+      "entity_id": "php",
+      "type": "technique",
+      "label": "Php",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "php"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2021-PHP-GIT-SERVER"
+      ]
+    },
+    {
+      "id": "technique-protest-payload",
+      "entity_id": "protest_payload",
+      "type": "technique",
+      "label": "Protest Payload",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "protest_payload"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2022-COLORS-FAKER",
+        "SC-2022-NODE-IPC"
+      ]
+    },
+    {
+      "id": "technique-protestware",
+      "entity_id": "protestware",
+      "type": "technique",
+      "label": "Protestware",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "protestware"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2022-COLORS-FAKER",
+        "SC-2022-NODE-IPC"
+      ]
+    },
+    {
+      "id": "technique-pypi",
+      "entity_id": "pypi",
+      "type": "technique",
+      "label": "Pypi",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "pypi"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2022-PYPI-CTX",
+        "SC-2022-PYTORCH-NIGHTLY",
+        "SC-2024-ULTRALYTICS-PYPI"
+      ]
+    },
+    {
+      "id": "technique-ransomware",
+      "entity_id": "ransomware",
+      "type": "technique",
+      "label": "Ransomware",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "ransomware"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2021-KASEYA-VSA"
+      ]
+    },
+    {
+      "id": "technique-ransomware-delivery",
+      "entity_id": "ransomware_delivery",
+      "type": "technique",
+      "label": "Ransomware Delivery",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "ransomware_delivery"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2017-NOTPETYA-MEDOC",
+        "SC-2021-KASEYA-VSA"
+      ]
+    },
+    {
+      "id": "technique-research",
+      "entity_id": "research",
+      "type": "technique",
+      "label": "Research",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "research"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2021-DEPENDENCY-CONFUSION"
+      ]
+    },
+    {
+      "id": "technique-self-propagating",
+      "entity_id": "self-propagating",
+      "type": "technique",
+      "label": "Self Propagating",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "self-propagating"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2025-NPM-SHAI-HULUD"
+      ]
+    },
+    {
+      "id": "technique-signed-update",
+      "entity_id": "signed-update",
+      "type": "technique",
+      "label": "Signed Update",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "signed-update"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2017-CCLEANER",
+        "SC-2019-ASUS-SHADOWHAMMER",
+        "SC-2023-THREE-CX-DESKTOP"
+      ]
+    },
+    {
+      "id": "technique-signed-update-compromise",
+      "entity_id": "signed_update_compromise",
+      "type": "technique",
+      "label": "Signed Update Compromise",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "signed_update_compromise"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2017-CCLEANER",
+        "SC-2019-ASUS-SHADOWHAMMER",
+        "SC-2020-SOLARWINDS-ORION",
+        "SC-2023-THREE-CX-DESKTOP"
+      ]
+    },
+    {
+      "id": "technique-software-update",
+      "entity_id": "software-update",
+      "type": "technique",
+      "label": "Software Update",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "software-update"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2017-NOTPETYA-MEDOC"
+      ]
+    },
+    {
+      "id": "technique-source-control",
+      "entity_id": "source-control",
+      "type": "technique",
+      "label": "Source Control",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "source-control"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2021-PHP-GIT-SERVER"
+      ]
+    },
+    {
+      "id": "technique-source-repository-compromise",
+      "entity_id": "source_repository_compromise",
+      "type": "technique",
+      "label": "Source Repository Compromise",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "source_repository_compromise"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2020-OCTOPUS-SCANNER",
+        "SC-2021-PHP-GIT-SERVER",
+        "SC-2024-XZ-UTILS"
+      ]
+    },
+    {
+      "id": "technique-sunburst",
+      "entity_id": "sunburst",
+      "type": "technique",
+      "label": "Sunburst",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "sunburst"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2020-SOLARWINDS-ORION"
+      ]
+    },
+    {
+      "id": "technique-targeted",
+      "entity_id": "targeted",
+      "type": "technique",
+      "label": "Targeted",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "targeted"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2019-ASUS-SHADOWHAMMER"
+      ]
+    },
+    {
+      "id": "technique-typosquat",
+      "entity_id": "typosquat",
+      "type": "technique",
+      "label": "Typosquat",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "typosquat"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2025-GO-BOLTDB-TYPOSQUAT"
+      ]
+    },
+    {
+      "id": "technique-vendor-update-compromise",
+      "entity_id": "vendor_update_compromise",
+      "type": "technique",
+      "label": "Vendor Update Compromise",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "vendor_update_compromise"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2017-NOTPETYA-MEDOC",
+        "SC-2021-KASEYA-VSA"
+      ]
+    },
+    {
+      "id": "technique-web3",
+      "entity_id": "web3",
+      "type": "technique",
+      "label": "Web3",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "web3"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2023-LEDGER-CONNECT-KIT",
+        "SC-2024-LOTTIE-PLAYER"
+      ]
+    },
+    {
+      "id": "technique-windows",
+      "entity_id": "windows",
+      "type": "technique",
+      "label": "Windows",
+      "tier": "technique",
+      "sev": null,
+      "time": null,
+      "parent": null,
+      "techniques": [
+        "windows"
+      ],
+      "purl": null,
+      "href": null,
+      "source_incident_ids": [
+        "SC-2017-CCLEANER"
+      ]
     }
   ],
   "edges": [
@@ -3409,6 +4548,1021 @@
       "type": "INCIDENT_AFFECTED_RELEASE",
       "evidence_tier": null,
       "source_refs": []
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-account-compromise->incident-SC-2021-UA-PARSER-JS",
+      "source": "technique-account-compromise",
+      "target": "incident-SC-2021-UA-PARSER-JS",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-account-takeover->incident-SC-2022-PYPI-CTX",
+      "source": "technique-account-takeover",
+      "target": "incident-SC-2022-PYPI-CTX",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-backdoor->incident-SC-2016-LINUX-MINT-ISO",
+      "source": "technique-backdoor",
+      "target": "incident-SC-2016-LINUX-MINT-ISO",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-backdoor->incident-SC-2017-CCLEANER",
+      "source": "technique-backdoor",
+      "target": "incident-SC-2017-CCLEANER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-backdoor->incident-SC-2019-ASUS-SHADOWHAMMER",
+      "source": "technique-backdoor",
+      "target": "incident-SC-2019-ASUS-SHADOWHAMMER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-backdoor->incident-SC-2020-SOLARWINDS-ORION",
+      "source": "technique-backdoor",
+      "target": "incident-SC-2020-SOLARWINDS-ORION",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-backdoor->incident-SC-2021-PHP-GIT-SERVER",
+      "source": "technique-backdoor",
+      "target": "incident-SC-2021-PHP-GIT-SERVER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-backdoor->incident-SC-2023-THREE-CX-DESKTOP",
+      "source": "technique-backdoor",
+      "target": "incident-SC-2023-THREE-CX-DESKTOP",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-backdoor->incident-SC-2024-XZ-UTILS",
+      "source": "technique-backdoor",
+      "target": "incident-SC-2024-XZ-UTILS",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-backdoor->incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "source": "technique-backdoor",
+      "target": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-build-system->incident-SC-2020-SOLARWINDS-ORION",
+      "source": "technique-build-system",
+      "target": "incident-SC-2020-SOLARWINDS-ORION",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-build-system-compromise->incident-SC-2020-OCTOPUS-SCANNER",
+      "source": "technique-build-system-compromise",
+      "target": "incident-SC-2020-OCTOPUS-SCANNER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-build-system-compromise->incident-SC-2020-SOLARWINDS-ORION",
+      "source": "technique-build-system-compromise",
+      "target": "incident-SC-2020-SOLARWINDS-ORION",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-build-system-compromise->incident-SC-2021-CODECOV-BASH-UPLOADER",
+      "source": "technique-build-system-compromise",
+      "target": "incident-SC-2021-CODECOV-BASH-UPLOADER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-build-system-compromise->incident-SC-2023-THREE-CX-DESKTOP",
+      "source": "technique-build-system-compromise",
+      "target": "incident-SC-2023-THREE-CX-DESKTOP",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-build-system-compromise->incident-SC-2024-ULTRALYTICS-PYPI",
+      "source": "technique-build-system-compromise",
+      "target": "incident-SC-2024-ULTRALYTICS-PYPI",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-cdn->incident-SC-2024-POLYFILL-IO",
+      "source": "technique-cdn",
+      "target": "incident-SC-2024-POLYFILL-IO",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-cdn-script-compromise->incident-SC-2024-POLYFILL-IO",
+      "source": "technique-cdn-script-compromise",
+      "target": "incident-SC-2024-POLYFILL-IO",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-ci-cd->incident-SC-2021-CODECOV-BASH-UPLOADER",
+      "source": "technique-ci-cd",
+      "target": "incident-SC-2021-CODECOV-BASH-UPLOADER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-ci-cd->incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
+      "source": "technique-ci-cd",
+      "target": "incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-ci-cd-action-compromise->incident-SC-2025-NPM-SHAI-HULUD",
+      "source": "technique-ci-cd-action-compromise",
+      "target": "incident-SC-2025-NPM-SHAI-HULUD",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-ci-cd-action-compromise->incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
+      "source": "technique-ci-cd-action-compromise",
+      "target": "incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-credential-theft->incident-SC-2018-ESLINT-SCOPE",
+      "source": "technique-credential-theft",
+      "target": "incident-SC-2018-ESLINT-SCOPE",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-credential-theft->incident-SC-2018-NPM-EVENT-STREAM",
+      "source": "technique-credential-theft",
+      "target": "incident-SC-2018-NPM-EVENT-STREAM",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-credential-theft->incident-SC-2021-CODECOV-BASH-UPLOADER",
+      "source": "technique-credential-theft",
+      "target": "incident-SC-2021-CODECOV-BASH-UPLOADER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-credential-theft->incident-SC-2021-UA-PARSER-JS",
+      "source": "technique-credential-theft",
+      "target": "incident-SC-2021-UA-PARSER-JS",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-credential-theft->incident-SC-2022-PYPI-CTX",
+      "source": "technique-credential-theft",
+      "target": "incident-SC-2022-PYPI-CTX",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-credential-theft->incident-SC-2022-PYTORCH-NIGHTLY",
+      "source": "technique-credential-theft",
+      "target": "incident-SC-2022-PYTORCH-NIGHTLY",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-credential-theft->incident-SC-2025-NPM-SHAI-HULUD",
+      "source": "technique-credential-theft",
+      "target": "incident-SC-2025-NPM-SHAI-HULUD",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-credential-theft->incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
+      "source": "technique-credential-theft",
+      "target": "incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-credentials->incident-SC-2021-CODECOV-BASH-UPLOADER",
+      "source": "technique-credentials",
+      "target": "incident-SC-2021-CODECOV-BASH-UPLOADER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-crypto-theft->incident-SC-2018-NPM-EVENT-STREAM",
+      "source": "technique-crypto-theft",
+      "target": "incident-SC-2018-NPM-EVENT-STREAM",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-crypto-theft->incident-SC-2023-LEDGER-CONNECT-KIT",
+      "source": "technique-crypto-theft",
+      "target": "incident-SC-2023-LEDGER-CONNECT-KIT",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-crypto-theft->incident-SC-2024-LOTTIE-PLAYER",
+      "source": "technique-crypto-theft",
+      "target": "incident-SC-2024-LOTTIE-PLAYER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-cryptomining->incident-SC-2021-UA-PARSER-JS",
+      "source": "technique-cryptomining",
+      "target": "incident-SC-2021-UA-PARSER-JS",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-cryptomining->incident-SC-2024-ULTRALYTICS-PYPI",
+      "source": "technique-cryptomining",
+      "target": "incident-SC-2024-ULTRALYTICS-PYPI",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-data-exfiltration->incident-SC-2021-CODECOV-BASH-UPLOADER",
+      "source": "technique-data-exfiltration",
+      "target": "incident-SC-2021-CODECOV-BASH-UPLOADER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-data-exfiltration->incident-SC-2021-DEPENDENCY-CONFUSION",
+      "source": "technique-data-exfiltration",
+      "target": "incident-SC-2021-DEPENDENCY-CONFUSION",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-data-exfiltration->incident-SC-2022-PYPI-CTX",
+      "source": "technique-data-exfiltration",
+      "target": "incident-SC-2022-PYPI-CTX",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-dependency->incident-SC-2018-NPM-EVENT-STREAM",
+      "source": "technique-dependency",
+      "target": "incident-SC-2018-NPM-EVENT-STREAM",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-dependency-confusion->incident-SC-2021-DEPENDENCY-CONFUSION",
+      "source": "technique-dependency-confusion",
+      "target": "incident-SC-2021-DEPENDENCY-CONFUSION",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-dependency-confusion->incident-SC-2022-PYTORCH-NIGHTLY",
+      "source": "technique-dependency-confusion",
+      "target": "incident-SC-2022-PYTORCH-NIGHTLY",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-dependency-confusion->incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "source": "technique-dependency-confusion",
+      "target": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-desktop->incident-SC-2023-THREE-CX-DESKTOP",
+      "source": "technique-desktop",
+      "target": "incident-SC-2023-THREE-CX-DESKTOP",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-destructive-payload->incident-SC-2017-NOTPETYA-MEDOC",
+      "source": "technique-destructive-payload",
+      "target": "incident-SC-2017-NOTPETYA-MEDOC",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-destructive-payload->incident-SC-2022-COLORS-FAKER",
+      "source": "technique-destructive-payload",
+      "target": "incident-SC-2022-COLORS-FAKER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-destructive-payload->incident-SC-2022-NODE-IPC",
+      "source": "technique-destructive-payload",
+      "target": "incident-SC-2022-NODE-IPC",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-developer-workstation-compromise->incident-SC-2018-ESLINT-SCOPE",
+      "source": "technique-developer-workstation-compromise",
+      "target": "incident-SC-2018-ESLINT-SCOPE",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-developer-workstation-compromise->incident-SC-2020-OCTOPUS-SCANNER",
+      "source": "technique-developer-workstation-compromise",
+      "target": "incident-SC-2020-OCTOPUS-SCANNER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-developer-workstation-compromise->incident-SC-2021-DEPENDENCY-CONFUSION",
+      "source": "technique-developer-workstation-compromise",
+      "target": "incident-SC-2021-DEPENDENCY-CONFUSION",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-developer-workstation-compromise->incident-SC-2022-PYTORCH-NIGHTLY",
+      "source": "technique-developer-workstation-compromise",
+      "target": "incident-SC-2022-PYTORCH-NIGHTLY",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-developer-workstation-compromise->incident-SC-2024-ULTRALYTICS-PYPI",
+      "source": "technique-developer-workstation-compromise",
+      "target": "incident-SC-2024-ULTRALYTICS-PYPI",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-developer-workstation-compromise->incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "source": "technique-developer-workstation-compromise",
+      "target": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-developer-workstation-compromise->incident-SC-2025-NPM-SHAI-HULUD",
+      "source": "technique-developer-workstation-compromise",
+      "target": "incident-SC-2025-NPM-SHAI-HULUD",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-developer-workstation-compromise->incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
+      "source": "technique-developer-workstation-compromise",
+      "target": "incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-distribution->incident-SC-2016-LINUX-MINT-ISO",
+      "source": "technique-distribution",
+      "target": "incident-SC-2016-LINUX-MINT-ISO",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-distribution-site-compromise->incident-SC-2016-LINUX-MINT-ISO",
+      "source": "technique-distribution-site-compromise",
+      "target": "incident-SC-2016-LINUX-MINT-ISO",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-downstream-customer-compromise->incident-SC-2017-NOTPETYA-MEDOC",
+      "source": "technique-downstream-customer-compromise",
+      "target": "incident-SC-2017-NOTPETYA-MEDOC",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-downstream-customer-compromise->incident-SC-2020-SOLARWINDS-ORION",
+      "source": "technique-downstream-customer-compromise",
+      "target": "incident-SC-2020-SOLARWINDS-ORION",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-downstream-customer-compromise->incident-SC-2021-KASEYA-VSA",
+      "source": "technique-downstream-customer-compromise",
+      "target": "incident-SC-2021-KASEYA-VSA",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-downstream-customer-compromise->incident-SC-2023-LEDGER-CONNECT-KIT",
+      "source": "technique-downstream-customer-compromise",
+      "target": "incident-SC-2023-LEDGER-CONNECT-KIT",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-downstream-customer-compromise->incident-SC-2023-THREE-CX-DESKTOP",
+      "source": "technique-downstream-customer-compromise",
+      "target": "incident-SC-2023-THREE-CX-DESKTOP",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-downstream-customer-compromise->incident-SC-2024-LOTTIE-PLAYER",
+      "source": "technique-downstream-customer-compromise",
+      "target": "incident-SC-2024-LOTTIE-PLAYER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-downstream-customer-compromise->incident-SC-2024-POLYFILL-IO",
+      "source": "technique-downstream-customer-compromise",
+      "target": "incident-SC-2024-POLYFILL-IO",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-downstream-customer-compromise->incident-SC-2025-NPM-SHAI-HULUD",
+      "source": "technique-downstream-customer-compromise",
+      "target": "incident-SC-2025-NPM-SHAI-HULUD",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-github->incident-SC-2020-OCTOPUS-SCANNER",
+      "source": "technique-github",
+      "target": "incident-SC-2020-OCTOPUS-SCANNER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-github-actions->incident-SC-2024-ULTRALYTICS-PYPI",
+      "source": "technique-github-actions",
+      "target": "incident-SC-2024-ULTRALYTICS-PYPI",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-github-actions->incident-SC-2025-NPM-SHAI-HULUD",
+      "source": "technique-github-actions",
+      "target": "incident-SC-2025-NPM-SHAI-HULUD",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-github-actions->incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
+      "source": "technique-github-actions",
+      "target": "incident-SC-2025-TJ-ACTIONS-CHANGED-FILES",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-golang->incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "source": "technique-golang",
+      "target": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-iso->incident-SC-2016-LINUX-MINT-ISO",
+      "source": "technique-iso",
+      "target": "incident-SC-2016-LINUX-MINT-ISO",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-java->incident-SC-2020-OCTOPUS-SCANNER",
+      "source": "technique-java",
+      "target": "incident-SC-2020-OCTOPUS-SCANNER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-javascript->incident-SC-2024-POLYFILL-IO",
+      "source": "technique-javascript",
+      "target": "incident-SC-2024-POLYFILL-IO",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-linux->incident-SC-2024-XZ-UTILS",
+      "source": "technique-linux",
+      "target": "incident-SC-2024-XZ-UTILS",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-maintainer-account->incident-SC-2018-ESLINT-SCOPE",
+      "source": "technique-maintainer-account",
+      "target": "incident-SC-2018-ESLINT-SCOPE",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-maintainer-account-compromise->incident-SC-2018-ESLINT-SCOPE",
+      "source": "technique-maintainer-account-compromise",
+      "target": "incident-SC-2018-ESLINT-SCOPE",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-maintainer-account-compromise->incident-SC-2021-UA-PARSER-JS",
+      "source": "technique-maintainer-account-compromise",
+      "target": "incident-SC-2021-UA-PARSER-JS",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-maintainer-account-compromise->incident-SC-2022-PYPI-CTX",
+      "source": "technique-maintainer-account-compromise",
+      "target": "incident-SC-2022-PYPI-CTX",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-maintainer-account-compromise->incident-SC-2023-LEDGER-CONNECT-KIT",
+      "source": "technique-maintainer-account-compromise",
+      "target": "incident-SC-2023-LEDGER-CONNECT-KIT",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-maintainer-account-compromise->incident-SC-2024-LOTTIE-PLAYER",
+      "source": "technique-maintainer-account-compromise",
+      "target": "incident-SC-2024-LOTTIE-PLAYER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-maintainer-account-compromise->incident-SC-2025-NPM-SHAI-HULUD",
+      "source": "technique-maintainer-account-compromise",
+      "target": "incident-SC-2025-NPM-SHAI-HULUD",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-malicious-dependency->incident-SC-2018-NPM-EVENT-STREAM",
+      "source": "technique-malicious-dependency",
+      "target": "incident-SC-2018-NPM-EVENT-STREAM",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-malicious-dependency->incident-SC-2024-XZ-UTILS",
+      "source": "technique-malicious-dependency",
+      "target": "incident-SC-2024-XZ-UTILS",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-malicious-dependency->incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "source": "technique-malicious-dependency",
+      "target": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-malicious-package->incident-SC-2021-NPM-RC",
+      "source": "technique-malicious-package",
+      "target": "incident-SC-2021-NPM-RC",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-malware-distribution->incident-SC-2016-LINUX-MINT-ISO",
+      "source": "technique-malware-distribution",
+      "target": "incident-SC-2016-LINUX-MINT-ISO",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-malware-distribution->incident-SC-2017-CCLEANER",
+      "source": "technique-malware-distribution",
+      "target": "incident-SC-2017-CCLEANER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-malware-distribution->incident-SC-2019-ASUS-SHADOWHAMMER",
+      "source": "technique-malware-distribution",
+      "target": "incident-SC-2019-ASUS-SHADOWHAMMER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-malware-distribution->incident-SC-2020-OCTOPUS-SCANNER",
+      "source": "technique-malware-distribution",
+      "target": "incident-SC-2020-OCTOPUS-SCANNER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-malware-distribution->incident-SC-2021-NPM-RC",
+      "source": "technique-malware-distribution",
+      "target": "incident-SC-2021-NPM-RC",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-malware-distribution->incident-SC-2023-THREE-CX-DESKTOP",
+      "source": "technique-malware-distribution",
+      "target": "incident-SC-2023-THREE-CX-DESKTOP",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-malware-distribution->incident-SC-2024-POLYFILL-IO",
+      "source": "technique-malware-distribution",
+      "target": "incident-SC-2024-POLYFILL-IO",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-module-proxy->incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "source": "technique-module-proxy",
+      "target": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-msp->incident-SC-2021-KASEYA-VSA",
+      "source": "technique-msp",
+      "target": "incident-SC-2021-KASEYA-VSA",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-notpetya->incident-SC-2017-NOTPETYA-MEDOC",
+      "source": "technique-notpetya",
+      "target": "incident-SC-2017-NOTPETYA-MEDOC",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-npm->incident-SC-2018-ESLINT-SCOPE",
+      "source": "technique-npm",
+      "target": "incident-SC-2018-ESLINT-SCOPE",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-npm->incident-SC-2018-NPM-EVENT-STREAM",
+      "source": "technique-npm",
+      "target": "incident-SC-2018-NPM-EVENT-STREAM",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-npm->incident-SC-2021-NPM-RC",
+      "source": "technique-npm",
+      "target": "incident-SC-2021-NPM-RC",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-npm->incident-SC-2021-UA-PARSER-JS",
+      "source": "technique-npm",
+      "target": "incident-SC-2021-UA-PARSER-JS",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-npm->incident-SC-2022-COLORS-FAKER",
+      "source": "technique-npm",
+      "target": "incident-SC-2022-COLORS-FAKER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-npm->incident-SC-2022-NODE-IPC",
+      "source": "technique-npm",
+      "target": "incident-SC-2022-NODE-IPC",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-npm->incident-SC-2023-LEDGER-CONNECT-KIT",
+      "source": "technique-npm",
+      "target": "incident-SC-2023-LEDGER-CONNECT-KIT",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-npm->incident-SC-2024-LOTTIE-PLAYER",
+      "source": "technique-npm",
+      "target": "incident-SC-2024-LOTTIE-PLAYER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-npm->incident-SC-2025-NPM-SHAI-HULUD",
+      "source": "technique-npm",
+      "target": "incident-SC-2025-NPM-SHAI-HULUD",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-package-repository-compromise->incident-SC-2018-ESLINT-SCOPE",
+      "source": "technique-package-repository-compromise",
+      "target": "incident-SC-2018-ESLINT-SCOPE",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-package-repository-compromise->incident-SC-2021-NPM-RC",
+      "source": "technique-package-repository-compromise",
+      "target": "incident-SC-2021-NPM-RC",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-package-repository-compromise->incident-SC-2021-UA-PARSER-JS",
+      "source": "technique-package-repository-compromise",
+      "target": "incident-SC-2021-UA-PARSER-JS",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-package-repository-compromise->incident-SC-2022-PYPI-CTX",
+      "source": "technique-package-repository-compromise",
+      "target": "incident-SC-2022-PYPI-CTX",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-package-repository-compromise->incident-SC-2023-LEDGER-CONNECT-KIT",
+      "source": "technique-package-repository-compromise",
+      "target": "incident-SC-2023-LEDGER-CONNECT-KIT",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-package-repository-compromise->incident-SC-2024-LOTTIE-PLAYER",
+      "source": "technique-package-repository-compromise",
+      "target": "incident-SC-2024-LOTTIE-PLAYER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-package-repository-compromise->incident-SC-2024-ULTRALYTICS-PYPI",
+      "source": "technique-package-repository-compromise",
+      "target": "incident-SC-2024-ULTRALYTICS-PYPI",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-package-repository-compromise->incident-SC-2025-NPM-SHAI-HULUD",
+      "source": "technique-package-repository-compromise",
+      "target": "incident-SC-2025-NPM-SHAI-HULUD",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-php->incident-SC-2021-PHP-GIT-SERVER",
+      "source": "technique-php",
+      "target": "incident-SC-2021-PHP-GIT-SERVER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-protest-payload->incident-SC-2022-COLORS-FAKER",
+      "source": "technique-protest-payload",
+      "target": "incident-SC-2022-COLORS-FAKER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-protest-payload->incident-SC-2022-NODE-IPC",
+      "source": "technique-protest-payload",
+      "target": "incident-SC-2022-NODE-IPC",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-protestware->incident-SC-2022-COLORS-FAKER",
+      "source": "technique-protestware",
+      "target": "incident-SC-2022-COLORS-FAKER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-protestware->incident-SC-2022-NODE-IPC",
+      "source": "technique-protestware",
+      "target": "incident-SC-2022-NODE-IPC",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-pypi->incident-SC-2022-PYPI-CTX",
+      "source": "technique-pypi",
+      "target": "incident-SC-2022-PYPI-CTX",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-pypi->incident-SC-2022-PYTORCH-NIGHTLY",
+      "source": "technique-pypi",
+      "target": "incident-SC-2022-PYTORCH-NIGHTLY",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-pypi->incident-SC-2024-ULTRALYTICS-PYPI",
+      "source": "technique-pypi",
+      "target": "incident-SC-2024-ULTRALYTICS-PYPI",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-ransomware->incident-SC-2021-KASEYA-VSA",
+      "source": "technique-ransomware",
+      "target": "incident-SC-2021-KASEYA-VSA",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-ransomware-delivery->incident-SC-2017-NOTPETYA-MEDOC",
+      "source": "technique-ransomware-delivery",
+      "target": "incident-SC-2017-NOTPETYA-MEDOC",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-ransomware-delivery->incident-SC-2021-KASEYA-VSA",
+      "source": "technique-ransomware-delivery",
+      "target": "incident-SC-2021-KASEYA-VSA",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-research->incident-SC-2021-DEPENDENCY-CONFUSION",
+      "source": "technique-research",
+      "target": "incident-SC-2021-DEPENDENCY-CONFUSION",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-self-propagating->incident-SC-2025-NPM-SHAI-HULUD",
+      "source": "technique-self-propagating",
+      "target": "incident-SC-2025-NPM-SHAI-HULUD",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-signed-update->incident-SC-2017-CCLEANER",
+      "source": "technique-signed-update",
+      "target": "incident-SC-2017-CCLEANER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-signed-update->incident-SC-2019-ASUS-SHADOWHAMMER",
+      "source": "technique-signed-update",
+      "target": "incident-SC-2019-ASUS-SHADOWHAMMER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-signed-update->incident-SC-2023-THREE-CX-DESKTOP",
+      "source": "technique-signed-update",
+      "target": "incident-SC-2023-THREE-CX-DESKTOP",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-signed-update-compromise->incident-SC-2017-CCLEANER",
+      "source": "technique-signed-update-compromise",
+      "target": "incident-SC-2017-CCLEANER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-signed-update-compromise->incident-SC-2019-ASUS-SHADOWHAMMER",
+      "source": "technique-signed-update-compromise",
+      "target": "incident-SC-2019-ASUS-SHADOWHAMMER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-signed-update-compromise->incident-SC-2020-SOLARWINDS-ORION",
+      "source": "technique-signed-update-compromise",
+      "target": "incident-SC-2020-SOLARWINDS-ORION",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-signed-update-compromise->incident-SC-2023-THREE-CX-DESKTOP",
+      "source": "technique-signed-update-compromise",
+      "target": "incident-SC-2023-THREE-CX-DESKTOP",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-software-update->incident-SC-2017-NOTPETYA-MEDOC",
+      "source": "technique-software-update",
+      "target": "incident-SC-2017-NOTPETYA-MEDOC",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-source-control->incident-SC-2021-PHP-GIT-SERVER",
+      "source": "technique-source-control",
+      "target": "incident-SC-2021-PHP-GIT-SERVER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-source-repository-compromise->incident-SC-2020-OCTOPUS-SCANNER",
+      "source": "technique-source-repository-compromise",
+      "target": "incident-SC-2020-OCTOPUS-SCANNER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-source-repository-compromise->incident-SC-2021-PHP-GIT-SERVER",
+      "source": "technique-source-repository-compromise",
+      "target": "incident-SC-2021-PHP-GIT-SERVER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-source-repository-compromise->incident-SC-2024-XZ-UTILS",
+      "source": "technique-source-repository-compromise",
+      "target": "incident-SC-2024-XZ-UTILS",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-sunburst->incident-SC-2020-SOLARWINDS-ORION",
+      "source": "technique-sunburst",
+      "target": "incident-SC-2020-SOLARWINDS-ORION",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-targeted->incident-SC-2019-ASUS-SHADOWHAMMER",
+      "source": "technique-targeted",
+      "target": "incident-SC-2019-ASUS-SHADOWHAMMER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-typosquat->incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "source": "technique-typosquat",
+      "target": "incident-SC-2025-GO-BOLTDB-TYPOSQUAT",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-vendor-update-compromise->incident-SC-2017-NOTPETYA-MEDOC",
+      "source": "technique-vendor-update-compromise",
+      "target": "incident-SC-2017-NOTPETYA-MEDOC",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-vendor-update-compromise->incident-SC-2021-KASEYA-VSA",
+      "source": "technique-vendor-update-compromise",
+      "target": "incident-SC-2021-KASEYA-VSA",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-web3->incident-SC-2023-LEDGER-CONNECT-KIT",
+      "source": "technique-web3",
+      "target": "incident-SC-2023-LEDGER-CONNECT-KIT",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-web3->incident-SC-2024-LOTTIE-PLAYER",
+      "source": "technique-web3",
+      "target": "incident-SC-2024-LOTTIE-PLAYER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
+    },
+    {
+      "id": "INCIDENT_TECHNIQUE:technique-windows->incident-SC-2017-CCLEANER",
+      "source": "technique-windows",
+      "target": "incident-SC-2017-CCLEANER",
+      "type": "INCIDENT_TECHNIQUE",
+      "derived": true
     },
     {
       "id": "MAINTAINS_REPOSITORY:maintainer-dominictarr->repo-github-com-dominictarr-event-stream",

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { buildSupplyChainGraphData } from '../../../scripts/build-supply-chain-graph.mjs';
 
 const moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const incidentRelativePath = 'data/supply-chain-incidents/incidents.json';
@@ -556,9 +557,21 @@ function buildGraphHeroModel(data) {
   const incidents = data.incidents.filter(Boolean);
   const entities = data?.entities && typeof data.entities === 'object' ? data.entities : {};
   const relationships = Array.isArray(data?.relationships) ? data.relationships : [];
-  const nodeCount =
-    incidents.length +
-    Object.values(entities).reduce((total, collection) => total + (Array.isArray(collection) ? collection.length : 0), 0);
+  const graphCorpus = {
+    incidents: incidents.filter((incident) => incident && typeof incident === 'object' && typeof incident.id === 'string'),
+    relationships: relationships.filter((relationship) => relationship && typeof relationship === 'object'),
+    entities: Object.fromEntries(
+      Object.entries(entities).map(([key, collection]) => [
+        key,
+        Array.isArray(collection)
+          ? collection.filter((entity) => entity && typeof entity === 'object' && typeof entity.id === 'string')
+          : [],
+      ])
+    ),
+  };
+  const graphData = buildSupplyChainGraphData(graphCorpus);
+  const nodeCount = Array.isArray(graphData.nodes) ? graphData.nodes.length : 0;
+  const edgeCount = Array.isArray(graphData.edges) ? graphData.edges.length : relationships.length;
   const latestIncident =
     incidents.length > 0
       ? incidents.map((incident) => incidentLinkRow(incident)).sort(compareDateDesc)[0] || null
@@ -570,7 +583,7 @@ function buildGraphHeroModel(data) {
       'A graph-first view of curated supply chain incidents and the packages, repositories, organizations, maintainers, actors, campaigns, releases, and accounts connected by evidence.',
     status: 'WebGL graph loading',
     nodeCount,
-    relationshipCount: relationships.length,
+    relationshipCount: edgeCount,
     latestIncident,
   };
   graphHeroModelCache.set(data, graphHeroModel);

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -91,6 +91,16 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
         <span data-sc-graph-status>{graphHero.status}</span>
         <span>Actor to Incident</span>
       </div>
+      <button
+        class="graph-focus-reflow"
+        type="button"
+        data-sc-graph-focus-reflow
+        aria-pressed="false"
+        hidden
+        disabled
+      >
+        Focus reflow
+      </button>
       <canvas
         class="sc-graph-canvas"
         data-sc-graph-canvas
@@ -599,9 +609,14 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
   }
 
   .graph-status,
+  .graph-focus-reflow,
   .graph-caption {
     position: absolute;
     z-index: 4;
+  }
+
+  .graph-status,
+  .graph-caption {
     display: flex;
     gap: 8px;
   }
@@ -609,6 +624,26 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
   .graph-status {
     top: 16px;
     left: 16px;
+  }
+
+  .graph-focus-reflow {
+    top: 16px;
+    right: 16px;
+    border: 1px solid rgba(232, 160, 32, 0.7);
+    border-radius: 4px;
+    background: rgba(8, 11, 16, 0.86);
+    color: var(--white);
+    cursor: pointer;
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.12em;
+    padding: 8px 10px;
+    text-transform: uppercase;
+  }
+
+  .graph-focus-reflow:disabled,
+  .graph-focus-reflow[hidden] {
+    display: none;
   }
 
   .graph-caption {


### PR DESCRIPTION
Replacement for stacked PR #1190 after G1 and G2 were merged through #1184 and #1191.

Scope:
- Adds technique nodes and INCIDENT_TECHNIQUE derived graph edges to the compiled payload.
- Adds G3 technique selection behavior: cross-actor highlight, stable wide-shot pullback, and Focus reflow toggle.
- Preserves G2 route/entity fallback behavior and incident focus filtering so technique edges do not pollute incident camera framing.

Validation run locally on current branch:
- node --check site/src/lib/supplyChainPages.mjs
- node --check site/public/js/supply-chain-graph-core.js
- node --check scripts/test-supply-chain-pages.mjs
- node --check scripts/build-supply-chain-graph.mjs
- node scripts/build-supply-chain-graph.mjs --check
- node scripts/test-supply-chain-pages.mjs
- python3 scripts/validate_supply_chain_incidents.py
- python3 scripts/validate_supply_chain_graph.py
- git diff --check

Review notes:
- Prior #1190 review feedback was addressed before recreating this PR.
- Recreated against main to avoid merging into the old G2 stack branch.