### PR TITLE
Supply Chain G7 incident propagation page

### DIFF
--- a/docs/supply-chain-pages.md
+++ b/docs/supply-chain-pages.md
@@ -67,6 +67,12 @@ edges render as solid lines; temporal precedence edges render as dim segmented
 lines. Large blooms are capped by a node budget and represented with an
 aggregation node instead of rendering every child at once.
 
+G7 adds an incident-page propagation timeline for incidents that have
+evidence-gated `SEEDED_BY` relationships. The section is corpus-driven and
+renders only modeled edges for that incident. Causal edges are labeled as
+causal; temporal edges are labeled as temporal precedence and styled separately
+so the page does not imply causation where the corpus only records ordering.
+
 ## Local Build
 
 Disabled/default build:
@@ -145,6 +151,10 @@ versioned PURL plus publish date when modeled. When
 maintainer date anchors and release publish dates are both present, incident
 pages derive a tenure-at-malicious-release row. The corpus stores the dated
 anchors only; it does not store a stale tenure field or score. When
+`SEEDED_BY` relationships are present for the incident, incident pages render a
+Propagation Timeline with source entity, target entity, edge tier, summary, and
+evidence references. Incidents without modeled propagation edges do not render
+that section. When
 Phase 2B actor or campaign links are present, incident pages also show threat
 actor links, campaign links, attribution confidence, and the local evidence
 basis for those edges. These links are corpus-driven convergence edges; they do

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -14,6 +14,7 @@ import { buildSupplyChainGraphData } from './build-supply-chain-graph.mjs';
 
 const data = loadSupplyChainData();
 const baseLayoutSource = readFileSync(new URL('../site/src/layouts/Base.astro', import.meta.url), 'utf-8');
+const supplyChainPagesSource = readFileSync(new URL('../site/src/lib/supplyChainPages.mjs', import.meta.url), 'utf-8');
 const supplyChainRouteSource = readFileSync(new URL('../site/src/pages/supply-chain/[...slug].astro', import.meta.url), 'utf-8');
 const supplyChainEntityListSource = readFileSync(new URL('../site/src/components/SupplyChainEntityList.astro', import.meta.url), 'utf-8');
 const supplyChainGraphSource = readFileSync(new URL('../site/public/js/supply-chain-graph-core.js', import.meta.url), 'utf-8');
