### PR TITLE
chore(pipeline): raise VulnCheck prefills and request reviewers

### DIFF
--- a/.github/pipeline/config.yml
+++ b/.github/pipeline/config.yml
@@ -84,7 +84,7 @@ discovery_sources:
     enabled: true               # Live source-packet/candidate prefill only; set false for rollback
     backup_url: "https://api.vulncheck.com/v3/backup/vulncheck-kev"
     lookback_days: 30
-    max_candidates: 20          # 20 per 3-hour run = 160/day candidate prefill ceiling
+    max_candidates: 30          # 30 per 3-hour run = 240/day candidate prefill ceiling
     backlog_fill: true          # After recent items, continue older unhandled newest-to-oldest
     sibling_limit_per_vendor_product_day: 4
     local_throttle_ms: 250      # 240/minute; intentionally below the 1,000/minute community limit

--- a/.github/workflows/pipeline-discovery.yml
+++ b/.github/workflows/pipeline-discovery.yml
@@ -175,6 +175,7 @@ jobs:
           fi
           node scripts/vulncheck-kev-intake.mjs \
             --execute \
+            --max-candidates 30 \
             --cache "$RUNNER_TEMP/vulncheck-kev-backup.json" \
             --out "$RUNNER_TEMP/vulncheck-kev-intake-result.json"
 
@@ -203,7 +204,22 @@ jobs:
 
             const BRANCH = process.env.DISCOVERY_BRANCH;
             const LABEL = process.env.DISCOVERY_LABEL;
+            const REVIEWERS = ['MahdiHedhli', 'dangermouse-bot', 'ernestpenfold-bot'];
             const { owner, repo } = context.repo;
+
+            async function requestDiscoveryReviewers(pullNumber) {
+              try {
+                await github.rest.pulls.requestReviewers({
+                  owner,
+                  repo,
+                  pull_number: pullNumber,
+                  reviewers: REVIEWERS,
+                });
+                console.log(`Requested reviewers on PR #${pullNumber}: ${REVIEWERS.join(', ')}`);
+              } catch (e) {
+                console.log(`Could not request all discovery reviewers on PR #${pullNumber}: ${e.message}`);
+              }
+            }
 
             // ── Enumerate task and source-packet prefill files currently on
             //    the branch but not on main. These are pending human review in
@@ -317,6 +333,7 @@ jobs:
             body += `**Merge** to accept the whole batch. **Close** (without merging) to discard this staged batch.\n`;
             body += `For a durable veto across future discovery runs, use the rejection-memory workflow and merge its PR.\n`;
             body += `Nothing auto-merges from this PR.\n\n`;
+            body += `Review requested: @MahdiHedhli @dangermouse-bot @ernestpenfold-bot.\n\n`;
             body += `---\n\n`;
             if (tasks.length > 0) {
               body += `**${tasks.length} task${tasks.length === 1 ? '' : 's'}** currently pending review.\n\n`;
@@ -365,6 +382,7 @@ jobs:
                 title,
                 body,
               });
+              await requestDiscoveryReviewers(pr.number);
             } else {
               console.log('Creating new discovery PR');
               const { data: pr } = await github.rest.pulls.create({
@@ -383,6 +401,7 @@ jobs:
               } catch (e) {
                 console.log(`Could not add label ${LABEL} to PR #${pr.number}: ${e.message}`);
               }
+              await requestDiscoveryReviewers(pr.number);
               console.log(`Opened PR #${pr.number}: ${pr.html_url}`);
             }
 

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -87,7 +87,7 @@ discovery queues are open, validated, and stable.
         prefill only. `node scripts/vulncheck-kev-intake.mjs --execute`
         requests the VulnCheck KEV backup descriptor, follows the published
         backup payload URL, selects records by top-level `date_added`
-        newest-first, emits up to 10 source-packet prefill artifacts per run,
+        newest-first, emits up to 30 source-packet prefill artifacts per run,
         and stages them in the discovery PR. It fills from the recent window
         first, then older unhandled records newest-to-oldest. It does not
         create draft tasks or article drafts. CISA remains authoritative for

--- a/scripts/pipeline-config.mjs
+++ b/scripts/pipeline-config.mjs
@@ -85,7 +85,7 @@ export const DEFAULTS = Object.freeze({
       enabled: true,
       backup_url: 'https://api.vulncheck.com/v3/backup/vulncheck-kev',
       lookback_days: 30,
-      max_candidates: 20,
+      max_candidates: 30,
       backlog_fill: true,
       sibling_limit_per_vendor_product_day: 4,
       local_throttle_ms: 250,


### PR DESCRIPTION
## Summary
- raises VulnCheck KEV source-packet prefill output to 30 candidates per run
- makes the discovery workflow pass `--max-candidates 30` explicitly
- requests/tags Kernel K, DangerMouseBot, and ErnestPenfoldBot on automated discovery PRs
- updates pipeline docs to match the 30-prefill behavior

## Validation
- `node --check scripts/pipeline-config.mjs`
- `node --check scripts/vulncheck-kev-intake.mjs`
- `npm --prefix scripts ci --no-audit --no-fund`
- `npm --prefix scripts test`
- `node --input-type=module -e "import fs from 'node:fs'; import yaml from 'js-yaml'; yaml.load(fs.readFileSync('../.github/workflows/pipeline-discovery.yml','utf8')); console.log('pipeline-discovery.yml parses');"` from `scripts/`\n- `git diff --check`\n\nReview requested: @MahdiHedhli @dangermouse-bot @ernestpenfold-bot.