### PR TITLE
docs: address actor identity review follow-up

### DIFF
--- a/docs/ADR-0007-entity-id-format.md
+++ b/docs/ADR-0007-entity-id-format.md
@@ -45,9 +45,9 @@ TP-EXP-YYYY-NNNN
 
 The `YYYY` component follows the pipeline allocation precedence: CVE year,
 then sourced disclosure year when no CVE year is available, then current year
-as a last-resort draft fallback. The `NNNN` sequence is zero-padded and scoped
-to the exploit domain and year. Once assigned to a non-draft record, the ID is
-immutable and must not be reused.
+as a last-resort draft fallback. The `NNNN` sequence is a four-digit,
+zero-padded integer scoped to the exploit domain and year. Once assigned to a
+non-draft record, the ID is immutable and must not be reused.
 
 This convention is enforced today by:
 

--- a/docs/ADR-0007-entity-id-format.md
+++ b/docs/ADR-0007-entity-id-format.md
@@ -6,8 +6,6 @@
 **Supersedes:** Actor-identity portions of `MANIFEST-SPEC.md` and
 `DATA-STANDARDS-v1.0.md` that require threat actor content records to use
 `entity_id: TP-APT-NNNN` / `apt_id: TP-APT-NNNN` as their primary identity.
-Also records the year-namespaced zero-day `exploitId` convention already
-enforced by the Astro schema and pipeline task runner.
 **Related:** `docs/schema-intake-pr1-reconciliation-20260618.md`,
 `docs/DATA-STANDARDS-v1.0.md`, `site/src/content.config.ts`
 

--- a/docs/ADR-0007-entity-id-format.md
+++ b/docs/ADR-0007-entity-id-format.md
@@ -43,10 +43,11 @@ the record needs a durable Threatpedia exploit identifier:
 TP-EXP-YYYY-NNNN
 ```
 
-The `YYYY` component is the calendar year of first public disclosure or first
-corpus appearance, whichever is earlier and source-supported. The `NNNN`
-sequence is zero-padded and scoped to the exploit domain and year. Once
-assigned to a non-draft record, the ID is immutable and must not be reused.
+The `YYYY` component follows the pipeline allocation precedence: CVE year,
+then sourced disclosure year when no CVE year is available, then current year
+as a last-resort draft fallback. The `NNNN` sequence is zero-padded and scoped
+to the exploit domain and year. Once assigned to a non-draft record, the ID is
+immutable and must not be reused.
 
 This convention is enforced today by:
 

--- a/docs/ADR-0007-entity-id-format.md
+++ b/docs/ADR-0007-entity-id-format.md
@@ -6,6 +6,8 @@
 **Supersedes:** Actor-identity portions of `MANIFEST-SPEC.md` and
 `DATA-STANDARDS-v1.0.md` that require threat actor content records to use
 `entity_id: TP-APT-NNNN` / `apt_id: TP-APT-NNNN` as their primary identity.
+Also records the year-namespaced zero-day `exploitId` convention already
+enforced by the Astro schema and pipeline task runner.
 **Related:** `docs/schema-intake-pr1-reconciliation-20260618.md`,
 `docs/DATA-STANDARDS-v1.0.md`, `site/src/content.config.ts`
 
@@ -33,6 +35,31 @@ using mandatory `TP-APT-NNNN` identifiers and mandatory `nation_state` /
 content model or the additive adversary-profile v0.5 compatibility layer.
 
 ## Decision
+
+### Zero-day and exploit IDs
+
+Zero-day and exploit records use an optional year-namespaced `exploitId` when
+the record needs a durable Threatpedia exploit identifier:
+
+```text
+TP-EXP-YYYY-NNNN
+```
+
+The `YYYY` component is the calendar year of first public disclosure or first
+corpus appearance, whichever is earlier and source-supported. The `NNNN`
+sequence is zero-padded and scoped to the exploit domain and year. Once
+assigned to a non-draft record, the ID is immutable and must not be reused.
+
+This convention is enforced today by:
+
+- `site/src/content.config.ts`, which accepts `exploitId` values matching
+  `TP-EXP-YYYY-NNNN`.
+- `scripts/pipeline-run-task.mjs`, which validates zero-day task output against
+  the same year-namespaced pattern.
+- `docs/PIPELINE.md`, which describes discovery allocating year-namespaced
+  zero-day exploit IDs per ADR 0007.
+
+### Threat actor content identity
 
 Threat actor content records remain slug-addressed site records under
 `site/src/content/threat-actors/**`.
@@ -72,6 +99,8 @@ and must not be hard-removed until migration coverage gates are satisfied.
 
 ## Consequences
 
+- Zero-day workers that consult ADR 0007 get the same `TP-EXP-YYYY-NNNN`
+  convention that the live schema and task runner enforce.
 - PR3 migration/rewrite work must preserve slug-addressed actor identity unless
   Kernel K approves a separate actor-ID migration plan.
 - Schema and validator work may support optional `aptId` / `externalIds`

--- a/docs/DATA-STANDARDS.md
+++ b/docs/DATA-STANDARDS.md
@@ -146,7 +146,7 @@ Non-Profit & NGO
 
 ## Incident Record — Field Specification
 
-### Pre-Migration Required Fields (Superseded For Live Threat-Actor Content)
+### Required Fields
 
 | Field | Type | Format | Validation |
 |---|---|---|---|
@@ -283,7 +283,7 @@ framework-mappings:
 > `nation_state` and snake_case `attribution_confidence` must not be
 > reintroduced as mandatory public actor fields by migration agents.
 
-### Required Fields
+### Pre-Migration Required Fields (Superseded For Live Threat-Actor Content)
 
 | Field | Type | Format | Notes |
 |---|---|---|---|


### PR DESCRIPTION
## Summary

Follow-up to merged PR #1252 addressing Codex review feedback left on the merged docs alignment PR.

Fixes:
- Adds the zero-day/exploit `TP-EXP-YYYY-NNNN` convention to ADR 0007 so zero-day workers that follow `docs/PIPELINE.md` references find the ID rule in the accepted ADR.
- Restores the incident required-fields heading in `docs/DATA-STANDARDS.md` so actor-only supersession language does not appear to weaken incident requirements.
- Moves the superseded heading to the APT registry section where it belongs.

## Scope

Docs-only follow-up. No schema, validator, corpus, migration, workflow, package, config, or pipeline behavior changes.

## Validation

- `git diff --check` PASS
- `git diff --cached --check` PASS
- Verified `docs/ADR-0007-entity-id-format.md` includes `TP-EXP-YYYY-NNNN`
- Verified `docs/DATA-STANDARDS.md` incident section is back to `### Required Fields`
- Verified `docs/DATA-STANDARDS.md` APT registry section carries the superseded heading

## Review

Addresses Codex threads from #1252:
- Include zero-day ID rules in ADR 0007
- Keep the incident required-fields section scoped to incidents

@MahdiHedhli @dangermouse-bot @ernestpenfold-bot please review.

@codex review
/gemini review
