### PR TITLE
Supply Chain G6 page graph binding

### DIFF
--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -491,6 +491,17 @@ assert.ok(
   'graph client should implement G6 page-to-graph commands and reverse active-state binding'
 );
 assert.ok(
+  supplyChainGraphSource.includes('this.onPageLoad = () =>') &&
+    supplyChainGraphSource.includes('!document.body.contains(this.root)') &&
+    supplyChainGraphSource.includes('this.destroy();') &&
+    supplyChainGraphSource.includes("document.removeEventListener('astro:page-load', this.onPageLoad)") &&
+    supplyChainGraphSource.includes("document.removeEventListener('click', this.onDocumentClick)") &&
+    supplyChainGraphSource.includes('this.resizeObserver?.disconnect()') &&
+    supplyChainGraphSource.includes('this.bloomWorker?.terminate()') &&
+    supplyChainGraphSource.includes('cancelAnimationFrame(this.animationFrame)'),
+  'graph client should clean up global listeners, observers, workers, and animation frames when the persisted island is removed'
+);
+assert.ok(
   supplyChainGraphSource.includes('labelPriority') &&
     supplyChainGraphSource.includes('labelCandidates') &&
     supplyChainGraphSource.includes('labelFits') &&

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -15,6 +15,7 @@ import { buildSupplyChainGraphData } from './build-supply-chain-graph.mjs';
 const data = loadSupplyChainData();
 const baseLayoutSource = readFileSync(new URL('../site/src/layouts/Base.astro', import.meta.url), 'utf-8');
 const supplyChainRouteSource = readFileSync(new URL('../site/src/pages/supply-chain/[...slug].astro', import.meta.url), 'utf-8');
+const supplyChainEntityListSource = readFileSync(new URL('../site/src/components/SupplyChainEntityList.astro', import.meta.url), 'utf-8');
 const supplyChainGraphSource = readFileSync(new URL('../site/public/js/supply-chain-graph-core.js', import.meta.url), 'utf-8');
 const supplyChainGraphPayload = JSON.parse(
   readFileSync(new URL('../site/public/supply-chain-graph.json', import.meta.url), 'utf-8')
@@ -53,6 +54,24 @@ assert.ok(routeUrls.has('/supply-chain/maintainers/maintainer-jia-tan/'), 'maint
 assert.ok(
   supplyChainRouteSource.includes('transition:persist="supply-chain-graph-hero"'),
   'route should persist graph hero across Supply Chain navigation'
+);
+assert.ok(
+  supplyChainRouteSource.includes('data-graph-target-type="stage"') &&
+    supplyChainRouteSource.includes('data-graph-target-type="actor"') &&
+    supplyChainRouteSource.includes('data-graph-target-type="incident"') &&
+    supplyChainRouteSource.includes('data-graph-target-value={row.stage}') &&
+    supplyChainRouteSource.includes('data-graph-target-value={incident.id}') &&
+    supplyChainRouteSource.includes('class={`attack-bar ${severityClass(row.severity)}`') &&
+    supplyChainRouteSource.includes('aria-label={`Filter graph to ${row.label}`}'),
+  'index panels should expose G6 graph command targets for stage, actor, and incident controls'
+);
+assert.ok(
+  supplyChainEntityListSource.includes('function graphTypeFor') &&
+    supplyChainEntityListSource.includes('function graphCommandFor') &&
+    supplyChainEntityListSource.includes("return 'select-entity'") &&
+    supplyChainEntityListSource.includes('data-graph-target-type={item.graphType}') &&
+    supplyChainEntityListSource.includes('data-graph-target-value={item.graphValue}'),
+  'entity lists should expose graph command targets while preserving routed links'
 );
 assert.ok(
   supplyChainRouteSource.includes('data-supply-chain-graph-root') &&
@@ -447,7 +466,7 @@ assert.ok(
   'graph client should render causal and temporal SEEDED_BY edges distinctly'
 );
 assert.ok(
-    supplyChainGraphSource.includes('handleKeydown') &&
+  supplyChainGraphSource.includes('handleKeydown') &&
     supplyChainGraphSource.includes('keyboardNodes()') &&
     supplyChainGraphSource.includes("closest?.('a, button, input, select, textarea, summary, [contenteditable=\"true\"]')") &&
     supplyChainGraphSource.includes("event.key === 'Escape'") &&
@@ -455,6 +474,16 @@ assert.ok(
     supplyChainGraphSource.includes('this.description.textContent') &&
     supplyChainGraphSource.includes('Keyboard graph controls are not active.'),
   'graph client should provide keyboard traversal and truthful ARIA selected-node/failure text'
+);
+assert.ok(
+  supplyChainGraphSource.includes("command === 'select-entity'") &&
+    supplyChainGraphSource.includes('syncPageSelection') &&
+    supplyChainGraphSource.includes("document.querySelectorAll('[data-graph-target-type][data-graph-target-value]')") &&
+    supplyChainGraphSource.includes("target.classList.toggle('graph-linked-active', isActive)") &&
+    supplyChainGraphSource.includes("target.setAttribute('aria-current', 'true')") &&
+    supplyChainGraphSource.includes('this.pageSelection = { type, value }') &&
+    supplyChainRouteSource.includes('.graph-linked-active'),
+  'graph client should implement G6 page-to-graph commands and reverse active-state binding'
 );
 assert.ok(
   supplyChainGraphSource.includes('labelPriority') &&

--- a/site/public/js/supply-chain-graph-core.js
+++ b/site/public/js/supply-chain-graph-core.js
@@ -669,11 +669,18 @@ class SupplyChainGraph {
       if (!commandTarget) return;
       const command = commandTarget.dataset.graphCommand;
       const value = commandTarget.dataset.graphValue;
+      const type = commandTarget.dataset.graphType;
       if (command === 'select-incident') this.selectByEntityId('incident', value);
       if (command === 'select-actor') this.selectByEntityId('actor', value);
+      if (command === 'select-entity' && type) {
+        if (!this.selectByEntityId(type, value)) this.selectEntityContext(type, value);
+      }
       if (command === 'filter-stage') this.filterStage(value);
     });
-    document.addEventListener('astro:page-load', () => this.selectFromRoute());
+    document.addEventListener('astro:page-load', () => {
+      this.selectFromRoute();
+      this.syncPageSelection();
+    });
     this.root.addEventListener('keydown', (event) => this.handleKeydown(event));
   }
 
@@ -795,15 +802,18 @@ class SupplyChainGraph {
       return;
     }
     this.selection = { type, value, nodes: new Set(incidentNodes.map((node) => node.id)) };
+    this.pageSelection = { type, value };
     this.setCameraTarget(fitBounds(incidentNodes, this.viewport, 180));
     this.updateCaption(
       entity?.label || value,
       `${incidentNodes.length} connected incident${incidentNodes.length === 1 ? '' : 's'} framed for this entity.`
     );
+    this.syncPageSelection();
   }
 
   showOverview() {
     this.selection = null;
+    this.pageSelection = { type: 'overview', value: 'recent' };
     this.keyboardNodeId = null;
     this.lastBloomIncidentId = null;
     this.setCameraTarget(fitBounds(this.recentNodes(), this.viewport));
@@ -811,17 +821,20 @@ class SupplyChainGraph {
       'Supply Chain Graph',
       `${this.payload.nodes.length} corpus nodes and ${this.payload.edges.length} typed edges loaded.`
     );
+    this.syncPageSelection();
   }
 
   filterStage(stage) {
     const nodes = this.layout.nodes.filter((node) => node.tier === 'incident' && node.attack_stage === stage);
     if (nodes.length === 0) return;
     this.selection = { type: 'stage', value: stage, nodes: new Set(nodes.map((node) => node.id)) };
+    this.pageSelection = { type: 'stage', value: stage };
     this.focusReflow = false;
     this.lastBloomIncidentId = null;
     this.updateReflowControl();
     this.setCameraTarget(fitBounds(nodes, this.viewport));
     this.updateCaption(`Attack stage: ${stage.replace(/_/g, ' ')}`, `${nodes.length} incident${nodes.length === 1 ? '' : 's'} selected.`);
+    this.syncPageSelection();
   }
 
   selectNode(node) {
@@ -838,6 +851,7 @@ class SupplyChainGraph {
         ? cluster.filter((item) => item.tier === 'technique' || item.tier === 'incident').map((item) => item.id)
         : cluster.some((item) => item.id === node.id) ? cluster.map((item) => item.id) : [node.id];
     this.selection = { type: node.type, value: node.id, nodes: new Set(selectionNodes) };
+    this.pageSelection = { type: node.type, value: node.entity_id || node.id };
     if (node.tier === 'technique') {
       this.frameSelectedTechniqueWideShot(cluster);
     } else if (node.tier === 'incident') {
@@ -849,6 +863,7 @@ class SupplyChainGraph {
     }
     this.updateCaption(node.label, node.summary || `${node.type.replace(/_/g, ' ')} node selected.`);
     this.updateReflowControl();
+    this.syncPageSelection();
   }
 
   keyboardNodes() {
@@ -1034,6 +1049,20 @@ class SupplyChainGraph {
     if (this.captionBody) this.captionBody.textContent = body;
     if (this.status) this.status.textContent = title;
     if (this.description) this.description.textContent = `${title}. ${body}`;
+  }
+
+  syncPageSelection() {
+    const active = this.pageSelection || { type: 'overview', value: 'recent' };
+    this.root.dataset.graphSelectionType = active.type;
+    this.root.dataset.graphSelectionValue = active.value;
+    document.querySelectorAll('[data-graph-target-type][data-graph-target-value]').forEach((target) => {
+      const targetType = target.dataset.graphTargetType;
+      const targetValue = target.dataset.graphTargetValue;
+      const isActive = targetType === active.type && targetValue === active.value;
+      target.classList.toggle('graph-linked-active', isActive);
+      if (isActive) target.setAttribute('aria-current', 'true');
+      else target.removeAttribute('aria-current');
+    });
   }
 
   colorForNode(node) {

--- a/site/public/js/supply-chain-graph-core.js
+++ b/site/public/js/supply-chain-graph-core.js
@@ -554,7 +554,7 @@ class SupplyChainGraph {
     this.bind();
     this.resize();
     this.selectFromRoute();
-    requestAnimationFrame(() => this.frame());
+    this.animationFrame = requestAnimationFrame(() => this.frame());
   }
 
   initWebGL() {
@@ -620,8 +620,8 @@ class SupplyChainGraph {
   }
 
   bind() {
-    const resizeObserver = new ResizeObserver(() => this.resize());
-    resizeObserver.observe(this.root);
+    this.resizeObserver = new ResizeObserver(() => this.resize());
+    this.resizeObserver.observe(this.root);
     this.canvas.addEventListener('pointerdown', (event) => {
       this.canvas.setPointerCapture(event.pointerId);
       this.drag = {
@@ -664,7 +664,7 @@ class SupplyChainGraph {
       this.reflowButton.setAttribute('aria-pressed', String(this.focusReflow));
       this.reflowButton.textContent = this.focusReflow ? 'Restore wide shot' : 'Focus reflow';
     });
-    document.addEventListener('click', (event) => {
+    this.onDocumentClick = (event) => {
       const commandTarget = event.target.closest('[data-graph-command][data-graph-value]');
       if (!commandTarget) return;
       const command = commandTarget.dataset.graphCommand;
@@ -676,12 +676,28 @@ class SupplyChainGraph {
         if (!this.selectByEntityId(type, value)) this.selectEntityContext(type, value);
       }
       if (command === 'filter-stage') this.filterStage(value);
-    });
-    document.addEventListener('astro:page-load', () => {
+    };
+    document.addEventListener('click', this.onDocumentClick);
+    this.onPageLoad = () => {
+      if (!document.body.contains(this.root)) {
+        this.destroy();
+        return;
+      }
       this.selectFromRoute();
       this.syncPageSelection();
-    });
+    };
+    document.addEventListener('astro:page-load', this.onPageLoad);
     this.root.addEventListener('keydown', (event) => this.handleKeydown(event));
+  }
+
+  destroy() {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    if (this.onDocumentClick) document.removeEventListener('click', this.onDocumentClick);
+    if (this.onPageLoad) document.removeEventListener('astro:page-load', this.onPageLoad);
+    this.resizeObserver?.disconnect();
+    this.bloomWorker?.terminate();
+    if (this.animationFrame) cancelAnimationFrame(this.animationFrame);
   }
 
   resize() {
@@ -1297,6 +1313,10 @@ class SupplyChainGraph {
   }
 
   frame() {
+    if (this.destroyed || !document.body.contains(this.root)) {
+      this.destroy();
+      return;
+    }
     this.camera = {
       cx: lerp(this.camera.cx, this.targetCamera.cx, this.reduceMotion ? 1 : 0.14),
       cy: lerp(this.camera.cy, this.targetCamera.cy, this.reduceMotion ? 1 : 0.14),
@@ -1311,7 +1331,7 @@ class SupplyChainGraph {
     this.drawNodes();
     this.drawLabels();
     this.currentVisibleGraph = null;
-    requestAnimationFrame(() => this.frame());
+    this.animationFrame = requestAnimationFrame(() => this.frame());
   }
 }
 

--- a/site/src/components/SupplyChainEntityList.astro
+++ b/site/src/components/SupplyChainEntityList.astro
@@ -1,6 +1,7 @@
 ---
 interface Item {
   href?: string | null;
+  id?: string;
   label: string;
   type?: string;
   entityType?: string;
@@ -17,16 +18,81 @@ const { title, items } = Astro.props;
 function titleCase(value?: string) {
   return String(value || '').toLowerCase().replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
 }
+
+function slugFromHref(href?: string | null) {
+  if (!href || !href.startsWith('/supply-chain/')) return null;
+  const parts = href.split('/').filter(Boolean);
+  return parts[parts.length - 1] || null;
+}
+
+function graphTypeFor(item: Item) {
+  const explicit = String(item.entityType || item.type || '').toLowerCase().replace(/\s+/g, '_');
+  if (explicit === 'threat_actor' || explicit === 'actor') return 'actor';
+  if (explicit === 'campaign') return 'campaign';
+  if (explicit === 'supply_chain_incident' || explicit === 'incident') return 'incident';
+  if (explicit === 'package' || explicit === 'repository' || explicit === 'organization' || explicit === 'maintainer') return explicit;
+  if (item.href?.startsWith('/supply-chain/incidents/')) return 'incident';
+  if (item.href?.startsWith('/supply-chain/packages/')) return 'package';
+  if (item.href?.startsWith('/supply-chain/repositories/')) return 'repository';
+  if (item.href?.startsWith('/supply-chain/organizations/')) return 'organization';
+  if (item.href?.startsWith('/supply-chain/maintainers/')) return 'maintainer';
+  if (item.href?.startsWith('/threat-actors/')) return 'actor';
+  if (item.href?.startsWith('/campaigns/')) return 'campaign';
+  return null;
+}
+
+function graphValueFor(item: Item) {
+  return item.id || slugFromHref(item.href);
+}
+
+function graphCommandFor(type: string | null) {
+  if (type === 'incident') return 'select-incident';
+  if (type === 'actor') return 'select-actor';
+  if (type) return 'select-entity';
+  return null;
+}
+
+const decoratedItems = items.map((item) => {
+  const graphType = graphTypeFor(item);
+  const graphValue = graphValueFor(item);
+  return {
+    ...item,
+    graphType,
+    graphValue,
+    graphCommand: graphValue ? graphCommandFor(graphType) : null,
+  };
+});
 ---
 
 <section class="sc-section">
   <h2>{title}</h2>
   {items.length > 0 ? (
     <ul class="entity-list">
-      {items.map((item) => (
+      {decoratedItems.map((item) => (
         <li>
           <span class="entity-main">
-            {item.href ? <a href={item.href}>{item.label}</a> : <span>{item.label}</span>}
+            {item.href ? (
+              <a
+                href={item.href}
+                data-graph-command={item.graphCommand}
+                data-graph-type={item.graphType}
+                data-graph-value={item.graphValue}
+                data-graph-target-type={item.graphType}
+                data-graph-target-value={item.graphValue}
+              >
+                {item.label}
+              </a>
+            ) : (
+              <span
+                data-graph-command={item.graphCommand}
+                data-graph-type={item.graphType}
+                data-graph-value={item.graphValue}
+                data-graph-target-type={item.graphType}
+                data-graph-target-value={item.graphValue}
+              >
+                {item.label}
+              </span>
+            )}
             {item.context && <small>{item.context}</small>}
           </span>
           {(item.entityType || item.type) && <em>{titleCase(item.entityType || item.type)}</em>}
@@ -80,6 +146,16 @@ function titleCase(value?: string) {
   .entity-list small {
     display: block;
     margin-top: 4px;
+  }
+
+  .entity-list [data-graph-target-type] {
+    border-radius: 4px;
+    transition: color 140ms ease, box-shadow 140ms ease;
+  }
+
+  .entity-list [data-graph-target-type].graph-linked-active {
+    color: var(--white);
+    box-shadow: 0 2px 0 var(--amber);
   }
 
   @media (max-width: 720px) {

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -171,13 +171,19 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
           </div>
           <div class="attack-bars">
             {page.attackVectorBars.map((row) => (
-              <div
+              <button
+                type="button"
                 class={`attack-bar ${severityClass(row.severity)}`}
                 style={percentStyle(row.percent)}
+                data-graph-command={row.command.type}
+                data-graph-value={row.command.value}
+                data-graph-target-type="stage"
+                data-graph-target-value={row.stage}
+                aria-label={`Filter graph to ${row.label}`}
               >
                 <span>{row.label}</span>
                 <strong>{row.count}</strong>
-              </div>
+              </button>
             ))}
           </div>
         </section>
@@ -194,6 +200,8 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
                 href={row.href || '#supply-chain-title'}
                 data-graph-command={row.command.type}
                 data-graph-value={row.command.value}
+                data-graph-target-type="actor"
+                data-graph-target-value={row.command.value}
               >
                 <span class="confidence-dot" data-confidence={row.confidence}></span>
                 <span>
@@ -219,6 +227,8 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
                 style={percentStyle(row.barPercent)}
                 data-graph-command={row.command.type}
                 data-graph-value={row.command.value}
+                data-graph-target-type="incident"
+                data-graph-target-value={row.command.value}
               >
                 <span class="dwell-title">{row.title}</span>
                 <span class="dwell-track">
@@ -240,7 +250,13 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
         </div>
         <div class="featured-grid">
           {page.featuredIncidents.map((incident) => (
-            <article class="incident-card" data-graph-command="select-incident" data-graph-value={incident.id}>
+            <article
+              class="incident-card"
+              data-graph-command="select-incident"
+              data-graph-value={incident.id}
+              data-graph-target-type="incident"
+              data-graph-target-value={incident.id}
+            >
               <a href={incident.href}>{incident.title}</a>
               <p>{incident.summary}</p>
               <div class="card-meta">
@@ -285,7 +301,14 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
         </div>
         <div class="incident-list-grid">
           {page.incidents.map((incident) => (
-            <a class="incident-list-row" href={incident.href}>
+            <a
+              class="incident-list-row"
+              href={incident.href}
+              data-graph-command="select-incident"
+              data-graph-value={incident.id}
+              data-graph-target-type="incident"
+              data-graph-target-value={incident.id}
+            >
               <span>
                 <strong>{incident.title}</strong>
                 <em>{incident.summary}</em>
@@ -849,6 +872,9 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
   }
 
   .attack-bar {
+    appearance: none;
+    width: 100%;
+    cursor: pointer;
     display: grid;
     grid-template-columns: 1fr auto;
     align-items: center;
@@ -856,6 +882,11 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
     gap: 16px;
     padding: 10px 12px;
     text-align: left;
+  }
+
+  .attack-bar,
+  .attack-bar:focus {
+    font: inherit;
   }
 
   .attack-bar::before {
@@ -892,6 +923,25 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
     gap: 12px;
     padding: 10px;
     text-decoration: none;
+  }
+
+  .attack-bar:hover,
+  .attack-bar:focus-visible,
+  .attribution-row:hover,
+  .attribution-row:focus-visible,
+  .dwell-row:hover,
+  .dwell-row:focus-visible,
+  .incident-card.graph-linked-active,
+  .incident-list-row:hover,
+  .incident-list-row:focus-visible,
+  .incident-list-row.graph-linked-active,
+  .graph-linked-active {
+    border-color: rgba(232, 160, 32, 0.72);
+    box-shadow: 0 0 0 1px rgba(232, 160, 32, 0.16), 0 10px 28px rgba(0, 0, 0, 0.22);
+  }
+
+  .graph-linked-active {
+    color: var(--white);
   }
 
   .attribution-row strong,


### PR DESCRIPTION
## Summary
- add graph command/target metadata to Supply Chain attack-vector bars, attribution rows, dwell rows, incident cards, incident lists, and entity links
- teach the persisted graph island to handle generic entity selection commands
- mirror graph selection back into page controls with active state and aria-current

## Validation
- node --check site/public/js/supply-chain-graph-core.js
- node --check scripts/test-supply-chain-pages.mjs
- node scripts/build-supply-chain-graph.mjs --check
- node scripts/test-supply-chain-pages.mjs
- python3 scripts/validate_supply_chain_incidents.py
- python3 scripts/validate_supply_chain_graph.py
- git diff --check
- cd site && npm run build
- cd site && ENABLE_SUPPLY_CHAIN_PAGES=true npm run build

## Scope
G6 only: page-to-graph controls and graph-to-page active-state binding. No scoring, no feed changes, no corpus expansion.