### PR TITLE
Supply Chain G5 labels and accessibility

### DIFF
--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -467,6 +467,11 @@ assert.ok(
   'graph client should provide keyboard traversal and truthful ARIA selected-node/failure text'
 );
 assert.ok(
+  supplyChainGraphSource.includes('this.keyboardNodeId = incidentNodes[0]?.id || null;') &&
+    supplyChainGraphSource.includes('this.keyboardNodeId = nodes[0]?.id || null;'),
+  'graph client should reset keyboard focus for context and stage selections'
+);
+assert.ok(
   supplyChainGraphSource.includes('labelPriority') &&
     supplyChainGraphSource.includes('labelCandidates') &&
     supplyChainGraphSource.includes('labelFits') &&

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -58,8 +58,11 @@ assert.ok(
   supplyChainRouteSource.includes('data-supply-chain-graph-root') &&
     supplyChainRouteSource.includes('data-sc-graph-canvas') &&
     supplyChainRouteSource.includes('data-sc-graph-focus-reflow') &&
+    supplyChainRouteSource.includes('aria-describedby="supply-chain-graph-description"') &&
+    supplyChainRouteSource.includes('tabindex="0"') &&
+    supplyChainRouteSource.includes('data-sc-graph-description') &&
     supplyChainRouteSource.includes('/js/supply-chain-graph-core.js'),
-  'route should mount the persisted WebGL graph island'
+  'route should mount the persisted keyboard-accessible WebGL graph island'
 );
 assert.ok(
   !supplyChainRouteSource.includes('class="graph-hero graph-hero-persistent"\n    transition:persist='),
@@ -434,6 +437,22 @@ assert.ok(
     supplyChainGraphSource.includes("edge.propagation_tier === 'temporal'") &&
     supplyChainGraphSource.includes("edge.propagation_tier === 'causal'"),
   'graph client should render causal and temporal SEEDED_BY edges distinctly'
+);
+assert.ok(
+  supplyChainGraphSource.includes('handleKeydown') &&
+    supplyChainGraphSource.includes('keyboardNodes()') &&
+    supplyChainGraphSource.includes("event.key === 'Escape'") &&
+    supplyChainGraphSource.includes('this.root.addEventListener') &&
+    supplyChainGraphSource.includes('this.description.textContent'),
+  'graph client should provide keyboard traversal and ARIA selected-node text'
+);
+assert.ok(
+  supplyChainGraphSource.includes('labelPriority') &&
+    supplyChainGraphSource.includes('labelCandidates') &&
+    supplyChainGraphSource.includes('labelFits') &&
+    supplyChainGraphSource.includes('this.labelPlacements') &&
+    supplyChainGraphSource.includes('sc-graph-label-keyboard'),
+  'graph client should provide greedy label de-confliction with placement hysteresis'
 );
 assert.ok(
   supplyChainGraphSource.includes('this.focusReflow') &&

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -65,6 +65,10 @@ assert.ok(
   'route should mount the persisted keyboard-accessible WebGL graph island'
 );
 assert.ok(
+  supplyChainRouteSource.includes('Supply Chain graph is loading. Keyboard controls become available after graph initialization.'),
+  'route should not announce keyboard graph controls before initialization succeeds'
+);
+assert.ok(
   !supplyChainRouteSource.includes('class="graph-hero graph-hero-persistent"\n    transition:persist='),
   'route should not persist page-specific hero copy or selection data'
 );
@@ -443,12 +447,14 @@ assert.ok(
   'graph client should render causal and temporal SEEDED_BY edges distinctly'
 );
 assert.ok(
-  supplyChainGraphSource.includes('handleKeydown') &&
+    supplyChainGraphSource.includes('handleKeydown') &&
     supplyChainGraphSource.includes('keyboardNodes()') &&
+    supplyChainGraphSource.includes("closest?.('a, button, input, select, textarea, summary, [contenteditable=\"true\"]')") &&
     supplyChainGraphSource.includes("event.key === 'Escape'") &&
     supplyChainGraphSource.includes('this.root.addEventListener') &&
-    supplyChainGraphSource.includes('this.description.textContent'),
-  'graph client should provide keyboard traversal and ARIA selected-node text'
+    supplyChainGraphSource.includes('this.description.textContent') &&
+    supplyChainGraphSource.includes('Keyboard graph controls are not active.'),
+  'graph client should provide keyboard traversal and truthful ARIA selected-node/failure text'
 );
 assert.ok(
   supplyChainGraphSource.includes('labelPriority') &&

--- a/site/public/js/supply-chain-graph-core.js
+++ b/site/public/js/supply-chain-graph-core.js
@@ -798,6 +798,7 @@ class SupplyChainGraph {
       return;
     }
     this.selection = { type, value, nodes: new Set(incidentNodes.map((node) => node.id)) };
+    this.keyboardNodeId = incidentNodes[0]?.id || null;
     this.lastBloomIncidentId = null;
     this.setCameraTarget(fitBounds(incidentNodes, this.viewport, 180));
     this.updateCaption(
@@ -821,6 +822,7 @@ class SupplyChainGraph {
     const nodes = this.layout.nodes.filter((node) => node.tier === 'incident' && node.attack_stage === stage);
     if (nodes.length === 0) return;
     this.selection = { type: 'stage', value: stage, nodes: new Set(nodes.map((node) => node.id)) };
+    this.keyboardNodeId = nodes[0]?.id || null;
     this.focusReflow = false;
     this.lastBloomIncidentId = null;
     this.updateReflowControl();

--- a/site/public/js/supply-chain-graph-core.js
+++ b/site/public/js/supply-chain-graph-core.js
@@ -858,6 +858,8 @@ class SupplyChainGraph {
   }
 
   handleKeydown(event) {
+    const interactiveTarget = event.target?.closest?.('a, button, input, select, textarea, summary, [contenteditable="true"]');
+    if (interactiveTarget && interactiveTarget !== this.root) return;
     const forwardKeys = new Set(['ArrowRight', 'ArrowDown']);
     const backwardKeys = new Set(['ArrowLeft', 'ArrowUp']);
     if (!forwardKeys.has(event.key) && !backwardKeys.has(event.key) && event.key !== 'Enter' && event.key !== 'Escape') return;
@@ -1296,6 +1298,8 @@ async function bootSupplyChainGraph() {
     root.dataset.graphStatus = 'failed';
     const status = root.querySelector('[data-sc-graph-status]');
     if (status) status.textContent = 'Graph unavailable';
+    const description = root.querySelector('[data-sc-graph-description]');
+    if (description) description.textContent = 'Supply Chain graph unavailable. Keyboard graph controls are not active.';
     console.error(error);
   }
 }

--- a/site/public/js/supply-chain-graph-core.js
+++ b/site/public/js/supply-chain-graph-core.js
@@ -523,6 +523,7 @@ class SupplyChainGraph {
     this.status = root.querySelector('[data-sc-graph-status]');
     this.captionTitle = root.querySelector('[data-sc-graph-caption-title]');
     this.captionBody = root.querySelector('[data-sc-graph-caption-body]');
+    this.description = root.querySelector('[data-sc-graph-description]');
     this.reflowButton = root.querySelector('[data-sc-graph-focus-reflow]');
     this.viewport = { width: 1, height: 1, dpr: 1 };
     this.layout = buildLayout(payload);
@@ -544,6 +545,7 @@ class SupplyChainGraph {
     this.targetCamera = { cx: 0, cy: 0, z: 1 };
     this.selection = null;
     this.focusReflow = false;
+    this.keyboardNodeId = null;
     this.drag = null;
     this.reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     this.gl = this.canvas.getContext('webgl2', { antialias: true }) || this.canvas.getContext('webgl', { antialias: true });
@@ -672,6 +674,7 @@ class SupplyChainGraph {
       if (command === 'filter-stage') this.filterStage(value);
     });
     document.addEventListener('astro:page-load', () => this.selectFromRoute());
+    this.root.addEventListener('keydown', (event) => this.handleKeydown(event));
   }
 
   resize() {
@@ -801,6 +804,7 @@ class SupplyChainGraph {
 
   showOverview() {
     this.selection = null;
+    this.keyboardNodeId = null;
     this.lastBloomIncidentId = null;
     this.setCameraTarget(fitBounds(this.recentNodes(), this.viewport));
     this.updateCaption(
@@ -822,6 +826,7 @@ class SupplyChainGraph {
 
   selectNode(node) {
     this.focusReflow = false;
+    this.keyboardNodeId = node.id;
     if (node.tier === 'incident') this.ensureBloomLayout(node.id);
     if (BLOOM_TIERS.has(node.tier)) {
       const incidentId = this.incidentIdForBloomNode(node.id);
@@ -844,6 +849,33 @@ class SupplyChainGraph {
     }
     this.updateCaption(node.label, node.summary || `${node.type.replace(/_/g, ' ')} node selected.`);
     this.updateReflowControl();
+  }
+
+  keyboardNodes() {
+    return this.visibleGraph().nodes
+      .filter((node) => !node.aggregate)
+      .sort((a, b) => tierRank(a.tier) - tierRank(b.tier) || (a.y - b.y) || (a.x - b.x));
+  }
+
+  handleKeydown(event) {
+    const forwardKeys = new Set(['ArrowRight', 'ArrowDown']);
+    const backwardKeys = new Set(['ArrowLeft', 'ArrowUp']);
+    if (!forwardKeys.has(event.key) && !backwardKeys.has(event.key) && event.key !== 'Enter' && event.key !== 'Escape') return;
+    event.preventDefault();
+    if (event.key === 'Escape') {
+      this.showOverview();
+      return;
+    }
+    const nodes = this.keyboardNodes();
+    if (!nodes.length) return;
+    const currentIndex = Math.max(0, nodes.findIndex((node) => node.id === this.keyboardNodeId));
+    if (event.key === 'Enter') {
+      this.selectNode(nodes[currentIndex]);
+      return;
+    }
+    const direction = forwardKeys.has(event.key) ? 1 : -1;
+    const nextIndex = (currentIndex + direction + nodes.length) % nodes.length;
+    this.selectNode(nodes[nextIndex]);
   }
 
   ensureBloomLayout(incidentId) {
@@ -1002,6 +1034,7 @@ class SupplyChainGraph {
     if (this.captionTitle) this.captionTitle.textContent = title;
     if (this.captionBody) this.captionBody.textContent = body;
     if (this.status) this.status.textContent = title;
+    if (this.description) this.description.textContent = `${title}. ${body}`;
   }
 
   colorForNode(node) {
@@ -1034,6 +1067,56 @@ class SupplyChainGraph {
     if (edge.type === 'PACKAGE_RELEASE' || edge.type === 'INCIDENT_AFFECTED_RELEASE') return SEVERITY_COLORS.release;
     if (edge.type === 'AFFECTED_ORGANIZATION' || edge.type === 'AFFECTED_PACKAGE') return SEVERITY_COLORS.package;
     return SEVERITY_COLORS.medium;
+  }
+
+  labelPriority(node) {
+    if (node.id === this.keyboardNodeId) return 100;
+    if (this.selection?.nodes?.has(node.id)) return 90;
+    if (node.tier === 'actor' || node.tier === 'technique') return 72;
+    if (node.tier === 'organization') return 62;
+    if (node.tier === 'campaign') return 54;
+    if (node.tier === 'incident') return 46;
+    if (node.tier === 'package') return 34;
+    if (node.tier === 'release') return 26;
+    return 10;
+  }
+
+  labelCandidates(node) {
+    const position = this.worldToScreen(this.displayNode(node));
+    const width = Math.min(220, Math.max(68, String(node.label || '').length * 7.4 + 16));
+    const height = 24;
+    const anchors = [
+      { anchorIndex: 0, x: 12, y: -10 },
+      { anchorIndex: 1, x: -width - 12, y: -10 },
+      { anchorIndex: 2, x: 12, y: 14 },
+      { anchorIndex: 3, x: -width - 12, y: 14 },
+      { anchorIndex: 4, x: -width / 2, y: -34 },
+      { anchorIndex: 5, x: -width / 2, y: 20 },
+    ];
+    const previous = this.labelPlacements?.get(node.id);
+    if (Number.isInteger(previous)) {
+      const index = anchors.findIndex((anchor) => anchor.anchorIndex === previous);
+      if (index > 0) anchors.unshift(anchors.splice(index, 1)[0]);
+    }
+    return anchors.map((offset) => ({
+      anchorIndex: offset.anchorIndex,
+      x: Math.round(position.x + offset.x),
+      y: Math.round(position.y + offset.y),
+      width,
+      height,
+    }));
+  }
+
+  labelFits(candidate, occupied) {
+    if (candidate.x < 8 || candidate.y < 8 || candidate.x + candidate.width > this.viewport.width - 8 || candidate.y + candidate.height > this.viewport.height - 8) {
+      return false;
+    }
+    return !occupied.some((box) =>
+      candidate.x < box.x + box.width + 6 &&
+      candidate.x + candidate.width + 6 > box.x &&
+      candidate.y < box.y + box.height + 6 &&
+      candidate.y + candidate.height + 6 > box.y
+    );
   }
 
   displayNode(node) {
@@ -1141,29 +1224,40 @@ class SupplyChainGraph {
   }
 
   drawLabels() {
-    const labelNodes = this.getVisibleGraph().nodes.filter(
-      (node) =>
-        node.tier === 'actor' ||
-        node.tier === 'campaign' ||
-        (node.tier === 'organization' && node.bloom_parent) ||
-        (node.tier === 'technique' && this.selection?.value === node.id) ||
-        this.selection?.nodes?.has(node.id)
-    );
-    const labels = labelNodes.slice(0, 24).map((node) => {
-      const position = this.worldToScreen(this.displayNode(node));
-      return {
-        node,
-        x: Math.round(position.x + 12),
-        y: Math.round(position.y - 10),
-      };
-    });
+    if (!this.labelPlacements) this.labelPlacements = new Map();
+    const occupied = [];
+    const nextPlacements = new Map();
+    const labelNodes = this.getVisibleGraph().nodes
+      .filter((node) => {
+        if (node.aggregate) return true;
+        if (node.tier === 'actor' || node.tier === 'campaign') return true;
+        if (node.tier === 'organization' && node.bloom_parent) return true;
+        if (node.tier === 'technique' && this.selection?.value === node.id) return true;
+        return this.selection?.nodes?.has(node.id) || node.id === this.keyboardNodeId;
+      })
+      .sort((a, b) => this.labelPriority(b) - this.labelPriority(a));
+    const labels = [];
+    for (const node of labelNodes) {
+      const candidate = this.labelCandidates(node).find((item) => this.labelFits(item, occupied));
+      if (!candidate) continue;
+      occupied.push(candidate);
+      nextPlacements.set(node.id, candidate.anchorIndex);
+      labels.push({ node, ...candidate });
+      if (labels.length >= 32) break;
+    }
+    this.labelPlacements = nextPlacements;
     const labelKey = labels.map((item) => `${item.node.id}:${item.x}:${item.y}`).join('|');
     if (labelKey === this.lastLabelKey) return;
     this.lastLabelKey = labelKey;
     this.labelLayer.replaceChildren(
       ...labels.map((item) => {
         const label = document.createElement('span');
-        label.className = `sc-graph-label sc-graph-label-${item.node.tier}`;
+        label.className = [
+          'sc-graph-label',
+          `sc-graph-label-${item.node.tier}`,
+          this.selection?.nodes?.has(item.node.id) ? 'sc-graph-label-selected' : '',
+          item.node.id === this.keyboardNodeId ? 'sc-graph-label-keyboard' : '',
+        ].filter(Boolean).join(' ');
         label.textContent = item.node.label;
         label.style.transform = `translate(${item.x}px, ${item.y}px)`;
         return label;

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -124,7 +124,7 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
         <span data-sc-graph-caption-body>Pan, zoom, and select actor, campaign, and incident tiers.</span>
       </div>
       <p id="supply-chain-graph-description" class="sr-only" data-sc-graph-description>
-        Supply Chain graph loaded. Use arrow keys while focused to move through visible graph nodes.
+        Supply Chain graph is loading. Keyboard controls become available after graph initialization.
       </p>
     </div>
     <div class="hero-copy">

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -86,6 +86,8 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
       data-graph-status="loading"
       role="application"
       aria-label="Persistent preview of the Supply Chain corpus graph"
+      aria-describedby="supply-chain-graph-description"
+      tabindex="0"
     >
       <div class="graph-status">
         <span data-sc-graph-status>{graphHero.status}</span>
@@ -121,6 +123,9 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
         <strong data-sc-graph-caption-title>Supply Chain Graph</strong>
         <span data-sc-graph-caption-body>Pan, zoom, and select actor, campaign, and incident tiers.</span>
       </div>
+      <p id="supply-chain-graph-description" class="sr-only" data-sc-graph-description>
+        Supply Chain graph loaded. Use arrow keys while focused to move through visible graph nodes.
+      </p>
     </div>
     <div class="hero-copy">
       <p class="eyebrow">{graphHero.eyebrow}</p>
@@ -555,6 +560,11 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
     background-size: 42px 42px, 42px 42px, auto, auto, auto;
   }
 
+  .graph-placeholder:focus-visible {
+    outline: 2px solid var(--amber);
+    outline-offset: 3px;
+  }
+
   .sc-graph-canvas {
     position: absolute;
     inset: 0;
@@ -591,6 +601,17 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
     padding: 5px 7px;
     text-transform: uppercase;
     white-space: nowrap;
+  }
+
+  .sc-graph-label-selected {
+    border-color: rgba(232, 160, 32, 0.82);
+    box-shadow: 0 0 0 1px rgba(232, 160, 32, 0.2), 0 10px 26px rgba(0, 0, 0, 0.36);
+    color: var(--white);
+  }
+
+  .sc-graph-label-keyboard {
+    outline: 2px solid var(--amber);
+    outline-offset: 2px;
   }
 
   .sc-graph-label-actor {


### PR DESCRIPTION
## Summary

Implements Supply Chain 1.0 G5 on top of #1195 / G4.

- Adds keyboard focusability and ARIA selected-node description to the persistent graph hero.
- Adds arrow-key traversal over visible graph nodes using the same selection/camera state as pointer selection.
- Adds Escape-to-overview behavior while the graph root is focused.
- Adds visible focus styles for the graph root and keyboard-selected labels.
- Replaces the simple first-24 label renderer with greedy label de-confliction, priority ordering, backing-plate labels, and placement hysteresis.
- Keeps non-bloom hidden entities falling back to incident-context framing instead of selecting placeholder coordinates.

## Scope boundaries

- Stacked on G4; no corpus data changes.
- No new routes, scoring, live feeds, graph DB, ML, or attribution automation.
- Does not implement G6 page-to-graph reverse binding beyond existing command hooks.

## Validation

- `node --check scripts/build-supply-chain-graph.mjs` PASS
- `node --check site/public/js/supply-chain-graph-core.js` PASS
- `node --check scripts/test-supply-chain-pages.mjs` PASS
- `node scripts/build-supply-chain-graph.mjs --check` PASS (`nodes=187 edges=285`)
- `node scripts/test-supply-chain-pages.mjs` PASS (`routes=84`)
- `python3 scripts/validate_supply_chain_incidents.py` PASS (`27 supply-chain incidents`)
- `python3 scripts/validate_supply_chain_graph.py` PASS (`entities=102 relationships=140`)
- `git diff --check` PASS
- `cd site && npm run build` PASS (`309 page(s) built`); existing campaign validator warnings remained non-fatal
- `cd site && ENABLE_SUPPLY_CHAIN_PAGES=true npm run build` PASS (`393 page(s) built`); existing campaign validator warnings remained non-fatal

## Reviewer notes

This PR is intentionally stacked after G4. Review #1195 first, then this PR. Gemini may be quota-limited; if so, EP/DM can serve as the independent non-author review lineage per sprint governance.
