### PR TITLE
fix: clarify Supply Chain graph search control

### DIFF
--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -68,8 +68,29 @@ assert.ok(
     supplyChainRouteSource.includes('data-sc-explore-enter') &&
     supplyChainRouteSource.includes('data-sc-explore-exit') &&
     supplyChainRouteSource.includes('class="sc-explore-rail"') &&
-    supplyChainRouteSource.includes('class="graph-icon-button"'),
+    supplyChainRouteSource.includes('class="graph-search-pill"') &&
+    supplyChainRouteSource.includes('aria-label="Search graph"'),
   'route should expose full-screen explore controls on the persisted graph island'
+);
+assert.ok(
+  supplyChainRouteSource.includes('<circle cx="11" cy="11" r="6.25"></circle>') &&
+    supplyChainRouteSource.includes('<path d="m16 16 4.2 4.2"></path>') &&
+    supplyChainRouteSource.includes('class="graph-search-label"') &&
+    supplyChainRouteSource.includes('>Search</span>') &&
+    supplyChainRouteSource.includes('class="graph-search-shortcut"') &&
+    supplyChainRouteSource.includes('⌘K / /') &&
+    supplyChainRouteSource.includes('.graph-search-pill svg') &&
+    supplyChainRouteSource.includes('stroke-width: 1.5') &&
+    supplyChainRouteSource.includes('stroke: currentColor'),
+  'graph search trigger should render as a magnifier search pill with shortcut hints'
+);
+assert.ok(
+  supplyChainRouteSource.includes(':global(.sc-search-backdrop)') &&
+    supplyChainRouteSource.includes(':global(.sc-search-palette)') &&
+    supplyChainRouteSource.includes(':global(.sc-search-input)') &&
+    supplyChainRouteSource.includes(':global(.sc-search-result[aria-selected=') &&
+    !supplyChainRouteSource.includes('\n  .sc-search-backdrop {'),
+  'dynamically-created graph search palette styles should be global, not Astro-scoped'
 );
 assert.ok(
   supplyChainRouteSource.includes('data-graph-target-type="stage"') &&
@@ -125,15 +146,29 @@ assert.ok(
 );
 assert.ok(
   supplyChainGraphSource.includes("const SEARCH_INDEX_URL = '/supply-chain-search-index.json'") &&
-    supplyChainGraphSource.includes('openSearchPalette()') &&
+    supplyChainGraphSource.includes('openSearchPalette(trigger = null)') &&
     supplyChainGraphSource.includes('scoreSearchEntry(entry, query)') &&
-    supplyChainGraphSource.includes("event.key.toLowerCase() === 'k' && (event.metaKey || event.ctrlKey)") &&
+    supplyChainGraphSource.includes("event.key.toLowerCase() === 'k' && (event.metaKey || event.ctrlKey) && !interactiveTarget") &&
     supplyChainGraphSource.includes("event.key === '/'") &&
     supplyChainGraphSource.includes('selectSearchResult(entry)') &&
     supplyChainGraphSource.includes('parseGraphStateParam') &&
     supplyChainGraphSource.includes('updateGraphUrl()') &&
     supplyChainGraphSource.includes('exitExploreRoute()'),
   'graph runtime should provide jump-to search, keyboard shortcuts, URL selection sync, and Esc explore exit'
+);
+assert.ok(
+  supplyChainGraphSource.includes("this.openSearchPalette(searchTarget)") &&
+    supplyChainGraphSource.includes('this.openSearchPalette()') &&
+    supplyChainGraphSource.includes('trigger instanceof Element') &&
+    supplyChainGraphSource.includes('document.activeElement instanceof Element') &&
+    supplyChainGraphSource.includes('document.activeElement !== this.root') &&
+    supplyChainGraphSource.includes("document.querySelector('[data-sc-search-open]') || this.root") &&
+    supplyChainGraphSource.includes("document.getElementById('menu-search')?.blur()") &&
+    supplyChainGraphSource.includes("backdrop.dataset.scSearchBackdrop = 'true'") &&
+    supplyChainGraphSource.includes("this.searchInput?.focus({ preventScroll: true })") &&
+    supplyChainGraphSource.includes('const returnTarget = this.searchReturnFocus?.isConnected ? this.searchReturnFocus : this.root') &&
+    supplyChainGraphSource.includes("if (event.target === backdrop) this.closeSearchPalette()"),
+  'graph search shortcuts should open the centered graph palette, avoid the global menu search, and restore trigger focus on close'
 );
 assert.ok(
   supplyChainGraphSource.includes('function shortNodeLabel') &&

--- a/site/public/js/supply-chain-graph-core.js
+++ b/site/public/js/supply-chain-graph-core.js
@@ -865,7 +865,8 @@ class SupplyChainGraph {
       const searchTarget = event.target.closest('[data-sc-search-open]');
       if (searchTarget) {
         event.preventDefault();
-        this.openSearchPalette();
+        event.stopPropagation();
+        this.openSearchPalette(searchTarget);
         return;
       }
       const exploreLink = event.target.closest('[data-sc-explore-enter], [data-sc-explore-exit]');
@@ -952,6 +953,7 @@ class SupplyChainGraph {
     const target = event.target instanceof Element ? event.target : null;
     const interactiveTarget = target?.closest('input, textarea, select, [contenteditable="true"]');
     const paletteOpen = Boolean(this.searchPalette?.isConnected);
+    const isSupplyChainPath = window.location.pathname === '/supply-chain' || window.location.pathname.startsWith('/supply-chain/');
 
     if (paletteOpen) {
       this.handleSearchKeydown(event);
@@ -967,8 +969,9 @@ class SupplyChainGraph {
     }
 
     const opensWithSlash = event.key === '/' && !interactiveTarget;
-    const opensWithCommand = event.key.toLowerCase() === 'k' && (event.metaKey || event.ctrlKey);
+    const opensWithCommand = event.key.toLowerCase() === 'k' && (event.metaKey || event.ctrlKey) && !interactiveTarget;
     if (!opensWithSlash && !opensWithCommand) return;
+    if (!isSupplyChainPath || !document.body.contains(this.root)) return;
     event.preventDefault();
     event.stopPropagation();
     event.stopImmediatePropagation();
@@ -983,15 +986,24 @@ class SupplyChainGraph {
     return this.searchIndex;
   }
 
-  openSearchPalette() {
+  openSearchPalette(trigger = null) {
+    if (trigger instanceof Element) this.searchReturnFocus = trigger;
+    else if (document.activeElement instanceof Element && document.activeElement !== document.body && document.activeElement !== this.root) {
+      this.searchReturnFocus = document.activeElement;
+    } else {
+      this.searchReturnFocus = document.querySelector('[data-sc-search-open]') || this.root;
+    }
+    document.getElementById('menu-search')?.blur();
+
     if (this.searchPalette?.isConnected) {
-      this.searchInput?.focus();
+      this.searchInput?.focus({ preventScroll: true });
       this.searchInput?.select();
       return;
     }
 
     const backdrop = document.createElement('div');
     backdrop.className = 'sc-search-backdrop';
+    backdrop.dataset.scSearchBackdrop = 'true';
     backdrop.setAttribute('role', 'presentation');
     backdrop.innerHTML = `
       <div class="sc-search-palette" role="dialog" aria-modal="true" aria-label="Search Supply Chain graph">
@@ -1021,7 +1033,10 @@ class SupplyChainGraph {
         this.searchResults = [];
         this.renderSearchResults('Search index unavailable.');
       });
-    requestAnimationFrame(() => this.searchInput?.focus());
+    requestAnimationFrame(() => {
+      this.searchInput?.focus({ preventScroll: true });
+      this.searchInput?.select();
+    });
   }
 
   closeSearchPalette() {
@@ -1030,7 +1045,9 @@ class SupplyChainGraph {
     this.searchPalette = null;
     this.searchInput = null;
     this.searchResultsEl = null;
-    this.root.focus({ preventScroll: true });
+    const returnTarget = this.searchReturnFocus?.isConnected ? this.searchReturnFocus : this.root;
+    this.searchReturnFocus = null;
+    returnTarget?.focus?.({ preventScroll: true });
   }
 
   handleSearchKeydown(event) {

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -85,13 +85,18 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
   >
     <div class="graph-chrome-actions" aria-label="Graph actions">
       <button
-        class="graph-icon-button"
+        class="graph-search-pill"
         type="button"
         data-sc-search-open
         aria-label="Search graph"
         title="Search graph"
       >
-        <span aria-hidden="true">K</span>
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <circle cx="11" cy="11" r="6.25"></circle>
+          <path d="m16 16 4.2 4.2"></path>
+        </svg>
+        <span class="graph-search-label" aria-hidden="true">Search</span>
+        <span class="graph-search-shortcut" aria-hidden="true">⌘K / /</span>
       </button>
       {isExplore ? (
         <a
@@ -802,10 +807,51 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
     text-decoration: none;
   }
 
+  .graph-search-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    height: 36px;
+    border: 1px solid rgba(232, 160, 32, 0.68);
+    border-radius: 4px;
+    background: rgba(8, 11, 16, 0.88);
+    color: var(--white);
+    cursor: pointer;
+    font: 700 0.72rem/1 var(--font-mono);
+    letter-spacing: 0.12em;
+    padding: 0 10px;
+    text-transform: uppercase;
+  }
+
+  .graph-search-pill svg {
+    flex: 0 0 auto;
+    width: 16px;
+    height: 16px;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 1.5;
+  }
+
+  .graph-search-label {
+    color: var(--text);
+  }
+
+  .graph-search-shortcut {
+    color: var(--muted);
+    font-size: 0.62rem;
+    letter-spacing: 0.14em;
+  }
+
   .graph-icon-button:hover,
-  .graph-icon-button:focus-visible {
+  .graph-icon-button:focus-visible,
+  .graph-search-pill:hover,
+  .graph-search-pill:focus-visible {
     border-color: var(--amber);
     box-shadow: 0 0 0 1px rgba(232, 160, 32, 0.18), 0 10px 24px rgba(0, 0, 0, 0.32);
+    outline: none;
     text-decoration: none;
   }
 
@@ -975,7 +1021,7 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
     padding: 10px;
   }
 
-  .sc-search-backdrop {
+  :global(.sc-search-backdrop) {
     position: fixed;
     inset: 0;
     z-index: 200;
@@ -985,7 +1031,7 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
     background: rgba(3, 5, 9, 0.62);
   }
 
-  .sc-search-palette {
+  :global(.sc-search-palette) {
     width: min(720px, 100%);
     border: 1px solid rgba(232, 160, 32, 0.45);
     border-radius: 6px;
@@ -993,7 +1039,7 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
     box-shadow: 0 24px 70px rgba(0, 0, 0, 0.54);
   }
 
-  .sc-search-input {
+  :global(.sc-search-input) {
     width: 100%;
     border: 0;
     border-bottom: 1px solid var(--border);
@@ -1004,14 +1050,14 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
     padding: 16px;
   }
 
-  .sc-search-results {
+  :global(.sc-search-results) {
     display: grid;
     max-height: min(56vh, 520px);
     overflow: auto;
     padding: 8px;
   }
 
-  .sc-search-result {
+  :global(.sc-search-result) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
     gap: 6px 12px;
@@ -1024,15 +1070,15 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
     text-align: left;
   }
 
-  .sc-search-result[aria-selected='true'],
-  .sc-search-result:hover,
-  .sc-search-result:focus-visible {
+  :global(.sc-search-result[aria-selected='true']),
+  :global(.sc-search-result:hover),
+  :global(.sc-search-result:focus-visible) {
     border-color: rgba(232, 160, 32, 0.58);
     background: rgba(232, 160, 32, 0.08);
     outline: none;
   }
 
-  .sc-search-title {
+  :global(.sc-search-title) {
     overflow: hidden;
     color: var(--white);
     font-weight: 600;
@@ -1041,9 +1087,9 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
     white-space: nowrap;
   }
 
-  .sc-search-type,
-  .sc-search-context,
-  .sc-search-empty {
+  :global(.sc-search-type),
+  :global(.sc-search-context),
+  :global(.sc-search-empty) {
     color: var(--muted);
     font-family: var(--font-mono);
     font-size: 0.66rem;
@@ -1051,14 +1097,14 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
     text-transform: uppercase;
   }
 
-  .sc-search-context {
+  :global(.sc-search-context) {
     grid-column: 1 / -1;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
-  .sc-search-empty {
+  :global(.sc-search-empty) {
     padding: 18px 10px;
   }
 
@@ -1898,6 +1944,21 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
 
     .graph-caption {
       display: block;
+    }
+
+    .graph-search-pill {
+      gap: 7px;
+      padding: 0 9px;
+    }
+
+    .graph-search-label {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
+      white-space: nowrap;
     }
 
     .graph-caption span {


### PR DESCRIPTION
## Summary

Fixes the G8 Supply Chain graph search UX bugs:

- Replaces the bare `K` graph search trigger with a search pill: magnifier SVG, `Search` label, and `⌘K / /` hint.
- Keeps `aria-label="Search graph"` on the trigger.
- Makes click, Cmd/Ctrl-K, and `/` open the graph palette and focus `.sc-search-input` instead of the global `#menu-search`.
- Restores focus to the trigger on Escape.
- Keeps backdrop click close behavior.
- Converts dynamically-created palette styles to `:global(...)` so Astro scoping does not leave the palette unstyled.

## Validation

Commands run:

- `node --check site/public/js/supply-chain-graph-core.js` — PASS
- `node scripts/test-supply-chain-pages.mjs` — PASS, routes=85
- `node scripts/build-supply-chain-graph.mjs --check` — PASS, nodes=187 / edges=285 / search=129
- `git diff --check` — PASS
- `ENABLE_SUPPLY_CHAIN_PAGES=true npm --prefix site run build` — PASS, 394 pages built

Browser acceptance on local Astro dev server at `http://127.0.0.1:4329/supply-chain/`:

- Desktop 1440x1000 — PASS
- Mobile 390x844 — PASS
- Search trigger renders visible magnifier and Search/shortcut text.
- Click opens centered `.sc-search-backdrop` with `display: grid` and focuses `.sc-search-input`.
- Cmd-K opens the graph palette and does not focus `#menu-search`.
- `/` opens the graph palette and does not focus `#menu-search`.
- Escape closes the palette and restores focus to `[data-sc-search-open]`.
- Backdrop click closes the palette.

Known unrelated output: campaign validator warnings for campaign records with fewer than the target two related incidents remain present; build exits successfully.

## Review

Small G8 UI/UX fix. Please route independent review to Ernest Penfold / DangerMouse; Gemini may be quota-limited.
