### PR TITLE
docs: reconcile roadmap with current Supply Chain reality

### DIFF
--- a/docs/supply-chain-pages.md
+++ b/docs/supply-chain-pages.md
@@ -3,6 +3,23 @@
 Threatpedia Supply Chain pages render the curated supply-chain incident corpus
 and graph primitives as static pages. The public label is **Supply Chain**.
 
+## Current Status
+
+The Supply Chain section is live in production behind the explicit
+`ENABLE_SUPPLY_CHAIN_PAGES=true` deployment flag. As of 2026-06-18, current
+`main` contains:
+
+- 27 curated supply-chain incidents
+- 85 generated Supply Chain routes when enabled
+- 187 compiled graph nodes, 285 graph edges, and 129 graph-search records
+- 140 validated graph relationships in the source relationship store
+- a persistent graph hero, technique focus, dive-and-bloom, panel binding,
+  accessibility/label handling, incident propagation timeline, and graph
+  search/explore mode
+
+The section remains corpus-driven. It still does not implement scoring, live
+ingestion, automated attribution, graph databases, or AI-generated conclusions.
+
 ## Feature Flag
 
 Pages are disabled by default.
@@ -21,6 +38,7 @@ When enabled, the static site generates:
 
 ```text
 /supply-chain/
+/supply-chain/explore/
 /supply-chain/incidents/[id]/
 /supply-chain/packages/[id]/
 /supply-chain/repositories/[id]/
@@ -72,6 +90,12 @@ evidence-gated `SEEDED_BY` relationships. The section is corpus-driven and
 renders only modeled edges for that incident. Causal edges are labeled as
 causal; temporal edges are labeled as temporal precedence and styled separately
 so the page does not imply causation where the corpus only records ordering.
+
+The post-G7 graph surface also includes a graph search/explore control backed
+by the compiled payload's `search` records. Search is a navigation aid over the
+already-modeled corpus; it does not query live feeds or infer new entities.
+The `/supply-chain/explore/` route provides a public graph-first exploration
+entry point over the same compiled payload.
 
 ## Local Build
 

--- a/docs/supply-chain-stack-status.md
+++ b/docs/supply-chain-stack-status.md
@@ -1,131 +1,130 @@
 # Supply Chain Stack Status
 
-Status recorded from the rebuilt Phase 1G readiness branch on 2026-06-13.
+Status recorded from current `main` on 2026-06-18.
 
-Result: PASS for the current post-squash stack. Supply Chain remains disabled
-by default unless `ENABLE_SUPPLY_CHAIN_PAGES=true` is set by an operator.
+Result: the Supply Chain corpus, graph primitives, public pages, and 1.0 graph
+surface are merged. Production deployment is enabled through the explicit
+`ENABLE_SUPPLY_CHAIN_PAGES=true` GitHub Pages build flag.
 
-## PR Chain Order
+## Current Production State
 
-| Order | Phase | PR | Branch | Head reviewed | Base | Status |
-|---:|---|---|---|---|---|---|
-| 1 | Phase 1A incident corpus | [#1130](https://github.com/MahdiHedhli/threatpedia/pull/1130) | `codex/supply-chain-phase1a` | merged before this rebuild | `main` | merged to `main` |
-| 2 | Phase 1B graph primitives | [#1131](https://github.com/MahdiHedhli/threatpedia/pull/1131) | `codex/supply-chain-phase1b` | `dca5adc2f127fa788460292b6de7938f0db82405` | `main` | merged to `main` |
-| 3 | Phase 1C corpus depth pass | [#1133](https://github.com/MahdiHedhli/threatpedia/pull/1133) | `codex/supply-chain-phase1c` | `52ba1f9fa28591bb5ae44abeba8b133375265b1e` | `main` | merged to `main` |
-| 4 | Phase 1D feature-flagged pages | [#1134](https://github.com/MahdiHedhli/threatpedia/pull/1134) | `codex/supply-chain-phase1d` | `a7dbf64842d54cad68ed2e20c01102060d4a4e16` | `main` | merged to `main` |
-| 5 | Phase 1E public polish | [#1135](https://github.com/MahdiHedhli/threatpedia/pull/1135) | `codex/supply-chain-phase1e` | folded into #1134 after stacked squash merge | `codex/supply-chain-phase1d` | no separate `main` merge needed |
-| 6 | Phase 1F featured editorial pages | [#1139](https://github.com/MahdiHedhli/threatpedia/pull/1139) | `codex/supply-chain-phase1f` | `c6f7f03de6737f4c5666357b4881c6c6e9654ecb` | `main` | merged to `main`; replaces closed #1136 |
-| 7 | Phase 1G public readiness gate | [#1138](https://github.com/MahdiHedhli/threatpedia/pull/1138) | `codex/supply-chain-phase1g` | rebuilt on current `main` | `main` | ready after current-head recheck |
+- `/supply-chain/` is generated in production builds when the deployment flag is
+  enabled.
+- The section is still static and corpus-driven: checked-in JSON is compiled at
+  build time; the browser consumes `site/public/supply-chain-graph.json`.
+- Current graph payload check: 187 nodes, 285 edges, 129 search records.
+- Current page test route count: 85 enabled Supply Chain routes.
+- Current corpus count: 27 incidents.
+- Current relationship-store count: 140 relationships.
 
-## Merge Notes
+## Merged Phase Chain
 
-The original stack was squash-merged in phases. Because squash merges changed
-the ancestry of the lower branches, later stacked PRs were rebuilt onto current
-`main` before merge rather than merged from stale stacked bases.
+| Phase | Purpose | Current state |
+|---|---|---|
+| Phase 0 | Release-event ingestion spine | Merged |
+| Phase 1A | Curated incident corpus | Merged |
+| Phase 1B | Entity and relationship primitives | Merged |
+| Phase 1C | Corpus depth pass | Merged |
+| Phase 1D | Feature-flagged static pages | Merged |
+| Phase 1E | Public polish | Merged |
+| Phase 1F | Featured editorial incident pages | Merged as replacement PR #1139 after #1136 could not be preserved |
+| Phase 1G | Public readiness gate | Merged |
+| Phase 1H | Preview deploy enablement | Merged |
+| Phase 1I | Production public enablement | Merged |
+| Phase 1J | Post-launch smoke and rollback gate | Merged |
+| Phase 2A | PURL foundation | Merged |
+| Phase 2B | Actor/campaign convergence | Merged |
+| Phase 2C | Release entity layer | Merged |
+| Phase 2D | Maintainer intelligence expansion | Merged |
+| Phase 2E | Connectivity-driven corpus expansion | Merged |
+| Phase 2F | PURL and edge audit | Merged |
+| Phase 2G | Backtest foundation | Merged |
+| Phase 2H | Release-spine integrity | Merged |
+| S0 | Evidence-gated `SEEDED_BY` propagation edges | Merged |
+| G1 | Persistent graph shell and landing-page theme | Merged |
+| G2 | Graph core and compiled graph payload | Merged |
+| G3 | Technique focus and reflow | Merged |
+| G4 | Dive-and-bloom with package/org/release tiers | Merged |
+| G5 | Labels and accessibility | Merged |
+| G6 | Page-to-graph binding | Merged |
+| G7 | Incident propagation page | Merged |
+| Post-G7 | Visual hierarchy restoration and graph search/explore mode | Merged |
 
-- #1135 was already merged into the stacked Phase 1D branch before #1134 was
-  rebuilt; its public polish changes are included in the #1134 merge.
-- #1136 could not be reopened because its deleted stacked base blocked GitHub
-  retargeting. It was rebuilt as #1139 and merged to `main`.
-- #1138 is the remaining readiness gate branch. It should be reread against
-  live GitHub state before merge and merged only with a current head SHA guard.
+## Current Validation Snapshot
 
-## Validation Commands And Results
-
-Run from the rebuilt Phase 1G branch based on `main` after #1139 merged.
+Run from current `main` on 2026-06-18:
 
 ```bash
 python3 scripts/validate_supply_chain_incidents.py
 ```
 
-Result: PASS. Validated 25 supply-chain incidents.
+Result: PASS. Validated 27 supply-chain incidents.
 
 ```bash
 python3 scripts/validate_supply_chain_graph.py
 ```
 
-Result: PASS. Validated graph primitives: 73 entities and 93 relationships.
+Result: PASS.
+
+```bash
+node scripts/build-supply-chain-graph.mjs --check
+```
+
+Result: PASS. Checked 187 graph nodes, 285 graph edges, and 129 search records.
 
 ```bash
 node scripts/test-supply-chain-pages.mjs
 ```
 
-Result: PASS. Supply Chain page tests passed with 74 routes.
+Result: PASS. Supply Chain page tests passed with 85 routes.
 
-```bash
-node --check scripts/check_supply_chain_public_readiness.mjs
-```
+## Current Graph Density
 
-Result: PASS.
+Current generated entity counts:
 
-```bash
-node scripts/check_supply_chain_public_readiness.mjs
-```
+| Entity type | Count |
+|---|---:|
+| Incidents | 27 |
+| Packages | 21 |
+| Releases | 7 |
+| Repositories | 11 |
+| Organizations | 19 |
+| Maintainers | 5 |
+| Build systems | 6 |
+| Distribution channels | 14 |
+| Compromised accounts | 10 |
+| Actors | 6 |
+| Campaigns | 3 |
+| Relationships | 140 |
+| `SEEDED_BY` propagation edges | 3 |
 
-Result: PASS. The readiness report was written to
-`.worker-state/supply-chain-public-readiness.json`.
+## Reality Notes
 
-```bash
-git diff --check
-```
+- The original stacked PR chain was squash-merged in phases. Later branches had
+  to be rebuilt onto current `main`; this is why replacement PRs exist for parts
+  of the stack.
+- The old Phase 1F PR #1136 was closed because its deleted stacked base blocked
+  clean preservation. The work was rebuilt and merged through #1139.
+- The G5/G6/G7 tail of the 1.0 visualization stack was also rebuilt onto
+  current `main` after squash-merge ancestry made the original stacked branches
+  misleading.
+- Campaign validator warnings may still appear in full Astro builds for
+  unrelated campaign records with fewer than the target two related incidents.
+  Those warnings are not Supply Chain readiness failures unless the build exits
+  non-zero.
 
-Result: PASS.
+## Remaining Boundaries
 
-## Readiness Report Summary
+The merged Supply Chain surface still does not implement:
 
-Latest report timestamp: `2026-06-13T17:12:08.137Z`.
+- scoring or risk ranking
+- soak/canary windows
+- live package-feed ingestion into public pages
+- graph databases
+- automated actor attribution
+- generated conclusions or policy recommendations
 
-```json
-{
-  "status": "pass",
-  "counts": {
-    "incidents": 25,
-    "packages": 16,
-    "repositories": 10,
-    "organizations": 17,
-    "maintainers": 5,
-    "build_systems": 6,
-    "distribution_channels": 11,
-    "compromised_accounts": 8,
-    "relationships": 93,
-    "expected_routes": 74,
-    "enabled_generated_routes": 74
-  },
-  "checks": [
-    "incident validation: pass",
-    "graph validation: pass",
-    "page model test: pass",
-    "site dependency install: pass",
-    "disabled build smoke: pass",
-    "enabled build smoke: pass"
-  ],
-  "failures": []
-}
-```
-
-Checked featured incident routes:
-
-- `/supply-chain/incidents/SC-2024-XZ-UTILS/`
-- `/supply-chain/incidents/SC-2023-THREE-CX-DESKTOP/`
-- `/supply-chain/incidents/SC-2020-SOLARWINDS-ORION/`
-- `/supply-chain/incidents/SC-2018-NPM-EVENT-STREAM/`
-- `/supply-chain/incidents/SC-2021-UA-PARSER-JS/`
-
-## Known Unrelated Warnings
-
-The full Astro builds emit existing campaign validator warnings for campaign
-records that have fewer than the target two related incidents. The validator
-still exits successfully and reports that campaign validation passed. These
-warnings are unrelated to the Supply Chain stack and did not block the disabled
-build, enabled build, or readiness gate.
-
-## Merge Plan
-
-1. Reread live state for #1138 after pushing the rebuilt Phase 1G branch.
-2. Confirm the PR base is `main`, the head SHA matches the rebuilt branch, and
-   changed files are limited to the readiness gate and operator docs.
-3. If review requirements remain the only blocker, use the recorded owner
-   authorization to admin squash merge with a current head SHA guard.
-4. Do not enable `ENABLE_SUPPLY_CHAIN_PAGES=true` by default as part of this
-   stack. Public enablement remains an operator/deployment configuration step
-   after the readiness gate is merged and passing.
+The next work should either deepen the corpus/relationships or add carefully
+bounded user-facing drill-downs over already-modeled data. It should not add a
+score before the release spine, evidence timestamps, actor/campaign links, and
+propagation edges are demonstrably dense enough to support one.

--- a/site/src/pages/roadmap.astro
+++ b/site/src/pages/roadmap.astro
@@ -2,6 +2,7 @@
 import Base from '../layouts/Base.astro';
 import { getCollection } from 'astro:content';
 import glossaryData from '../data/glossary-index.json';
+import { loadSupplyChainData } from '../lib/supplyChainPages.mjs';
 
 // Sourced at build time from the Astro content collections so the roadmap
 // never drifts from the corpus. Glossary count comes from the static data
@@ -13,6 +14,7 @@ const [incidents, campaigns, actors, zeroDays] = await Promise.all([
   getCollection('threat-actors'),
   getCollection('zero-days'),
 ]);
+const supplyChain = loadSupplyChainData();
 
 const counts = {
   incidents: incidents.length,
@@ -20,6 +22,8 @@ const counts = {
   actors: actors.length,
   zeroDays: zeroDays.length,
   glossaryTerms: Array.isArray(glossaryData) ? glossaryData.length : Object.keys(glossaryData).length,
+  supplyChainIncidents: supplyChain.incidents.length,
+  supplyChainRelationships: supplyChain.relationships.length,
 };
 
 // Format for rendering (commas in large numbers)
@@ -98,10 +102,10 @@ const fmt = (n: number) => n.toLocaleString('en-US');
     <div class="progress-bar-wrap">
       <div class="progress-label">
         <span>Overall Progress</span>
-        <span>Phase 2 &mdash; 48%</span>
+        <span>Phase 2 &mdash; 64%</span>
       </div>
       <div class="progress-track">
-        <div class="progress-fill" style="width: 48%"></div>
+        <div class="progress-fill" style="width: 64%"></div>
       </div>
     </div>
 
@@ -207,9 +211,9 @@ const fmt = (n: number) => n.toLocaleString('en-US');
         <div class="item-status done">&#10003;</div>
         <div class="item-body">
           <div class="item-title">Astro Static Site</div>
-          <div class="item-desc">Migrated from vanilla HTML to Astro 5 with content collections, Zod schema validation, and GitHub Pages deployment. Unified layout and component system.</div>
+          <div class="item-desc">Migrated from vanilla HTML to Astro 6 with content collections, Zod schema validation, and GitHub Pages deployment. Unified layout and component system.</div>
           <div class="item-meta">
-            <span class="item-tag">Astro 5</span>
+            <span class="item-tag">Astro 6</span>
             <span class="item-tag">content collections</span>
           </div>
         </div>
@@ -240,12 +244,26 @@ const fmt = (n: number) => n.toLocaleString('en-US');
         <div class="item-status wip">&#9673;</div>
         <div class="item-body">
           <div class="item-title">Automated Discovery Pipeline</div>
-          <div class="item-desc">High-trust feed ingestion (CISA KEV, NVD/CVE, CISA Advisories, NCSC UK, vendor PSIRTs) with a confidence-scored triage layer. Above-threshold events auto-draft articles; below-threshold flagged for human review.</div>
+          <div class="item-desc">High-trust feed ingestion and task creation across CISA KEV, NVD/CVE, CISA advisories, NCSC UK, vendor PSIRTs, and VulnCheck KEV prefills. Source packets and review gates remain the publication boundary; VulnCheck is first-class evidence but not official CISA KEV truth or a standalone drafting authority.</div>
           <div class="item-meta">
             <span class="item-tag">CISA KEV</span>
             <span class="item-tag">NVD</span>
             <span class="item-tag">NCSC UK</span>
-            <span class="item-tag">confidence-scored</span>
+            <span class="item-tag">VulnCheck prefills</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="item">
+        <div class="item-status done">&#10003;</div>
+        <div class="item-body">
+          <div class="item-title">Supply Chain Graph Surface</div>
+          <div class="item-desc">Static, corpus-driven Supply Chain section with {counts.supplyChainIncidents} curated incidents, {counts.supplyChainRelationships} validated relationships, a persistent graph hero, technique focus, dive-and-bloom, page-to-graph binding, incident propagation timelines, and graph search.</div>
+          <div class="item-meta">
+            <span class="item-tag">Supply Chain</span>
+            <span class="item-tag">graph payload</span>
+            <span class="item-tag">no scoring</span>
+            <span class="item-tag">live</span>
           </div>
         </div>
       </div>
@@ -481,7 +499,7 @@ const fmt = (n: number) => n.toLocaleString('en-US');
     </div>
 
     <div class="last-updated">
-      Last updated: April 16, 2026 &mdash; This roadmap is a living document and subject to change.
+      Last updated: June 18, 2026 &mdash; This roadmap is a living document and subject to change.
     </div>
   </div>
 </Base>


### PR DESCRIPTION
## Summary

Updates public documentation and the public roadmap to reflect the current production reality of the Supply Chain work and VulnCheck-assisted pipeline state.

## Changes

- Adds a current-status section to `docs/supply-chain-pages.md` with live route, graph, relationship, and feature-surface counts.
- Replaces the stale stacked-PR status document with the current merged Supply Chain phase state and validation snapshot.
- Updates the public roadmap page to reflect Astro 6, live VulnCheck prefills, the review-gate boundary, and the now-live Supply Chain graph surface.

## Validation

- `git diff --check` — PASS
- `python3 scripts/validate_supply_chain_incidents.py` — PASS, 27 incidents
- `python3 scripts/validate_supply_chain_graph.py` — PASS
- `node scripts/build-supply-chain-graph.mjs --check` — PASS, 187 nodes / 285 edges / 129 search records
- `node scripts/test-supply-chain-pages.mjs` — PASS, 85 routes
- `npm --prefix site ci --no-audit --no-fund` — PASS
- `rm -rf site/dist && npm --prefix site run build` — PASS, disabled build generated 309 pages
- `rm -rf site/dist && ENABLE_SUPPLY_CHAIN_PAGES=true npm --prefix site run build` — PASS, enabled build generated 394 pages

Known unrelated warnings: the Astro builds still emit existing campaign validator warnings for campaigns with fewer than the target two related incidents. The validator exits successfully; these warnings are not introduced by this docs reconciliation.

## Review

Requested review from non-author review lanes. Public behavior is documentation-only; no runtime pipeline or content generation behavior changes are included.
