### PR TITLE
Supply Chain G4 dive and bloom

### DIFF
--- a/docs/supply-chain-pages.md
+++ b/docs/supply-chain-pages.md
@@ -55,9 +55,17 @@ adds cross-cutting technique/exploit nodes derived from incident vectors, tags,
 and impact categories. Selecting a technique highlights its incidents across
 actor lanes and pulls the camera back to a stable wide shot. The optional
 `Focus reflow` control clusters those incidents around the selected technique
-node and can be toggled back to the wide shot. Package and release nodes are
-preserved in the payload for later level-of-detail slices, but they remain
-payload-only until the dive-and-bloom work lands.
+node and can be toggled back to the wide shot.
+
+G4 adds incident-scoped dive-and-bloom behavior. Package, release, and
+organization tiers stay culled from the GPU in the far/default view. Selecting
+an incident, selecting a package or organization page, or zooming close enough
+to an incident activates a bounded bloom from the compiled graph payload. The
+bloom includes affected organizations, packages, releases, package-release
+edges, and evidence-tiered `SEEDED_BY` propagation edges. Causal propagation
+edges render as solid lines; temporal precedence edges render as dim segmented
+lines. Large blooms are capped by a node budget and represented with an
+aggregation node instead of rendering every child at once.
 
 ## Local Build
 

--- a/scripts/build-supply-chain-graph.mjs
+++ b/scripts/build-supply-chain-graph.mjs
@@ -142,7 +142,7 @@ function normalizeRelationshipEdge(relationship, nodeIds) {
     target: relationship.target,
   };
 
