### PR TITLE
feat: add adversary schema foundation v0.5

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -7,7 +7,7 @@
     "check:supply-chain-preview": "node check_supply_chain_preview.mjs",
     "check:supply-chain-public-readiness": "node check_supply_chain_public_readiness.mjs",
     "social:share-x": "node social-share-x.mjs",
-    "test": "node test-vulncheck-kev-intake.mjs && node test-pipeline-dispatcher-stall.cjs"
+    "test": "node test-vulncheck-kev-intake.mjs && node test-pipeline-dispatcher-stall.cjs && node test-adversary-schema-foundation.mjs"
   },
   "keywords": [],
   "author": "",

--- a/scripts/test-adversary-schema-foundation.mjs
+++ b/scripts/test-adversary-schema-foundation.mjs
@@ -148,6 +148,17 @@ assertNoErrors(lockBitStyle, 'LockBit-style criminalOperation with operatingMode
 
 {
   const result = classifyAnchorCollision(
+    { externalIds: { mitreAttackGroup: 'G0045', vendorRefs: [] } },
+    { externalIds: { mitreAttackGroup: 'G0050', vendorRefs: [] } },
+  );
+  assert.equal(result.classification, 'hard_anchor_conflict');
+  assert.equal(result.action, 'ep_disambiguation');
+  assert.deepEqual(result.conflicts, ['mitreAttackGroup']);
+  assert.equal(result.autoMerge, false);
+}
+
+{
+  const result = classifyAnchorCollision(
     { externalIds: { malpediaActor: 'apt10', vendorRefs: [] } },
     { externalIds: { malpediaActor: 'apt10', vendorRefs: [] } },
   );

--- a/scripts/test-adversary-schema-foundation.mjs
+++ b/scripts/test-adversary-schema-foundation.mjs
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import {
+  classifyAnchorCollision,
+  getAdversaryProfileValidationIssues,
+} from '../site/src/lib/adversaryProfileValidation.mjs';
+
+function issues(record) {
+  return getAdversaryProfileValidationIssues(record);
+}
+
+function messages(list) {
+  return list.map((issue) => issue.message);
+}
+
+function assertNoErrors(record, label) {
+  assert.deepEqual(messages(issues(record).errors), [], label);
+}
+
+function sourceRef(id = 'src-1') {
+  return { sourceId: id };
+}
+
+const liveLegacyRecord = {
+  name: 'APT29',
+  aliases: ['Cozy Bear'],
+  attributionConfidence: 'A1',
+  reviewStatus: 'under_review',
+  sources: [
+    {
+      url: 'https://attack.mitre.org/groups/G0016/',
+      publisher: 'MITRE ATT&CK',
+      publisherType: 'research',
+      reliability: 'R1',
+      publicationDate: '2025-10-17',
+    },
+  ],
+};
+
+{
+  const result = issues(liveLegacyRecord);
+  assert.equal(result.errors.length, 0, 'existing legacy threat actor remains valid');
+  assert.ok(messages(result.warnings).some((message) => /entityKind is absent/.test(message)), 'legacy missing v0.5 fields warn');
+  assert.ok(messages(result.warnings).some((message) => /attributionConfidence remains accepted legacy/.test(message)), 'legacy attributionConfidence warns');
+}
+
+const sparseDraft = {
+  name: 'UNC0000',
+  aliases: [],
+  reviewStatus: 'draft_ai',
+  entityKind: 'unknown_cluster',
+  isAnalyticConstruct: true,
+  sources: [
+    {
+      url: 'https://example.com/report',
+      publisher: 'Example Research',
+      publisherType: 'research',
+      reliability: 'R2',
+      publicationDate: '2026-06-18',
+    },
+  ],
+};
+assertNoErrors(sparseDraft, 'sparse draft_ai v0.5-shaped record is valid');
+
+const certifiedWithHardAnchor = {
+  ...sparseDraft,
+  reviewStatus: 'certified',
+  entityKind: 'activity_cluster',
+  externalIds: { mitreAttackGroup: 'G0045', vendorRefs: [] },
+  canonicalNameSource: 'mitre',
+  namingRationale: 'MITRE ATT&CK is the dominant source for this bootstrap record.',
+};
+assertNoErrors(certifiedWithHardAnchor, 'certified path (a) accepts a hard non-vendor anchor');
+
+const certifiedWithAliases = {
+  ...sparseDraft,
+  reviewStatus: 'certified',
+  aliases: ['Example Bear', 'Example Panda'],
+  aliasRecords: [
+    { value: 'Example Bear', sourceOrg: 'Vendor One', status: 'current', confidence: 'B' },
+    { value: 'Example Panda', sourceOrg: 'Vendor Two', status: 'current', confidence: 'C' },
+  ],
+  canonicalNameSource: 'common',
+  namingRationale: 'Two independent vendors use stable aliases for the same public cluster.',
+};
+assertNoErrors(certifiedWithAliases, 'certified path (b) accepts two independent aliases plus namingRationale');
+
+const lockBitStyle = {
+  ...sparseDraft,
+  name: 'LockBit',
+  reviewStatus: 'certified',
+  entityKind: 'criminal_operation',
+  operatingModels: ['ransomware_operation', 'affiliate_program', 'data_extortion'],
+  aliases: ['LockBit 3.0', 'LockBit Black'],
+  aliasRecords: [
+    { value: 'LockBit 3.0', sourceOrg: 'Vendor One', status: 'current', confidence: 'B' },
+    { value: 'LockBit Black', sourceOrg: 'Vendor Two', status: 'current', confidence: 'B' },
+  ],
+  canonicalNameSource: 'common',
+  namingRationale: 'Dominant public brand across vendor and government reporting.',
+  relationshipClaims: [
+    {
+      predicate: 'uses_malware',
+      targetType: 'malware_family',
+      targetId: null,
+      unresolved: true,
+      labelIfUnresolved: 'LockBit ransomware',
+      externalRefs: { malpediaFamily: 'win.lockbit' },
+      confidence: 'B',
+      sources: [sourceRef()],
+    },
+  ],
+};
+assertNoErrors(lockBitStyle, 'LockBit-style criminalOperation with operatingModels is valid');
+
+{
+  const result = issues({
+    ...sparseDraft,
+    externalIds: { malpediaActor: 'win.lockbit', vendorRefs: [] },
+  });
+  assert.ok(messages(result.errors).some((message) => /malpediaActor must be a Malpedia actor slug/.test(message)), 'malpediaActor rejects malware-family keys');
+}
+
+{
+  const result = issues(lockBitStyle);
+  assert.equal(result.errors.filter((issue) => issue.path.join('.') === 'relationshipClaims.0.externalRefs.malpediaFamily').length, 0, 'malpedia family key is accepted only under relationshipClaims[].externalRefs.malpediaFamily');
+}
+
+{
+  const result = classifyAnchorCollision(
+    { externalIds: { mitreAttackGroup: 'G0045', vendorRefs: [] } },
+    { externalIds: { mitreAttackGroup: 'G0045', vendorRefs: [] } },
+  );
+  assert.equal(result.classification, 'deterministic_merge_candidate');
+  assert.equal(result.action, 'auto_merge_eligible');
+  assert.equal(result.autoMerge, true);
+}
+
+{
+  const result = classifyAnchorCollision(
+    { externalIds: { mitreAttackGroup: 'G0045', mispGalaxyUuid: '11111111-1111-4111-8111-111111111111', vendorRefs: [] } },
+    { externalIds: { mitreAttackGroup: 'G0045', mispGalaxyUuid: '22222222-2222-4222-8222-222222222222', vendorRefs: [] } },
+  );
+  assert.equal(result.classification, 'hard_anchor_conflict');
+  assert.equal(result.action, 'ep_disambiguation');
+  assert.equal(result.autoMerge, false);
+}
+
+{
+  const result = classifyAnchorCollision(
+    { externalIds: { malpediaActor: 'apt10', vendorRefs: [] } },
+    { externalIds: { malpediaActor: 'apt10', vendorRefs: [] } },
+  );
+  assert.equal(result.classification, 'soft_anchor_merge_candidate');
+  assert.equal(result.action, 'ep_disambiguation');
+  assert.equal(result.autoMerge, false);
+}
+
+{
+  const left = { externalIds: { mitreAttackGroup: 'G0045', vendorRefs: [] } };
+  const snapshot = JSON.stringify(left);
+  classifyAnchorCollision(left, { externalIds: { mitreAttackGroup: 'G0045', vendorRefs: [] } });
+  assert.equal(JSON.stringify(left), snapshot, 'anchor classification is pure and does not silently mutate content');
+}
+
+{
+  const result = issues({
+    ...sparseDraft,
+    aliases: ['Hand Edited Alias'],
+    aliasRecords: [
+      { value: 'Derived Alias', sourceOrg: 'Vendor One', status: 'current', confidence: 'B' },
+    ],
+  });
+  assert.ok(messages(result.warnings).some((message) => /aliases should be derived/.test(message)), 'derived aliases mismatch warns');
+}
+
+{
+  const result = issues({
+    ...sparseDraft,
+    attributionConfidence: 'A3',
+    attributionClaims: [
+      {
+        claimType: 'suspected_sponsor',
+        value: 'CN',
+        confidence: 'R1',
+        sources: [sourceRef()],
+      },
+    ],
+  });
+  assert.ok(messages(result.warnings).some((message) => /attributionConfidence remains accepted legacy/.test(message)), 'attributionConfidence remains accepted with warning');
+  assert.ok(messages(result.errors).some((message) => /Source reliability R1-R4 must not appear as claim confidence/.test(message)), 'source reliability cannot be claim confidence');
+}
+
+{
+  const result = issues({
+    ...sparseDraft,
+    importedSourceConfidence: 95,
+  });
+  assert.ok(messages(result.errors).some((message) => /MISP-only/.test(message)), 'importedSourceConfidence is MISP-only');
+}
+
+{
+  const result = issues({
+    ...sparseDraft,
+    externalIds: {
+      mispGalaxyUuid: '11111111-1111-4111-8111-111111111111',
+      vendorRefs: [],
+    },
+    importedSourceConfidence: 101,
+  });
+  assert.ok(messages(result.errors).some((message) => /integer from 0 to 100/.test(message)), 'importedSourceConfidence must be numeric 0-100');
+}
+
+{
+  const result = issues({
+    ...sparseDraft,
+    relationshipClaims: [
+      {
+        predicate: 'uses_malware',
+        targetType: 'malware_family',
+        targetId: 'TP-MAL-LOCKBIT',
+        unresolved: true,
+        confidence: 'B',
+        sources: [sourceRef()],
+      },
+    ],
+  });
+  assert.ok(messages(result.errors).some((message) => /targetId to be null/.test(message)), 'unresolved relationship requires targetId null');
+  assert.ok(messages(result.errors).some((message) => /labelIfUnresolved/.test(message)), 'unresolved relationship requires labelIfUnresolved');
+}
+
+{
+  const result = issues({
+    ...sparseDraft,
+    relationshipClaims: [
+      {
+        predicate: 'exhibits_technique',
+        targetType: 'attackTechnique',
+        targetId: 'T1195.002',
+        unresolved: false,
+        confidence: 'B',
+        sources: [sourceRef()],
+      },
+    ],
+  });
+  assert.ok(messages(result.errors).some((message) => /attackVersion/.test(message)), 'attack technique target requires attackVersion');
+}
+
+{
+  const result = issues({
+    ...sparseDraft,
+    relationshipClaims: [
+      {
+        predicate: 'uses_malware',
+        targetType: 'malware_family',
+        targetId: 'TP-MAL-LOCKBIT',
+        unresolved: false,
+        externalRefs: { mitreAttackGroup: 'G0045' },
+        confidence: 'B',
+        sources: [sourceRef()],
+      },
+    ],
+  });
+  assert.ok(messages(result.errors).some((message) => /never actor identity anchors/.test(message)), 'externalRefs stores target entity IDs only');
+}
+
+{
+  const result = issues({
+    ...sparseDraft,
+    externalIds: {
+      malpediaFamily: 'win.lockbit',
+      vendorRefs: [],
+    },
+  });
+  assert.ok(messages(result.errors).some((message) => /not a valid actor externalIds key/.test(message)), 'malware IDs must not live under externalIds');
+}
+
+{
+  const complete = issues({
+    ...sparseDraft,
+    revisions: [
+      {
+        actor: 'kernel-k',
+        provider: 'openai',
+        model: 'codex',
+        action: 'created',
+        ref: 'PR2',
+        at: '2026-06-18T00:00:00Z',
+      },
+    ],
+  });
+  assert.equal(complete.errors.filter((issue) => issue.path[0] === 'revisions').length, 0, 'complete revisions[] validates');
+
+  const incomplete = issues({
+    ...sparseDraft,
+    revisions: [{ actor: 'kernel-k', provider: 'openai', model: 'codex', action: 'created', ref: 'PR2' }],
+  });
+  assert.ok(messages(incomplete.errors).some((message) => /revisions\[\]\.at is required/.test(message)), 'revisions[] requires at');
+}
+
+console.log('adversary schema foundation tests passed');

--- a/scripts/test-adversary-schema-foundation.mjs
+++ b/scripts/test-adversary-schema-foundation.mjs
@@ -52,6 +52,7 @@ const sparseDraft = {
   isAnalyticConstruct: true,
   sources: [
     {
+      id: 'src-1',
       url: 'https://example.com/report',
       publisher: 'Example Research',
       publisherType: 'research',
@@ -61,6 +62,42 @@ const sparseDraft = {
   ],
 };
 assertNoErrors(sparseDraft, 'sparse draft_ai v0.5-shaped record is valid');
+
+assertNoErrors({
+  ...sparseDraft,
+  attributionClaims: [
+    {
+      claimType: 'located_in',
+      value: 'Unknown',
+      confidence: 'D',
+      sources: [sourceRef()],
+    },
+  ],
+  relationshipClaims: [
+    {
+      predicate: 'associated_with',
+      targetType: 'identity',
+      targetId: 'TP-APT-0001',
+      confidence: 'D',
+      sources: [sourceRef()],
+    },
+  ],
+}, 'claim sourceId references resolve against sources[].id');
+
+{
+  const result = issues({
+    ...sparseDraft,
+    attributionClaims: [
+      {
+        claimType: 'located_in',
+        value: 'Unknown',
+        confidence: 'D',
+        sources: [sourceRef('missing-source')],
+      },
+    ],
+  });
+  assert.ok(messages(result.errors).some((message) => /sourceId must reference an existing sources\[\]\.id/.test(message)), 'dangling attribution sourceId is rejected');
+}
 
 const certifiedWithHardAnchor = {
   ...sparseDraft,

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -7,6 +7,17 @@
  */
 import { defineCollection, z } from 'astro:content';
 import { glob } from 'astro/loaders';
+import {
+  ALIAS_STATUSES,
+  ATTRIBUTION_CLAIM_TYPES,
+  CANONICAL_NAME_SOURCES,
+  CLAIM_CONFIDENCE_VALUES,
+  ENTITY_KINDS,
+  OPERATING_MODELS,
+  RELATIONSHIP_PREDICATES,
+  RELATIONSHIP_TARGET_TYPES,
+  getAdversaryProfileValidationIssues,
+} from './lib/adversaryProfileValidation.mjs';
 
 /** Shared enums */
 const reviewStatus = z.enum([
@@ -25,6 +36,17 @@ const confidenceGrade = z.enum(['A', 'B', 'C', 'D', 'F']);
 const attributionConfidence = z.enum(['A1', 'A2', 'A3', 'A4', 'A5', 'A6']);
 
 const sourceReliability = z.enum(['R1', 'R2', 'R3', 'R4']);
+
+const adversaryEntityKind = z.enum(ENTITY_KINDS);
+
+const adversaryOperatingModel = z.union([
+  z.enum(OPERATING_MODELS),
+  z.string().regex(/^x-[A-Za-z0-9][A-Za-z0-9_-]*$/),
+]);
+
+const claimConfidence = z.enum(CLAIM_CONFIDENCE_VALUES);
+
+const canonicalNameSource = z.enum(CANONICAL_NAME_SOURCES);
 
 const generatedBy = z.enum([
   'ai_ingestion',
@@ -119,6 +141,74 @@ const frameworkMapping = z.object({
   evidence: z.string().min(1).optional(),
   notes: z.string().optional(),
 });
+
+const adversaryVendorRef = z.object({
+  vendor: z.string().min(1),
+  name: z.string().min(1).nullable().optional(),
+}).strict();
+
+const adversaryAptId = z.string().regex(/^TP-APT-\d{4,}$/);
+
+const adversaryExternalIds = z.object({
+  mitreAttackGroup: z.string().regex(/^G\d{4}$/).nullable().optional(),
+  mispGalaxyUuid: z.string().uuid().nullable().optional(),
+  malpediaActor: z.string().min(1).nullable().optional(),
+  etdaSlug: z.string().min(1).nullable().optional(),
+  vendorRefs: z.array(adversaryVendorRef).default([]),
+}).strict();
+
+const adversaryClaimSourceRef = z.object({
+  sourceId: z.string().min(1),
+}).strict();
+
+const adversaryAliasRecord = z.object({
+  value: z.string().min(1),
+  sourceOrg: z.string().min(1),
+  sourceRef: z.string().min(1).nullable().optional(),
+  status: z.enum(ALIAS_STATUSES),
+  confidence: claimConfidence,
+  notes: z.string().optional(),
+}).strict();
+
+const adversaryAttributionClaim = z.object({
+  claimType: z.enum(ATTRIBUTION_CLAIM_TYPES),
+  value: z.string().min(1),
+  subOrg: z.string().min(1).optional(),
+  confidence: claimConfidence,
+  basis: z.array(z.string().min(1)).default([]),
+  sources: z.array(adversaryClaimSourceRef).min(1),
+  importedSourceConfidence: z.number().int().min(0).max(100).optional(),
+}).strict();
+
+const adversaryRelationshipExternalRefs = z.object({
+  malpediaFamily: z.string().min(1).optional(),
+  mitreSoftware: z.string().regex(/^S\d{4}$/).optional(),
+}).catchall(z.string().min(1));
+
+const adversaryRelationshipClaim = z.object({
+  predicate: z.enum(RELATIONSHIP_PREDICATES),
+  targetType: z.enum(RELATIONSHIP_TARGET_TYPES),
+  targetId: z.string().min(1).nullable().optional(),
+  unresolved: z.boolean().default(false),
+  labelIfUnresolved: z.string().min(1).nullable().optional(),
+  firstSeen: z.union([z.string().min(1), z.number()]).optional(),
+  lastSeen: z.union([z.string().min(1), z.number()]).nullable().optional(),
+  asOf: z.string().min(1).optional(),
+  lastVerifiedAt: z.string().min(1).optional(),
+  externalRefs: adversaryRelationshipExternalRefs.optional(),
+  attackVersion: z.string().min(1).optional(),
+  confidence: claimConfidence,
+  sources: z.array(adversaryClaimSourceRef).min(1),
+}).strict();
+
+const adversaryRevision = z.object({
+  actor: z.string().min(1),
+  provider: z.string().min(1),
+  model: z.string().min(1),
+  action: z.string().min(1),
+  ref: z.string().min(1),
+  at: z.string().min(1),
+}).strict();
 
 /**
  * Incidents collection — bounded cybersecurity events.
@@ -267,6 +357,23 @@ const threatActors = defineCollection({
     atlasMappings: z.array(atlasMapping).default([]),
     'framework-mappings': z.array(frameworkMapping).default([]),
 
+    // Additive adversary-profile v0.5 fields. These stay optional for legacy
+    // records until a reviewed migration makes them corpus-wide requirements.
+    aptId: adversaryAptId.optional(),
+    entityKind: adversaryEntityKind.optional(),
+    isAnalyticConstruct: z.boolean().optional(),
+    operatingModels: z.array(adversaryOperatingModel).default([]),
+    externalIds: adversaryExternalIds.optional(),
+    aliasRecords: z.array(adversaryAliasRecord).optional(),
+    attributionClaims: z.array(adversaryAttributionClaim).optional(),
+    relationshipClaims: z.array(adversaryRelationshipClaim).optional(),
+    importedSourceConfidence: z.number().int().min(0).max(100).optional(),
+    notPubliclyEstablished: z.boolean().optional(),
+    canonicalNameSource: canonicalNameSource.optional(),
+    canonicalNameSourceDetail: z.string().min(1).optional(),
+    namingRationale: z.string().min(1).optional(),
+    revisions: z.array(adversaryRevision).optional(),
+
     // Quality
     attributionConfidence: attributionConfidence.optional(),
     attributionRationale: z.string().max(500).optional(),
@@ -279,6 +386,16 @@ const threatActors = defineCollection({
 
     // References
     sources: z.array(sourceSchema).default([]),
+  }).superRefine((data, ctx) => {
+    const { errors } = getAdversaryProfileValidationIssues(data);
+
+    for (const error of errors) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: error.path,
+        message: error.message,
+      });
+    }
   }),
 });
 

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -93,6 +93,7 @@ const mappingConfidence = z.enum(['confirmed', 'probable', 'possible']);
 
 /** Source citation schema per SOURCE-SPEC v1.0 */
 const sourceSchema = z.object({
+  id: z.string().min(1).optional(),
   url: z.string().url(),
   publisher: z.string(),
   publisherType: z.enum(['government', 'vendor', 'media', 'research', 'community']),

--- a/site/src/lib/adversaryProfileValidation.mjs
+++ b/site/src/lib/adversaryProfileValidation.mjs
@@ -310,7 +310,7 @@ export function classifyAnchorCollision(left, right) {
     (key) => present(leftExternalIds[key]) && present(rightExternalIds[key]) && leftExternalIds[key] !== rightExternalIds[key],
   );
 
-  if (sharedHardAnchors.length > 0 && conflictingHardAnchors.length > 0) {
+  if (conflictingHardAnchors.length > 0) {
     return {
       classification: 'hard_anchor_conflict',
       action: 'ep_disambiguation',

--- a/site/src/lib/adversaryProfileValidation.mjs
+++ b/site/src/lib/adversaryProfileValidation.mjs
@@ -1,0 +1,354 @@
+export const ENTITY_KINDS = [
+  'activity_cluster',
+  'state_unit',
+  'state_sponsored_group',
+  'criminal_group',
+  'criminal_operation',
+  'hacktivist_collective',
+  'individual_persona',
+  'unknown_cluster',
+  'disputed_cluster',
+];
+
+export const OPERATING_MODELS = [
+  'ransomware_operation',
+  'affiliate_program',
+  'data_extortion',
+  'malware_brand',
+  'access_broker',
+  'botnet_service',
+  'marketplace',
+  'hacktivist_campaigning',
+  'unknown',
+];
+
+export const CLAIM_CONFIDENCE_VALUES = ['A', 'B', 'C', 'D', 'E', 'F'];
+export const SOURCE_RELIABILITY_VALUES = ['R1', 'R2', 'R3', 'R4'];
+
+export const CANONICAL_NAME_SOURCES = [
+  'threatpedia',
+  'mitre',
+  'misp',
+  'vendor',
+  'government',
+  'common',
+  'other',
+];
+
+export const ALIAS_STATUSES = ['current', 'deprecated', 'disputed'];
+
+export const ATTRIBUTION_CLAIM_TYPES = [
+  'suspected_sponsor',
+  'operates_for',
+  'located_in',
+  'linked_to_actor',
+  'aka_real_world',
+];
+
+export const RELATIONSHIP_PREDICATES = [
+  'uses_malware',
+  'uses_tool',
+  'exhibits_technique',
+  'conducted_campaign',
+  'attributed_to_identity',
+  'successor_of',
+  'splinter_of',
+  'merged_into',
+  'shares_infrastructure_with',
+  'associated_with',
+];
+
+export const RELATIONSHIP_TARGET_TYPES = [
+  'malware_family',
+  'tool',
+  'attack_technique',
+  'attackTechnique',
+  'campaign',
+  'identity',
+  'adversary_profile',
+  'adversaryProfile',
+];
+
+const ANALYTIC_CONSTRUCT_KINDS = new Set(['activity_cluster', 'unknown_cluster', 'disputed_cluster']);
+const CRIMINAL_KINDS = new Set(['criminal_group', 'criminal_operation']);
+const MALPEDIA_FAMILY_PREFIX_RE = /^(?:apk|elf|ios|jar|js|osx|ps1|py|vbs|win)\./i;
+const HARD_ANCHOR_KEYS = ['mitreAttackGroup', 'mispGalaxyUuid'];
+const SOFT_ANCHOR_KEYS = ['malpediaActor', 'etdaSlug'];
+const ACTOR_EXTERNAL_ID_KEYS = new Set([
+  'mitreAttackGroup',
+  'mispGalaxyUuid',
+  'malpediaActor',
+  'etdaSlug',
+  'vendorRefs',
+]);
+const RELATIONSHIP_EXTERNAL_REF_KEYS = new Set(['malpediaFamily', 'mitreSoftware']);
+
+function present(value) {
+  return value !== undefined && value !== null && String(value).trim() !== '';
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function uniqueValues(values) {
+  return [...new Set(values.filter(present).map((value) => String(value).trim()))];
+}
+
+function normalizeVendorRef(ref) {
+  if (!ref || typeof ref !== 'object') return null;
+  if (!present(ref.vendor) || !present(ref.name)) return null;
+  return `${String(ref.vendor).trim().toLowerCase()}::${String(ref.name).trim().toLowerCase()}`;
+}
+
+function sourceCount(claim) {
+  return asArray(claim?.sources).length;
+}
+
+function hasNonVendorAnchor(externalIds = {}) {
+  return SOFT_ANCHOR_KEYS.concat(HARD_ANCHOR_KEYS).some((key) => present(externalIds[key]));
+}
+
+function hasTwoIndependentAliases(aliasRecords = []) {
+  return uniqueValues(asArray(aliasRecords).map((alias) => alias?.sourceOrg)).length >= 2;
+}
+
+function hasV05IdentityFields(data) {
+  return [
+    'aptId',
+    'entityKind',
+    'isAnalyticConstruct',
+    'externalIds',
+    'aliasRecords',
+    'attributionClaims',
+    'relationshipClaims',
+    'importedSourceConfidence',
+    'notPubliclyEstablished',
+    'canonicalNameSource',
+    'canonicalNameSourceDetail',
+    'namingRationale',
+    'revisions',
+  ].some((field) => data[field] !== undefined);
+}
+
+function issue(path, message) {
+  return { path, message };
+}
+
+export function isMalpediaFamilyKey(value) {
+  return typeof value === 'string' && MALPEDIA_FAMILY_PREFIX_RE.test(value.trim());
+}
+
+export function getAdversaryProfileValidationIssues(record) {
+  const errors = [];
+  const warnings = [];
+  const data = record && typeof record === 'object' ? record : {};
+  const externalIds = data.externalIds && typeof data.externalIds === 'object' ? data.externalIds : {};
+  const aliasRecords = asArray(data.aliasRecords);
+  const attributionClaims = asArray(data.attributionClaims);
+  const relationshipClaims = asArray(data.relationshipClaims);
+  const revisions = asArray(data.revisions);
+
+  for (const field of ['entityKind', 'isAnalyticConstruct', 'externalIds', 'aliasRecords', 'attributionClaims', 'relationshipClaims', 'revisions']) {
+    if (data[field] === undefined) {
+      warnings.push(issue([field], `${field} is absent; PR2 keeps this warning-mode for legacy records.`));
+    }
+  }
+
+  if (data.entityKind !== undefined && !ENTITY_KINDS.includes(data.entityKind)) {
+    errors.push(issue(['entityKind'], `entityKind must be one of: ${ENTITY_KINDS.join(', ')}`));
+  }
+
+  if (data.entityKind && ANALYTIC_CONSTRUCT_KINDS.has(data.entityKind) && data.isAnalyticConstruct !== true) {
+    errors.push(issue(['isAnalyticConstruct'], `${data.entityKind} records must set isAnalyticConstruct to true.`));
+  }
+
+  for (const [index, value] of asArray(data.operatingModels).entries()) {
+    if (!OPERATING_MODELS.includes(value) && !(typeof value === 'string' && value.startsWith('x-'))) {
+      errors.push(issue(['operatingModels', index], 'operatingModels values must be controlled vocabulary values or x-* extensions.'));
+    }
+  }
+
+  if (data.reviewStatus === 'certified' && hasV05IdentityFields(data)) {
+    if (!present(data.canonicalNameSource)) {
+      errors.push(issue(['canonicalNameSource'], 'certified adversary profiles require canonicalNameSource.'));
+    }
+    if (!present(data.namingRationale)) {
+      errors.push(issue(['namingRationale'], 'certified adversary profiles require namingRationale.'));
+    }
+    if (!hasNonVendorAnchor(externalIds) && !hasTwoIndependentAliases(aliasRecords)) {
+      errors.push(issue(['externalIds'], 'certified adversary profiles require a non-vendor anchor or two independent sourced aliases.'));
+    }
+    if (CRIMINAL_KINDS.has(data.entityKind) && asArray(data.operatingModels).length === 0) {
+      errors.push(issue(['operatingModels'], `${data.entityKind} certified records require operatingModels.`));
+    }
+  }
+
+  if (data.canonicalNameSource === 'other' && !present(data.canonicalNameSourceDetail)) {
+    errors.push(issue(['canonicalNameSourceDetail'], 'canonicalNameSourceDetail is required when canonicalNameSource is other.'));
+  }
+
+  if (isMalpediaFamilyKey(externalIds.malpediaActor)) {
+    errors.push(issue(['externalIds', 'malpediaActor'], 'malpediaActor must be a Malpedia actor slug, not a malware-family key.'));
+  }
+
+  for (const key of Object.keys(externalIds)) {
+    if (!ACTOR_EXTERNAL_ID_KEYS.has(key)) {
+      errors.push(issue(['externalIds', key], `${key} is not a valid actor externalIds key.`));
+    }
+  }
+
+  if (data.importedSourceConfidence !== undefined) {
+    if (!Number.isInteger(data.importedSourceConfidence) || data.importedSourceConfidence < 0 || data.importedSourceConfidence > 100) {
+      errors.push(issue(['importedSourceConfidence'], 'importedSourceConfidence must be an integer from 0 to 100.'));
+    }
+    if (!present(externalIds.mispGalaxyUuid)) {
+      errors.push(issue(['importedSourceConfidence'], 'importedSourceConfidence is MISP-only and requires externalIds.mispGalaxyUuid.'));
+    }
+  }
+
+  for (const [index, alias] of aliasRecords.entries()) {
+    if (!ALIAS_STATUSES.includes(alias?.status)) {
+      errors.push(issue(['aliasRecords', index, 'status'], 'aliasRecords[].status must be current, deprecated, or disputed.'));
+    }
+    if (!CLAIM_CONFIDENCE_VALUES.includes(alias?.confidence)) {
+      errors.push(issue(['aliasRecords', index, 'confidence'], 'aliasRecords[].confidence must use claim confidence A-F.'));
+    }
+  }
+
+  if (aliasRecords.length > 0) {
+    const aliasValues = uniqueValues(asArray(data.aliases)).sort();
+    const derivedValues = uniqueValues(aliasRecords.map((alias) => alias?.value)).sort();
+    if (JSON.stringify(aliasValues) !== JSON.stringify(derivedValues)) {
+      warnings.push(issue(['aliases'], 'aliases should be derived from aliasRecords[].value once aliasRecords are present.'));
+    }
+  }
+
+  for (const [index, claim] of attributionClaims.entries()) {
+    if (!ATTRIBUTION_CLAIM_TYPES.includes(claim?.claimType)) {
+      errors.push(issue(['attributionClaims', index, 'claimType'], 'attributionClaims[].claimType is invalid.'));
+    }
+    if (!CLAIM_CONFIDENCE_VALUES.includes(claim?.confidence)) {
+      errors.push(issue(['attributionClaims', index, 'confidence'], 'attributionClaims[].confidence must use claim confidence A-F.'));
+    }
+    if (SOURCE_RELIABILITY_VALUES.includes(claim?.confidence)) {
+      errors.push(issue(['attributionClaims', index, 'confidence'], 'Source reliability R1-R4 must not appear as claim confidence.'));
+    }
+    if (sourceCount(claim) === 0) {
+      errors.push(issue(['attributionClaims', index, 'sources'], 'attributionClaims[] entries require at least one source reference.'));
+    }
+    if (claim?.importedSourceConfidence !== undefined) {
+      if (!Number.isInteger(claim.importedSourceConfidence) || claim.importedSourceConfidence < 0 || claim.importedSourceConfidence > 100) {
+        errors.push(issue(['attributionClaims', index, 'importedSourceConfidence'], 'importedSourceConfidence must be an integer from 0 to 100.'));
+      }
+      if (!present(externalIds.mispGalaxyUuid)) {
+        errors.push(issue(['attributionClaims', index, 'importedSourceConfidence'], 'importedSourceConfidence is MISP-only and requires externalIds.mispGalaxyUuid.'));
+      }
+    }
+  }
+
+  for (const [index, claim] of relationshipClaims.entries()) {
+    if (!RELATIONSHIP_PREDICATES.includes(claim?.predicate)) {
+      errors.push(issue(['relationshipClaims', index, 'predicate'], 'relationshipClaims[].predicate is invalid.'));
+    }
+    if (!RELATIONSHIP_TARGET_TYPES.includes(claim?.targetType)) {
+      errors.push(issue(['relationshipClaims', index, 'targetType'], 'relationshipClaims[].targetType is invalid.'));
+    }
+    if (claim?.unresolved === true) {
+      if (claim.targetId !== null) {
+        errors.push(issue(['relationshipClaims', index, 'targetId'], 'unresolved relationships require targetId to be null.'));
+      }
+      if (!present(claim.labelIfUnresolved)) {
+        errors.push(issue(['relationshipClaims', index, 'labelIfUnresolved'], 'unresolved relationships require labelIfUnresolved.'));
+      }
+    } else if (!present(claim?.targetId)) {
+      errors.push(issue(['relationshipClaims', index, 'targetId'], 'resolved relationships require targetId.'));
+    }
+    if ((claim?.targetType === 'attack_technique' || claim?.targetType === 'attackTechnique') && !present(claim.attackVersion)) {
+      errors.push(issue(['relationshipClaims', index, 'attackVersion'], 'attack technique relationships require attackVersion.'));
+    }
+    if (!CLAIM_CONFIDENCE_VALUES.includes(claim?.confidence)) {
+      errors.push(issue(['relationshipClaims', index, 'confidence'], 'relationshipClaims[].confidence must use claim confidence A-F.'));
+    }
+    if (SOURCE_RELIABILITY_VALUES.includes(claim?.confidence)) {
+      errors.push(issue(['relationshipClaims', index, 'confidence'], 'Source reliability R1-R4 must not appear as claim confidence.'));
+    }
+    if (sourceCount(claim) === 0) {
+      errors.push(issue(['relationshipClaims', index, 'sources'], 'relationshipClaims[] entries require at least one source reference.'));
+    }
+    const refs = claim?.externalRefs && typeof claim.externalRefs === 'object' ? claim.externalRefs : {};
+    for (const key of Object.keys(refs)) {
+      if (!RELATIONSHIP_EXTERNAL_REF_KEYS.has(key) && !key.startsWith('x-')) {
+        errors.push(issue(['relationshipClaims', index, 'externalRefs', key], `${key} is not a valid relationship target externalRefs key.`));
+      }
+      if (ACTOR_EXTERNAL_ID_KEYS.has(key)) {
+        errors.push(issue(['relationshipClaims', index, 'externalRefs', key], 'externalRefs stores target entity IDs only, never actor identity anchors.'));
+      }
+    }
+  }
+
+  if (data.attributionConfidence !== undefined) {
+    warnings.push(issue(['attributionConfidence'], 'attributionConfidence remains accepted legacy data; attributionClaims[] is the structured target.'));
+  }
+
+  for (const [index, revision] of revisions.entries()) {
+    for (const field of ['actor', 'provider', 'model', 'action', 'ref', 'at']) {
+      if (!present(revision?.[field])) {
+        errors.push(issue(['revisions', index, field], `revisions[].${field} is required when revisions are present.`));
+      }
+    }
+  }
+
+  return { errors, warnings };
+}
+
+export function classifyAnchorCollision(left, right) {
+  const leftExternalIds = left?.externalIds || {};
+  const rightExternalIds = right?.externalIds || {};
+  const sharedHardAnchors = HARD_ANCHOR_KEYS.filter((key) => present(leftExternalIds[key]) && leftExternalIds[key] === rightExternalIds[key]);
+  const conflictingHardAnchors = HARD_ANCHOR_KEYS.filter(
+    (key) => present(leftExternalIds[key]) && present(rightExternalIds[key]) && leftExternalIds[key] !== rightExternalIds[key],
+  );
+
+  if (sharedHardAnchors.length > 0 && conflictingHardAnchors.length > 0) {
+    return {
+      classification: 'hard_anchor_conflict',
+      action: 'ep_disambiguation',
+      autoMerge: false,
+      anchors: sharedHardAnchors,
+      conflicts: conflictingHardAnchors,
+    };
+  }
+
+  if (sharedHardAnchors.length > 0) {
+    return {
+      classification: 'deterministic_merge_candidate',
+      action: 'auto_merge_eligible',
+      autoMerge: true,
+      anchors: sharedHardAnchors,
+      conflicts: [],
+    };
+  }
+
+  const sharedSoftAnchors = SOFT_ANCHOR_KEYS.filter((key) => present(leftExternalIds[key]) && leftExternalIds[key] === rightExternalIds[key]);
+  const leftVendorRefs = new Set(asArray(leftExternalIds.vendorRefs).map(normalizeVendorRef).filter(Boolean));
+  const sharedVendorRefs = asArray(rightExternalIds.vendorRefs).map(normalizeVendorRef).filter((value) => value && leftVendorRefs.has(value));
+
+  if (sharedSoftAnchors.length > 0 || sharedVendorRefs.length > 0) {
+    return {
+      classification: 'soft_anchor_merge_candidate',
+      action: 'ep_disambiguation',
+      autoMerge: false,
+      anchors: [...sharedSoftAnchors, ...sharedVendorRefs.map((value) => `vendorRefs:${value}`)],
+      conflicts: [],
+    };
+  }
+
+  return {
+    classification: 'no_anchor_match',
+    action: 'no_merge_signal',
+    autoMerge: false,
+    anchors: [],
+    conflicts: [],
+  };
+}

--- a/site/src/lib/adversaryProfileValidation.mjs
+++ b/site/src/lib/adversaryProfileValidation.mjs
@@ -105,6 +105,10 @@ function sourceCount(claim) {
   return asArray(claim?.sources).length;
 }
 
+function collectSourceIds(sources = []) {
+  return asArray(sources).map((source) => source?.id).filter(present).map((id) => String(id).trim());
+}
+
 function hasNonVendorAnchor(externalIds = {}) {
   return SOFT_ANCHOR_KEYS.concat(HARD_ANCHOR_KEYS).some((key) => present(externalIds[key]));
 }
@@ -148,6 +152,8 @@ export function getAdversaryProfileValidationIssues(record) {
   const attributionClaims = asArray(data.attributionClaims);
   const relationshipClaims = asArray(data.relationshipClaims);
   const revisions = asArray(data.revisions);
+  const sourceIds = collectSourceIds(data.sources);
+  const knownSourceIds = new Set(sourceIds);
 
   for (const field of ['entityKind', 'isAnalyticConstruct', 'externalIds', 'aliasRecords', 'attributionClaims', 'relationshipClaims', 'revisions']) {
     if (data[field] === undefined) {
@@ -207,6 +213,12 @@ export function getAdversaryProfileValidationIssues(record) {
     }
   }
 
+  for (const [index, source] of asArray(data.sources).entries()) {
+    if (present(source?.id) && sourceIds.filter((id) => id === String(source.id).trim()).length > 1) {
+      errors.push(issue(['sources', index, 'id'], 'sources[].id values must be unique when present.'));
+    }
+  }
+
   for (const [index, alias] of aliasRecords.entries()) {
     if (!ALIAS_STATUSES.includes(alias?.status)) {
       errors.push(issue(['aliasRecords', index, 'status'], 'aliasRecords[].status must be current, deprecated, or disputed.'));
@@ -236,6 +248,13 @@ export function getAdversaryProfileValidationIssues(record) {
     }
     if (sourceCount(claim) === 0) {
       errors.push(issue(['attributionClaims', index, 'sources'], 'attributionClaims[] entries require at least one source reference.'));
+    }
+    for (const [sourceIndex, sourceRef] of asArray(claim?.sources).entries()) {
+      if (!present(sourceRef?.sourceId)) {
+        errors.push(issue(['attributionClaims', index, 'sources', sourceIndex, 'sourceId'], 'attributionClaims[].sources[].sourceId is required.'));
+      } else if (!knownSourceIds.has(String(sourceRef.sourceId).trim())) {
+        errors.push(issue(['attributionClaims', index, 'sources', sourceIndex, 'sourceId'], 'attributionClaims[].sources[].sourceId must reference an existing sources[].id.'));
+      }
     }
     if (claim?.importedSourceConfidence !== undefined) {
       if (!Number.isInteger(claim.importedSourceConfidence) || claim.importedSourceConfidence < 0 || claim.importedSourceConfidence > 100) {
@@ -275,6 +294,13 @@ export function getAdversaryProfileValidationIssues(record) {
     }
     if (sourceCount(claim) === 0) {
       errors.push(issue(['relationshipClaims', index, 'sources'], 'relationshipClaims[] entries require at least one source reference.'));
+    }
+    for (const [sourceIndex, sourceRef] of asArray(claim?.sources).entries()) {
+      if (!present(sourceRef?.sourceId)) {
+        errors.push(issue(['relationshipClaims', index, 'sources', sourceIndex, 'sourceId'], 'relationshipClaims[].sources[].sourceId is required.'));
+      } else if (!knownSourceIds.has(String(sourceRef.sourceId).trim())) {
+        errors.push(issue(['relationshipClaims', index, 'sources', sourceIndex, 'sourceId'], 'relationshipClaims[].sources[].sourceId must reference an existing sources[].id.'));
+      }
     }
     const refs = claim?.externalRefs && typeof claim.externalRefs === 'object' ? claim.externalRefs : {};
     for (const key of Object.keys(refs)) {


### PR DESCRIPTION
## Summary

PR2 implements the additive adversary-profile v0.5 schema foundation for the live `site/src/content/threat-actors/**` collection.

This PR keeps the compatibility posture from PR1/PR1B:
- content-layer fields are camelCase
- `reviewStatus` and its lifecycle enum are unchanged
- `sources[].reliability` remains R1-R4; no `source_rating` rename
- legacy `mitreMappings` and `attributionConfidence` remain accepted
- new v0.5 fields are optional/warning-mode for legacy records
- malformed new fields hard-fail when present

## Scope

Added:
- additive threat-actor schema fields: `aptId`, `entityKind`, `isAnalyticConstruct`, `operatingModels`, `externalIds`, `aliasRecords`, `attributionClaims`, `relationshipClaims`, `importedSourceConfidence`, `notPubliclyEstablished`, `canonicalNameSource`, `canonicalNameSourceDetail`, `namingRationale`, `revisions`
- pure adversary validation/helper module
- PR2 regression tests for v0.5 compatibility, confidence scale separation, relationship rules, and anchor collision classification
- scripts test wiring for the new test file

Not added:
- no PR3 dry-run tooling
- no intake v1.2
- no campaigns/incidents schema work
- no anchor backfill
- no corpus migration or rewrite
- no graph database, scoring, automated attribution, or merge automation
- no content mutation from anchor helpers

## Validation

- `node --check site/src/lib/adversaryProfileValidation.mjs && node --check scripts/test-adversary-schema-foundation.mjs && node scripts/test-adversary-schema-foundation.mjs` — PASS
- `npm --prefix scripts test` — PASS
- `npm --prefix site run build` — PASS
- `git diff --check` — PASS

Known unrelated output: `npm --prefix site run build` emits existing campaign validator warnings about related-incident counts, then passes the campaign validator and completes the Astro build.

## Review

@MahdiHedhli @dangermouse-bot @ernestpenfold-bot review requested.

@codex review
/gemini review