### PR TITLE
docs: align threat actor identity policy

### DIFF
--- a/docs/ADR-0007-entity-id-format.md
+++ b/docs/ADR-0007-entity-id-format.md
@@ -1,0 +1,85 @@
+# ADR 0007 - Entity ID Format Convention
+
+**Date:** 2026-06-18
+**Status:** Accepted
+**Deciders:** Kernel K
+**Supersedes:** Actor-identity portions of `MANIFEST-SPEC.md` and
+`DATA-STANDARDS-v1.0.md` that require threat actor content records to use
+`entity_id: TP-APT-NNNN` / `apt_id: TP-APT-NNNN` as their primary identity.
+**Related:** `docs/schema-intake-pr1-reconciliation-20260618.md`,
+`docs/DATA-STANDARDS-v1.0.md`, `site/src/content.config.ts`
+
+---
+
+## Context
+
+Threatpedia's live public site is an Astro static site. Threat actor records
+are content files in:
+
+```text
+site/src/content/threat-actors/**
+```
+
+The active public corpus is slug-addressed through that collection path. Public
+threat actor records do not currently carry required `TP-APT-*` identifiers,
+`apt_id` values, or populated external anchor registries. The PR1 and PR1B
+schema/intake audits confirmed that the live content shape uses camelCase
+frontmatter, `reviewStatus` lifecycle values, `sources[].reliability` R1-R4,
+and legacy `attributionConfidence`.
+
+Older manifest and data-standard prose described APT/threat-actor entities as
+using mandatory `TP-APT-NNNN` identifiers and mandatory `nation_state` /
+`attribution_confidence` fields. That prose no longer matches the live Astro
+content model or the additive adversary-profile v0.5 compatibility layer.
+
+## Decision
+
+Threat actor content records remain slug-addressed site records under
+`site/src/content/threat-actors/**`.
+
+Numeric `TP-APT-*` identifiers and the camelCase `aptId` field, if introduced
+or populated later, are compatibility/export identifiers only. They are not the
+primary content identity, are optional for legacy records, and must be
+introduced only through an approved migration or enrichment plan. Agents must
+not mint `TP-APT-*` identifiers silently while drafting, validating, migrating,
+or rewriting threat actor content.
+
+Structured attribution moves toward sourced `attributionClaims[]` in the
+adversary-profile v0.5 model. Existing `attributionConfidence` remains an
+accepted legacy/display field during the phased deprecation period and must not
+be hard-removed until migration coverage gates are satisfied.
+
+Threat actor content records must not be made to hard-fail solely because they
+lack `aptId`, `TP-APT-*`, `nation_state`, or snake_case
+`attribution_confidence` fields.
+
+## Supersession / Manifest Alignment
+
+This ADR supersedes the actor-identity portions of `MANIFEST-SPEC.md` and
+`DATA-STANDARDS-v1.0.md` that require APT/threat-actor entities to use
+`entity_id: TP-APT-NNNN` or `apt_id: TP-APT-NNNN` and that require
+`nation_state` / `attribution_confidence` as mandatory actor fields.
+
+Threat actor content in the live Astro collection remains slug-addressed under
+`site/src/content/threat-actors/**`. Numeric `TP-APT-*` / `aptId` identifiers,
+if introduced later, are compatibility/export identifiers only. They are
+additive, optional for legacy records, and must be introduced only through an
+approved migration or enrichment plan.
+
+Structured attribution moves toward sourced `attributionClaims[]`. Legacy
+`attributionConfidence` remains accepted during the phased deprecation period
+and must not be hard-removed until migration coverage gates are satisfied.
+
+## Consequences
+
+- PR3 migration/rewrite work must preserve slug-addressed actor identity unless
+  Kernel K approves a separate actor-ID migration plan.
+- Schema and validator work may support optional `aptId` / `externalIds`
+  fields, but existing legacy records stay warning-compatible when those fields
+  are absent.
+- Export layers may map actors to STIX intrusion-set, MITRE ATT&CK group, MISP
+  Galaxy, Malpedia, ETDA, or vendor identifiers through external anchors, but
+  those anchors do not replace the content slug.
+- Historical standards that describe mandatory `apt_id`, `nation_state`, or
+  snake_case `attribution_confidence` for actor content should be read as
+  superseded for the live Astro threat-actor collection.

--- a/docs/DATA-STANDARDS-v1.0.md
+++ b/docs/DATA-STANDARDS-v1.0.md
@@ -13,6 +13,30 @@ Version 1.0 is the **operating schema** for the freeze-and-sweep normalization p
 
 When the Founding Board is seated, v1.0 becomes the working draft they review. Their first act is to publish v1.1 with any changes they require. The empty-board period ratifies via Colonel K (project lead), DangerMouse (Claude), and Penfold (Gemini).
 