-  return {
+  const edge = {
     id: `${relationship.type}:${directed.source}->${directed.target}`,
     source: directed.source,
     target: directed.target,
@@ -150,6 +150,11 @@ function normalizeRelationshipEdge(relationship, nodeIds) {
     evidence_tier: relationship.evidence_tier || null,
     source_refs: Array.isArray(relationship.source_refs) ? relationship.source_refs : [],
   };
+  if (Array.isArray(relationship.evidence_refs)) edge.evidence_refs = relationship.evidence_refs;
+  if (relationship.propagation_tier) edge.propagation_tier = relationship.propagation_tier;
+  if (relationship.source_incident_id) edge.source_incident_id = relationship.source_incident_id;
+  if (relationship.summary) edge.summary = relationship.summary;
+  return edge;
 }
 
 function deriveIncidentContextEdges(nodes, incidents, entities) {
@@ -321,7 +326,9 @@ export function buildSupplyChainGraphData(corpus = loadCorpus()) {
       g2_drawable_tiers: ['actor', 'campaign', 'incident'],
       g3_drawable_tiers: ['actor', 'campaign', 'incident', 'technique'],
       technique_focus: 'wide-shot-default-with-operator-reflow',
-      package_release_lod: 'payload-only-until-G4',
+      package_release_lod: 'g4-dive-and-bloom',
+      bloom_tiers: ['organization', 'package', 'release'],
+      seeded_by_edges: 'causal-solid-temporal-dashed',
       layout: 'time-anchored-actor-lanes',
     },
     counts,

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -434,6 +434,11 @@ assert.ok(
   'graph client should not keep cached bloom visible after semantic zoom or incident selection ends'
 );
 assert.ok(
+  supplyChainGraphSource.includes('if (this.selection) return null;') &&
+    supplyChainGraphSource.includes("if (node.tier !== 'incident' && !BLOOM_TIERS.has(node.tier)) this.lastBloomIncidentId = null;"),
+  'graph client should prevent actor/campaign/entity selections from implicitly reactivating semantic bloom'
+);
+assert.ok(
   supplyChainGraphSource.includes("edge.type === 'SEEDED_BY'") &&
     supplyChainGraphSource.includes("edge.propagation_tier === 'temporal'") &&
     supplyChainGraphSource.includes("edge.propagation_tier === 'causal'"),

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -430,6 +430,10 @@ assert.ok(
   'graph client should include G4 semantic zoom, worker-settled bloom layout, LOD culling, and aggregation paths'
 );
 assert.ok(
+  !supplyChainGraphSource.includes('return this.ensureBloomLayout(this.lastBloomIncidentId)'),
+  'graph client should not keep cached bloom visible after semantic zoom or incident selection ends'
+);
+assert.ok(
   supplyChainGraphSource.includes("edge.type === 'SEEDED_BY'") &&
     supplyChainGraphSource.includes("edge.propagation_tier === 'temporal'") &&
     supplyChainGraphSource.includes("edge.propagation_tier === 'causal'"),

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -439,6 +439,11 @@ assert.ok(
   'graph client should prevent actor/campaign/entity selections from implicitly reactivating semantic bloom'
 );
 assert.ok(
+  supplyChainGraphSource.includes('if (visibleChildren.length === 0)') &&
+    supplyChainGraphSource.includes('return { incidentId: incident.id, nodes: [], edges: [], hiddenCount: 0, bounds: boundsForNodes([incident]) };'),
+  'graph client should not fabricate virtual bloom nodes for incidents without payload children'
+);
+assert.ok(
   supplyChainGraphSource.includes("edge.type === 'SEEDED_BY'") &&
     supplyChainGraphSource.includes("edge.propagation_tier === 'temporal'") &&
     supplyChainGraphSource.includes("edge.propagation_tier === 'causal'"),

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -354,13 +354,23 @@ assert.ok(
 );
 assert.equal(
   supplyChainGraphPayload.renderer_contract.package_release_lod,
-  'payload-only-until-G4',
-  'graph payload should keep package and release tiers payload-only until G4'
+  'g4-dive-and-bloom',
+  'graph payload should declare G4 package/release dive-and-bloom behavior'
+);
+assert.deepEqual(
+  supplyChainGraphPayload.renderer_contract.bloom_tiers,
+  ['organization', 'package', 'release'],
+  'graph payload should declare G4 bloom tiers'
+);
+assert.equal(
+  supplyChainGraphPayload.renderer_contract.seeded_by_edges,
+  'causal-solid-temporal-dashed',
+  'graph payload should declare SEEDED_BY rendering treatment'
 );
 assert.ok(
   supplyChainGraphPayload.nodes.some((node) => node.type === 'package') &&
     supplyChainGraphPayload.nodes.some((node) => node.type === 'release'),
-  'graph payload should preserve package and release nodes for later LOD slices'
+  'graph payload should preserve package and release nodes for G4 bloom rendering'
 );
 assert.ok(
   supplyChainGraphPayload.nodes.some((node) => node.type === 'actor') &&
@@ -376,14 +386,24 @@ assert.ok(
   'graph payload should include actor, campaign, and technique graph edges'
 );
 assert.ok(
+  supplyChainGraphPayload.edges.some(
+    (edge) => edge.type === 'SEEDED_BY' && edge.propagation_tier === 'causal' && edge.evidence_refs.length > 0
+  ) &&
+    supplyChainGraphPayload.edges.some(
+      (edge) => edge.type === 'SEEDED_BY' && edge.propagation_tier === 'temporal' && edge.evidence_refs.length > 0
+    ),
+  'graph payload should preserve evidence-tiered SEEDED_BY propagation edges for G4'
+);
+assert.ok(
   supplyChainGraphSource.includes("getContext('webgl2'") &&
     supplyChainGraphSource.includes("getContext('webgl'") &&
     supplyChainGraphSource.includes('class SupplyChainQuadtree') &&
-    supplyChainGraphSource.includes('function isG2DrawableNode') &&
-    supplyChainGraphSource.includes("const DRAWABLE_TIERS = new Set(['actor', 'campaign', 'incident', 'technique'])") &&
-    supplyChainGraphSource.includes('const layoutNodes = Array.from(nodeById.values())') &&
-    supplyChainGraphSource.includes("layoutNodes.filter((node) => node.tier === 'incident')") &&
-    supplyChainGraphSource.includes("layoutNodes.filter((node) => node.tier === 'technique')") &&
+    supplyChainGraphSource.includes('function isBaseDrawableNode') &&
+    supplyChainGraphSource.includes("const BASE_DRAWABLE_TIERS = new Set(['actor', 'campaign', 'incident', 'technique'])") &&
+    supplyChainGraphSource.includes("const BLOOM_TIERS = new Set(['organization', 'package', 'release'])") &&
+    supplyChainGraphSource.includes('const baseNodes = allNodes.filter(isBaseDrawableNode)') &&
+    supplyChainGraphSource.includes("baseNodes.filter((node) => node.tier === 'incident')") &&
+    supplyChainGraphSource.includes("baseNodes.filter((node) => node.tier === 'technique')") &&
     supplyChainGraphSource.includes('selectEntityContext') &&
     supplyChainGraphSource.includes('source_incident_ids') &&
     supplyChainGraphSource.includes('connected incident') &&
@@ -393,7 +413,27 @@ assert.ok(
     supplyChainGraphSource.includes('this.lastLabelKey') &&
     supplyChainGraphSource.includes('this.payload.nodes.length') &&
     supplyChainGraphSource.includes('corpus nodes and'),
-  'graph client should use WebGL, quadtree picking, G2/G3 LOD culling, clone-backed layout, clamped camera targets, cached labels, and ready status'
+  'graph client should use WebGL, quadtree picking, G2/G3 base LOD culling, clone-backed layout, clamped camera targets, cached labels, and ready status'
+);
+assert.ok(
+  supplyChainGraphSource.includes('BLOOM_Z_THRESHOLD') &&
+    supplyChainGraphSource.includes('buildBloomContext') &&
+    supplyChainGraphSource.includes('buildBloomLayout') &&
+    supplyChainGraphSource.includes('visibleGraph()') &&
+    supplyChainGraphSource.includes('BLOOM_NODE_BUDGET') &&
+    supplyChainGraphSource.includes('activeBloomIncidentId') &&
+    supplyChainGraphSource.includes('ensureSemanticBloom') &&
+    supplyChainGraphSource.includes('createBloomLayoutWorker') &&
+    supplyChainGraphSource.includes('new Worker') &&
+    supplyChainGraphSource.includes('worker_settled') &&
+    supplyChainGraphSource.includes('!BASE_DRAWABLE_TIERS.has(node.tier) && !BLOOM_TIERS.has(node.tier)'),
+  'graph client should include G4 semantic zoom, worker-settled bloom layout, LOD culling, and aggregation paths'
+);
+assert.ok(
+  supplyChainGraphSource.includes("edge.type === 'SEEDED_BY'") &&
+    supplyChainGraphSource.includes("edge.propagation_tier === 'temporal'") &&
+    supplyChainGraphSource.includes("edge.propagation_tier === 'causal'"),
+  'graph client should render causal and temporal SEEDED_BY edges distinctly'
 );
 assert.ok(
   supplyChainGraphSource.includes('this.focusReflow') &&

--- a/site/public/js/supply-chain-graph-core.js
+++ b/site/public/js/supply-chain-graph-core.js
@@ -1,5 +1,8 @@
 const GRAPH_DATA_URL = '/supply-chain-graph.json';
-const DRAWABLE_TIERS = new Set(['actor', 'campaign', 'incident', 'technique']);
+const BASE_DRAWABLE_TIERS = new Set(['actor', 'campaign', 'incident', 'technique']);
+const BLOOM_TIERS = new Set(['organization', 'package', 'release']);
+const BLOOM_NODE_BUDGET = 28;
+const BLOOM_Z_THRESHOLD = 1.55;
 const SEVERITY_COLORS = {
   critical: [1.0, 0.267, 0.267, 1],
   high: [1.0, 0.647, 0.0, 1],
@@ -8,6 +11,10 @@ const SEVERITY_COLORS = {
   actor: [1.0, 0.267, 0.267, 1],
   campaign: [0.91, 0.627, 0.125, 1],
   technique: [0.804, 0.835, 0.878, 1],
+  organization: [0.49, 0.69, 1.0, 1],
+  package: [0.318, 0.812, 0.4, 1],
+  release: [0.804, 0.835, 0.878, 1],
+  propagation: [1.0, 0.647, 0.0, 1],
   default: [0.804, 0.835, 0.878, 1],
   muted: [0.353, 0.416, 0.494, 0.32],
 };
@@ -34,11 +41,21 @@ function tierRank(tier) {
   if (tier === 'technique') return 1;
   if (tier === 'campaign') return 2;
   if (tier === 'incident') return 3;
-  return 3;
+  if (tier === 'organization') return 4;
+  if (tier === 'package') return 5;
+  if (tier === 'release') return 6;
+  return 7;
 }
 
-function isG2DrawableNode(node) {
-  return DRAWABLE_TIERS.has(node?.tier);
+function isBaseDrawableNode(node) {
+  return BASE_DRAWABLE_TIERS.has(node?.tier);
+}
+
+function bloomRank(node) {
+  if (node.tier === 'organization') return 0;
+  if (node.tier === 'package') return 1;
+  if (node.tier === 'release') return 2;
+  return 3;
 }
 
 class SupplyChainQuadtree {
@@ -145,14 +162,212 @@ function fitBounds(nodes, viewport, padding = 120) {
   };
 }
 
+function boundsForNodes(nodes, fallback = { x0: -1200, y0: -240, x1: 1200, y1: 720 }) {
+  if (!nodes.length) return { ...fallback };
+  return nodes.reduce(
+    (acc, node) => ({
+      x0: Math.min(acc.x0, node.x - (node.radius || 10) * 3),
+      y0: Math.min(acc.y0, node.y - (node.radius || 10) * 3),
+      x1: Math.max(acc.x1, node.x + (node.radius || 10) * 3),
+      y1: Math.max(acc.y1, node.y + (node.radius || 10) * 3),
+    }),
+    { x0: Infinity, y0: Infinity, x1: -Infinity, y1: -Infinity }
+  );
+}
+
+function mergeBounds(...boundsList) {
+  return boundsList.filter(Boolean).reduce(
+    (acc, bounds) => ({
+      x0: Math.min(acc.x0, bounds.x0),
+      y0: Math.min(acc.y0, bounds.y0),
+      x1: Math.max(acc.x1, bounds.x1),
+      y1: Math.max(acc.y1, bounds.y1),
+    }),
+    { x0: Infinity, y0: Infinity, x1: -Infinity, y1: -Infinity }
+  );
+}
+
+function incidentNodeIdFromSourceIncidentId(sourceIncidentId) {
+  return sourceIncidentId ? `incident-${sourceIncidentId}` : null;
+}
+
+function sortBloomNodes(nodes) {
+  return nodes.sort((a, b) => bloomRank(a) - bloomRank(b) || (a.label || '').localeCompare(b.label || ''));
+}
+
+function packageIdForRelease(releaseId, edges) {
+  const edge = edges.find((item) => item.type === 'PACKAGE_RELEASE' && item.target === releaseId);
+  return edge?.source || null;
+}
+
+function buildBloomLayout(incident, context, sourceNodes, sourceEdges, offset = 0) {
+  const centerX = incident.x + 280;
+  const centerY = incident.y + 16;
+  const orgIds = context.orgIds.length > 0 ? context.orgIds : ['virtual-org-unattributed'];
+  const visibleChildren = sortBloomNodes(
+    [...context.orgIds, ...context.packageIds, ...context.releaseIds]
+      .map((id) => sourceNodes.get(id))
+      .filter(Boolean)
+  );
+  const needsAggregation = visibleChildren.length > BLOOM_NODE_BUDGET;
+  const visibleIds = new Set(
+    visibleChildren
+      .slice(0, BLOOM_NODE_BUDGET)
+      .map((node) => node.id)
+  );
+  context.orgIds.forEach((id) => visibleIds.add(id));
+  const hiddenCount = needsAggregation
+    ? visibleChildren.filter((node) => !visibleIds.has(node.id) && !context.orgIds.includes(node.id)).length
+    : 0;
+
+  const nodes = [];
+  orgIds.forEach((orgId, orgIndex) => {
+    const source = sourceNodes.get(orgId);
+    const angle = ((orgIndex + offset * 0.03) / Math.max(1, orgIds.length)) * Math.PI * 2 - Math.PI / 2;
+    const orgRadius = orgIds.length === 1 ? 0 : 96 + orgIds.length * 8;
+    const orgNode = source
+      ? { ...source }
+      : {
+          id: orgId,
+          entity_id: orgId,
+          type: 'organization',
+          tier: 'organization',
+          label: 'Unattributed Cluster',
+          radius: 11,
+        };
+    orgNode.x = centerX + Math.cos(angle) * orgRadius;
+    orgNode.y = centerY + Math.sin(angle) * orgRadius;
+    orgNode.radius = 12;
+    orgNode.bloom_parent = incident.id;
+    nodes.push(orgNode);
+
+    const packagesForOrg = context.packageIds
+      .map((id) => sourceNodes.get(id))
+      .filter((node) => node && visibleIds.has(node.id))
+      .filter((node, index) => {
+        if (orgIds.length === 1) return true;
+        return index % orgIds.length === orgIndex;
+      });
+    packagesForOrg.forEach((packageNode, packageIndex) => {
+      const packageAngle = (packageIndex / Math.max(1, packagesForOrg.length)) * Math.PI * 2 - Math.PI / 2;
+      const packageRadius = 54 + Math.floor(packageIndex / 8) * 30;
+      nodes.push({
+        ...packageNode,
+        x: orgNode.x + Math.cos(packageAngle) * packageRadius,
+        y: orgNode.y + Math.sin(packageAngle) * packageRadius,
+        radius: 8,
+        bloom_parent: incident.id,
+      });
+    });
+  });
+
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+  context.releaseIds
+    .map((id) => sourceNodes.get(id))
+    .filter((node) => node && visibleIds.has(node.id))
+    .forEach((releaseNode, releaseIndex) => {
+      const packageId = packageIdForRelease(releaseNode.id, sourceEdges);
+      const parentPackage = packageId ? nodeById.get(packageId) : null;
+      const angle = (releaseIndex % 4) * (Math.PI / 2) + Math.PI / 4;
+      const anchor = parentPackage || incident;
+      const radius = parentPackage ? 30 : 128;
+      const node = {
+        ...releaseNode,
+        x: anchor.x + Math.cos(angle) * radius,
+        y: anchor.y + Math.sin(angle) * radius,
+        radius: 6,
+        bloom_parent: incident.id,
+      };
+      nodes.push(node);
+      nodeById.set(node.id, node);
+    });
+
+  if (hiddenCount > 0) {
+    nodes.push({
+      id: `${incident.id}::bloom-more`,
+      entity_id: `${incident.id}::bloom-more`,
+      type: 'aggregate',
+      tier: 'package',
+      label: `+${hiddenCount} more`,
+      x: centerX + 164,
+      y: centerY + 118,
+      radius: 10,
+      bloom_parent: incident.id,
+      aggregate: true,
+    });
+  }
+
+  const visibleSet = new Set(nodes.map((node) => node.id));
+  const edgeTypes = new Set(['AFFECTED_ORGANIZATION', 'AFFECTED_PACKAGE', 'PACKAGE_RELEASE', 'INCIDENT_AFFECTED_RELEASE', 'SEEDED_BY']);
+  const edges = sourceEdges
+    .filter((edge) => edgeTypes.has(edge.type))
+    .filter((edge) => {
+      if (edge.source === incident.id && visibleSet.has(edge.target)) return true;
+      if (edge.target === incident.id && visibleSet.has(edge.source)) return true;
+      if (visibleSet.has(edge.source) && visibleSet.has(edge.target)) return true;
+      if (edge.type === 'SEEDED_BY' && edge.source_incident_id && incidentNodeIdFromSourceIncidentId(edge.source_incident_id) === incident.id) {
+        return visibleSet.has(edge.source) && visibleSet.has(edge.target);
+      }
+      return false;
+    });
+
+  return { incidentId: incident.id, nodes, edges, hiddenCount, bounds: boundsForNodes([incident, ...nodes]) };
+}
+
+function buildBloomContext(incidentNodes, allNodes, edges) {
+  const contextByIncident = new Map(incidentNodes.map((incident) => [
+    incident.id,
+    { incidentId: incident.id, orgIds: [], packageIds: [], releaseIds: [] },
+  ]));
+  const add = (incidentId, key, value) => {
+    if (!incidentId || !value || !contextByIncident.has(incidentId)) return;
+    const list = contextByIncident.get(incidentId)[key];
+    if (!list.includes(value)) list.push(value);
+  };
+
+  edges.forEach((edge) => {
+    if (edge.type === 'AFFECTED_ORGANIZATION') add(edge.source, 'orgIds', edge.target);
+    if (edge.type === 'AFFECTED_PACKAGE') add(edge.source, 'packageIds', edge.target);
+    if (edge.type === 'INCIDENT_AFFECTED_RELEASE') add(edge.source, 'releaseIds', edge.target);
+    if (edge.type === 'PACKAGE_RELEASE') {
+      allNodes.forEach((node) => {
+        if (Array.isArray(node.source_incident_ids) && node.id === edge.source) {
+          node.source_incident_ids.forEach((sourceIncidentId) => add(`incident-${sourceIncidentId}`, 'releaseIds', edge.target));
+        }
+      });
+    }
+    if (edge.type === 'SEEDED_BY') {
+      const incidentId = incidentNodeIdFromSourceIncidentId(edge.source_incident_id);
+      add(incidentId, edge.source?.startsWith('release-') ? 'releaseIds' : 'packageIds', edge.source);
+      add(incidentId, edge.target?.startsWith('release-') ? 'releaseIds' : 'packageIds', edge.target);
+      const sourcePackageId = edge.source?.startsWith('release-') ? packageIdForRelease(edge.source, edges) : null;
+      const targetPackageId = edge.target?.startsWith('release-') ? packageIdForRelease(edge.target, edges) : null;
+      add(incidentId, 'packageIds', sourcePackageId);
+      add(incidentId, 'packageIds', targetPackageId);
+    }
+  });
+
+  allNodes.forEach((node) => {
+    if (!BLOOM_TIERS.has(node.tier) || !Array.isArray(node.source_incident_ids)) return;
+    node.source_incident_ids.forEach((sourceIncidentId) => {
+      const incidentId = `incident-${sourceIncidentId}`;
+      if (node.tier === 'organization') add(incidentId, 'orgIds', node.id);
+      if (node.tier === 'package') add(incidentId, 'packageIds', node.id);
+      if (node.tier === 'release') add(incidentId, 'releaseIds', node.id);
+    });
+  });
+
+  return contextByIncident;
+}
+
 function buildLayout(payload) {
-  const drawableNodes = payload.nodes.filter(isG2DrawableNode);
-  const nodeById = new Map(drawableNodes.map((node) => [node.id, { ...node }]));
-  const layoutNodes = Array.from(nodeById.values());
-  const incidentNodes = layoutNodes.filter((node) => node.tier === 'incident');
-  const actorNodes = layoutNodes.filter((node) => node.tier === 'actor');
-  const campaignNodes = layoutNodes.filter((node) => node.tier === 'campaign');
-  const techniqueNodes = layoutNodes.filter((node) => node.tier === 'technique');
+  const allNodes = payload.nodes.map((node) => ({ ...node }));
+  const nodeById = new Map(allNodes.map((node) => [node.id, node]));
+  const baseNodes = allNodes.filter(isBaseDrawableNode);
+  const incidentNodes = baseNodes.filter((node) => node.tier === 'incident');
+  const actorNodes = baseNodes.filter((node) => node.tier === 'actor');
+  const campaignNodes = baseNodes.filter((node) => node.tier === 'campaign');
+  const techniqueNodes = baseNodes.filter((node) => node.tier === 'technique');
   const actorIds = new Set(actorNodes.map((node) => node.id));
   const campaignIds = new Set(campaignNodes.map((node) => node.id));
   const incidentActor = new Map();
@@ -222,11 +437,18 @@ function buildLayout(payload) {
     node.radius = 12;
   });
 
-  const laidOutNodes = Array.from(nodeById.values()).sort((a, b) => tierRank(a.tier) - tierRank(b.tier));
+  allNodes.forEach((node) => {
+    if (node.x !== undefined && node.y !== undefined) return;
+    node.x = 0;
+    node.y = 0;
+    node.radius = node.tier === 'release' ? 6 : node.tier === 'package' ? 8 : node.tier === 'organization' ? 12 : 9;
+  });
+
+  const laidOutNodes = baseNodes.sort((a, b) => tierRank(a.tier) - tierRank(b.tier));
   const laidOutById = new Map(laidOutNodes.map((node) => [node.id, node]));
   const edges = payload.edges
-    .filter((edge) => laidOutById.has(edge.source) && laidOutById.has(edge.target))
-    .map((edge) => ({ ...edge, sourceNode: laidOutById.get(edge.source), targetNode: laidOutById.get(edge.target) }));
+    .filter((edge) => nodeById.has(edge.source) && nodeById.has(edge.target))
+    .map((edge) => ({ ...edge, sourceNode: nodeById.get(edge.source), targetNode: nodeById.get(edge.target) }));
   const bounds = laidOutNodes.reduce(
     (acc, node) => ({
       x0: Math.min(acc.x0, node.x - 180),
@@ -239,7 +461,57 @@ function buildLayout(payload) {
 
   const quadtree = new SupplyChainQuadtree(bounds);
   laidOutNodes.forEach((node) => quadtree.insert(node));
-  return { nodes: laidOutNodes, nodeById: laidOutById, edges, bounds, quadtree };
+  const bloomContext = buildBloomContext(incidentNodes, allNodes, edges);
+  return { nodes: laidOutNodes, allNodes, nodeById, baseNodeById: laidOutById, edges, bounds, quadtree, bloomContext };
+}
+
+function createBloomLayoutWorker() {
+  if (!('Worker' in window) || !('Blob' in window) || !('URL' in window)) return null;
+  const source = `
+    function boundsForNodes(nodes) {
+      return nodes.reduce((acc, node) => ({
+        x0: Math.min(acc.x0, node.x - (node.radius || 8) * 3),
+        y0: Math.min(acc.y0, node.y - (node.radius || 8) * 3),
+        x1: Math.max(acc.x1, node.x + (node.radius || 8) * 3),
+        y1: Math.max(acc.y1, node.y + (node.radius || 8) * 3),
+      }), { x0: Infinity, y0: Infinity, x1: -Infinity, y1: -Infinity });
+    }
+    self.onmessage = (event) => {
+      const { requestId, incident, layout } = event.data || {};
+      const nodes = (layout?.nodes || []).map((node) => ({ ...node }));
+      for (let iteration = 0; iteration < 10; iteration += 1) {
+        for (let a = 0; a < nodes.length; a += 1) {
+          for (let b = a + 1; b < nodes.length; b += 1) {
+            const left = nodes[a];
+            const right = nodes[b];
+            if (left.aggregate || right.aggregate) continue;
+            const minDistance = (left.radius || 8) + (right.radius || 8) + 13;
+            const dx = right.x - left.x;
+            const dy = right.y - left.y;
+            const distance = Math.hypot(dx, dy) || 1;
+            if (distance >= minDistance) continue;
+            const push = (minDistance - distance) / 2;
+            const ux = dx / distance;
+            const uy = dy / distance;
+            left.x -= ux * push;
+            left.y -= uy * push;
+            right.x += ux * push;
+            right.y += uy * push;
+          }
+        }
+      }
+      self.postMessage({
+        requestId,
+        layout: {
+          ...layout,
+          nodes,
+          bounds: boundsForNodes([incident, ...nodes]),
+          worker_settled: true,
+        },
+      });
+    };
+  `;
+  return new Worker(URL.createObjectURL(new Blob([source], { type: 'text/javascript' })));
 }
 
 class SupplyChainGraph {
@@ -254,6 +526,20 @@ class SupplyChainGraph {
     this.reflowButton = root.querySelector('[data-sc-graph-focus-reflow]');
     this.viewport = { width: 1, height: 1, dpr: 1 };
     this.layout = buildLayout(payload);
+    this.bloomLayouts = new Map();
+    this.bloomWorkerRequests = new Map();
+    this.bloomWorker = createBloomLayoutWorker();
+    if (this.bloomWorker) {
+      this.bloomWorker.onmessage = (event) => {
+        const { requestId, layout } = event.data || {};
+        const incidentId = this.bloomWorkerRequests.get(requestId);
+        this.bloomWorkerRequests.delete(requestId);
+        if (!incidentId || !layout) return;
+        this.bloomLayouts.set(incidentId, layout);
+        this.lastLabelKey = '';
+      };
+    }
+    this.lastBloomIncidentId = null;
     this.camera = { cx: 0, cy: 0, z: 1 };
     this.targetCamera = { cx: 0, cy: 0, z: 1 };
     this.selection = null;
@@ -367,6 +653,7 @@ class SupplyChainGraph {
       event.preventDefault();
       const zoomFactor = Math.exp(-event.deltaY * 0.001);
       this.setCameraTarget({ ...this.targetCamera, z: clamp(this.targetCamera.z * zoomFactor, 0.22, 3.4) });
+      this.ensureSemanticBloom();
     }, { passive: false });
     this.reflowButton?.addEventListener('click', () => {
       if (this.selection?.type !== 'technique') return;
@@ -415,11 +702,16 @@ class SupplyChainGraph {
     return this.layout.nodes.filter((node) => relatedIds.has(node.id));
   }
 
+  activeBounds() {
+    const bloom = this.activeBloomLayout();
+    return bloom ? mergeBounds(this.layout.bounds, bloom.bounds) : this.layout.bounds;
+  }
+
   setCameraTarget(target, immediate = false) {
     const z = clamp(target.z, 0.22, 3.4);
     const halfWidth = this.viewport.width / z / 2;
     const halfHeight = this.viewport.height / z / 2;
-    const bounds = this.layout.bounds;
+    const bounds = this.activeBounds();
     this.targetCamera = {
       cx: clampAxis(target.cx, bounds.x0 + halfWidth, bounds.x1 - halfWidth),
       cy: clampAxis(target.cy, bounds.y0 + halfHeight, bounds.y1 - halfHeight),
@@ -446,8 +738,9 @@ class SupplyChainGraph {
   pick(clientX, clientY) {
     const world = this.screenToWorld(clientX, clientY);
     const radius = 24 / this.camera.z;
+    const visible = this.visibleGraph();
     if (this.focusReflow && this.selection?.type === 'technique') {
-      const nearest = this.layout.nodes.reduce((best, node) => {
+      const nearest = visible.nodes.reduce((best, node) => {
         const displayNode = this.displayNode(node);
         const distance = Math.hypot(displayNode.x - world.x, displayNode.y - world.y);
         if (distance > radius || (best && best.distance <= distance)) return best;
@@ -455,7 +748,7 @@ class SupplyChainGraph {
       }, null);
       return nearest?.point || null;
     }
-    const nearest = this.layout.quadtree.nearest(world.x, world.y, radius);
+    const nearest = visible.quadtree.nearest(world.x, world.y, radius);
     return nearest?.point || null;
   }
 
@@ -475,10 +768,11 @@ class SupplyChainGraph {
 
   selectByEntityId(type, value) {
     const normalizedType = type === 'threat actor' || type === 'threat_actor' ? 'actor' : type;
-    const node = this.layout.nodes.find(
+    const node = this.layout.allNodes.find(
       (item) => item.type === normalizedType && (item.id === value || item.entity_id === value)
     );
     if (!node) return false;
+    if (!BASE_DRAWABLE_TIERS.has(node.tier) && !BLOOM_TIERS.has(node.tier)) return false;
     this.selectNode(node);
     return true;
   }
@@ -507,6 +801,7 @@ class SupplyChainGraph {
 
   showOverview() {
     this.selection = null;
+    this.lastBloomIncidentId = null;
     this.setCameraTarget(fitBounds(this.recentNodes(), this.viewport));
     this.updateCaption(
       'Supply Chain Graph',
@@ -519,6 +814,7 @@ class SupplyChainGraph {
     if (nodes.length === 0) return;
     this.selection = { type: 'stage', value: stage, nodes: new Set(nodes.map((node) => node.id)) };
     this.focusReflow = false;
+    this.lastBloomIncidentId = null;
     this.updateReflowControl();
     this.setCameraTarget(fitBounds(nodes, this.viewport));
     this.updateCaption(`Attack stage: ${stage.replace(/_/g, ' ')}`, `${nodes.length} incident${nodes.length === 1 ? '' : 's'} selected.`);
@@ -526,19 +822,110 @@ class SupplyChainGraph {
 
   selectNode(node) {
     this.focusReflow = false;
+    if (node.tier === 'incident') this.ensureBloomLayout(node.id);
+    if (BLOOM_TIERS.has(node.tier)) {
+      const incidentId = this.incidentIdForBloomNode(node.id);
+      if (incidentId) this.ensureBloomLayout(incidentId);
+    }
     const cluster = this.clusterFor(node);
     const selectionNodes =
       node.tier === 'technique'
         ? cluster.filter((item) => item.tier === 'technique' || item.tier === 'incident').map((item) => item.id)
-        : [node.id];
+        : cluster.some((item) => item.id === node.id) ? cluster.map((item) => item.id) : [node.id];
     this.selection = { type: node.type, value: node.id, nodes: new Set(selectionNodes) };
     if (node.tier === 'technique') {
       this.frameSelectedTechniqueWideShot(cluster);
+    } else if (node.tier === 'incident') {
+      this.setCameraTarget(fitBounds(this.clusterFor(node), this.viewport, 190));
+    } else if (BLOOM_TIERS.has(node.tier)) {
+      this.setCameraTarget(fitBounds(cluster, this.viewport, 180));
     } else {
       this.setCameraTarget(fitBounds(cluster, this.viewport, node.tier === 'incident' ? 170 : 140));
     }
     this.updateCaption(node.label, node.summary || `${node.type.replace(/_/g, ' ')} node selected.`);
     this.updateReflowControl();
+  }
+
+  ensureBloomLayout(incidentId) {
+    const incident = this.layout.baseNodeById.get(incidentId);
+    const context = this.layout.bloomContext.get(incidentId);
+    if (!incident || !context) return null;
+    if (!this.bloomLayouts.has(incidentId)) {
+      const layout = buildBloomLayout(incident, context, this.layout.nodeById, this.layout.edges);
+      this.bloomLayouts.set(incidentId, layout);
+      if (this.bloomWorker) {
+        const requestId = `${incidentId}:${performance.now()}`;
+        this.bloomWorkerRequests.set(requestId, incidentId);
+        this.bloomWorker.postMessage({ requestId, incident, layout });
+      }
+    }
+    this.lastBloomIncidentId = incidentId;
+    return this.bloomLayouts.get(incidentId);
+  }
+
+  activeBloomIncidentId() {
+    if (this.selection?.type === 'incident') return this.selection.value;
+    if (this.selection && BLOOM_TIERS.has(this.selection.type)) {
+      const incidentId = this.incidentIdForBloomNode(this.selection.value);
+      if (incidentId) return incidentId;
+    }
+    if (this.camera.z < BLOOM_Z_THRESHOLD || this.focusReflow) return null;
+    const worldCenter = { x: this.camera.cx, y: this.camera.cy };
+    const nearest = this.layout.nodes
+      .filter((node) => node.tier === 'incident')
+      .reduce((best, node) => {
+        const distance = Math.hypot(node.x - worldCenter.x, node.y - worldCenter.y);
+        if (distance > 190 || (best && best.distance <= distance)) return best;
+        return { node, distance };
+      }, null);
+    return nearest?.node?.id || null;
+  }
+
+  ensureSemanticBloom() {
+    const incidentId = this.activeBloomIncidentId();
+    if (incidentId) this.ensureBloomLayout(incidentId);
+  }
+
+  activeBloomLayout() {
+    const incidentId = this.activeBloomIncidentId();
+    if (incidentId) return this.ensureBloomLayout(incidentId);
+    if (this.lastBloomIncidentId && this.selection?.type !== 'stage' && !this.focusReflow) {
+      return this.ensureBloomLayout(this.lastBloomIncidentId);
+    }
+    return null;
+  }
+
+  incidentIdForBloomNode(nodeId) {
+    for (const [incidentId, bloom] of this.bloomLayouts.entries()) {
+      if (bloom.nodes.some((node) => node.id === nodeId)) return incidentId;
+    }
+    for (const [incidentId, context] of this.layout.bloomContext.entries()) {
+      if (context.orgIds.includes(nodeId) || context.packageIds.includes(nodeId) || context.releaseIds.includes(nodeId)) return incidentId;
+    }
+    return null;
+  }
+
+  visibleGraph() {
+    const bloom = this.activeBloomLayout();
+    const nodes = bloom ? [...this.layout.nodes, ...bloom.nodes] : this.layout.nodes;
+    const visibleById = new Map(nodes.map((node) => [node.id, node]));
+    const edges = this.layout.edges
+      .filter((edge) => visibleById.has(edge.source) && visibleById.has(edge.target))
+      .filter((edge) => {
+        if (!bloom && (BLOOM_TIERS.has(edge.sourceNode?.tier) || BLOOM_TIERS.has(edge.targetNode?.tier))) return false;
+        if (edge.type === 'SEEDED_BY') return Boolean(bloom);
+        if (bloom?.edges.some((bloomEdge) => bloomEdge.id === edge.id)) return true;
+        return BASE_DRAWABLE_TIERS.has(edge.sourceNode?.tier) && BASE_DRAWABLE_TIERS.has(edge.targetNode?.tier);
+      })
+      .map((edge) => ({ ...edge, sourceNode: visibleById.get(edge.source), targetNode: visibleById.get(edge.target) }));
+    const bounds = bloom ? mergeBounds(this.layout.bounds, bloom.bounds) : this.layout.bounds;
+    const quadtree = new SupplyChainQuadtree(bounds);
+    nodes.forEach((node) => quadtree.insert(node));
+    return { nodes, nodeById: visibleById, edges, bounds, quadtree };
+  }
+
+  getVisibleGraph() {
+    return this.currentVisibleGraph || this.visibleGraph();
   }
 
   frameSelectedTechniqueWideShot(cluster = null) {
@@ -566,6 +953,8 @@ class SupplyChainGraph {
         if (edge.target === node.id) clusterIds.add(edge.source);
         if (edge.source === node.id) clusterIds.add(edge.target);
       });
+      const bloom = this.ensureBloomLayout(node.id);
+      bloom?.nodes.forEach((item) => clusterIds.add(item.id));
     } else if (node.tier === 'technique') {
       this.layout.edges.forEach((edge) => {
         if (edge.source === node.id && edge.type === 'INCIDENT_TECHNIQUE') {
@@ -580,8 +969,24 @@ class SupplyChainGraph {
           });
         }
       });
+    } else if (BLOOM_TIERS.has(node.tier)) {
+      const incidentId = this.incidentIdForBloomNode(node.id);
+      if (incidentId) {
+        clusterIds.add(incidentId);
+        const bloom = this.ensureBloomLayout(incidentId);
+        bloom?.nodes.forEach((item) => {
+          if (item.id === node.id || item.tier === 'organization' || item.tier === 'package') clusterIds.add(item.id);
+        });
+        bloom?.edges.forEach((edge) => {
+          if (edge.type === 'SEEDED_BY' && (edge.source === node.id || edge.target === node.id)) {
+            clusterIds.add(edge.source);
+            clusterIds.add(edge.target);
+          }
+        });
+      }
     }
-    return this.layout.nodes.filter((item) => clusterIds.has(item.id));
+    const visible = this.getVisibleGraph();
+    return visible.nodes.filter((item) => clusterIds.has(item.id));
   }
 
   updateReflowControl() {
@@ -601,6 +1006,9 @@ class SupplyChainGraph {
 
   colorForNode(node) {
     if (node.tier === 'technique') return SEVERITY_COLORS.technique;
+    if (node.tier === 'organization') return SEVERITY_COLORS.organization;
+    if (node.tier === 'package') return node.aggregate ? SEVERITY_COLORS.muted : SEVERITY_COLORS.package;
+    if (node.tier === 'release') return SEVERITY_COLORS.release;
     if (this.selection?.type === 'stage' && node.tier === 'incident') {
       return this.selection.nodes.has(node.id) ? SEVERITY_COLORS[node.sev] || SEVERITY_COLORS.default : SEVERITY_COLORS.muted;
     }
@@ -614,8 +1022,18 @@ class SupplyChainGraph {
 
   edgeAlpha(edge) {
     if (!this.selection) return 0.28;
+    if (edge.type === 'SEEDED_BY') return edge.propagation_tier === 'causal' ? 0.78 : 0.42;
     if (this.selection.nodes?.has(edge.source) || this.selection.nodes?.has(edge.target)) return 0.64;
     return 0.1;
+  }
+
+  colorForEdge(edge) {
+    if (edge.type === 'ATTRIBUTED_TO_ACTOR') return SEVERITY_COLORS.high;
+    if (edge.type === 'INCIDENT_TECHNIQUE') return SEVERITY_COLORS.technique;
+    if (edge.type === 'SEEDED_BY') return edge.propagation_tier === 'causal' ? SEVERITY_COLORS.propagation : SEVERITY_COLORS.muted;
+    if (edge.type === 'PACKAGE_RELEASE' || edge.type === 'INCIDENT_AFFECTED_RELEASE') return SEVERITY_COLORS.release;
+    if (edge.type === 'AFFECTED_ORGANIZATION' || edge.type === 'AFFECTED_PACKAGE') return SEVERITY_COLORS.package;
+    return SEVERITY_COLORS.medium;
   }
 
   displayNode(node) {
@@ -636,18 +1054,31 @@ class SupplyChainGraph {
   drawEdges() {
     const gl = this.gl;
     const values = [];
-    this.layout.edges.forEach((edge) => {
-      const alpha = this.edgeAlpha(edge);
-      const color =
-        edge.type === 'ATTRIBUTED_TO_ACTOR'
-          ? SEVERITY_COLORS.high
-          : edge.type === 'INCIDENT_TECHNIQUE'
-            ? SEVERITY_COLORS.technique
-            : SEVERITY_COLORS.medium;
-      const sourceNode = this.displayNode(edge.sourceNode);
-      const targetNode = this.displayNode(edge.targetNode);
+    const visible = this.getVisibleGraph();
+    const pushSegment = (sourceNode, targetNode, color, alpha) => {
       values.push(sourceNode.x, sourceNode.y, color[0], color[1], color[2], alpha);
       values.push(targetNode.x, targetNode.y, color[0], color[1], color[2], alpha);
+    };
+    visible.edges.forEach((edge) => {
+      const alpha = this.edgeAlpha(edge);
+      const color = this.colorForEdge(edge);
+      const sourceNode = this.displayNode(edge.sourceNode);
+      const targetNode = this.displayNode(edge.targetNode);
+      if (edge.type === 'SEEDED_BY' && edge.propagation_tier === 'temporal') {
+        const segments = 10;
+        for (let index = 0; index < segments; index += 2) {
+          const a = index / segments;
+          const b = (index + 1) / segments;
+          pushSegment(
+            { x: lerp(sourceNode.x, targetNode.x, a), y: lerp(sourceNode.y, targetNode.y, a) },
+            { x: lerp(sourceNode.x, targetNode.x, b), y: lerp(sourceNode.y, targetNode.y, b) },
+            color,
+            alpha
+          );
+        }
+      } else {
+        pushSegment(sourceNode, targetNode, color, alpha);
+      }
     });
     gl.useProgram(this.edgeProgram);
     gl.bindBuffer(gl.ARRAY_BUFFER, this.edgeBuffer);
@@ -672,7 +1103,7 @@ class SupplyChainGraph {
   drawNodes() {
     const gl = this.gl;
     const values = [];
-    this.layout.nodes.forEach((node) => {
+    this.getVisibleGraph().nodes.forEach((node) => {
       const displayNode = this.displayNode(node);
       const color = this.colorForNode(node);
       const selected = this.selection?.nodes?.has(node.id);
@@ -710,10 +1141,11 @@ class SupplyChainGraph {
   }
 
   drawLabels() {
-    const labelNodes = this.layout.nodes.filter(
+    const labelNodes = this.getVisibleGraph().nodes.filter(
       (node) =>
         node.tier === 'actor' ||
         node.tier === 'campaign' ||
+        (node.tier === 'organization' && node.bloom_parent) ||
         (node.tier === 'technique' && this.selection?.value === node.id) ||
         this.selection?.nodes?.has(node.id)
     );
@@ -745,12 +1177,15 @@ class SupplyChainGraph {
       cy: lerp(this.camera.cy, this.targetCamera.cy, this.reduceMotion ? 1 : 0.14),
       z: lerp(this.camera.z, this.targetCamera.z, this.reduceMotion ? 1 : 0.16),
     };
+    this.ensureSemanticBloom();
+    this.currentVisibleGraph = this.visibleGraph();
     const gl = this.gl;
     gl.clearColor(0.031, 0.043, 0.063, 1);
     gl.clear(gl.COLOR_BUFFER_BIT);
     this.drawEdges();
     this.drawNodes();
     this.drawLabels();
+    this.currentVisibleGraph = null;
     requestAnimationFrame(() => this.frame());
   }
 }

--- a/site/public/js/supply-chain-graph-core.js
+++ b/site/public/js/supply-chain-graph-core.js
@@ -203,12 +203,15 @@ function packageIdForRelease(releaseId, edges) {
 function buildBloomLayout(incident, context, sourceNodes, sourceEdges, offset = 0) {
   const centerX = incident.x + 280;
   const centerY = incident.y + 16;
-  const orgIds = context.orgIds.length > 0 ? context.orgIds : ['virtual-org-unattributed'];
   const visibleChildren = sortBloomNodes(
     [...context.orgIds, ...context.packageIds, ...context.releaseIds]
       .map((id) => sourceNodes.get(id))
       .filter(Boolean)
   );
+  if (visibleChildren.length === 0) {
+    return { incidentId: incident.id, nodes: [], edges: [], hiddenCount: 0, bounds: boundsForNodes([incident]) };
+  }
+  const orgIds = context.orgIds.length > 0 ? context.orgIds : ['virtual-org-unattributed'];
   const needsAggregation = visibleChildren.length > BLOOM_NODE_BUDGET;
   const visibleIds = new Set(
     visibleChildren

--- a/site/public/js/supply-chain-graph-core.js
+++ b/site/public/js/supply-chain-graph-core.js
@@ -792,6 +792,7 @@ class SupplyChainGraph {
       return;
     }
     this.selection = { type, value, nodes: new Set(incidentNodes.map((node) => node.id)) };
+    this.lastBloomIncidentId = null;
     this.setCameraTarget(fitBounds(incidentNodes, this.viewport, 180));
     this.updateCaption(
       entity?.label || value,
@@ -822,6 +823,7 @@ class SupplyChainGraph {
 
   selectNode(node) {
     this.focusReflow = false;
+    if (node.tier !== 'incident' && !BLOOM_TIERS.has(node.tier)) this.lastBloomIncidentId = null;
     if (node.tier === 'incident') this.ensureBloomLayout(node.id);
     if (BLOOM_TIERS.has(node.tier)) {
       const incidentId = this.incidentIdForBloomNode(node.id);
@@ -869,6 +871,7 @@ class SupplyChainGraph {
       const incidentId = this.incidentIdForBloomNode(this.selection.value);
       if (incidentId) return incidentId;
     }
+    if (this.selection) return null;
     if (this.camera.z < BLOOM_Z_THRESHOLD || this.focusReflow) return null;
     const worldCenter = { x: this.camera.cx, y: this.camera.cy };
     const nearest = this.layout.nodes

--- a/site/public/js/supply-chain-graph-core.js
+++ b/site/public/js/supply-chain-graph-core.js
@@ -888,11 +888,7 @@ class SupplyChainGraph {
 
   activeBloomLayout() {
     const incidentId = this.activeBloomIncidentId();
-    if (incidentId) return this.ensureBloomLayout(incidentId);
-    if (this.lastBloomIncidentId && this.selection?.type !== 'stage' && !this.focusReflow) {
-      return this.ensureBloomLayout(this.lastBloomIncidentId);
-    }
-    return null;
+    return incidentId ? this.ensureBloomLayout(incidentId) : null;
   }
 
   incidentIdForBloomNode(nodeId) {
@@ -905,8 +901,8 @@ class SupplyChainGraph {
     return null;
   }
 
-  visibleGraph() {
-    const bloom = this.activeBloomLayout();
+  visibleGraph(forcedBloom = null) {
+    const bloom = forcedBloom || this.activeBloomLayout();
     const nodes = bloom ? [...this.layout.nodes, ...bloom.nodes] : this.layout.nodes;
     const visibleById = new Map(nodes.map((node) => [node.id, node]));
     const edges = this.layout.edges
@@ -939,6 +935,7 @@ class SupplyChainGraph {
 
   clusterFor(node) {
     const clusterIds = new Set([node.id]);
+    let forcedBloom = null;
     if (node.tier === 'actor') {
       this.layout.edges.forEach((edge) => {
         if (edge.source === node.id) clusterIds.add(edge.target);
@@ -953,8 +950,8 @@ class SupplyChainGraph {
         if (edge.target === node.id) clusterIds.add(edge.source);
         if (edge.source === node.id) clusterIds.add(edge.target);
       });
-      const bloom = this.ensureBloomLayout(node.id);
-      bloom?.nodes.forEach((item) => clusterIds.add(item.id));
+      forcedBloom = this.ensureBloomLayout(node.id);
+      forcedBloom?.nodes.forEach((item) => clusterIds.add(item.id));
     } else if (node.tier === 'technique') {
       this.layout.edges.forEach((edge) => {
         if (edge.source === node.id && edge.type === 'INCIDENT_TECHNIQUE') {
@@ -973,11 +970,11 @@ class SupplyChainGraph {
       const incidentId = this.incidentIdForBloomNode(node.id);
       if (incidentId) {
         clusterIds.add(incidentId);
-        const bloom = this.ensureBloomLayout(incidentId);
-        bloom?.nodes.forEach((item) => {
+        forcedBloom = this.ensureBloomLayout(incidentId);
+        forcedBloom?.nodes.forEach((item) => {
           if (item.id === node.id || item.tier === 'organization' || item.tier === 'package') clusterIds.add(item.id);
         });
-        bloom?.edges.forEach((edge) => {
+        forcedBloom?.edges.forEach((edge) => {
           if (edge.type === 'SEEDED_BY' && (edge.source === node.id || edge.target === node.id)) {
             clusterIds.add(edge.source);
             clusterIds.add(edge.target);
@@ -985,7 +982,7 @@ class SupplyChainGraph {
         });
       }
     }
-    const visible = this.getVisibleGraph();
+    const visible = this.visibleGraph(forcedBloom);
     return visible.nodes.filter((item) => clusterIds.has(item.id));
   }
 

--- a/site/public/supply-chain-graph.json
+++ b/site/public/supply-chain-graph.json
@@ -19,7 +19,13 @@
       "technique"
     ],
     "technique_focus": "wide-shot-default-with-operator-reflow",
-    "package_release_lod": "payload-only-until-G4",
+    "package_release_lod": "g4-dive-and-bloom",
+    "bloom_tiers": [
+      "organization",
+      "package",
+      "release"
+    ],
+    "seeded_by_edges": "causal-solid-temporal-dashed",
     "layout": "time-anchored-actor-lanes"
   },
   "counts": {
@@ -5682,7 +5688,13 @@
       "target": "pkg-generic-3cx-desktopapp",
       "type": "SEEDED_BY",
       "evidence_tier": null,
-      "source_refs": []
+      "source_refs": [],
+      "evidence_refs": [
+        "ref-mandiant-3cx"
+      ],
+      "propagation_tier": "causal",
+      "source_incident_id": "SC-2023-THREE-CX-DESKTOP",
+      "summary": "Mandiant documented the 3CX compromise as a cascade from a prior X_TRADER software supply-chain compromise; this edge records that public causal relationship without inferring additional downstream steps."
     },
     {
       "id": "SEEDED_BY:pkg-npm-rxnt-authentication->release-npm-ctrl-tinycolor-4-1-1",
@@ -5690,7 +5702,14 @@
       "target": "release-npm-ctrl-tinycolor-4-1-1",
       "type": "SEEDED_BY",
       "evidence_tier": null,
-      "source_refs": []
+      "source_refs": [],
+      "evidence_refs": [
+        "ref-stepsecurity-shai-hulud",
+        "ref-wiz-shai-hulud"
+      ],
+      "propagation_tier": "temporal",
+      "source_incident_id": "SC-2025-NPM-SHAI-HULUD",
+      "summary": "Public reporting places rxnt-authentication activity before the @ctrl/tinycolor wave and describes token reuse, but this edge is temporal precedence rather than asserted package-to-package causation."
     },
     {
       "id": "SEEDED_BY:release-npm-ctrl-tinycolor-4-1-1->release-npm-ctrl-tinycolor-4-1-2",
@@ -5698,7 +5717,14 @@
       "target": "release-npm-ctrl-tinycolor-4-1-2",
       "type": "SEEDED_BY",
       "evidence_tier": null,
-      "source_refs": []
+      "source_refs": [],
+      "evidence_refs": [
+        "ref-npm-tinycolor-registry",
+        "ref-wiz-shai-hulud"
+      ],
+      "propagation_tier": "temporal",
+      "source_incident_id": "SC-2025-NPM-SHAI-HULUD",
+      "summary": "The npm registry metadata records adjacent malicious @ctrl/tinycolor releases on the same date; this edge preserves ordered wave structure without asserting causation."
     },
     {
       "id": "SOURCE_ARTIFACT_DIVERGENCE:incident-SC-2016-LINUX-MINT-ISO->channel-linux-website-download-linux-mint-download-site",


### PR DESCRIPTION
## Summary

Implements Supply Chain 1.0 G4: incident-scoped dive-and-bloom over the existing compiled graph payload.

- Keeps actor/campaign/incident/technique as the default/far drawable tiers.
- Blooms organization, package, and release nodes only when an incident is selected, an entity route targets a bloom node, or semantic zoom approaches an incident.
- Adds bounded bloom layout with a node budget and aggregation node.
- Runs a worker-settled overlap pass for bloom child positions.
- Renders `SEEDED_BY` propagation edges distinctly: causal as solid, temporal as dim segmented lines.
- Preserves evidence metadata for `SEEDED_BY` in `site/public/supply-chain-graph.json`.
- Updates Supply Chain page docs and source tests for the G4 contract.

## Scope boundaries

- No corpus data changes.
- No scoring, risk engine, live feeds, graph DB, ML, or attribution automation.
- No new public routes or production enablement default changes.

## Validation

- `node --check site/public/js/supply-chain-graph-core.js` PASS
- `node --check scripts/build-supply-chain-graph.mjs` PASS
- `node --check scripts/test-supply-chain-pages.mjs` PASS
- `node scripts/build-supply-chain-graph.mjs --check` PASS (`nodes=187 edges=285`)
- `node scripts/test-supply-chain-pages.mjs` PASS (`routes=84`)
- `python3 scripts/validate_supply_chain_incidents.py` PASS (`27 supply-chain incidents`)
- `python3 scripts/validate_supply_chain_graph.py` PASS (`entities=102 relationships=140`)
- `git diff --check` PASS
- `cd site && npm run build` PASS (`309 page(s) built`); existing campaign validator warnings remained non-fatal
- `cd site && ENABLE_SUPPLY_CHAIN_PAGES=true npm run build` PASS (`393 page(s) built`); existing campaign validator warnings remained non-fatal

## Reviewer notes

Gemini may be quota-limited; if so, please use EP/DM as the independent non-author review lineage per the sprint governance.