@@ -72,6 +73,15 @@ assert.ok(
     supplyChainEntityListSource.includes('data-graph-target-type={item.graphType}') &&
     supplyChainEntityListSource.includes('data-graph-target-value={item.graphValue}'),
   'entity lists should expose graph command targets while preserving routed links'
+);
+assert.ok(
+  supplyChainPagesSource.includes('function incidentPropagationTimeline') &&
+    supplyChainPagesSource.includes("relationship.type === 'SEEDED_BY'") &&
+    supplyChainPagesSource.includes('relationship.source_incident_id === incidentId') &&
+    supplyChainRouteSource.includes('page.propagationTimeline.length > 0') &&
+    supplyChainRouteSource.includes('class={`propagation-hop propagation-${edge.tier}`}') &&
+    supplyChainRouteSource.includes('Evidence-Gated Propagation'),
+  'incident pages should render G7 propagation timelines from local SEEDED_BY edges only'
 );
 assert.ok(
   supplyChainRouteSource.includes('data-supply-chain-graph-root') &&
@@ -548,6 +558,7 @@ assert.ok(codecov.sections.buildSystems.length > 0, 'incident page should includ
 assert.ok(codecov.sections.distributionChannels.length > 0, 'incident page should include distribution channels');
 assert.ok(codecov.incident.references.length > 0, 'incident page should include references');
 assert.equal(codecov.editorialSections.length, 0, 'non-featured incident page should not render editorial sections');
+assert.equal(codecov.propagationTimeline.length, 0, 'incidents without SEEDED_BY edges should not expose propagation timelines');
 assert.ok(codecov.connectedEntities.length > 0, 'incident page should include relationship-aware connected entities');
 assert.equal(
   new Set(codecov.connectedEntities.map((entity) => entity.href || entity.id)).size,
@@ -654,6 +665,19 @@ assert.ok(
 assert.ok(
   threeCx.sections.campaigns.some((campaign) => campaign.href === '/campaigns/lazarus-3cx-supply-chain-compromise-2023/'),
   '3CX page should link to the existing campaign page'
+);
+assert.equal(threeCx.propagationTimeline.length, 1, '3CX page should expose the X_TRADER causal propagation edge');
+assert.equal(threeCx.propagationTimeline[0].tier, 'causal', '3CX propagation edge should preserve causal tier');
+assert.ok(
+  threeCx.propagationTimeline[0].references.length > 0,
+  '3CX propagation edge should resolve evidence references'
+);
+
+const shaiHulud = getSupplyChainIncidentPage('SC-2025-NPM-SHAI-HULUD', data);
+assert.equal(shaiHulud.propagationTimeline.length, 2, 'Shai-Hulud page should expose temporal wave propagation edges');
+assert.ok(
+  shaiHulud.propagationTimeline.every((edge) => edge.tier === 'temporal' && edge.references.length > 0),
+  'Shai-Hulud temporal propagation edges should preserve tier and evidence references'
 );
 
 const eventStreamPackage = getSupplyChainEntityPage('packages', 'pkg-npm-event-stream', data);

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -512,6 +512,62 @@ function attributionEvidenceFor(incident) {
   }));
 }
 
+function propagationNode(data, nodeId) {
+  const incident = data.incidentByNodeId.get(nodeId);
+  if (incident) {
+    return {
+      id: incident.id,
+      label: incident.title,
+      entityType: 'Supply Chain Incident',
+      href: `/supply-chain/incidents/${incident.id}/`,
+      publishedAt: incident.first_observed_at || incident.first_public_warning_at || incident.disclosed_at || null,
+      purl: null,
+    };
+  }
+  const entity = data.entityById.get(nodeId);
+  if (!entity) {
+    return {
+      id: nodeId,
+      label: nodeId,
+      entityType: 'Unknown',
+      href: null,
+      publishedAt: null,
+      purl: null,
+    };
+  }
+  return {
+    id: entity.id,
+    label: entity.name || entity.id,
+    entityType: entityTypeLabel(entity),
+    href: linkForEntity(entity),
+    publishedAt: entity.published_at || null,
+    purl: entity.purl || null,
+  };
+}
+
+function incidentPropagationTimeline(data, incidentId) {
+  const incident = data.incidents.find((item) => item.id === incidentId);
+  if (!incident) return [];
+  const referenceById = referenceMapFor(incident);
+  return data.relationships
+    .filter((relationship) => relationship.type === 'SEEDED_BY' && relationship.source_incident_id === incidentId)
+    .map((relationship, index) => {
+      const source = propagationNode(data, relationship.source);
+      const target = propagationNode(data, relationship.target);
+      const sortDate = source.publishedAt || target.publishedAt || incidentSortDate(incident);
+      return {
+        id: `propagation-${incidentId}-${index + 1}`,
+        source,
+        target,
+        tier: relationship.propagation_tier,
+        summary: relationship.summary,
+        sortDate,
+        references: (relationship.evidence_refs || []).map((referenceId) => referenceById.get(referenceId)).filter(Boolean),
+      };
+    })
+    .sort((a, b) => (a.sortDate || '').localeCompare(b.sortDate || '') || a.source.label.localeCompare(b.source.label));
+}
+
 function editorialSectionsFor(incident) {
   const referenceById = referenceMapFor(incident);
   return editorialSectionDefinitions
@@ -812,6 +868,7 @@ export function getSupplyChainIncidentPage(id, data = loadSupplyChainData()) {
     incident,
     graphHero: buildGraphHeroModel(data),
     editorialSections: editorialSectionsFor(incident),
+    propagationTimeline: incidentPropagationTimeline(data, id),
     connectedEntities: incidentConnectedEntities(data, id),
     seo: {
       title: `Supply Chain: ${incident.title}`,

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -394,6 +394,43 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
         </div>
       )}
 
+      {page.propagationTimeline.length > 0 && (
+        <section class="sc-section propagation-section" aria-labelledby="propagation-title">
+          <div class="section-heading">
+            <p class="eyebrow">Evidence-Gated Propagation</p>
+            <h2 id="propagation-title">Propagation Timeline</h2>
+          </div>
+          <ol class="propagation-timeline">
+            {page.propagationTimeline.map((edge) => (
+              <li class={`propagation-hop propagation-${edge.tier}`}>
+                <div class="propagation-node">
+                  <span>{edge.source.entityType}</span>
+                  {edge.source.href ? <a href={edge.source.href}>{edge.source.label}</a> : <strong>{edge.source.label}</strong>}
+                  {edge.source.purl && <code>{edge.source.purl}</code>}
+                  {edge.source.publishedAt && <time>Published {edge.source.publishedAt}</time>}
+                </div>
+                <div class="propagation-link">
+                  <span>{titleCase(edge.tier)}</span>
+                  <i aria-hidden="true"></i>
+                </div>
+                <div class="propagation-node">
+                  <span>{edge.target.entityType}</span>
+                  {edge.target.href ? <a href={edge.target.href}>{edge.target.label}</a> : <strong>{edge.target.label}</strong>}
+                  {edge.target.purl && <code>{edge.target.purl}</code>}
+                  {edge.target.publishedAt && <time>Published {edge.target.publishedAt}</time>}
+                </div>
+                <p>{edge.summary}</p>
+                <ul class="citation-list">
+                  {edge.references.map((reference) => (
+                    <li><a href={reference.url} target="_blank" rel="noopener noreferrer">{referenceLabel(reference)}</a></li>
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ol>
+        </section>
+      )}
+
       <EntityList title="Affected Packages" items={page.sections.packages} />
       <EntityList title="Affected Releases" items={page.sections.releases} />
       <EntityList title="Repositories" items={page.sections.repositories} />
@@ -1290,6 +1327,96 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
     padding: 4px 7px;
   }
 
+  .propagation-timeline {
+    display: grid;
+    gap: 14px;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .propagation-hop {
+    display: grid;
+    grid-template-columns: minmax(190px, 1fr) minmax(96px, 0.38fr) minmax(190px, 1fr);
+    gap: 14px;
+    align-items: stretch;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--surface);
+    padding: 16px;
+  }
+
+  .propagation-hop > p,
+  .propagation-hop > .citation-list {
+    grid-column: 1 / -1;
+  }
+
+  .propagation-hop > p {
+    color: var(--text);
+    line-height: 1.6;
+    margin: 0;
+  }
+
+  .propagation-node {
+    display: grid;
+    gap: 7px;
+    align-content: start;
+    border: 1px solid rgba(30, 39, 51, 0.86);
+    border-radius: 4px;
+    background: rgba(8, 11, 16, 0.42);
+    padding: 12px;
+    min-width: 0;
+  }
+
+  .propagation-node span,
+  .propagation-link span,
+  .propagation-node time {
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.64rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .propagation-node a,
+  .propagation-node strong {
+    color: var(--white);
+    font-family: var(--font-serif);
+    font-size: 1rem;
+    line-height: 1.25;
+    min-width: 0;
+  }
+
+  .propagation-node code {
+    overflow-wrap: anywhere;
+    color: var(--amber);
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+  }
+
+  .propagation-link {
+    display: grid;
+    align-content: center;
+    gap: 9px;
+    text-align: center;
+  }
+
+  .propagation-link i {
+    display: block;
+    width: 100%;
+    border-top: 2px solid var(--amber);
+  }
+
+  .propagation-temporal .propagation-link i {
+    border-top-style: dashed;
+    border-top-color: var(--muted);
+    opacity: 0.82;
+  }
+
+  .propagation-causal .propagation-link span {
+    color: var(--severity-high);
+  }
+
   .metric-grid,
   .detail-grid {
     display: grid;
@@ -1419,9 +1546,14 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
     }
 
     .timeline-list li,
+    .propagation-hop,
     .entity-list li,
     .reference-list li {
       display: block;
+    }
+
+    .propagation-link {
+      margin: 12px 0;
     }
 
     .entity-list em,


### PR DESCRIPTION
## Summary
- Supersedes #1198 with a clean branch based on current main after G6 squash-merge cleanup.
- Adds the incident propagation surface fed by SEEDED_BY relationships.
- Adds page-data helpers and tests for propagation rows, evidence tiers, and relationship rendering.

## Scope
- G7 only: docs, page data helper, supply-chain route rendering, and page tests.
- No scoring, no live feeds, no graph database, no automated attribution.

## Validation
- node --check scripts/test-supply-chain-pages.mjs
- node --check scripts/build-supply-chain-graph.mjs
- node scripts/build-supply-chain-graph.mjs --check
- node scripts/test-supply-chain-pages.mjs
- python3 scripts/validate_supply_chain_incidents.py
- python3 scripts/validate_supply_chain_graph.py
- git diff --check
- npm --prefix site ci --no-audit --no-fund
- npm --prefix site run build
- ENABLE_SUPPLY_CHAIN_PAGES=true npm --prefix site run build

Known unrelated warning: campaign validator emits pre-existing related-incident count warnings but passes.