### PR TITLE
Fix supply-chain explore overlay and toggle

### DIFF
--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -69,8 +69,26 @@ assert.ok(
     supplyChainRouteSource.includes('data-sc-explore-exit') &&
     supplyChainRouteSource.includes('class="sc-explore-rail"') &&
     supplyChainRouteSource.includes('class="graph-search-pill"') &&
-    supplyChainRouteSource.includes('aria-label="Search graph"'),
+    supplyChainRouteSource.includes('aria-label="Search graph"') &&
+    supplyChainRouteSource.includes('title="Full screen"') &&
+    supplyChainRouteSource.includes('aria-label="Toggle full screen"') &&
+    supplyChainRouteSource.includes('title="Exit full screen"'),
   'route should expose full-screen explore controls on the persisted graph island'
+);
+assert.ok(
+  supplyChainRouteSource.includes(':global(body.sc-explore-active)') &&
+    supplyChainRouteSource.includes('overflow: hidden') &&
+    supplyChainRouteSource.includes(':global(body.sc-explore-active) :global(main)') &&
+    supplyChainRouteSource.includes('position: fixed') &&
+    supplyChainRouteSource.includes('max-width: none') &&
+    supplyChainRouteSource.includes(':global(body.sc-explore-active) .graph-hero-explore') &&
+    supplyChainRouteSource.includes('.graph-hero-explore .graph-chrome-actions') &&
+    supplyChainRouteSource.includes('right: 376px') &&
+    supplyChainRouteSource.includes('z-index: 1000') &&
+    supplyChainRouteSource.includes('background: var(--bg)') &&
+    supplyChainRouteSource.includes('.graph-icon-button svg') &&
+    supplyChainRouteSource.includes('stroke: currentColor'),
+  'full-screen explore should lock background scroll, cover the viewport, and render an SVG icon control'
 );
 assert.ok(
   supplyChainRouteSource.includes('<circle cx="11" cy="11" r="6.25"></circle>') &&
@@ -635,6 +653,16 @@ assert.ok(
     supplyChainGraphSource.includes('this.pageSelection = { type, value }') &&
     supplyChainRouteSource.includes('.graph-linked-active'),
   'graph client should implement G6 page-to-graph commands and reverse active-state binding'
+);
+assert.ok(
+  supplyChainGraphSource.includes('syncExploreMode()') &&
+    supplyChainGraphSource.includes("document.body.classList.toggle('sc-explore-active', active)") &&
+    supplyChainGraphSource.includes('queueExploreResize()') &&
+    supplyChainGraphSource.includes("window.dispatchEvent(new Event('resize'))") &&
+    supplyChainGraphSource.includes('restoreExploreScroll()') &&
+    supplyChainGraphSource.includes("sessionStorage.setItem('sc-explore-scroll-y'") &&
+    supplyChainGraphSource.includes('exitLink.click()'),
+  'graph client should toggle explore body state, resize the canvas, preserve scroll, and exit without forcing a reload'
 );
 assert.ok(
   supplyChainGraphSource.includes('this.onPageLoad = () =>') &&

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -660,6 +660,8 @@ assert.ok(
     supplyChainGraphSource.includes('queueExploreResize()') &&
     supplyChainGraphSource.includes("window.dispatchEvent(new Event('resize'))") &&
     supplyChainGraphSource.includes('restoreExploreScroll()') &&
+    supplyChainGraphSource.includes('clearExploreMode()') &&
+    supplyChainGraphSource.includes("document.body.classList.remove('sc-explore-active')") &&
     supplyChainGraphSource.includes("sessionStorage.setItem('sc-explore-scroll-y'") &&
     supplyChainGraphSource.includes('exitLink.click()'),
   'graph client should toggle explore body state, resize the canvas, preserve scroll, and exit without forcing a reload'

--- a/site/public/js/supply-chain-graph-core.js
+++ b/site/public/js/supply-chain-graph-core.js
@@ -736,6 +736,7 @@ class SupplyChainGraph {
     this.initWebGL();
     this.bind();
     this.resize();
+    this.syncExploreMode();
     this.selectFromRoute();
     this.animationFrame = requestAnimationFrame(() => this.frame());
   }
@@ -871,6 +872,7 @@ class SupplyChainGraph {
       }
       const exploreLink = event.target.closest('[data-sc-explore-enter], [data-sc-explore-exit]');
       if (exploreLink) {
+        this.prepareExploreNavigation(exploreLink);
         this.syncExploreLink(exploreLink);
         return;
       }
@@ -894,6 +896,7 @@ class SupplyChainGraph {
         this.destroy();
         return;
       }
+      this.syncExploreMode();
       this.selectFromRoute();
       this.syncPageSelection();
     };
@@ -929,6 +932,45 @@ class SupplyChainGraph {
     link.href = `${target.pathname}${target.search}${target.hash}`;
   }
 
+  prepareExploreNavigation(link) {
+    if (link.matches('[data-sc-explore-enter]') && !this.isExploreRoute()) {
+      sessionStorage.setItem('sc-explore-scroll-y', String(window.scrollY || 0));
+    }
+    if (link.matches('[data-sc-explore-exit]')) {
+      sessionStorage.setItem('sc-explore-restore-scroll', 'true');
+    }
+  }
+
+  syncExploreMode() {
+    const active = this.isExploreRoute();
+    const wasActive = document.body.classList.contains('sc-explore-active');
+    document.body.classList.toggle('sc-explore-active', active);
+    if (!active) this.restoreExploreScroll();
+    if (active !== wasActive) this.queueExploreResize();
+  }
+
+  queueExploreResize() {
+    const resize = () => {
+      if (this.destroyed || !document.body.contains(this.root)) return;
+      this.resize();
+      window.dispatchEvent(new Event('resize'));
+    };
+    requestAnimationFrame(() => {
+      resize();
+      requestAnimationFrame(resize);
+    });
+  }
+
+  restoreExploreScroll() {
+    if (sessionStorage.getItem('sc-explore-restore-scroll') !== 'true') return;
+    const scrollY = Number(sessionStorage.getItem('sc-explore-scroll-y') || 0);
+    sessionStorage.removeItem('sc-explore-restore-scroll');
+    sessionStorage.removeItem('sc-explore-scroll-y');
+    requestAnimationFrame(() => {
+      window.scrollTo(0, Number.isFinite(scrollY) ? scrollY : 0);
+    });
+  }
+
   updateGraphUrl() {
     if (this.suppressUrlSync) return;
     const url = new URL(window.location.href);
@@ -943,9 +985,17 @@ class SupplyChainGraph {
   }
 
   exitExploreRoute() {
+    const exitLink = document.querySelector('[data-sc-explore-exit]');
+    if (exitLink instanceof HTMLAnchorElement) {
+      this.prepareExploreNavigation(exitLink);
+      this.syncExploreLink(exitLink);
+      exitLink.click();
+      return;
+    }
     const url = new URL('/supply-chain/', window.location.href);
     const state = this.currentGraphStateParam();
     if (state) url.searchParams.set('graph', state);
+    sessionStorage.setItem('sc-explore-restore-scroll', 'true');
     window.location.href = `${url.pathname}${url.search}`;
   }
 

--- a/site/public/js/supply-chain-graph-core.js
+++ b/site/public/js/supply-chain-graph-core.js
@@ -906,6 +906,7 @@ class SupplyChainGraph {
 
   destroy() {
     if (this.destroyed) return;
+    this.clearExploreMode();
     this.destroyed = true;
     if (this.onDocumentClick) document.removeEventListener('click', this.onDocumentClick);
     if (this.onDocumentKeydown) document.removeEventListener('keydown', this.onDocumentKeydown, { capture: true });
@@ -947,6 +948,14 @@ class SupplyChainGraph {
     document.body.classList.toggle('sc-explore-active', active);
     if (!active) this.restoreExploreScroll();
     if (active !== wasActive) this.queueExploreResize();
+  }
+
+  clearExploreMode() {
+    const wasActive = document.body.classList.contains('sc-explore-active');
+    document.body.classList.remove('sc-explore-active');
+    if (wasActive) this.restoreExploreScroll();
+    sessionStorage.removeItem('sc-explore-restore-scroll');
+    sessionStorage.removeItem('sc-explore-scroll-y');
   }
 
   queueExploreResize() {

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -103,20 +103,38 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
           class="graph-icon-button"
           href="/supply-chain/"
           data-sc-explore-exit
-          aria-label="Exit full-screen explore"
-          title="Exit full-screen explore"
+          aria-label="Exit full screen"
+          title="Exit full screen"
         >
-          <span aria-hidden="true">x</span>
+          <svg aria-hidden="true" viewBox="0 0 24 24">
+            <path d="M8 3v5H3"></path>
+            <path d="M3 8l6-6"></path>
+            <path d="M16 3v5h5"></path>
+            <path d="M21 8l-6-6"></path>
+            <path d="M8 21v-5H3"></path>
+            <path d="M3 16l6 6"></path>
+            <path d="M16 21v-5h5"></path>
+            <path d="M21 16l-6 6"></path>
+          </svg>
         </a>
       ) : (
         <a
           class="graph-icon-button"
           href="/supply-chain/explore/"
           data-sc-explore-enter
-          aria-label="Open full-screen explore"
-          title="Open full-screen explore"
+          aria-label="Toggle full screen"
+          title="Full screen"
         >
-          <span aria-hidden="true">[]</span>
+          <svg aria-hidden="true" viewBox="0 0 24 24">
+            <path d="M3 9V3h6"></path>
+            <path d="M3 3l7 7"></path>
+            <path d="M21 9V3h-6"></path>
+            <path d="M21 3l-7 7"></path>
+            <path d="M3 15v6h6"></path>
+            <path d="M3 21l7-7"></path>
+            <path d="M21 15v6h-6"></path>
+            <path d="M21 21l-7-7"></path>
+          </svg>
         </a>
       )}
     </div>
@@ -756,14 +774,35 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
   .graph-hero-explore {
     position: fixed;
     inset: 0;
-    z-index: 120;
+    z-index: 1000;
     display: grid;
     grid-template-columns: minmax(0, 1fr) minmax(300px, 360px);
     grid-template-rows: 1fr;
     gap: 0;
     max-width: none;
     margin: 0;
-    background: rgba(3, 5, 9, 0.96);
+    background: var(--bg);
+  }
+
+  :global(body.sc-explore-active) {
+    overflow: hidden;
+  }
+
+  :global(body.sc-explore-active) :global(main) {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    max-width: none;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+  }
+
+  :global(body.sc-explore-active) .graph-hero-explore {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    background: var(--bg);
   }
 
   .graph-hero-explore .graph-placeholder {
@@ -788,6 +827,10 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
     z-index: 5;
     display: flex;
     gap: 8px;
+  }
+
+  .graph-hero-explore .graph-chrome-actions {
+    right: 376px;
   }
 
   .graph-icon-button {
@@ -833,6 +876,16 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
     stroke-linecap: round;
     stroke-linejoin: round;
     stroke-width: 1.5;
+  }
+
+  .graph-icon-button svg {
+    width: 16px;
+    height: 16px;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 1.65;
   }
 
   .graph-search-label {
@@ -1913,6 +1966,10 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
 
     .graph-hero-explore .graph-placeholder {
       min-height: 100svh;
+    }
+
+    .graph-hero-explore .graph-chrome-actions {
+      right: 16px;
     }
 
     .graph-hero-explore .graph-caption {


### PR DESCRIPTION
## Summary
- Make supply-chain explore mode a true fixed top-layer host, with body scroll lock and opaque background coverage over nav/ticker/footer.
- Dispatch graph resize on explore enter/exit while preserving the persisted graph island and route-based state.
- Replace the bare full-screen glyph with SVG expand/exit icons and keep the controls clear of the docked desktop rail.
- Add regression coverage for the explore overlay, icon labels, scroll/resize hooks, and exit behavior.

## Verification
- `node scripts/test-supply-chain-pages.mjs`
- `cd site && ENABLE_SUPPLY_CHAIN_PAGES=true npm run build`
- Production preview browser verification at `1440x900` and `390x844`: enter/exit route, footer/ticker covered, body scroll locked, canvas backing size refreshed, explicit exit and Esc return to hero, rail/drawer inside fixed container.

Reviewers requested: @MahdiHedhli @dangermouse-bot @ernestpenfold-bot

Review triggers to follow in PR comments: @codex review and /gemini review.