+### Current Actor Identity Amendment
+
+ADR 0007 (`docs/ADR-0007-entity-id-format.md`) supersedes the portions of this
+pre-migration standard that require APT/threat-actor content records to use
+`apt_id: TP-APT-NNNN` as their primary identity or to carry mandatory
+`nation_state` / snake_case `attribution_confidence` fields.
+
+The live Astro threat-actor collection is canonical for public actor content:
+
+```text
+site/src/content/threat-actors/**
+```
+
+Threat actor records remain slug-addressed for site/content identity. Optional
+`TP-APT-*` / `aptId` values, if introduced later, are compatibility/export
+identifiers only and must be populated through an approved migration or
+enrichment plan. Existing legacy records must not hard-fail solely because they
+lack `aptId`, `TP-APT-*`, `nation_state`, or snake_case
+`attribution_confidence`.
+
+Structured attribution moves toward sourced `attributionClaims[]` in the
+adversary-profile compatibility layer. Existing `attributionConfidence` remains
+an accepted legacy/display field during the phased deprecation period.
+
 ---
 
 ## What Changed From v0.1
@@ -345,7 +369,15 @@ Do not put ATLAS `AML.*` identifiers in `mitreMappings`; ATT&CK and ATLAS mappin
 
 ## 5. APT Registry — Field Specification
 
-### 5.1 Required Fields
+> **Actor identity amendment:** This pre-migration APT registry table is not the
+> live public threat-actor content contract. For the live Astro collection,
+> `site/src/content/threat-actors/**` and `site/src/content.config.ts` govern.
+> Actor records are slug-addressed; `aptId` / `TP-APT-*` identifiers are
+> optional compatibility/export anchors, not mandatory primary content IDs.
+> `nation_state` and snake_case `attribution_confidence` must not be
+> reintroduced as mandatory public actor fields by migration agents.
+
+### 5.1 Pre-Migration Required Fields (Superseded For Live Threat-Actor Content)
 
 | Field | Type | Notes |
 |---|---|---|
@@ -440,7 +472,9 @@ The 77-to-11 reduction is the single biggest structural cleanup in v1.0. It also
 
 Every article header renders these 7 fields. No more, no fewer. Empty values render as "Unknown" or "TBD" — they do not get omitted.
 
-1. **Incident ID** (`event_id` for incidents, `apt_id` for entity profiles, `campaign_id` for campaigns)
+1. **Incident ID** (`event_id` for incidents, slug for live threat-actor
+   content, `campaign_id` for campaigns; optional `aptId` only as a future
+   compatibility/export anchor)
 2. **Title**
 3. **Severity** (color-coded by `impact_severity`)
 4. **Review Status badge** (with confidence grade in v1.1+)
@@ -719,18 +753,28 @@ Plus the JSON-LD block from §13.
 
 ## 16. ID Conventions
 
+> **Actor identity amendment:** Threat actor public content uses slug identity
+> under `site/src/content/threat-actors/**`. `TP-APT-*` / `aptId` may be added
+> later as optional compatibility/export identifiers only. Do not mint or
+> require them silently during PR3 migration/rewrite work.
+
 | Entity | Pattern | Example |
 |---|---|---|
 | Incident | `TP-YYYY-NNNN` | `TP-2026-0035` |
 | Campaign | `TP-CAMP-NNNN` | `TP-CAMP-0001` |
-| APT | `TP-APT-NNNN` | `TP-APT-0001` |
+| APT / threat actor content | Slug under `site/src/content/threat-actors/**`; optional `TP-APT-*` / `aptId` export anchor only | `sandworm`; optional `TP-APT-0001` |
 | Malware | `TP-MAL-NNNN` | `TP-MAL-0001` |
 | Zero-Day | `TP-0DAY-NNNN` | `TP-0DAY-0001` |
 | Disclosure Credit | `DC-NNNN` | `DC-0001` |
 | Source | `SRC-NNNN` | `SRC-0001` |
 | Sighting | UUID | `550e8400-...` |
 
-The previous `TP-TA-NNNN` pattern (used for ShinyHunters) is deprecated. Threat actor profiles use `TP-APT-NNNN`. The audit found ShinyHunters filed as `TP-TA-0008` inside the `incidents` collection — this is a category error and gets corrected during normalization.
+The previous `TP-TA-NNNN` pattern (used for ShinyHunters) is deprecated. Live
+threat actor content now uses slug identity under
+`site/src/content/threat-actors/**`; `TP-APT-*` / `aptId` values are optional
+compatibility/export anchors only. The audit found ShinyHunters filed as
+`TP-TA-0008` inside the `incidents` collection — this is a historical category
+error and must not be used as precedent for new actor-ID minting.
 
 ---
 

