### PR TITLE
fix: gate certified operating models

### DIFF
--- a/scripts/test-adversary-schema-foundation.mjs
+++ b/scripts/test-adversary-schema-foundation.mjs
@@ -122,6 +122,30 @@ const certifiedWithAliases = {
 };
 assertNoErrors(certifiedWithAliases, 'certified path (b) accepts two independent aliases plus namingRationale');
 
+{
+  const certifiedLegacy = issues({
+    name: 'Legacy Certified',
+    aliases: [],
+    reviewStatus: 'certified',
+    operatingModels: [],
+    sources: sparseDraft.sources,
+  });
+  assert.equal(certifiedLegacy.errors.length, 0, 'empty default operatingModels does not trigger v0.5 certification gate');
+}
+
+{
+  const result = issues({
+    name: 'Operating Model Only',
+    aliases: [],
+    reviewStatus: 'certified',
+    operatingModels: ['ransomware_operation'],
+    sources: sparseDraft.sources,
+  });
+  assert.ok(messages(result.errors).some((message) => /canonicalNameSource/.test(message)), 'non-empty operatingModels triggers certified canonicalNameSource requirement');
+  assert.ok(messages(result.errors).some((message) => /namingRationale/.test(message)), 'non-empty operatingModels triggers certified namingRationale requirement');
+  assert.ok(messages(result.errors).some((message) => /non-vendor anchor/.test(message)), 'non-empty operatingModels triggers certified anchor or sourced-alias requirement');
+}
+
 const lockBitStyle = {
   ...sparseDraft,
   name: 'LockBit',

--- a/site/src/lib/adversaryProfileValidation.mjs
+++ b/site/src/lib/adversaryProfileValidation.mjs
@@ -118,6 +118,10 @@ function hasTwoIndependentAliases(aliasRecords = []) {
 }
 
 function hasV05IdentityFields(data) {
+  if (asArray(data.operatingModels).length > 0) {
+    return true;
+  }
+
   return [
     'aptId',
     'entityKind',


### PR DESCRIPTION
## Summary

Bounded PR2 follow-up for the final Codex finding on merged PR #1245.

Fixes the certified v0.5 gate so a certified adversary profile that adds non-empty `operatingModels` is treated as v0.5-shaped data and must also provide the certification evidence fields. Empty/default `operatingModels: []` remains legacy-safe and does not force existing records through the new gate.

## Scope

Changed only:
- `site/src/lib/adversaryProfileValidation.mjs`
- `scripts/test-adversary-schema-foundation.mjs`

No PR3 work, no migration tooling, no corpus edits, no intake classifier work, no pipeline behavior changes.

## Validation

- `node --check site/src/lib/adversaryProfileValidation.mjs` — PASS
- `node --check scripts/test-adversary-schema-foundation.mjs` — PASS
- `node scripts/test-adversary-schema-foundation.mjs` — PASS
- `npm --prefix scripts test` — PASS
- `npm --prefix site run build` — PASS
- `git diff --check` — PASS

Known unrelated output: existing campaign related-incident warnings; campaign validation and Astro build pass.

@MahdiHedhli @dangermouse-bot @ernestpenfold-bot review requested.

@codex review
/gemini review