--- a/docs/DATA-STANDARDS.md
+++ b/docs/DATA-STANDARDS.md
@@ -10,6 +10,30 @@ This document defines the data standards governing how Threatpedia collects, str
 
 All items marked `[ ]` are open for Founding Board input.
 
+## Current Actor Identity Amendment
+
+ADR 0007 (`docs/ADR-0007-entity-id-format.md`) supersedes the actor-identity
+portions of this draft that require APT/threat-actor content records to use
+`apt_id: TP-APT-NNNN` as their primary identity or to carry mandatory
+`nation_state` / snake_case `attribution_confidence` fields.
+
+The live Astro threat-actor collection is canonical for public actor content:
+
+```text
+site/src/content/threat-actors/**
+```
+
+Threat actor records remain slug-addressed for site/content identity. Optional
+`TP-APT-*` / `aptId` values, if introduced later, are compatibility/export
+identifiers only and must be populated through an approved migration or
+enrichment plan. Existing legacy records must not hard-fail solely because they
+lack `aptId`, `TP-APT-*`, `nation_state`, or snake_case
+`attribution_confidence`.
+
+Structured attribution moves toward sourced `attributionClaims[]`; existing
+`attributionConfidence` remains an accepted legacy/display field during the
+phased deprecation period.
+
 ---
 
 ## Entity Types & Relationships
@@ -122,7 +146,7 @@ Non-Profit & NGO
 
 ## Incident Record — Field Specification
 
-### Required Fields
+### Pre-Migration Required Fields (Superseded For Live Threat-Actor Content)
 
 | Field | Type | Format | Validation |
 |---|---|---|---|
@@ -250,6 +274,14 @@ framework-mappings:
 ---
 
 ## APT Registry — Field Specification
+
+> **Actor identity amendment:** This draft APT registry table is not the live
+> public threat-actor content contract. For the live Astro collection,
+> `site/src/content/threat-actors/**` and `site/src/content.config.ts` govern.
+> Actor records are slug-addressed; `aptId` / `TP-APT-*` identifiers are
+> optional compatibility/export anchors, not mandatory primary content IDs.
+> `nation_state` and snake_case `attribution_confidence` must not be
+> reintroduced as mandatory public actor fields by migration agents.
 
 ### Required Fields
 


### PR DESCRIPTION
## Summary

Resolves the documented actor-identity conflict before PR3 migration work by making the public docs match the live Astro threat-actor policy.

Changes:
- Adds accepted public ADR 0007 for threat actor identity alignment.
- Marks older MANIFEST/DATA-STANDARDS actor-ID requirements as superseded for live Astro threat-actor content.
- Clarifies that `site/src/content/threat-actors/**` remains the canonical public actor collection and that actors are slug-addressed.
- States `TP-APT-*` / `aptId` values are optional compatibility/export anchors only and must not be silently minted.
- Preserves `attributionConfidence` as legacy accepted while structured attribution moves toward `attributionClaims[]`.

## Scope

Docs/spec alignment only.

No schema changes, validator changes, corpus/content changes, migration tooling, intake classifier work, workflow/package/config/pipeline behavior changes, TP-APT minting, or re-slugging.

## Investigation

Inspected public docs and schema surfaces including:
- `docs/DATA-STANDARDS.md`
- `docs/DATA-STANDARDS-v1.0.md`
- `docs/schema-intake-pr1-reconciliation-20260618.md`
- `site/src/content.config.ts`
- public task references to `MANIFEST-SPEC.md` and ADR 0007

Also checked private control-plane copies only to understand the conflict; this PR does not publish private internals.

Search terms included: `TP-APT`, `apt_id`, `entity_id`, `threat actor`, `threat-actor`, `apt`, `nation_state`, `attribution_confidence`, `attributionConfidence`, `MANIFEST-SPEC`, `ADR 0007`, `Supersedes`, and `Status`.

## Validation

- `git diff --cached --check` PASS
- Searched public docs for remaining unsuperseded mandatory `TP-APT` actor-identity language; remaining hits are either the new supersession text, historical audit findings, live optional schema support, or non-actor/supply-chain fields.
- No dedicated markdown lint target was found; `rg` only found a prose-filter word list in `scripts/pipeline-run-task.mjs`.

## Review

@MahdiHedhli @dangermouse-bot @ernestpenfold-bot please review.

@codex review
/gemini review
