### PR TITLE
Add supply-chain malware family lineage view

### DIFF
--- a/data/supply-chain-malware-families/families.json
+++ b/data/supply-chain-malware-families/families.json
@@ -14,6 +14,28 @@
       "actor-teampcp"
     ],
     "first_seen": "2025-09-16",
+    "timeline_ticks": [
+      {
+        "label": "Sep 2025",
+        "x": 90
+      },
+      {
+        "label": "Dec 2025",
+        "x": 330
+      },
+      {
+        "label": "May 2026",
+        "x": 565
+      },
+      {
+        "label": "Jun 1-5",
+        "x": 905
+      },
+      {
+        "label": "Jun 6+",
+        "x": 1110
+      }
+    ],
     "sources": [
       {
         "id": "ref-wiz-shai-hulud",

--- a/data/supply-chain-malware-families/families.json
+++ b/data/supply-chain-malware-families/families.json
@@ -1,0 +1,356 @@
+[
+  {
+    "schema_version": "supply-chain-malware-family/1",
+    "id": "family-shai-hulud",
+    "name": "Shai-Hulud",
+    "aliases": [
+      "Shai Hulud",
+      "Shai-Hulud worm family",
+      "Mini Shai-Hulud"
+    ],
+    "summary": "A self-propagating supply-chain worm family spanning npm, PyPI, and RubyGems activity, modeled as genealogy rather than infection propagation.",
+    "root_actor_id": "actor-shai-hulud-operator",
+    "associated_actor_ids": [
+      "actor-teampcp"
+    ],
+    "first_seen": "2025-09-16",
+    "sources": [
+      {
+        "id": "ref-wiz-shai-hulud",
+        "title": "Shai-Hulud npm supply-chain attack",
+        "publisher": "Wiz",
+        "url": "https://www.wiz.io/blog/shai-hulud-npm-supply-chain-attack",
+        "published_at": "2025-09-16"
+      },
+      {
+        "id": "ref-microsoft-shai-hulud-2",
+        "title": "Shai-Hulud 2.0 guidance",
+        "publisher": "Microsoft Security Blog",
+        "url": "https://www.microsoft.com/en-us/security/blog/2025/12/09/shai-hulud-2-0-guidance-for-detecting-investigating-and-defending-against-the-supply-chain-attack/",
+        "published_at": "2025-12-09"
+      },
+      {
+        "id": "ref-socket-tanstack-mini-shai",
+        "title": "TanStack npm packages compromised in Mini Shai-Hulud supply-chain attack",
+        "publisher": "Socket Research Team",
+        "url": "https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack",
+        "published_at": "2026-05-11"
+      },
+      {
+        "id": "ref-stepsecurity-mini-shai",
+        "title": "Mini Shai-Hulud is back",
+        "publisher": "StepSecurity",
+        "url": "https://www.stepsecurity.io/blog/mini-shai-hulud-is-back-a-self-spreading-supply-chain-attack-hits-the-npm-ecosystem",
+        "published_at": "2026-05-11"
+      }
+    ],
+    "strains": [
+      {
+        "id": "strain-shai-hulud",
+        "name": "Shai-Hulud",
+        "aliases": [
+          "Shai Hulud"
+        ],
+        "first_seen": "2025-09-16",
+        "ecosystems": [
+          "npm"
+        ],
+        "lineage_role": "origin",
+        "lineage_confidence": "origin",
+        "severity": "medium",
+        "key_mutation": "Origin strain: self-replicating npm worm with token theft and auto-republish behavior.",
+        "retained_features": [],
+        "mutation_summary": "Created the family template: developer token theft, public exfiltration repositories, and automated republishing into other npm packages.",
+        "provenance_abuse": "Static token theft",
+        "attribution": {
+          "label": "Unattributed",
+          "confidence": "unknown"
+        },
+        "incident_ids": [
+          "SC-2025-NPM-SHAI-HULUD"
+        ],
+        "layout": {
+          "x": 90,
+          "y": 250
+        }
+      },
+      {
+        "id": "strain-shai-hulud-2",
+        "name": "Shai-Hulud 2.0",
+        "aliases": [
+          "Shai Hulud 2.0"
+        ],
+        "first_seen": "2025-11-24",
+        "ecosystems": [
+          "npm"
+        ],
+        "lineage_role": "descendant",
+        "lineage_confidence": "confirmed",
+        "severity": "medium",
+        "key_mutation": "Second wave with broader package reach and faster propagation.",
+        "retained_features": [
+          "token theft",
+          "auto-republish"
+        ],
+        "mutation_summary": "Expanded the original playbook into a larger wave while retaining token theft and automated republishing.",
+        "provenance_abuse": "Static token theft",
+        "attribution": {
+          "actor_id": "actor-teampcp",
+          "label": "TeamPCP",
+          "confidence": "likely"
+        },
+        "incident_ids": [
+          "SC-2025-SHAI-HULUD-2"
+        ],
+        "layout": {
+          "x": 330,
+          "y": 250
+        }
+      },
+      {
+        "id": "strain-mini-shai-hulud",
+        "name": "Mini Shai-Hulud",
+        "aliases": [
+          "Mini Shai Hulud"
+        ],
+        "first_seen": "2026-05-11",
+        "ecosystems": [
+          "npm",
+          "PyPI",
+          "RubyGems"
+        ],
+        "lineage_role": "reimplementation",
+        "lineage_confidence": "confirmed",
+        "severity": "high",
+        "key_mutation": "Trusted publishing and OIDC token abuse across multiple package ecosystems.",
+        "retained_features": [
+          "self-propagation",
+          "credential theft"
+        ],
+        "mutation_summary": "Shifted the worm from static-token theft toward CI/CD trusted-publishing abuse, OIDC token extraction, and cross-ecosystem package propagation.",
+        "provenance_abuse": "Trusted publishing / OIDC",
+        "attribution": {
+          "actor_id": "actor-teampcp",
+          "label": "TeamPCP",
+          "confidence": "likely"
+        },
+        "incident_ids": [
+          "SC-2026-MINI-SHAI-HULUD"
+        ],
+        "layout": {
+          "x": 565,
+          "y": 250
+        }
+      },
+      {
+        "id": "strain-miasma",
+        "name": "Miasma",
+        "aliases": [
+          "The Spreading Blight"
+        ],
+        "first_seen": "2026-06-01",
+        "ecosystems": [
+          "npm"
+        ],
+        "lineage_role": "suspected_fork",
+        "lineage_confidence": "suspected",
+        "severity": "critical",
+        "key_mutation": "binding.gyp install-time evasion, per-infection encryption, and prompt-injection targeting AI coding agents.",
+        "retained_features": [
+          "trusted-publishing abuse",
+          "self-propagation"
+        ],
+        "mutation_summary": "Added per-infection encryption, binding.gyp execution, and AI-assistant prompt-injection behavior while retaining the released Mini Shai-Hulud playbook.",
+        "provenance_abuse": "Trusted publishing / OIDC",
+        "attribution": {
+          "actor_id": "actor-teampcp",
+          "label": "Suspected TeamPCP",
+          "confidence": "suspected"
+        },
+        "incident_ids": [],
+        "layout": {
+          "x": 905,
+          "y": 150
+        }
+      },
+      {
+        "id": "strain-hades-shai-hulud",
+        "name": "Hades",
+        "aliases": [
+          "Hades Shai-Hulud lineage strain"
+        ],
+        "first_seen": "2026-06-06",
+        "ecosystems": [
+          "PyPI"
+        ],
+        "lineage_role": "evolution",
+        "lineage_confidence": "confirmed",
+        "severity": "critical",
+        "key_mutation": "PyPI move with Artifactory-focused reconnaissance and broader propagation.",
+        "retained_features": [
+          "Miasma evasion",
+          "AI-assistant targeting"
+        ],
+        "mutation_summary": "Carried Miasma behavior into PyPI and added Artifactory-focused reconnaissance.",
+        "provenance_abuse": "OIDC",
+        "attribution": {
+          "label": "Suspected",
+          "confidence": "suspected"
+        },
+        "incident_ids": [],
+        "layout": {
+          "x": 1110,
+          "y": 88
+        }
+      },
+      {
+        "id": "strain-ironworm",
+        "name": "IronWorm",
+        "aliases": [
+          "Iron Worm"
+        ],
+        "first_seen": "2026-06-06",
+        "ecosystems": [
+          "npm"
+        ],
+        "lineage_role": "suspected_clone",
+        "lineage_confidence": "suspected",
+        "severity": "high",
+        "key_mutation": "Rust ELF payload delivered through a preinstall hook.",
+        "retained_features": [
+          "credential-driven self-replication"
+        ],
+        "mutation_summary": "A suspected cosmetic clone over the released base, with a Rust ELF payload and preinstall execution.",
+        "provenance_abuse": "Preinstall hook",
+        "attribution": {
+          "label": "Unclear",
+          "confidence": "unknown"
+        },
+        "incident_ids": [],
+        "layout": {
+          "x": 905,
+          "y": 400
+        }
+      }
+    ],
+    "fork_events": [
+      {
+        "id": "fork-mini-shai-source-release",
+        "name": "Mini Shai-Hulud source open-sourced",
+        "date": "2026-05-12",
+        "summary": "Public release of the framework is modeled as the fork point that lowers later look-alike edges to suspected unless separate code-overlap or researcher-attestation evidence exists.",
+        "source_refs": [
+          "ref-stepsecurity-mini-shai",
+          "ref-socket-tanstack-mini-shai"
+        ],
+        "layout": {
+          "x": 735,
+          "y": 250
+        }
+      }
+    ],
+    "lineage_edges": [
+      {
+        "source": "strain-shai-hulud-2",
+        "target": "strain-shai-hulud",
+        "type": "EVOLVED_FROM",
+        "evidence_class": "confirmed",
+        "confidence": "confirmed",
+        "relation_kind": "descendant",
+        "mutation_delta": [
+          "scale",
+          "faster propagation"
+        ],
+        "external_refs": [
+          {
+            "source_ref": "ref-microsoft-shai-hulud-2"
+          }
+        ],
+        "summary": "The second wave retained the Shai-Hulud worm playbook while increasing scale and propagation speed."
+      },
+      {
+        "source": "strain-mini-shai-hulud",
+        "target": "strain-shai-hulud-2",
+        "type": "EVOLVED_FROM",
+        "evidence_class": "confirmed",
+        "confidence": "confirmed",
+        "relation_kind": "evolution",
+        "mutation_delta": [
+          "added PyPI",
+          "added trusted publishing",
+          "OIDC token theft"
+        ],
+        "external_refs": [
+          {
+            "source_ref": "ref-socket-tanstack-mini-shai"
+          },
+          {
+            "source_ref": "ref-stepsecurity-mini-shai"
+          }
+        ],
+        "summary": "Mini Shai-Hulud is modeled as the industrialized cross-ecosystem evolution of the Shai-Hulud worm pattern."
+      },
+      {
+        "source": "strain-miasma",
+        "target": "strain-mini-shai-hulud",
+        "type": "VARIANT_OF",
+        "evidence_class": "suspected",
+        "confidence": "suspected",
+        "relation_kind": "playbook_adoption",
+        "mutation_delta": [
+          "binding.gyp install evasion",
+          "per-infection encryption",
+          "AI coding-agent prompt injection"
+        ],
+        "suspected_reason": "Mini Shai-Hulud source release makes resemblance insufficient for confirmed descent or actor attribution.",
+        "fork_event_id": "fork-mini-shai-source-release",
+        "external_refs": [
+          {
+            "source_ref": "ref-stepsecurity-mini-shai"
+          }
+        ],
+        "summary": "Miasma is treated as a suspected fork from the released framework unless stronger code-overlap or researcher-attestation evidence lands."
+      },
+      {
+        "source": "strain-hades-shai-hulud",
+        "target": "strain-miasma",
+        "type": "EVOLVED_FROM",
+        "evidence_class": "confirmed",
+        "confidence": "confirmed",
+        "relation_kind": "evolution",
+        "mutation_delta": [
+          "moved to PyPI",
+          "Artifactory reconnaissance",
+          "broader propagation"
+        ],
+        "external_refs": [
+          {
+            "source_ref": "ref-stepsecurity-mini-shai"
+          }
+        ],
+        "summary": "Hades is modeled as an evolution of Miasma in the worked example."
+      },
+      {
+        "source": "strain-ironworm",
+        "target": "strain-mini-shai-hulud",
+        "type": "VARIANT_OF",
+        "evidence_class": "suspected",
+        "confidence": "suspected",
+        "relation_kind": "cosmetic_clone",
+        "mutation_delta": [
+          "Rust ELF payload",
+          "preinstall hook",
+          "cosmetic fork"
+        ],
+        "suspected_reason": "The public source-release fork point means a look-alike clone is not enough to assert confirmed descent.",
+        "fork_event_id": "fork-mini-shai-source-release",
+        "external_refs": [
+          {
+            "source_ref": "ref-stepsecurity-mini-shai"
+          }
+        ],
+        "summary": "IronWorm is a suspected sibling clone over the released base rather than a confirmed descendant."
+      }
+    ]
+  }
+]

--- a/data/supply-chain-malware-families/families.json
+++ b/data/supply-chain-malware-families/families.json
@@ -64,6 +64,13 @@
         "publisher": "StepSecurity",
         "url": "https://www.stepsecurity.io/blog/mini-shai-hulud-is-back-a-self-spreading-supply-chain-attack-hits-the-npm-ecosystem",
         "published_at": "2026-05-11"
+      },
+      {
+        "id": "ref-stepsecurity-hades-campaign",
+        "title": "The Hades Campaign: Graph ML PyPI Packages Deploy Cross-Platform Memory Scrapers, AI Analyst Misdirection, and a Wiper Deterrent",
+        "publisher": "StepSecurity",
+        "url": "https://www.stepsecurity.io/blog/the-hades-campaign-pypi-packages",
+        "published_at": "2026-06-08"
       }
     ],
     "strains": [
@@ -206,7 +213,7 @@
           "PyPI"
         ],
         "lineage_role": "evolution",
-        "lineage_confidence": "confirmed",
+        "lineage_confidence": "suspected",
         "severity": "critical",
         "key_mutation": "PyPI move with Artifactory-focused reconnaissance and broader propagation.",
         "retained_features": [
@@ -348,7 +355,7 @@
         "suspected_reason": "Current cited reporting supports Hades as a Miasma-like successor in the worked example, but does not independently establish code-overlap or explicit researcher-attested descent.",
         "external_refs": [
           {
-            "source_ref": "ref-stepsecurity-mini-shai"
+            "source_ref": "ref-stepsecurity-hades-campaign"
           }
         ],
         "summary": "Hades is modeled as a suspected evolution of Miasma pending explicit code-overlap or researcher-attestation evidence."

--- a/data/supply-chain-malware-families/families.json
+++ b/data/supply-chain-malware-families/families.json
@@ -337,20 +337,21 @@
         "source": "strain-hades-shai-hulud",
         "target": "strain-miasma",
         "type": "EVOLVED_FROM",
-        "evidence_class": "confirmed",
-        "confidence": "confirmed",
+        "evidence_class": "suspected",
+        "confidence": "suspected",
         "relation_kind": "evolution",
         "mutation_delta": [
           "moved to PyPI",
           "Artifactory reconnaissance",
           "broader propagation"
         ],
+        "suspected_reason": "Current cited reporting supports Hades as a Miasma-like successor in the worked example, but does not independently establish code-overlap or explicit researcher-attested descent.",
         "external_refs": [
           {
             "source_ref": "ref-stepsecurity-mini-shai"
           }
         ],
-        "summary": "Hades is modeled as an evolution of Miasma in the worked example."
+        "summary": "Hades is modeled as a suspected evolution of Miasma pending explicit code-overlap or researcher-attestation evidence."
       },
       {
         "source": "strain-ironworm",

--- a/docs/supply-chain-graph-primitives.md
+++ b/docs/supply-chain-graph-primitives.md
@@ -10,6 +10,10 @@ precise public release evidence. Phase 2D strengthens maintainer entities with
 dated anchors and explicit repository/account links.
 The Supply Chain 1.0 S0 pass adds evidence-gated `SEEDED_BY` propagation
 edges for hand-modeled compromise chains.
+The 1.x lineage pass adds malware-family objects and evidence-gated
+`EVOLVED_FROM` / `VARIANT_OF` genealogy edges for strain evolution. These are
+kept separate from `SEEDED_BY`: genealogy says one strain descends from or
+resembles another; propagation says one compromise enabled another.
 
 This is a lightweight relationship layer, not a graph database.
 
@@ -17,6 +21,7 @@ This is a lightweight relationship layer, not a graph database.
 
 ```text
 data/supply-chain-incidents/incidents.json
+data/supply-chain-malware-families/families.json
 ```
 
 ## Generated Entity Files
@@ -177,6 +182,54 @@ create the package entity so the `SEEDED_BY` edge resolves, but it will not emit
 `AFFECTED_PACKAGE` or `AFFECTED_ORGANIZATION` edges for that upstream seed on
 the downstream incident.
 
+## Malware-Family Lineage
+
+```text
+data/supply-chain-malware-families/families.json
+```
+
+Malware-family objects model strain genealogy as a first-class supply-chain
+view. Each family carries:
+
+- `id`: stable `family-*` identifier
+- `name` and `aliases`: display and search names
+- `sources[]`: source records used by fork events and lineage edges
+- `strains[]`: `strain-*` nodes with first-seen date, ecosystems, mutation
+  summary, provenance-abuse summary, attribution label/confidence, and related
+  incident IDs
+- `fork_events[]`: `fork-*` markers such as a source release or leak that
+  changes how later similarity evidence should be graded
+- `lineage_edges[]`: directed child-to-parent edges
+
+Lineage edge types are:
+
+- `EVOLVED_FROM`: confirmed or suspected descent from an older strain
+- `VARIANT_OF`: non-linear fork, cosmetic clone, sibling fork, or playbook
+  adoption where direct descent is not asserted
+
+Every lineage edge carries:
+
+- `evidence_class` / `confidence`: `confirmed` or `suspected`; confirmed
+  requires code overlap or explicit researcher attestation
+- `relation_kind`: `descendant`, `evolution`, `cosmetic_clone`,
+  `playbook_adoption`, or `sibling_fork`
+- `mutation_delta[]`: concise labels for what changed
+- `external_refs[]`: family source refs supporting the edge
+- `suspected_reason`: required when confidence is `suspected`
+
+Validators require lineage endpoints to resolve to strains in the same family,
+source refs to resolve to family sources, suspected edges to explain the
+uncertainty, and the lineage graph to remain acyclic.
+
+The graph build emits malware-family, malware-strain, and fork-event nodes into
+`site/public/supply-chain-graph.json`, adds family and strain jump targets to
+`site/public/supply-chain-search-index.json`, and emits STIX 2.1 malware and
+relationship objects to:
+
+```text
+site/public/supply-chain-malware-families-stix.json
+```
+
 ## Current Graph Density
 
 The Phase 2E pass over 27 incidents currently emits:
@@ -195,6 +248,9 @@ The Phase 2E pass over 27 incidents currently emits:
 
 After S0, the graph also carries 3 `SEEDED_BY` propagation edges across the
 3CX/X_TRADER and Shai-Hulud modeled chains.
+After the lineage pass, the graph also carries the Shai-Hulud malware-family
+worked example with six strain nodes, one source-release fork event, and five
+`EVOLVED_FROM` / `VARIANT_OF` genealogy edges.
 
 ## Build and Validate
 

--- a/scripts/build-supply-chain-graph.mjs
+++ b/scripts/build-supply-chain-graph.mjs
@@ -394,7 +394,7 @@ function malwareFamilyEdges(malwareFamilies = [], nodeIds) {
         relation_kind: edge.relation_kind || null,
         mutation_delta: Array.isArray(edge.mutation_delta) ? edge.mutation_delta : [],
         source_refs: Array.isArray(edge.external_refs)
-          ? edge.external_refs.map((ref) => ref.source_ref).filter(Boolean)
+          ? edge.external_refs.map((ref) => ref?.source_ref).filter(Boolean)
           : [],
         fork_event_id: edge.fork_event_id || null,
         summary: edge.summary || '',
@@ -713,7 +713,7 @@ export function buildSupplyChainSearchIndex(corpus = loadCorpus()) {
         family.aliases || [],
         family.summary,
         (family.strains || []).flatMap((strain) => [strain.id, strain.name, strain.aliases || []]),
-      ],
+      ].flat(Infinity),
     });
     (family.strains || []).forEach((strain) => {
       addEntry({
@@ -730,7 +730,7 @@ export function buildSupplyChainSearchIndex(corpus = loadCorpus()) {
           strain.incident_ids || [],
           family.name,
           family.aliases || [],
-        ],
+        ].flat(Infinity),
       });
     });
   });
@@ -767,12 +767,30 @@ function stixTimestamp(value) {
   return `${dateValue}T00:00:00.000Z`;
 }
 
+function stixMalwareTypes(family, strain) {
+  const explicitTypes = [strain.malware_types, family.malware_types].find((types) => Array.isArray(types) && types.length > 0);
+  if (explicitTypes) return uniqueStrings(explicitTypes);
+
+  const searchableText = stringsFromValue([
+    family.name,
+    family.aliases,
+    family.summary,
+    strain.name,
+    strain.aliases,
+    strain.key_mutation,
+    strain.mutation_summary,
+  ]).join(' ').toLowerCase();
+  if (/\bworm\b|self[- ]propagat/.test(searchableText)) return ['worm'];
+  return [];
+}
+
 export function buildMalwareFamilyStixBundle(corpus = loadCorpus()) {
   const objects = [];
   (corpus.malwareFamilies || []).forEach((family) => {
     const malwareIds = new Map();
     (family.strains || []).forEach((strain) => {
       const malwareId = stixId('malware', `threatpedia:${strain.id}`);
+      const malwareTypes = stixMalwareTypes(family, strain);
       malwareIds.set(strain.id, malwareId);
       objects.push({
         type: 'malware',
@@ -782,7 +800,7 @@ export function buildMalwareFamilyStixBundle(corpus = loadCorpus()) {
         modified: '2026-06-22T00:00:00.000Z',
         name: strain.name || strain.id,
         is_family: false,
-        malware_types: ['trojan'],
+        ...(malwareTypes.length > 0 ? { malware_types: malwareTypes } : {}),
         aliases: strain.aliases || [],
         first_seen: stixTimestamp(strain.first_seen),
         description: strain.mutation_summary || strain.key_mutation || family.summary,

--- a/scripts/build-supply-chain-graph.mjs
+++ b/scripts/build-supply-chain-graph.mjs
@@ -829,10 +829,13 @@ export function buildMalwareFamilyStixBundle(corpus = loadCorpus()) {
         source_ref: sourceRef,
         target_ref: targetRef,
         description: edge.summary,
-        external_references: (edge.external_refs || []).map((ref) => ({
-          source_name: 'Threatpedia',
-          external_id: ref.source_ref,
-        })),
+        external_references: (Array.isArray(edge.external_refs) ? edge.external_refs : [])
+          .map((ref) => ref?.source_ref)
+          .filter(Boolean)
+          .map((sourceRef) => ({
+            source_name: 'Threatpedia',
+            external_id: sourceRef,
+          })),
         'x_threatpedia_relation_kind': edge.relation_kind,
         'x_threatpedia_confidence': edge.confidence,
         'x_threatpedia_mutation_delta': edge.mutation_delta || [],

--- a/scripts/build-supply-chain-graph.mjs
+++ b/scripts/build-supply-chain-graph.mjs
@@ -739,11 +739,17 @@ export function buildSupplyChainSearchIndex(corpus = loadCorpus()) {
 
 function stixUuid(seed) {
   const hex = createHash('sha256').update(seed).digest('hex').slice(0, 32);
-  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-4${hex.slice(13, 16)}-${(parseInt(hex.slice(16, 17), 16) & 0x3 | 0x8).toString(16)}${hex.slice(17, 20)}-${hex.slice(20, 32)}`;
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-4${hex.slice(12, 15)}-${((parseInt(hex.slice(15, 16), 16) & 0x3) | 0x8).toString(16)}${hex.slice(16, 19)}-${hex.slice(19, 31)}`;
 }
 
 function stixId(type, seed) {
   return `${type}--${stixUuid(seed)}`;
+}
+
+function stixTimestamp(value) {
+  if (!value) return undefined;
+  const dateValue = value.length === 7 ? `${value}-01` : value;
+  return `${dateValue}T00:00:00.000Z`;
 }
 
 export function buildMalwareFamilyStixBundle(corpus = loadCorpus()) {
@@ -763,7 +769,7 @@ export function buildMalwareFamilyStixBundle(corpus = loadCorpus()) {
         is_family: false,
         malware_types: ['trojan'],
         aliases: strain.aliases || [],
-        first_seen: strain.first_seen ? `${strain.first_seen}T00:00:00.000Z` : undefined,
+        first_seen: stixTimestamp(strain.first_seen),
         description: strain.mutation_summary || strain.key_mutation || family.summary,
         external_references: [
           {

--- a/scripts/build-supply-chain-graph.mjs
+++ b/scripts/build-supply-chain-graph.mjs
@@ -771,7 +771,7 @@ function stixMalwareTypes(family, strain) {
   const explicitTypes = [strain.malware_types, family.malware_types].find((types) => Array.isArray(types) && types.length > 0);
   if (explicitTypes) return uniqueStrings(explicitTypes);
 
-  const searchableText = stringsFromValue([
+  const searchableText = [
     family.name,
     family.aliases,
     family.summary,
@@ -779,7 +779,7 @@ function stixMalwareTypes(family, strain) {
     strain.aliases,
     strain.key_mutation,
     strain.mutation_summary,
-  ]).join(' ').toLowerCase();
+  ].flat(Infinity).filter((value) => typeof value === 'string').join(' ').toLowerCase();
   if (/\bworm\b|self[- ]propagat/.test(searchableText)) return ['worm'];
   return [];
 }

--- a/scripts/build-supply-chain-graph.mjs
+++ b/scripts/build-supply-chain-graph.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -9,6 +10,7 @@ const dataRoot = path.join(repoRoot, 'data');
 const outputPath = path.join(repoRoot, 'site/public/supply-chain-graph.json');
 const searchIndexOutputPath = path.join(repoRoot, 'site/public/supply-chain-search-index.json');
 const supplyChainCandidateQueuePath = path.join(repoRoot, '.github/pipeline/supply-chain-candidates/latest.json');
+const malwareFamilyStixOutputPath = path.join(repoRoot, 'site/public/supply-chain-malware-families-stix.json');
 
 const entityFiles = {
   accounts: 'accounts.json',
@@ -43,6 +45,9 @@ const tierByType = {
   campaign: 'campaign',
   distribution_channel: 'supporting',
   incident: 'incident',
+  malware_family: 'malware_family',
+  malware_strain: 'malware_strain',
+  fork_event: 'fork_event',
   maintainer: 'maintainer',
   organization: 'organization',
   package: 'package',
@@ -208,6 +213,7 @@ function incidentTechniques(incident) {
 function loadCorpus() {
   const incidents = readJson(path.join(dataRoot, 'supply-chain-incidents/incidents.json'));
   const relationships = readJson(path.join(dataRoot, 'supply-chain-relationships/relationships.json'));
+  const malwareFamilies = readJson(path.join(dataRoot, 'supply-chain-malware-families/families.json'));
   const entities = Object.fromEntries(
     Object.entries(entityFiles).map(([key, filename]) => [
       key,
@@ -215,7 +221,7 @@ function loadCorpus() {
     ])
   );
   const candidateQueue = readOptionalJson(supplyChainCandidateQueuePath);
-  return { incidents, relationships, entities, candidateQueue };
+  return { incidents, relationships, entities, candidateQueue, malwareFamilies };
 }
 
 function uniqueEdges(edges) {
@@ -259,6 +265,144 @@ function normalizeRelationshipEdge(relationship, nodeIds) {
   return edge;
 }
 
+function malwareFamilyHref(familyId) {
+  return `/supply-chain/malware-families/${familyId}/`;
+}
+
+function strainHref(familyId, strainId) {
+  return `${malwareFamilyHref(familyId)}#${strainId}`;
+}
+
+function malwareFamilyNodes(malwareFamilies = []) {
+  return malwareFamilies.flatMap((family) => {
+    if (!family?.id) return [];
+    const familyNode = {
+      id: family.id,
+      entity_id: family.id,
+      type: 'malware_family',
+      label: family.name || family.id,
+      short_label: shortDisplayLabel(family.name || family.id),
+      tier: tierByType.malware_family,
+      sev: null,
+      time: family.first_seen || null,
+      parent: family.root_actor_id || null,
+      techniques: [],
+      purl: null,
+      href: malwareFamilyHref(family.id),
+      aliases: Array.isArray(family.aliases) ? family.aliases : [],
+      source_incident_ids: Array.from(
+        new Set((family.strains || []).flatMap((strain) => Array.isArray(strain.incident_ids) ? strain.incident_ids : []))
+      ).sort(),
+    };
+    const strainNodes = (family.strains || []).map((strain) => ({
+      id: strain.id,
+      entity_id: strain.id,
+      type: 'malware_strain',
+      label: strain.name || strain.id,
+      short_label: shortDisplayLabel(strain.name || strain.id),
+      tier: tierByType.malware_strain,
+      sev: strain.severity || null,
+      time: strain.first_seen || null,
+      parent: family.id,
+      techniques: Array.isArray(strain.ecosystems) ? strain.ecosystems : [],
+      purl: null,
+      href: strainHref(family.id, strain.id),
+      aliases: Array.isArray(strain.aliases) ? strain.aliases : [],
+      family_id: family.id,
+      lineage_confidence: strain.lineage_confidence || null,
+      source_incident_ids: Array.isArray(strain.incident_ids) ? strain.incident_ids : [],
+    }));
+    const forkNodes = (family.fork_events || []).map((event) => ({
+      id: event.id,
+      entity_id: event.id,
+      type: 'fork_event',
+      label: event.name || event.id,
+      short_label: shortDisplayLabel(event.name || event.id),
+      tier: tierByType.fork_event,
+      sev: null,
+      time: event.date || null,
+      parent: family.id,
+      techniques: [],
+      purl: null,
+      href: `${malwareFamilyHref(family.id)}#${event.id}`,
+      aliases: [],
+      family_id: family.id,
+      source_incident_ids: [],
+    }));
+    return [familyNode, ...strainNodes, ...forkNodes];
+  });
+}
+
+function malwareFamilyEdges(malwareFamilies = [], nodeIds) {
+  const edges = [];
+  malwareFamilies.forEach((family) => {
+    if (!family?.id || !nodeIds.has(family.id)) return;
+    (family.associated_actor_ids || []).forEach((actorId) => {
+      if (nodeIds.has(actorId)) {
+        edges.push({
+          id: `MALWARE_FAMILY_ACTOR:${actorId}->${family.id}`,
+          source: actorId,
+          target: family.id,
+          type: 'ATTRIBUTED_TO_ACTOR',
+          derived: true,
+        });
+      }
+    });
+    (family.strains || []).forEach((strain) => {
+      if (!nodeIds.has(strain.id)) return;
+      edges.push({
+        id: `MALWARE_FAMILY_STRAIN:${family.id}->${strain.id}`,
+        source: family.id,
+        target: strain.id,
+        type: 'HAS_STRAIN',
+        derived: true,
+      });
+      (strain.incident_ids || []).forEach((incidentId) => {
+        const incidentNode = `incident-${incidentId}`;
+        if (nodeIds.has(incidentNode)) {
+          edges.push({
+            id: `STRAIN_INCIDENT:${strain.id}->${incidentNode}`,
+            source: strain.id,
+            target: incidentNode,
+            type: 'STRAIN_INCIDENT',
+            derived: true,
+          });
+        }
+      });
+    });
+    (family.fork_events || []).forEach((event) => {
+      if (nodeIds.has(event.id)) {
+        edges.push({
+          id: `MALWARE_FAMILY_FORK_EVENT:${family.id}->${event.id}`,
+          source: family.id,
+          target: event.id,
+          type: 'FORK_EVENT',
+          derived: true,
+        });
+      }
+    });
+    (family.lineage_edges || []).forEach((edge) => {
+      if (!nodeIds.has(edge.source) || !nodeIds.has(edge.target)) return;
+      edges.push({
+        id: `${edge.type}:${edge.source}->${edge.target}`,
+        source: edge.source,
+        target: edge.target,
+        type: edge.type,
+        evidence_class: edge.evidence_class || edge.confidence || null,
+        confidence: edge.confidence || null,
+        relation_kind: edge.relation_kind || null,
+        mutation_delta: Array.isArray(edge.mutation_delta) ? edge.mutation_delta : [],
+        source_refs: Array.isArray(edge.external_refs)
+          ? edge.external_refs.map((ref) => ref.source_ref).filter(Boolean)
+          : [],
+        fork_event_id: edge.fork_event_id || null,
+        summary: edge.summary || '',
+      });
+    });
+  });
+  return edges;
+}
+
 function deriveIncidentContextEdges(nodes, incidents, entities) {
   const edges = [];
   const actorIds = new Set((entities.actors || []).map((actor) => actor.id));
@@ -295,7 +439,7 @@ function deriveIncidentContextEdges(nodes, incidents, entities) {
 }
 
 export function buildSupplyChainGraphData(corpus = loadCorpus()) {
-  const { incidents, relationships, entities, candidateQueue = null } = corpus;
+  const { incidents, relationships, entities, candidateQueue = null, malwareFamilies = [] } = corpus;
   const nodes = [];
 
   incidents.forEach((incident) => {
@@ -373,12 +517,14 @@ export function buildSupplyChainGraphData(corpus = loadCorpus()) {
       });
     });
   });
+  nodes.push(...malwareFamilyNodes(malwareFamilies));
 
   const nodeIds = new Set(nodes.map((node) => node.id));
   const corpusEdges = relationships
     .map((relationship) => normalizeRelationshipEdge(relationship, nodeIds))
     .filter(Boolean);
   const derivedEdges = deriveIncidentContextEdges(nodes, incidents, entities);
+  const lineageEdges = malwareFamilyEdges(malwareFamilies, nodeIds);
   const techniqueEdges = incidents.flatMap((incident) =>
     incidentTechniques(incident).map((technique) => {
       const source = `technique-${slugify(technique)}`;
@@ -392,7 +538,7 @@ export function buildSupplyChainGraphData(corpus = loadCorpus()) {
       };
     })
   );
-  const edges = uniqueEdges([...corpusEdges, ...derivedEdges, ...techniqueEdges]);
+  const edges = uniqueEdges([...corpusEdges, ...derivedEdges, ...lineageEdges, ...techniqueEdges]);
 
   const parentByIncident = new Map();
   edges.forEach((edge) => {
@@ -442,6 +588,7 @@ export function buildSupplyChainGraphData(corpus = loadCorpus()) {
       package_release_lod: 'g4-dive-and-bloom',
       bloom_tiers: ['organization', 'package', 'release'],
       seeded_by_edges: 'causal-solid-temporal-dashed',
+      evolved_from_edges: 'confirmed-solid-suspected-dashed',
       layout: 'time-anchored-actor-lanes',
     },
     counts,
@@ -452,7 +599,7 @@ export function buildSupplyChainGraphData(corpus = loadCorpus()) {
 }
 
 export function buildSupplyChainSearchIndex(corpus = loadCorpus()) {
-  const { incidents, relationships, entities } = corpus;
+  const { incidents, relationships, entities, malwareFamilies = [] } = corpus;
   const entriesById = new Map();
   const incidentById = new Map(incidents.map((incident) => [incident.id, incident]));
   const entityById = new Map();
@@ -552,7 +699,108 @@ export function buildSupplyChainSearchIndex(corpus = loadCorpus()) {
     });
   });
 
+  malwareFamilies.forEach((family) => {
+    addEntry({
+      id: family.id,
+      type: 'malware_family',
+      displayName: family.name || family.id,
+      aliases: [
+        family.id,
+        family.aliases || [],
+        family.summary,
+        (family.strains || []).flatMap((strain) => [strain.id, strain.name, strain.aliases || []]),
+      ],
+    });
+    (family.strains || []).forEach((strain) => {
+      addEntry({
+        id: strain.id,
+        type: 'malware_strain',
+        displayName: strain.name || strain.id,
+        aliases: [
+          strain.id,
+          strain.aliases || [],
+          strain.key_mutation,
+          strain.mutation_summary,
+          strain.ecosystems || [],
+          strain.incident_ids || [],
+          family.name,
+          family.aliases || [],
+        ],
+      });
+    });
+  });
+
   return Array.from(entriesById.values()).sort((a, b) => a.type.localeCompare(b.type) || a.displayName.localeCompare(b.displayName) || a.id.localeCompare(b.id));
+}
+
+function stixUuid(seed) {
+  const hex = createHash('sha256').update(seed).digest('hex').slice(0, 32);
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-4${hex.slice(13, 16)}-${(parseInt(hex.slice(16, 17), 16) & 0x3 | 0x8).toString(16)}${hex.slice(17, 20)}-${hex.slice(20, 32)}`;
+}
+
+function stixId(type, seed) {
+  return `${type}--${stixUuid(seed)}`;
+}
+
+export function buildMalwareFamilyStixBundle(corpus = loadCorpus()) {
+  const objects = [];
+  (corpus.malwareFamilies || []).forEach((family) => {
+    const malwareIds = new Map();
+    (family.strains || []).forEach((strain) => {
+      const malwareId = stixId('malware', `threatpedia:${strain.id}`);
+      malwareIds.set(strain.id, malwareId);
+      objects.push({
+        type: 'malware',
+        spec_version: '2.1',
+        id: malwareId,
+        created: '2026-06-22T00:00:00.000Z',
+        modified: '2026-06-22T00:00:00.000Z',
+        name: strain.name || strain.id,
+        is_family: false,
+        malware_types: ['trojan'],
+        aliases: strain.aliases || [],
+        first_seen: strain.first_seen ? `${strain.first_seen}T00:00:00.000Z` : undefined,
+        description: strain.mutation_summary || strain.key_mutation || family.summary,
+        external_references: [
+          {
+            source_name: 'Threatpedia',
+            external_id: strain.id,
+            url: `https://threatpedia.wiki/supply-chain/malware-families/${family.id}/#${strain.id}`,
+          },
+        ],
+        'x_threatpedia_family_id': family.id,
+        'x_threatpedia_lineage_confidence': strain.lineage_confidence || null,
+      });
+    });
+    (family.lineage_edges || []).forEach((edge) => {
+      const sourceRef = malwareIds.get(edge.source);
+      const targetRef = malwareIds.get(edge.target);
+      if (!sourceRef || !targetRef) return;
+      objects.push({
+        type: 'relationship',
+        spec_version: '2.1',
+        id: stixId('relationship', `threatpedia:${edge.source}:${edge.type}:${edge.target}`),
+        created: '2026-06-22T00:00:00.000Z',
+        modified: '2026-06-22T00:00:00.000Z',
+        relationship_type: edge.type === 'VARIANT_OF' ? 'variant-of' : 'derived-from',
+        source_ref: sourceRef,
+        target_ref: targetRef,
+        description: edge.summary,
+        external_references: (edge.external_refs || []).map((ref) => ({
+          source_name: 'Threatpedia',
+          external_id: ref.source_ref,
+        })),
+        'x_threatpedia_relation_kind': edge.relation_kind,
+        'x_threatpedia_confidence': edge.confidence,
+        'x_threatpedia_mutation_delta': edge.mutation_delta || [],
+      });
+    });
+  });
+  return {
+    type: 'bundle',
+    id: stixId('bundle', 'threatpedia:supply-chain-malware-families'),
+    objects,
+  };
 }
 
 function stableStringify(value) {
@@ -562,8 +810,10 @@ function stableStringify(value) {
 export function writeSupplyChainGraphData(options = {}) {
   const graph = buildSupplyChainGraphData();
   const searchIndex = buildSupplyChainSearchIndex();
+  const malwareFamilyStix = buildMalwareFamilyStixBundle();
   const current = existsSync(outputPath) ? readFileSync(outputPath, 'utf8') : '';
   const currentSearchIndex = existsSync(searchIndexOutputPath) ? readFileSync(searchIndexOutputPath, 'utf8') : '';
+  const currentStix = existsSync(malwareFamilyStixOutputPath) ? readFileSync(malwareFamilyStixOutputPath, 'utf8') : '';
   if (current) {
     try {
       const currentGraph = JSON.parse(current);
@@ -574,6 +824,7 @@ export function writeSupplyChainGraphData(options = {}) {
   }
   const serialized = stableStringify(graph);
   const serializedSearchIndex = stableStringify(searchIndex);
+  const serializedStix = stableStringify(malwareFamilyStix);
   if (options.check) {
     if (current !== serialized) {
       throw new Error(`${path.relative(repoRoot, outputPath)} is out of date; run node scripts/build-supply-chain-graph.mjs`);
@@ -581,12 +832,16 @@ export function writeSupplyChainGraphData(options = {}) {
     if (currentSearchIndex !== serializedSearchIndex) {
       throw new Error(`${path.relative(repoRoot, searchIndexOutputPath)} is out of date; run node scripts/build-supply-chain-graph.mjs`);
     }
-    return { graph, searchIndex, outputPath, searchIndexOutputPath, changed: false };
+    if (currentStix !== serializedStix) {
+      throw new Error(`${path.relative(repoRoot, malwareFamilyStixOutputPath)} is out of date; run node scripts/build-supply-chain-graph.mjs`);
+    }
+    return { graph, searchIndex, malwareFamilyStix, outputPath, searchIndexOutputPath, malwareFamilyStixOutputPath, changed: false };
   }
   mkdirSync(path.dirname(outputPath), { recursive: true });
   writeFileSync(outputPath, serialized);
   writeFileSync(searchIndexOutputPath, serializedSearchIndex);
-  return { graph, searchIndex, outputPath, searchIndexOutputPath, changed: true };
+  writeFileSync(malwareFamilyStixOutputPath, serializedStix);
+  return { graph, searchIndex, malwareFamilyStix, outputPath, searchIndexOutputPath, malwareFamilyStixOutputPath, changed: true };
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/scripts/build-supply-chain-graph.mjs
+++ b/scripts/build-supply-chain-graph.mjs
@@ -11,6 +11,7 @@ const outputPath = path.join(repoRoot, 'site/public/supply-chain-graph.json');
 const searchIndexOutputPath = path.join(repoRoot, 'site/public/supply-chain-search-index.json');
 const supplyChainCandidateQueuePath = path.join(repoRoot, '.github/pipeline/supply-chain-candidates/latest.json');
 const malwareFamilyStixOutputPath = path.join(repoRoot, 'site/public/supply-chain-malware-families-stix.json');
+const stixUuidNamespace = '0a7b40c2-47b4-5506-81fd-3dfb15155024';
 
 const entityFiles = {
   accounts: 'accounts.json',
@@ -737,9 +738,23 @@ export function buildSupplyChainSearchIndex(corpus = loadCorpus()) {
   return Array.from(entriesById.values()).sort((a, b) => a.type.localeCompare(b.type) || a.displayName.localeCompare(b.displayName) || a.id.localeCompare(b.id));
 }
 
+function uuidBytes(uuid) {
+  return Buffer.from(uuid.replaceAll('-', ''), 'hex');
+}
+
+function formatUuid(bytes) {
+  const hex = Buffer.from(bytes).toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
 function stixUuid(seed) {
-  const hex = createHash('sha256').update(seed).digest('hex').slice(0, 32);
-  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-4${hex.slice(12, 15)}-${((parseInt(hex.slice(15, 16), 16) & 0x3) | 0x8).toString(16)}${hex.slice(16, 19)}-${hex.slice(19, 31)}`;
+  const digest = createHash('sha1')
+    .update(Buffer.concat([uuidBytes(stixUuidNamespace), Buffer.from(seed, 'utf8')]))
+    .digest()
+    .subarray(0, 16);
+  digest[6] = (digest[6] & 0x0f) | 0x50;
+  digest[8] = (digest[8] & 0x3f) | 0x80;
+  return formatUuid(digest);
 }
 
 function stixId(type, seed) {

--- a/scripts/build-supply-chain-graph.mjs
+++ b/scripts/build-supply-chain-graph.mjs
@@ -656,14 +656,16 @@ export function buildSupplyChainSearchIndex(corpus = loadCorpus()) {
     if (targetEntity) addIncidentAlias(sourceIncidentId, entityBaseAliases(targetEntity));
   });
 
-  const addEntry = ({ id, type, displayName, aliases }) => {
+  const addEntry = ({ id, type, displayName, aliases, href }) => {
     if (!id || !type || !displayName) return;
-    entriesById.set(id, {
+    const entry = {
       id,
       type,
       displayName,
       aliases: uniqueStrings(aliases).filter((alias) => alias.toLowerCase() !== String(displayName).toLowerCase()),
-    });
+    };
+    if (href) entry.href = href;
+    entriesById.set(id, entry);
   };
 
   incidents.forEach((incident) => {
@@ -704,6 +706,7 @@ export function buildSupplyChainSearchIndex(corpus = loadCorpus()) {
       id: family.id,
       type: 'malware_family',
       displayName: family.name || family.id,
+      href: malwareFamilyHref(family.id),
       aliases: [
         family.id,
         family.aliases || [],
@@ -716,6 +719,7 @@ export function buildSupplyChainSearchIndex(corpus = loadCorpus()) {
         id: strain.id,
         type: 'malware_strain',
         displayName: strain.name || strain.id,
+        href: strainHref(family.id, strain.id),
         aliases: [
           strain.id,
           strain.aliases || [],

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -220,6 +220,13 @@ assert.ok(
     malwareFamilyStixPayload.objects.some((object) => object.type === 'relationship' && object.relationship_type === 'variant-of'),
   'malware-family STIX bundle should include malware strain objects and variant relationships'
 );
+const monthOnlyStixFixture = structuredClone(data);
+monthOnlyStixFixture.malwareFamilies[0].strains[0].first_seen = '2025-09';
+assert.equal(
+  buildMalwareFamilyStixBundle(monthOnlyStixFixture).objects.find((object) => object.type === 'malware' && object.name === 'Shai-Hulud')?.first_seen,
+  '2025-09-01T00:00:00.000Z',
+  'month-only malware strain dates should emit valid full STIX timestamps'
+);
 assert.ok(
   supplyChainGraphSource.includes('REST_NODE_BUDGET = 40') &&
     supplyChainGraphSource.includes('RECENT_WINDOW_DAYS = 183') &&

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -224,6 +224,12 @@ assert.equal(
   'malware strain search targets should navigate to the family anchor'
 );
 assert.ok(
+  supplyChainSearchIndexPayload
+    .filter((entry) => entry.type === 'malware_family' || entry.type === 'malware_strain')
+    .every((entry) => entry.aliases.every((alias) => typeof alias === 'string')),
+  'malware-family search aliases should be flattened before indexing'
+);
+assert.ok(
   supplyChainGraphSource.includes('if (entry.href)') &&
     supplyChainGraphSource.includes('window.location.href = entry.href'),
   'graph search should navigate entries with explicit hrefs before graph-selection fallback'
@@ -239,6 +245,11 @@ assert.ok(
 assert.ok(
   malwareFamilyStixPayload.objects.every((object) => /^[a-z-]+--[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(object.id)),
   'malware-family STIX object identifiers should use deterministic UUIDv5 shape'
+);
+assert.deepEqual(
+  malwareFamilyStixPayload.objects.find((object) => object.type === 'malware' && object.name === 'Mini Shai-Hulud')?.malware_types,
+  ['worm'],
+  'malware-family STIX objects should derive malware type from the family/strain model'
 );
 const monthOnlyStixFixture = structuredClone(data);
 monthOnlyStixFixture.malwareFamilies[0].strains[0].first_seen = '2025-09';

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -75,6 +75,10 @@ assert.deepEqual(
   data.malwareFamilies[0].timeline_ticks,
   'malware-family timeline ticks should come from the family object'
 );
+assert.ok(
+  !supplyChainPagesSource.includes("{ label: 'Sep 2025', x: 90 }"),
+  'malware-family page model should not fall back to Shai-Hulud-specific timeline ticks'
+);
 assert.deepEqual(
   shaiHuludFamily.phylogeny.parentByChild['strain-miasma'],
   ['strain-mini-shai-hulud'],

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -75,6 +75,16 @@ assert.deepEqual(
   data.malwareFamilies[0].timeline_ticks,
   'malware-family timeline ticks should come from the family object'
 );
+assert.deepEqual(
+  shaiHuludFamily.phylogeny.parentByChild['strain-miasma'],
+  ['strain-mini-shai-hulud'],
+  'malware-family parent map should retain parent arrays for DAG lineage'
+);
+assert.equal(
+  shaiHuludFamily.phylogeny.edges.find((edge) => edge.id === 'strain-ironworm->strain-mini-shai-hulud')?.labelY,
+  306,
+  'fork-linked lineage labels should align from the fork marker layout'
+);
 assert.ok(
   supplyChainRouteSource.includes('transition:persist="supply-chain-graph-hero"'),
   'route should persist graph hero across Supply Chain navigation'
@@ -172,6 +182,12 @@ assert.ok(
   'lineage detail script should render dataset-backed content as text, not HTML'
 );
 assert.ok(
+  supplyChainRouteSource.includes('const stack = [id]') &&
+    supplyChainRouteSource.includes('Array.isArray(parents[child])') &&
+    supplyChainRouteSource.includes('activeEdges.add(`${child}->${parent}`)'),
+  'lineage detail script should trace all parent edges in a DAG lineage'
+);
+assert.ok(
   supplyChainRouteSource.includes('data-supply-chain-graph-root') &&
     supplyChainRouteSource.includes('data-sc-graph-canvas') &&
     supplyChainRouteSource.includes('data-sc-graph-focus-reflow') &&
@@ -219,6 +235,10 @@ assert.ok(
   malwareFamilyStixPayload.objects.some((object) => object.type === 'malware' && object.name === 'Mini Shai-Hulud') &&
     malwareFamilyStixPayload.objects.some((object) => object.type === 'relationship' && object.relationship_type === 'variant-of'),
   'malware-family STIX bundle should include malware strain objects and variant relationships'
+);
+assert.ok(
+  malwareFamilyStixPayload.objects.every((object) => /^[a-z-]+--[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(object.id)),
+  'malware-family STIX object identifiers should use deterministic UUIDv5 shape'
 );
 const monthOnlyStixFixture = structuredClone(data);
 monthOnlyStixFixture.malwareFamilies[0].strains[0].first_seen = '2025-09';

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -188,7 +188,9 @@ assert.ok(
 assert.ok(
   supplyChainRouteSource.includes('const stack = [id]') &&
     supplyChainRouteSource.includes('Array.isArray(parents[child])') &&
-    supplyChainRouteSource.includes('activeEdges.add(`${child}->${parent}`)'),
+    supplyChainRouteSource.includes('activeEdges.add(`${child}->${parent}`)') &&
+    supplyChainRouteSource.includes('data-lineage-edge={`${edge.source}->${edge.target}`}') &&
+    supplyChainRouteSource.includes('data-lineage-edge-label={`${edge.source}->${edge.target}`}'),
   'lineage detail script should trace all parent edges in a DAG lineage'
 );
 assert.ok(

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -7,11 +7,12 @@ import {
   getSupplyChainExploreModel,
   getSupplyChainIncidentPage,
   getSupplyChainIndexModel,
+  getSupplyChainMalwareFamilyPage,
   getSupplyChainRoutes,
   loadSupplyChainData,
   validateSupplyChainPageData,
 } from '../site/src/lib/supplyChainPages.mjs';
-import { buildSupplyChainGraphData, buildSupplyChainSearchIndex } from './build-supply-chain-graph.mjs';
+import { buildMalwareFamilyStixBundle, buildSupplyChainGraphData, buildSupplyChainSearchIndex } from './build-supply-chain-graph.mjs';
 
 const data = loadSupplyChainData();
 const baseLayoutSource = readFileSync(new URL('../site/src/layouts/Base.astro', import.meta.url), 'utf-8');
@@ -24,6 +25,9 @@ const supplyChainGraphPayload = JSON.parse(
 );
 const supplyChainSearchIndexPayload = JSON.parse(
   readFileSync(new URL('../site/public/supply-chain-search-index.json', import.meta.url), 'utf-8')
+);
+const malwareFamilyStixPayload = JSON.parse(
+  readFileSync(new URL('../site/public/supply-chain-malware-families-stix.json', import.meta.url), 'utf-8')
 );
 
 function routeUrl(route) {
@@ -57,6 +61,15 @@ assert.ok(routeUrls.has('/supply-chain/packages/pkg-golang-github-com-boltdb-go-
 assert.ok(routeUrls.has('/supply-chain/repositories/repo-github-com-codecov-codecov-bash/'), 'repository route should be generated');
 assert.ok(routeUrls.has('/supply-chain/organizations/org-codecov/'), 'organization route should be generated');
 assert.ok(routeUrls.has('/supply-chain/maintainers/maintainer-jia-tan/'), 'maintainer route should be generated');
+assert.ok(routeUrls.has('/supply-chain/malware-families/family-shai-hulud/'), 'malware-family lineage route should be generated');
+const shaiHuludFamily = getSupplyChainMalwareFamilyPage('family-shai-hulud', data);
+assert.equal(shaiHuludFamily.kind, 'malware-family', 'malware-family page model should use dedicated kind');
+assert.ok(
+  shaiHuludFamily.phylogeny.edges.some((edge) => edge.type === 'EVOLVED_FROM' && edge.confidence === 'confirmed') &&
+    shaiHuludFamily.phylogeny.edges.some((edge) => edge.type === 'VARIANT_OF' && edge.confidence === 'suspected') &&
+    shaiHuludFamily.phylogeny.forks.some((event) => event.id === 'fork-mini-shai-source-release'),
+  'malware-family page should model confirmed genealogy, suspected forks, and fork events'
+);
 assert.ok(
   supplyChainRouteSource.includes('transition:persist="supply-chain-graph-hero"'),
   'route should persist graph hero across Supply Chain navigation'
@@ -138,6 +151,16 @@ assert.ok(
   'incident pages should render G7 propagation timelines from local SEEDED_BY edges only'
 );
 assert.ok(
+  supplyChainRouteSource.includes("page.kind === 'malware-family'") &&
+    supplyChainRouteSource.includes('data-lineage-stage') &&
+    supplyChainRouteSource.includes('lineage-edge lineage-${edge.confidence}') &&
+    supplyChainRouteSource.includes('Strain Comparison') &&
+    supplyChainRouteSource.includes('Family Changelog') &&
+    supplyChainRouteSource.includes('EVOLVED_FROM') &&
+    supplyChainRouteSource.includes('SEEDED_BY'),
+  'malware-family pages should render phylogeny, strain table, changelog, and genealogy/infection distinction'
+);
+assert.ok(
   supplyChainRouteSource.includes('data-supply-chain-graph-root') &&
     supplyChainRouteSource.includes('data-sc-graph-canvas') &&
     supplyChainRouteSource.includes('data-sc-graph-focus-reflow') &&
@@ -154,6 +177,27 @@ assert.ok(
 assert.ok(
   supplyChainGraphPayload.nodes.some((node) => node.tier === 'incident' && node.short_label && node.short_label !== node.label),
   'graph payload should include short incident labels for the visual label layer'
+);
+assert.ok(
+  supplyChainGraphPayload.nodes.some((node) => node.id === 'family-shai-hulud' && node.type === 'malware_family') &&
+    supplyChainGraphPayload.nodes.some((node) => node.id === 'strain-mini-shai-hulud' && node.type === 'malware_strain') &&
+    supplyChainGraphPayload.nodes.some((node) => node.id === 'fork-mini-shai-source-release' && node.type === 'fork_event') &&
+    supplyChainGraphPayload.edges.some((edge) => edge.type === 'EVOLVED_FROM' && edge.mutation_delta?.includes('added PyPI')) &&
+    supplyChainGraphPayload.edges.some((edge) => edge.type === 'VARIANT_OF' && edge.confidence === 'suspected'),
+  'graph payload should include malware-family, strain, fork-event, and EVOLVED_FROM/VARIANT_OF primitives'
+);
+assert.ok(
+  supplyChainSearchIndexPayload.some((entry) => entry.id === 'family-shai-hulud' && entry.type === 'malware_family') &&
+    supplyChainSearchIndexPayload.some((entry) => entry.id === 'strain-ironworm' && entry.type === 'malware_strain'),
+  'search index should include malware-family and strain jump targets'
+);
+const generatedStixBundle = buildMalwareFamilyStixBundle(data);
+assert.deepEqual(malwareFamilyStixPayload, generatedStixBundle, 'malware-family STIX bundle should be generated from the same data object');
+assert.equal(malwareFamilyStixPayload.type, 'bundle', 'malware-family STIX output should be a STIX bundle');
+assert.ok(
+  malwareFamilyStixPayload.objects.some((object) => object.type === 'malware' && object.name === 'Mini Shai-Hulud') &&
+    malwareFamilyStixPayload.objects.some((object) => object.type === 'relationship' && object.relationship_type === 'variant-of'),
+  'malware-family STIX bundle should include malware strain objects and variant relationships'
 );
 assert.ok(
   supplyChainGraphSource.includes('REST_NODE_BUDGET = 40') &&
@@ -325,7 +369,8 @@ const expectedRouteCount =
   data.entities.packages.length +
   data.entities.repositories.length +
   data.entities.organizations.length +
-  data.entities.maintainers.length;
+  data.entities.maintainers.length +
+  data.malwareFamilies.length;
 assert.equal(routes.length, expectedRouteCount, 'enabled route count should match routed page types');
 
 const index = getSupplyChainIndexModel(data);

--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -70,6 +70,11 @@ assert.ok(
     shaiHuludFamily.phylogeny.forks.some((event) => event.id === 'fork-mini-shai-source-release'),
   'malware-family page should model confirmed genealogy, suspected forks, and fork events'
 );
+assert.deepEqual(
+  shaiHuludFamily.phylogeny.ticks,
+  data.malwareFamilies[0].timeline_ticks,
+  'malware-family timeline ticks should come from the family object'
+);
 assert.ok(
   supplyChainRouteSource.includes('transition:persist="supply-chain-graph-hero"'),
   'route should persist graph hero across Supply Chain navigation'
@@ -161,6 +166,12 @@ assert.ok(
   'malware-family pages should render phylogeny, strain table, changelog, and genealogy/infection distinction'
 );
 assert.ok(
+  supplyChainRouteSource.includes('detail.replaceChildren') &&
+    supplyChainRouteSource.includes('textContent') &&
+    !supplyChainRouteSource.includes('detail.innerHTML'),
+  'lineage detail script should render dataset-backed content as text, not HTML'
+);
+assert.ok(
   supplyChainRouteSource.includes('data-supply-chain-graph-root') &&
     supplyChainRouteSource.includes('data-sc-graph-canvas') &&
     supplyChainRouteSource.includes('data-sc-graph-focus-reflow') &&
@@ -190,6 +201,16 @@ assert.ok(
   supplyChainSearchIndexPayload.some((entry) => entry.id === 'family-shai-hulud' && entry.type === 'malware_family') &&
     supplyChainSearchIndexPayload.some((entry) => entry.id === 'strain-ironworm' && entry.type === 'malware_strain'),
   'search index should include malware-family and strain jump targets'
+);
+assert.equal(
+  supplyChainSearchIndexPayload.find((entry) => entry.id === 'strain-ironworm')?.href,
+  '/supply-chain/malware-families/family-shai-hulud/#strain-ironworm',
+  'malware strain search targets should navigate to the family anchor'
+);
+assert.ok(
+  supplyChainGraphSource.includes('if (entry.href)') &&
+    supplyChainGraphSource.includes('window.location.href = entry.href'),
+  'graph search should navigate entries with explicit hrefs before graph-selection fallback'
 );
 const generatedStixBundle = buildMalwareFamilyStixBundle(data);
 assert.deepEqual(malwareFamilyStixPayload, generatedStixBundle, 'malware-family STIX bundle should be generated from the same data object');

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -23,6 +23,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_CORPUS_PATH = REPO_ROOT / "data" / "supply-chain-incidents" / "incidents.json"
 DEFAULT_ENTITY_DIR = REPO_ROOT / "data" / "supply-chain-entities"
 DEFAULT_RELATIONSHIP_PATH = REPO_ROOT / "data" / "supply-chain-relationships" / "relationships.json"
+DEFAULT_MALWARE_FAMILY_PATH = REPO_ROOT / "data" / "supply-chain-malware-families" / "families.json"
 
 ENTITY_FILES = {
     "accounts": "accounts.json",
@@ -86,6 +87,11 @@ ENTITY_TYPE_REQUIRED_FIELDS = {
     "repositories": ["host", "url", "owner"],
 }
 DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+MONTH_PATTERN = re.compile(r"^\d{4}-\d{2}$")
+VALID_LINEAGE_EDGE_TYPES = {"EVOLVED_FROM", "VARIANT_OF"}
+VALID_LINEAGE_CONFIDENCE = {"confirmed", "suspected"}
+VALID_RELATION_KIND = {"descendant", "evolution", "cosmetic_clone", "playbook_adoption", "sibling_fork"}
+VALID_STRAIN_CONFIDENCE = {"origin", "confirmed", "suspected"}
 
 
 def load_json(path: Path) -> Any:
@@ -138,6 +144,12 @@ def parse_date(value: Any) -> date | None:
         return date.fromisoformat(value)
     except ValueError:
         return None
+
+
+def is_date_or_month(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    return bool(DATE_PATTERN.fullmatch(value) or MONTH_PATTERN.fullmatch(value))
 
 
 def incident_node_id(incident_id: str) -> str:
@@ -451,6 +463,181 @@ def validate_seeded_by_acyclic(edges: list[tuple[str, str, str]]) -> list[str]:
     return errors
 
 
+def validate_directed_acyclic_edges(edges: list[tuple[str, str, str]], label: str) -> list[str]:
+    graph: dict[str, list[str]] = {}
+    for source, target, _path in edges:
+        graph.setdefault(source, []).append(target)
+
+    errors: list[str] = []
+    visiting: set[str] = set()
+    visited: set[str] = set()
+    stack: list[str] = []
+
+    def visit(node: str) -> None:
+        if node in visited:
+            return
+        if node in visiting:
+            cycle = " -> ".join(stack[stack.index(node) :] + [node]) if node in stack else node
+            errors.append(f"{label} cycle detected: {cycle}")
+            return
+        visiting.add(node)
+        stack.append(node)
+        for target in graph.get(node, []):
+            visit(target)
+        stack.pop()
+        visiting.remove(node)
+        visited.add(node)
+
+    for source in graph:
+        visit(source)
+    return errors
+
+
+def validate_malware_families(
+    malware_families: Any,
+    *,
+    raw_incident_ids: set[str],
+    entity_ids: set[str],
+) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(malware_families, list):
+        return ["malware_families: expected list"]
+
+    family_ids: set[str] = set()
+    all_strain_ids: set[str] = set()
+    all_fork_event_ids: set[str] = set()
+    lineage_edges: list[tuple[str, str, str]] = []
+
+    for family_index, family in enumerate(malware_families):
+        path = f"malware_families[{family_index}]"
+        if not isinstance(family, dict):
+            errors.append(f"{path}: expected object")
+            continue
+        family_id = family.get("id")
+        if not isinstance(family_id, str) or not family_id.startswith("family-"):
+            errors.append(f"{path}.id: expected family-* id")
+            continue
+        if family_id in family_ids:
+            errors.append(f"{family_id}: duplicate malware family id")
+        family_ids.add(family_id)
+        if not isinstance(family.get("name"), str) or not family["name"].strip():
+            errors.append(f"{family_id}.name: expected non-empty string")
+        root_actor_id = family.get("root_actor_id")
+        if root_actor_id is not None and root_actor_id not in entity_ids:
+            errors.append(f"{family_id}.root_actor_id: unknown actor/entity id {root_actor_id!r}")
+        for actor_index, actor_id in enumerate(family.get("associated_actor_ids") or []):
+            if not isinstance(actor_id, str) or actor_id not in entity_ids:
+                errors.append(f"{family_id}.associated_actor_ids[{actor_index}]: unknown actor/entity id {actor_id!r}")
+
+        source_ids = {
+            source.get("id")
+            for source in family.get("sources") or []
+            if isinstance(source, dict) and isinstance(source.get("id"), str)
+        }
+        if not source_ids:
+            errors.append(f"{family_id}.sources: expected at least one source")
+
+        strain_ids: set[str] = set()
+        strains = family.get("strains")
+        if not isinstance(strains, list) or not strains:
+            errors.append(f"{family_id}.strains: expected non-empty list")
+            strains = []
+        for strain_index, strain in enumerate(strains):
+            strain_path = f"{family_id}.strains[{strain_index}]"
+            if not isinstance(strain, dict):
+                errors.append(f"{strain_path}: expected object")
+                continue
+            strain_id = strain.get("id")
+            if not isinstance(strain_id, str) or not strain_id.startswith("strain-"):
+                errors.append(f"{strain_path}.id: expected strain-* id")
+                continue
+            if strain_id in strain_ids or strain_id in all_strain_ids:
+                errors.append(f"{strain_id}: duplicate malware strain id")
+            strain_ids.add(strain_id)
+            all_strain_ids.add(strain_id)
+            if not isinstance(strain.get("name"), str) or not strain["name"].strip():
+                errors.append(f"{strain_id}.name: expected non-empty string")
+            if not is_date_or_month(strain.get("first_seen")):
+                errors.append(f"{strain_id}.first_seen: expected YYYY-MM-DD or YYYY-MM")
+            if strain.get("lineage_confidence") not in VALID_STRAIN_CONFIDENCE:
+                errors.append(f"{strain_id}.lineage_confidence: expected one of {sorted(VALID_STRAIN_CONFIDENCE)}")
+            if not isinstance(strain.get("mutation_summary"), str) or len(strain["mutation_summary"].strip()) < 20:
+                errors.append(f"{strain_id}.mutation_summary: expected descriptive mutation summary")
+            if not isinstance(strain.get("ecosystems"), list) or not strain["ecosystems"]:
+                errors.append(f"{strain_id}.ecosystems: expected non-empty list")
+            for incident_index, incident_id in enumerate(strain.get("incident_ids") or []):
+                if not isinstance(incident_id, str) or incident_id not in raw_incident_ids:
+                    errors.append(f"{strain_id}.incident_ids[{incident_index}]: unknown incident id {incident_id!r}")
+
+        fork_event_ids: set[str] = set()
+        for event_index, event in enumerate(family.get("fork_events") or []):
+            event_path = f"{family_id}.fork_events[{event_index}]"
+            if not isinstance(event, dict):
+                errors.append(f"{event_path}: expected object")
+                continue
+            event_id = event.get("id")
+            if not isinstance(event_id, str) or not event_id.startswith("fork-"):
+                errors.append(f"{event_path}.id: expected fork-* id")
+                continue
+            if event_id in fork_event_ids or event_id in all_fork_event_ids:
+                errors.append(f"{event_id}: duplicate fork event id")
+            fork_event_ids.add(event_id)
+            all_fork_event_ids.add(event_id)
+            if not is_date_or_month(event.get("date")):
+                errors.append(f"{event_id}.date: expected YYYY-MM-DD or YYYY-MM")
+            if not isinstance(event.get("summary"), str) or len(event["summary"].strip()) < 20:
+                errors.append(f"{event_id}.summary: expected descriptive summary")
+            for ref_index, source_ref in enumerate(event.get("source_refs") or []):
+                if source_ref not in source_ids:
+                    errors.append(f"{event_id}.source_refs[{ref_index}]: unknown family source ref {source_ref!r}")
+
+        for edge_index, edge in enumerate(family.get("lineage_edges") or []):
+            edge_path = f"{family_id}.lineage_edges[{edge_index}]"
+            if not isinstance(edge, dict):
+                errors.append(f"{edge_path}: expected object")
+                continue
+            edge_type = edge.get("type")
+            source = edge.get("source")
+            target = edge.get("target")
+            if edge_type not in VALID_LINEAGE_EDGE_TYPES:
+                errors.append(f"{edge_path}.type: expected EVOLVED_FROM or VARIANT_OF")
+            if source not in strain_ids:
+                errors.append(f"{edge_path}.source: unknown strain id {source!r}")
+            if target not in strain_ids:
+                errors.append(f"{edge_path}.target: unknown strain id {target!r}")
+            if source == target:
+                errors.append(f"{edge_path}: source and target cannot be the same")
+            if edge.get("confidence") not in VALID_LINEAGE_CONFIDENCE:
+                errors.append(f"{edge_path}.confidence: expected confirmed or suspected")
+            if edge.get("evidence_class") not in VALID_LINEAGE_CONFIDENCE:
+                errors.append(f"{edge_path}.evidence_class: expected confirmed or suspected")
+            if edge.get("relation_kind") not in VALID_RELATION_KIND:
+                errors.append(f"{edge_path}.relation_kind: expected one of {sorted(VALID_RELATION_KIND)}")
+            mutation_delta = edge.get("mutation_delta")
+            if not isinstance(mutation_delta, list) or not mutation_delta:
+                errors.append(f"{edge_path}.mutation_delta: expected non-empty list")
+            elif not all(isinstance(item, str) and item.strip() for item in mutation_delta):
+                errors.append(f"{edge_path}.mutation_delta: expected non-empty string entries")
+            external_refs = edge.get("external_refs")
+            if not isinstance(external_refs, list) or not external_refs:
+                errors.append(f"{edge_path}.external_refs: expected non-empty list")
+            else:
+                for ref_index, ref in enumerate(external_refs):
+                    source_ref = ref.get("source_ref") if isinstance(ref, dict) else None
+                    if source_ref not in source_ids:
+                        errors.append(f"{edge_path}.external_refs[{ref_index}].source_ref: unknown family source ref {source_ref!r}")
+            if edge.get("confidence") == "suspected" and not isinstance(edge.get("suspected_reason"), str):
+                errors.append(f"{edge_path}.suspected_reason: suspected edges must explain uncertainty")
+            fork_event_id = edge.get("fork_event_id")
+            if fork_event_id is not None and fork_event_id not in fork_event_ids:
+                errors.append(f"{edge_path}.fork_event_id: unknown fork event {fork_event_id!r}")
+            if isinstance(source, str) and isinstance(target, str):
+                lineage_edges.append((source, target, edge_path))
+
+    errors.extend(validate_directed_acyclic_edges(lineage_edges, "EVOLVED_FROM"))
+    return errors
+
+
 def validate_corpus_implied_relationships(corpus: list[dict[str, Any]], relationships: Any) -> list[str]:
     errors: list[str] = []
     if not isinstance(relationships, list):
@@ -548,7 +735,12 @@ def validate_corpus_implied_relationships(corpus: list[dict[str, Any]], relation
     return errors
 
 
-def validate_graph(corpus: Any, entities_by_type: dict[str, Any], relationships: Any) -> list[str]:
+def validate_graph(
+    corpus: Any,
+    entities_by_type: dict[str, Any],
+    relationships: Any,
+    malware_families: Any | None = None,
+) -> list[str]:
     errors: list[str] = []
     if not isinstance(corpus, list):
         errors.append("corpus: expected list")
@@ -575,6 +767,14 @@ def validate_graph(corpus: Any, entities_by_type: dict[str, Any], relationships:
         )
     )
     errors.extend(validate_corpus_implied_relationships(corpus, relationships))
+    if malware_families is not None:
+        errors.extend(
+            validate_malware_families(
+                malware_families,
+                raw_incident_ids=raw_incident_ids,
+                entity_ids=all_entity_ids,
+            )
+        )
     return errors
 
 
@@ -583,17 +783,19 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS_PATH)
     parser.add_argument("--entity-dir", type=Path, default=DEFAULT_ENTITY_DIR)
     parser.add_argument("--relationships", type=Path, default=DEFAULT_RELATIONSHIP_PATH)
+    parser.add_argument("--malware-families", type=Path, default=DEFAULT_MALWARE_FAMILY_PATH)
     args = parser.parse_args(argv)
 
     try:
         corpus = load_json(args.corpus)
         entities_by_type = load_entities(args.entity_dir)
         relationships = load_json(args.relationships)
+        malware_families = load_json(args.malware_families)
     except (OSError, json.JSONDecodeError) as exc:
         print(f"failed to load supply-chain graph inputs: {exc}", file=sys.stderr)
         return 2
 
-    errors = validate_graph(corpus, entities_by_type, relationships)
+    errors = validate_graph(corpus, entities_by_type, relationships, malware_families)
     if errors:
         print("Supply-chain graph validation failed:", file=sys.stderr)
         for error in errors:

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import re
 import sys
 from typing import Any
+from urllib.parse import urlparse
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
@@ -92,6 +93,8 @@ VALID_LINEAGE_EDGE_TYPES = {"EVOLVED_FROM", "VARIANT_OF"}
 VALID_LINEAGE_CONFIDENCE = {"confirmed", "suspected"}
 VALID_RELATION_KIND = {"descendant", "evolution", "cosmetic_clone", "playbook_adoption", "sibling_fork"}
 VALID_STRAIN_CONFIDENCE = {"origin", "confirmed", "suspected"}
+VALID_STRAIN_SEVERITY = {"low", "medium", "high", "critical"}
+VALID_ATTRIBUTION_CONFIDENCE = {"unknown", "suspected", "likely", "confirmed"}
 
 
 def load_json(path: Path) -> Any:
@@ -167,6 +170,17 @@ def validate_layout(errors: list[str], path: str, layout: Any) -> None:
     for axis in ("x", "y"):
         if not isinstance(layout.get(axis), (int, float)):
             errors.append(f"{path}.layout.{axis}: expected number")
+
+
+def is_http_url(value: Any) -> bool:
+    if not isinstance(value, str) or not value.strip():
+        return False
+    try:
+        parsed = urlparse(value)
+        _ = parsed.port
+    except ValueError:
+        return False
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
 
 
 def incident_node_id(incident_id: str) -> str:
@@ -567,6 +581,13 @@ def validate_malware_families(
             if source_id in source_ids:
                 errors.append(f"{family_id}.sources[{source_index}].id: duplicate source id {source_id!r}")
             source_ids.add(source_id)
+            for field in ("title", "publisher"):
+                if not isinstance(source.get(field), str) or not source[field].strip():
+                    errors.append(f"{family_id}.sources[{source_index}].{field}: expected non-empty string")
+            if not is_http_url(source.get("url")):
+                errors.append(f"{family_id}.sources[{source_index}].url: expected valid HTTP/HTTPS URL")
+            if not is_date_or_month(source.get("published_at")):
+                errors.append(f"{family_id}.sources[{source_index}].published_at: expected YYYY-MM-DD or YYYY-MM")
         if not source_ids:
             errors.append(f"{family_id}.sources: expected at least one source")
 
@@ -608,11 +629,24 @@ def validate_malware_families(
                 errors.append(f"{strain_id}.first_seen: expected YYYY-MM-DD or YYYY-MM")
             if strain.get("lineage_confidence") not in VALID_STRAIN_CONFIDENCE:
                 errors.append(f"{strain_id}.lineage_confidence: expected one of {sorted(VALID_STRAIN_CONFIDENCE)}")
+            if strain.get("severity") not in VALID_STRAIN_SEVERITY:
+                errors.append(f"{strain_id}.severity: expected low, medium, high, or critical")
             if not isinstance(strain.get("mutation_summary"), str) or len(strain["mutation_summary"].strip()) < 20:
                 errors.append(f"{strain_id}.mutation_summary: expected descriptive mutation summary")
             if not isinstance(strain.get("ecosystems"), list) or not strain["ecosystems"]:
                 errors.append(f"{strain_id}.ecosystems: expected non-empty list")
             validate_layout(errors, strain_id, strain.get("layout"))
+            attribution = strain.get("attribution")
+            if not isinstance(attribution, dict):
+                errors.append(f"{strain_id}.attribution: expected object")
+            else:
+                actor_id = attribution.get("actor_id")
+                if actor_id is not None and actor_id not in entity_ids:
+                    errors.append(f"{strain_id}.attribution.actor_id: unknown actor/entity id {actor_id!r}")
+                if not isinstance(attribution.get("label"), str) or not attribution["label"].strip():
+                    errors.append(f"{strain_id}.attribution.label: expected non-empty string")
+                if attribution.get("confidence") not in VALID_ATTRIBUTION_CONFIDENCE:
+                    errors.append(f"{strain_id}.attribution.confidence: expected unknown, suspected, likely, or confirmed")
             incident_ids = strain.get("incident_ids")
             if incident_ids is not None:
                 if not isinstance(incident_ids, list):
@@ -641,6 +675,8 @@ def validate_malware_families(
                         errors.append(f"{event_id}: duplicate fork event id")
                     fork_event_ids.add(event_id)
                     all_fork_event_ids.add(event_id)
+                    if not isinstance(event.get("name"), str) or not event["name"].strip():
+                        errors.append(f"{event_id}.name: expected non-empty string")
                     if not is_date_or_month(event.get("date")):
                         errors.append(f"{event_id}.date: expected YYYY-MM-DD or YYYY-MM")
                     if not isinstance(event.get("summary"), str) or len(event["summary"].strip()) < 20:

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -737,7 +737,7 @@ def validate_malware_families(
                     if source_ref not in source_ids:
                         errors.append(f"{edge_path}.external_refs[{ref_index}].source_ref: unknown family source ref {source_ref!r}")
             suspected_reason = edge.get("suspected_reason")
-            if edge.get("confidence") == "suspected" and (
+            if (edge.get("confidence") == "suspected" or edge.get("evidence_class") == "suspected") and (
                 not isinstance(suspected_reason, str) or not suspected_reason.strip()
             ):
                 errors.append(f"{edge_path}.suspected_reason: suspected edges must explain uncertainty")

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -554,6 +554,21 @@ def validate_malware_families(
         family_ids.add(family_id)
         if not isinstance(family.get("name"), str) or not family["name"].strip():
             errors.append(f"{family_id}.name: expected non-empty string")
+        schema_version = family.get("schema_version")
+        if not isinstance(schema_version, str) or not schema_version.strip():
+            errors.append(f"{family_id}.schema_version: expected non-empty string")
+        if not isinstance(family.get("summary"), str) or not family["summary"].strip():
+            errors.append(f"{family_id}.summary: expected non-empty string")
+        if not is_date_or_month(family.get("first_seen")):
+            errors.append(f"{family_id}.first_seen: expected YYYY-MM-DD or YYYY-MM")
+        aliases = family.get("aliases")
+        if aliases is not None:
+            if not isinstance(aliases, list):
+                errors.append(f"{family_id}.aliases: expected list")
+            else:
+                for alias_index, alias in enumerate(aliases):
+                    if not isinstance(alias, str) or not alias.strip():
+                        errors.append(f"{family_id}.aliases[{alias_index}]: expected non-empty string")
         root_actor_id = family.get("root_actor_id")
         if root_actor_id is not None and root_actor_id not in entity_ids:
             errors.append(f"{family_id}.root_actor_id: unknown actor/entity id {root_actor_id!r}")
@@ -636,6 +651,26 @@ def validate_malware_families(
                 errors.append(f"{strain_id}.mutation_summary: expected descriptive mutation summary")
             if not isinstance(strain.get("ecosystems"), list) or not strain["ecosystems"]:
                 errors.append(f"{strain_id}.ecosystems: expected non-empty list")
+            if not isinstance(strain.get("key_mutation"), str) or not strain["key_mutation"].strip():
+                errors.append(f"{strain_id}.key_mutation: expected non-empty string")
+            if not isinstance(strain.get("provenance_abuse"), str) or not strain["provenance_abuse"].strip():
+                errors.append(f"{strain_id}.provenance_abuse: expected non-empty string")
+            retained_features = strain.get("retained_features")
+            if retained_features is not None:
+                if not isinstance(retained_features, list):
+                    errors.append(f"{strain_id}.retained_features: expected list")
+                else:
+                    for feature_index, feature in enumerate(retained_features):
+                        if not isinstance(feature, str) or not feature.strip():
+                            errors.append(f"{strain_id}.retained_features[{feature_index}]: expected non-empty string")
+            strain_aliases = strain.get("aliases")
+            if strain_aliases is not None:
+                if not isinstance(strain_aliases, list):
+                    errors.append(f"{strain_id}.aliases: expected list")
+                else:
+                    for alias_index, alias in enumerate(strain_aliases):
+                        if not isinstance(alias, str) or not alias.strip():
+                            errors.append(f"{strain_id}.aliases[{alias_index}]: expected non-empty string")
             validate_layout(errors, strain_id, strain.get("layout"))
             attribution = strain.get("attribution")
             if not isinstance(attribution, dict):

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -593,18 +593,18 @@ def validate_malware_families(
             errors.append(f"{family_id}.sources: expected at least one source")
 
         timeline_ticks = family.get("timeline_ticks")
-        if timeline_ticks is not None:
-            if not isinstance(timeline_ticks, list):
-                errors.append(f"{family_id}.timeline_ticks: expected list")
-            else:
-                for tick_index, tick in enumerate(timeline_ticks):
-                    if not isinstance(tick, dict):
-                        errors.append(f"{family_id}.timeline_ticks[{tick_index}]: expected object")
-                        continue
-                    if not isinstance(tick.get("label"), str) or not tick["label"].strip():
-                        errors.append(f"{family_id}.timeline_ticks[{tick_index}].label: expected non-empty string")
-                    if not isinstance(tick.get("x"), (int, float)):
-                        errors.append(f"{family_id}.timeline_ticks[{tick_index}].x: expected number")
+        if not isinstance(timeline_ticks, list) or not timeline_ticks:
+            errors.append(f"{family_id}.timeline_ticks: expected non-empty list")
+            timeline_ticks = []
+        for tick_index, tick in enumerate(timeline_ticks):
+            if not isinstance(tick, dict):
+                errors.append(f"{family_id}.timeline_ticks[{tick_index}]: expected object")
+                continue
+            if not isinstance(tick.get("label"), str) or not tick["label"].strip():
+                errors.append(f"{family_id}.timeline_ticks[{tick_index}].label: expected non-empty string")
+            tick_x = tick.get("x")
+            if not isinstance(tick_x, (int, float)) or isinstance(tick_x, bool):
+                errors.append(f"{family_id}.timeline_ticks[{tick_index}].x: expected number")
 
         strain_ids: set[str] = set()
         strains = family.get("strains")

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -570,8 +570,9 @@ def validate_malware_families(
                     if not isinstance(alias, str) or not alias.strip():
                         errors.append(f"{family_id}.aliases[{alias_index}]: expected non-empty string")
         root_actor_id = family.get("root_actor_id")
-        if root_actor_id is not None and root_actor_id not in entity_ids:
-            errors.append(f"{family_id}.root_actor_id: unknown actor/entity id {root_actor_id!r}")
+        if root_actor_id is not None:
+            if not isinstance(root_actor_id, str) or root_actor_id not in entity_ids:
+                errors.append(f"{family_id}.root_actor_id: unknown actor/entity id {root_actor_id!r}")
         associated_actor_ids = family.get("associated_actor_ids")
         if associated_actor_ids is not None:
             if not isinstance(associated_actor_ids, list):
@@ -677,8 +678,9 @@ def validate_malware_families(
                 errors.append(f"{strain_id}.attribution: expected object")
             else:
                 actor_id = attribution.get("actor_id")
-                if actor_id is not None and actor_id not in entity_ids:
-                    errors.append(f"{strain_id}.attribution.actor_id: unknown actor/entity id {actor_id!r}")
+                if actor_id is not None:
+                    if not isinstance(actor_id, str) or actor_id not in entity_ids:
+                        errors.append(f"{strain_id}.attribution.actor_id: unknown actor/entity id {actor_id!r}")
                 if not isinstance(attribution.get("label"), str) or not attribution["label"].strip():
                     errors.append(f"{strain_id}.attribution.label: expected non-empty string")
                 if attribution.get("confidence") not in VALID_ATTRIBUTION_CONFIDENCE:
@@ -724,7 +726,7 @@ def validate_malware_families(
                             errors.append(f"{event_id}.source_refs: expected list")
                         else:
                             for ref_index, source_ref in enumerate(source_refs):
-                                if source_ref not in source_ids:
+                                if not isinstance(source_ref, str) or source_ref not in source_ids:
                                     errors.append(f"{event_id}.source_refs[{ref_index}]: unknown family source ref {source_ref!r}")
 
         lineage_edge_items = family.get("lineage_edges")
@@ -743,9 +745,9 @@ def validate_malware_families(
             target = edge.get("target")
             if edge_type not in VALID_LINEAGE_EDGE_TYPES:
                 errors.append(f"{edge_path}.type: expected EVOLVED_FROM or VARIANT_OF")
-            if source not in strain_ids:
+            if not isinstance(source, str) or source not in strain_ids:
                 errors.append(f"{edge_path}.source: unknown strain id {source!r}")
-            if target not in strain_ids:
+            if not isinstance(target, str) or target not in strain_ids:
                 errors.append(f"{edge_path}.target: unknown strain id {target!r}")
             if source == target:
                 errors.append(f"{edge_path}: source and target cannot be the same")
@@ -769,7 +771,7 @@ def validate_malware_families(
                         errors.append(f"{edge_path}.external_refs[{ref_index}]: expected object")
                         continue
                     source_ref = ref.get("source_ref")
-                    if source_ref not in source_ids:
+                    if not isinstance(source_ref, str) or source_ref not in source_ids:
                         errors.append(f"{edge_path}.external_refs[{ref_index}].source_ref: unknown family source ref {source_ref!r}")
             suspected_reason = edge.get("suspected_reason")
             if (edge.get("confidence") == "suspected" or edge.get("evidence_class") == "suspected") and (
@@ -777,8 +779,9 @@ def validate_malware_families(
             ):
                 errors.append(f"{edge_path}.suspected_reason: suspected edges must explain uncertainty")
             fork_event_id = edge.get("fork_event_id")
-            if fork_event_id is not None and fork_event_id not in fork_event_ids:
-                errors.append(f"{edge_path}.fork_event_id: unknown fork event {fork_event_id!r}")
+            if fork_event_id is not None:
+                if not isinstance(fork_event_id, str) or fork_event_id not in fork_event_ids:
+                    errors.append(f"{edge_path}.fork_event_id: unknown fork event {fork_event_id!r}")
             if isinstance(source, str) and isinstance(target, str):
                 lineage_edges.append((source, target, edge_path))
 

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -555,6 +555,8 @@ def validate_malware_families(
             if not isinstance(source_id, str) or not source_id.strip():
                 errors.append(f"{family_id}.sources[{source_index}].id: expected non-empty string")
                 continue
+            if source_id in source_ids:
+                errors.append(f"{family_id}.sources[{source_index}].id: duplicate source id {source_id!r}")
             source_ids.add(source_id)
         if not source_ids:
             errors.append(f"{family_id}.sources: expected at least one source")
@@ -643,8 +645,10 @@ def validate_malware_families(
                                     errors.append(f"{event_id}.source_refs[{ref_index}]: unknown family source ref {source_ref!r}")
 
         lineage_edge_items = family.get("lineage_edges")
-        if not isinstance(lineage_edge_items, list) or not lineage_edge_items:
-            errors.append(f"{family_id}.lineage_edges: expected non-empty list")
+        if lineage_edge_items is None:
+            lineage_edge_items = []
+        elif not isinstance(lineage_edge_items, list):
+            errors.append(f"{family_id}.lineage_edges: expected list")
             lineage_edge_items = []
         for edge_index, edge in enumerate(lineage_edge_items):
             edge_path = f"{family_id}.lineage_edges[{edge_index}]"
@@ -678,7 +682,10 @@ def validate_malware_families(
                 errors.append(f"{edge_path}.external_refs: expected non-empty list")
             else:
                 for ref_index, ref in enumerate(external_refs):
-                    source_ref = ref.get("source_ref") if isinstance(ref, dict) else None
+                    if not isinstance(ref, dict):
+                        errors.append(f"{edge_path}.external_refs[{ref_index}]: expected object")
+                        continue
+                    source_ref = ref.get("source_ref")
                     if source_ref not in source_ids:
                         errors.append(f"{edge_path}.external_refs[{ref_index}].source_ref: unknown family source ref {source_ref!r}")
             suspected_reason = edge.get("suspected_reason")

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -168,7 +168,8 @@ def validate_layout(errors: list[str], path: str, layout: Any) -> None:
         errors.append(f"{path}.layout: expected object with numeric x/y")
         return
     for axis in ("x", "y"):
-        if not isinstance(layout.get(axis), (int, float)):
+        value = layout.get(axis)
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
             errors.append(f"{path}.layout.{axis}: expected number")
 
 

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -160,6 +160,15 @@ def is_date_or_month(value: Any) -> bool:
     return False
 
 
+def validate_layout(errors: list[str], path: str, layout: Any) -> None:
+    if not isinstance(layout, dict):
+        errors.append(f"{path}.layout: expected object with numeric x/y")
+        return
+    for axis in ("x", "y"):
+        if not isinstance(layout.get(axis), (int, float)):
+            errors.append(f"{path}.layout.{axis}: expected number")
+
+
 def incident_node_id(incident_id: str) -> str:
     return f"incident-{incident_id}"
 
@@ -603,6 +612,7 @@ def validate_malware_families(
                 errors.append(f"{strain_id}.mutation_summary: expected descriptive mutation summary")
             if not isinstance(strain.get("ecosystems"), list) or not strain["ecosystems"]:
                 errors.append(f"{strain_id}.ecosystems: expected non-empty list")
+            validate_layout(errors, strain_id, strain.get("layout"))
             incident_ids = strain.get("incident_ids")
             if incident_ids is not None:
                 if not isinstance(incident_ids, list):
@@ -635,6 +645,7 @@ def validate_malware_families(
                         errors.append(f"{event_id}.date: expected YYYY-MM-DD or YYYY-MM")
                     if not isinstance(event.get("summary"), str) or len(event["summary"].strip()) < 20:
                         errors.append(f"{event_id}.summary: expected descriptive summary")
+                    validate_layout(errors, event_id, event.get("layout"))
                     source_refs = event.get("source_refs")
                     if source_refs is not None:
                         if not isinstance(source_refs, list):

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -149,7 +149,15 @@ def parse_date(value: Any) -> date | None:
 def is_date_or_month(value: Any) -> bool:
     if not isinstance(value, str):
         return False
-    return bool(DATE_PATTERN.fullmatch(value) or MONTH_PATTERN.fullmatch(value))
+    if DATE_PATTERN.fullmatch(value):
+        return parse_date(value) is not None
+    if MONTH_PATTERN.fullmatch(value):
+        try:
+            date.fromisoformat(f"{value}-01")
+            return True
+        except ValueError:
+            return False
+    return False
 
 
 def incident_node_id(incident_id: str) -> str:
@@ -525,17 +533,45 @@ def validate_malware_families(
         root_actor_id = family.get("root_actor_id")
         if root_actor_id is not None and root_actor_id not in entity_ids:
             errors.append(f"{family_id}.root_actor_id: unknown actor/entity id {root_actor_id!r}")
-        for actor_index, actor_id in enumerate(family.get("associated_actor_ids") or []):
-            if not isinstance(actor_id, str) or actor_id not in entity_ids:
-                errors.append(f"{family_id}.associated_actor_ids[{actor_index}]: unknown actor/entity id {actor_id!r}")
+        associated_actor_ids = family.get("associated_actor_ids")
+        if associated_actor_ids is not None:
+            if not isinstance(associated_actor_ids, list):
+                errors.append(f"{family_id}.associated_actor_ids: expected list")
+            else:
+                for actor_index, actor_id in enumerate(associated_actor_ids):
+                    if not isinstance(actor_id, str) or actor_id not in entity_ids:
+                        errors.append(f"{family_id}.associated_actor_ids[{actor_index}]: unknown actor/entity id {actor_id!r}")
 
-        source_ids = {
-            source.get("id")
-            for source in family.get("sources") or []
-            if isinstance(source, dict) and isinstance(source.get("id"), str)
-        }
+        sources = family.get("sources")
+        source_ids: set[str] = set()
+        if not isinstance(sources, list) or not sources:
+            errors.append(f"{family_id}.sources: expected non-empty list")
+            sources = []
+        for source_index, source in enumerate(sources):
+            if not isinstance(source, dict):
+                errors.append(f"{family_id}.sources[{source_index}]: expected object")
+                continue
+            source_id = source.get("id")
+            if not isinstance(source_id, str) or not source_id.strip():
+                errors.append(f"{family_id}.sources[{source_index}].id: expected non-empty string")
+                continue
+            source_ids.add(source_id)
         if not source_ids:
             errors.append(f"{family_id}.sources: expected at least one source")
+
+        timeline_ticks = family.get("timeline_ticks")
+        if timeline_ticks is not None:
+            if not isinstance(timeline_ticks, list):
+                errors.append(f"{family_id}.timeline_ticks: expected list")
+            else:
+                for tick_index, tick in enumerate(timeline_ticks):
+                    if not isinstance(tick, dict):
+                        errors.append(f"{family_id}.timeline_ticks[{tick_index}]: expected object")
+                        continue
+                    if not isinstance(tick.get("label"), str) or not tick["label"].strip():
+                        errors.append(f"{family_id}.timeline_ticks[{tick_index}].label: expected non-empty string")
+                    if not isinstance(tick.get("x"), (int, float)):
+                        errors.append(f"{family_id}.timeline_ticks[{tick_index}].x: expected number")
 
         strain_ids: set[str] = set()
         strains = family.get("strains")
@@ -565,33 +601,52 @@ def validate_malware_families(
                 errors.append(f"{strain_id}.mutation_summary: expected descriptive mutation summary")
             if not isinstance(strain.get("ecosystems"), list) or not strain["ecosystems"]:
                 errors.append(f"{strain_id}.ecosystems: expected non-empty list")
-            for incident_index, incident_id in enumerate(strain.get("incident_ids") or []):
-                if not isinstance(incident_id, str) or incident_id not in raw_incident_ids:
-                    errors.append(f"{strain_id}.incident_ids[{incident_index}]: unknown incident id {incident_id!r}")
+            incident_ids = strain.get("incident_ids")
+            if incident_ids is not None:
+                if not isinstance(incident_ids, list):
+                    errors.append(f"{strain_id}.incident_ids: expected list")
+                else:
+                    for incident_index, incident_id in enumerate(incident_ids):
+                        if not isinstance(incident_id, str) or incident_id not in raw_incident_ids:
+                            errors.append(f"{strain_id}.incident_ids[{incident_index}]: unknown incident id {incident_id!r}")
 
         fork_event_ids: set[str] = set()
-        for event_index, event in enumerate(family.get("fork_events") or []):
-            event_path = f"{family_id}.fork_events[{event_index}]"
-            if not isinstance(event, dict):
-                errors.append(f"{event_path}: expected object")
-                continue
-            event_id = event.get("id")
-            if not isinstance(event_id, str) or not event_id.startswith("fork-"):
-                errors.append(f"{event_path}.id: expected fork-* id")
-                continue
-            if event_id in fork_event_ids or event_id in all_fork_event_ids:
-                errors.append(f"{event_id}: duplicate fork event id")
-            fork_event_ids.add(event_id)
-            all_fork_event_ids.add(event_id)
-            if not is_date_or_month(event.get("date")):
-                errors.append(f"{event_id}.date: expected YYYY-MM-DD or YYYY-MM")
-            if not isinstance(event.get("summary"), str) or len(event["summary"].strip()) < 20:
-                errors.append(f"{event_id}.summary: expected descriptive summary")
-            for ref_index, source_ref in enumerate(event.get("source_refs") or []):
-                if source_ref not in source_ids:
-                    errors.append(f"{event_id}.source_refs[{ref_index}]: unknown family source ref {source_ref!r}")
+        fork_events = family.get("fork_events")
+        if fork_events is not None:
+            if not isinstance(fork_events, list):
+                errors.append(f"{family_id}.fork_events: expected list")
+            else:
+                for event_index, event in enumerate(fork_events):
+                    event_path = f"{family_id}.fork_events[{event_index}]"
+                    if not isinstance(event, dict):
+                        errors.append(f"{event_path}: expected object")
+                        continue
+                    event_id = event.get("id")
+                    if not isinstance(event_id, str) or not event_id.startswith("fork-"):
+                        errors.append(f"{event_path}.id: expected fork-* id")
+                        continue
+                    if event_id in fork_event_ids or event_id in all_fork_event_ids:
+                        errors.append(f"{event_id}: duplicate fork event id")
+                    fork_event_ids.add(event_id)
+                    all_fork_event_ids.add(event_id)
+                    if not is_date_or_month(event.get("date")):
+                        errors.append(f"{event_id}.date: expected YYYY-MM-DD or YYYY-MM")
+                    if not isinstance(event.get("summary"), str) or len(event["summary"].strip()) < 20:
+                        errors.append(f"{event_id}.summary: expected descriptive summary")
+                    source_refs = event.get("source_refs")
+                    if source_refs is not None:
+                        if not isinstance(source_refs, list):
+                            errors.append(f"{event_id}.source_refs: expected list")
+                        else:
+                            for ref_index, source_ref in enumerate(source_refs):
+                                if source_ref not in source_ids:
+                                    errors.append(f"{event_id}.source_refs[{ref_index}]: unknown family source ref {source_ref!r}")
 
-        for edge_index, edge in enumerate(family.get("lineage_edges") or []):
+        lineage_edge_items = family.get("lineage_edges")
+        if not isinstance(lineage_edge_items, list) or not lineage_edge_items:
+            errors.append(f"{family_id}.lineage_edges: expected non-empty list")
+            lineage_edge_items = []
+        for edge_index, edge in enumerate(lineage_edge_items):
             edge_path = f"{family_id}.lineage_edges[{edge_index}]"
             if not isinstance(edge, dict):
                 errors.append(f"{edge_path}: expected object")
@@ -626,7 +681,10 @@ def validate_malware_families(
                     source_ref = ref.get("source_ref") if isinstance(ref, dict) else None
                     if source_ref not in source_ids:
                         errors.append(f"{edge_path}.external_refs[{ref_index}].source_ref: unknown family source ref {source_ref!r}")
-            if edge.get("confidence") == "suspected" and not isinstance(edge.get("suspected_reason"), str):
+            suspected_reason = edge.get("suspected_reason")
+            if edge.get("confidence") == "suspected" and (
+                not isinstance(suspected_reason, str) or not suspected_reason.strip()
+            ):
                 errors.append(f"{edge_path}.suspected_reason: suspected edges must explain uncertainty")
             fork_event_id = edge.get("fork_event_id")
             if fork_event_id is not None and fork_event_id not in fork_event_ids:

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -529,7 +529,7 @@ def validate_malware_families(
     malware_families: Any,
     *,
     raw_incident_ids: set[str],
-    entity_ids: set[str],
+    actor_ids: set[str],
 ) -> list[str]:
     errors: list[str] = []
     if not isinstance(malware_families, list):
@@ -571,16 +571,16 @@ def validate_malware_families(
                         errors.append(f"{family_id}.aliases[{alias_index}]: expected non-empty string")
         root_actor_id = family.get("root_actor_id")
         if root_actor_id is not None:
-            if not isinstance(root_actor_id, str) or root_actor_id not in entity_ids:
-                errors.append(f"{family_id}.root_actor_id: unknown actor/entity id {root_actor_id!r}")
+            if not isinstance(root_actor_id, str) or root_actor_id not in actor_ids:
+                errors.append(f"{family_id}.root_actor_id: unknown actor id {root_actor_id!r}")
         associated_actor_ids = family.get("associated_actor_ids")
         if associated_actor_ids is not None:
             if not isinstance(associated_actor_ids, list):
                 errors.append(f"{family_id}.associated_actor_ids: expected list")
             else:
                 for actor_index, actor_id in enumerate(associated_actor_ids):
-                    if not isinstance(actor_id, str) or actor_id not in entity_ids:
-                        errors.append(f"{family_id}.associated_actor_ids[{actor_index}]: unknown actor/entity id {actor_id!r}")
+                    if not isinstance(actor_id, str) or actor_id not in actor_ids:
+                        errors.append(f"{family_id}.associated_actor_ids[{actor_index}]: unknown actor id {actor_id!r}")
 
         sources = family.get("sources")
         source_ids: set[str] = set()
@@ -684,8 +684,8 @@ def validate_malware_families(
             else:
                 actor_id = attribution.get("actor_id")
                 if actor_id is not None:
-                    if not isinstance(actor_id, str) or actor_id not in entity_ids:
-                        errors.append(f"{strain_id}.attribution.actor_id: unknown actor/entity id {actor_id!r}")
+                    if not isinstance(actor_id, str) or actor_id not in actor_ids:
+                        errors.append(f"{strain_id}.attribution.actor_id: unknown actor id {actor_id!r}")
                 if not isinstance(attribution.get("label"), str) or not attribution["label"].strip():
                     errors.append(f"{strain_id}.attribution.label: expected non-empty string")
                 if attribution.get("confidence") not in VALID_ATTRIBUTION_CONFIDENCE:
@@ -906,8 +906,10 @@ def validate_graph(
     references_by_incident = collect_reference_ids_by_incident(corpus)
     incident_ids = collect_incident_ids(corpus)
     all_entity_ids: set[str] = set()
+    entity_ids_by_type: dict[str, set[str]] = {}
     for entity_type, entities in entities_by_type.items():
         entity_ids = validate_entity_file(errors, entity_type, entities, raw_incident_ids)
+        entity_ids_by_type[entity_type] = entity_ids
         duplicates = all_entity_ids & entity_ids
         for entity_id in sorted(duplicates):
             errors.append(f"{entity_id}: duplicate id across entity files")
@@ -928,7 +930,7 @@ def validate_graph(
             validate_malware_families(
                 malware_families,
                 raw_incident_ids=raw_incident_ids,
-                entity_ids=all_entity_ids,
+                actor_ids=entity_ids_by_type.get("actors", set()),
             )
         )
     return errors

--- a/scripts/validate_supply_chain_graph.py
+++ b/scripts/validate_supply_chain_graph.py
@@ -650,8 +650,13 @@ def validate_malware_families(
                 errors.append(f"{strain_id}.severity: expected low, medium, high, or critical")
             if not isinstance(strain.get("mutation_summary"), str) or len(strain["mutation_summary"].strip()) < 20:
                 errors.append(f"{strain_id}.mutation_summary: expected descriptive mutation summary")
-            if not isinstance(strain.get("ecosystems"), list) or not strain["ecosystems"]:
+            ecosystems = strain.get("ecosystems")
+            if not isinstance(ecosystems, list) or not ecosystems:
                 errors.append(f"{strain_id}.ecosystems: expected non-empty list")
+            else:
+                for ecosystem_index, ecosystem in enumerate(ecosystems):
+                    if not isinstance(ecosystem, str) or not ecosystem.strip():
+                        errors.append(f"{strain_id}.ecosystems[{ecosystem_index}]: expected non-empty string")
             if not isinstance(strain.get("key_mutation"), str) or not strain["key_mutation"].strip():
                 errors.append(f"{strain_id}.key_mutation: expected non-empty string")
             if not isinstance(strain.get("provenance_abuse"), str) or not strain["provenance_abuse"].strip():

--- a/site/public/js/supply-chain-graph-core.js
+++ b/site/public/js/supply-chain-graph-core.js
@@ -1203,6 +1203,10 @@ class SupplyChainGraph {
 
   selectSearchResult(entry) {
     this.closeSearchPalette();
+    if (entry.href) {
+      window.location.href = entry.href;
+      return;
+    }
     if (!this.selectByEntityId(entry.type, entry.id)) {
       this.selectEntityContext(entry.type, entry.id);
     }

--- a/site/public/supply-chain-graph.json
+++ b/site/public/supply-chain-graph.json
@@ -4272,7 +4272,7 @@
         "Hades Shai-Hulud lineage strain"
       ],
       "family_id": "family-shai-hulud",
-      "lineage_confidence": "confirmed",
+      "lineage_confidence": "suspected",
       "source_incident_ids": []
     },
     {
@@ -6939,7 +6939,7 @@
         "broader propagation"
       ],
       "source_refs": [
-        "ref-stepsecurity-mini-shai"
+        "ref-stepsecurity-hades-campaign"
       ],
       "fork_event_id": null,
       "summary": "Hades is modeled as a suspected evolution of Miasma pending explicit code-overlap or researcher-attestation evidence."

--- a/site/public/supply-chain-graph.json
+++ b/site/public/supply-chain-graph.json
@@ -34,6 +34,7 @@
       "release"
     ],
     "seeded_by_edges": "causal-solid-temporal-dashed",
+    "evolved_from_edges": "confirmed-solid-suspected-dashed",
     "layout": "time-anchored-actor-lanes"
   },
   "counts": {
@@ -48,7 +49,10 @@
     "organization": 27,
     "package": 31,
     "release": 12,
-    "repository": 17
+    "repository": 17,
+    "malware_family": 1,
+    "malware_strain": 6,
+    "fork_event": 1
   },
   "attack_stages": [
     {
@@ -1336,6 +1340,47 @@
       "source_incident_ids": [
         "SC-2024-POLYFILL-IO"
       ]
+    },
+    {
+      "id": "family-shai-hulud",
+      "entity_id": "family-shai-hulud",
+      "type": "malware_family",
+      "label": "Shai-Hulud",
+      "short_label": "Shai-Hulud",
+      "tier": "malware_family",
+      "sev": null,
+      "time": "2025-09-16",
+      "parent": "actor-shai-hulud-operator",
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/malware-families/family-shai-hulud/",
+      "aliases": [
+        "Shai Hulud",
+        "Shai-Hulud worm family",
+        "Mini Shai-Hulud"
+      ],
+      "source_incident_ids": [
+        "SC-2025-NPM-SHAI-HULUD",
+        "SC-2025-SHAI-HULUD-2",
+        "SC-2026-MINI-SHAI-HULUD"
+      ]
+    },
+    {
+      "id": "fork-mini-shai-source-release",
+      "entity_id": "fork-mini-shai-source-release",
+      "type": "fork_event",
+      "label": "Mini Shai-Hulud source open-sourced",
+      "short_label": "Mini Shai-Hulud source open-sou...",
+      "tier": "fork_event",
+      "sev": null,
+      "time": "2026-05-12",
+      "parent": "family-shai-hulud",
+      "techniques": [],
+      "purl": null,
+      "href": "/supply-chain/malware-families/family-shai-hulud/#fork-mini-shai-source-release",
+      "aliases": [],
+      "family_id": "family-shai-hulud",
+      "source_incident_ids": []
     },
     {
       "id": "incident-SC-2016-LINUX-MINT-ISO",
@@ -4209,6 +4254,146 @@
       ]
     },
     {
+      "id": "strain-hades-shai-hulud",
+      "entity_id": "strain-hades-shai-hulud",
+      "type": "malware_strain",
+      "label": "Hades",
+      "short_label": "Hades",
+      "tier": "malware_strain",
+      "sev": "critical",
+      "time": "2026-06-06",
+      "parent": "family-shai-hulud",
+      "techniques": [
+        "PyPI"
+      ],
+      "purl": null,
+      "href": "/supply-chain/malware-families/family-shai-hulud/#strain-hades-shai-hulud",
+      "aliases": [
+        "Hades Shai-Hulud lineage strain"
+      ],
+      "family_id": "family-shai-hulud",
+      "lineage_confidence": "confirmed",
+      "source_incident_ids": []
+    },
+    {
+      "id": "strain-ironworm",
+      "entity_id": "strain-ironworm",
+      "type": "malware_strain",
+      "label": "IronWorm",
+      "short_label": "IronWorm",
+      "tier": "malware_strain",
+      "sev": "high",
+      "time": "2026-06-06",
+      "parent": "family-shai-hulud",
+      "techniques": [
+        "npm"
+      ],
+      "purl": null,
+      "href": "/supply-chain/malware-families/family-shai-hulud/#strain-ironworm",
+      "aliases": [
+        "Iron Worm"
+      ],
+      "family_id": "family-shai-hulud",
+      "lineage_confidence": "suspected",
+      "source_incident_ids": []
+    },
+    {
+      "id": "strain-miasma",
+      "entity_id": "strain-miasma",
+      "type": "malware_strain",
+      "label": "Miasma",
+      "short_label": "Miasma",
+      "tier": "malware_strain",
+      "sev": "critical",
+      "time": "2026-06-01",
+      "parent": "family-shai-hulud",
+      "techniques": [
+        "npm"
+      ],
+      "purl": null,
+      "href": "/supply-chain/malware-families/family-shai-hulud/#strain-miasma",
+      "aliases": [
+        "The Spreading Blight"
+      ],
+      "family_id": "family-shai-hulud",
+      "lineage_confidence": "suspected",
+      "source_incident_ids": []
+    },
+    {
+      "id": "strain-mini-shai-hulud",
+      "entity_id": "strain-mini-shai-hulud",
+      "type": "malware_strain",
+      "label": "Mini Shai-Hulud",
+      "short_label": "Mini Shai-Hulud",
+      "tier": "malware_strain",
+      "sev": "high",
+      "time": "2026-05-11",
+      "parent": "family-shai-hulud",
+      "techniques": [
+        "npm",
+        "PyPI",
+        "RubyGems"
+      ],
+      "purl": null,
+      "href": "/supply-chain/malware-families/family-shai-hulud/#strain-mini-shai-hulud",
+      "aliases": [
+        "Mini Shai Hulud"
+      ],
+      "family_id": "family-shai-hulud",
+      "lineage_confidence": "confirmed",
+      "source_incident_ids": [
+        "SC-2026-MINI-SHAI-HULUD"
+      ]
+    },
+    {
+      "id": "strain-shai-hulud",
+      "entity_id": "strain-shai-hulud",
+      "type": "malware_strain",
+      "label": "Shai-Hulud",
+      "short_label": "Shai-Hulud",
+      "tier": "malware_strain",
+      "sev": "medium",
+      "time": "2025-09-16",
+      "parent": "family-shai-hulud",
+      "techniques": [
+        "npm"
+      ],
+      "purl": null,
+      "href": "/supply-chain/malware-families/family-shai-hulud/#strain-shai-hulud",
+      "aliases": [
+        "Shai Hulud"
+      ],
+      "family_id": "family-shai-hulud",
+      "lineage_confidence": "origin",
+      "source_incident_ids": [
+        "SC-2025-NPM-SHAI-HULUD"
+      ]
+    },
+    {
+      "id": "strain-shai-hulud-2",
+      "entity_id": "strain-shai-hulud-2",
+      "type": "malware_strain",
+      "label": "Shai-Hulud 2.0",
+      "short_label": "Shai-Hulud 2.0",
+      "tier": "malware_strain",
+      "sev": "medium",
+      "time": "2025-11-24",
+      "parent": "family-shai-hulud",
+      "techniques": [
+        "npm"
+      ],
+      "purl": null,
+      "href": "/supply-chain/malware-families/family-shai-hulud/#strain-shai-hulud-2",
+      "aliases": [
+        "Shai Hulud 2.0"
+      ],
+      "family_id": "family-shai-hulud",
+      "lineage_confidence": "confirmed",
+      "source_incident_ids": [
+        "SC-2025-SHAI-HULUD-2"
+      ]
+    },
+    {
       "id": "technique-account-compromise",
       "entity_id": "account-compromise",
       "type": "technique",
@@ -6741,6 +6926,63 @@
       "source_refs": []
     },
     {
+      "id": "EVOLVED_FROM:strain-hades-shai-hulud->strain-miasma",
+      "source": "strain-hades-shai-hulud",
+      "target": "strain-miasma",
+      "type": "EVOLVED_FROM",
+      "evidence_class": "confirmed",
+      "confidence": "confirmed",
+      "relation_kind": "evolution",
+      "mutation_delta": [
+        "moved to PyPI",
+        "Artifactory reconnaissance",
+        "broader propagation"
+      ],
+      "source_refs": [
+        "ref-stepsecurity-mini-shai"
+      ],
+      "fork_event_id": null,
+      "summary": "Hades is modeled as an evolution of Miasma in the worked example."
+    },
+    {
+      "id": "EVOLVED_FROM:strain-mini-shai-hulud->strain-shai-hulud-2",
+      "source": "strain-mini-shai-hulud",
+      "target": "strain-shai-hulud-2",
+      "type": "EVOLVED_FROM",
+      "evidence_class": "confirmed",
+      "confidence": "confirmed",
+      "relation_kind": "evolution",
+      "mutation_delta": [
+        "added PyPI",
+        "added trusted publishing",
+        "OIDC token theft"
+      ],
+      "source_refs": [
+        "ref-socket-tanstack-mini-shai",
+        "ref-stepsecurity-mini-shai"
+      ],
+      "fork_event_id": null,
+      "summary": "Mini Shai-Hulud is modeled as the industrialized cross-ecosystem evolution of the Shai-Hulud worm pattern."
+    },
+    {
+      "id": "EVOLVED_FROM:strain-shai-hulud-2->strain-shai-hulud",
+      "source": "strain-shai-hulud-2",
+      "target": "strain-shai-hulud",
+      "type": "EVOLVED_FROM",
+      "evidence_class": "confirmed",
+      "confidence": "confirmed",
+      "relation_kind": "descendant",
+      "mutation_delta": [
+        "scale",
+        "faster propagation"
+      ],
+      "source_refs": [
+        "ref-microsoft-shai-hulud-2"
+      ],
+      "fork_event_id": null,
+      "summary": "The second wave retained the Shai-Hulud worm playbook while increasing scale and propagation speed."
+    },
+    {
       "id": "INCIDENT_AFFECTED_RELEASE:incident-SC-2018-NPM-EVENT-STREAM->release-npm-flatmap-stream-0-1-1",
       "source": "incident-SC-2018-NPM-EVENT-STREAM",
       "target": "release-npm-flatmap-stream-0-1-1",
@@ -8445,6 +8687,62 @@
       "source_refs": []
     },
     {
+      "id": "MALWARE_FAMILY_ACTOR:actor-teampcp->family-shai-hulud",
+      "source": "actor-teampcp",
+      "target": "family-shai-hulud",
+      "type": "ATTRIBUTED_TO_ACTOR",
+      "derived": true
+    },
+    {
+      "id": "MALWARE_FAMILY_FORK_EVENT:family-shai-hulud->fork-mini-shai-source-release",
+      "source": "family-shai-hulud",
+      "target": "fork-mini-shai-source-release",
+      "type": "FORK_EVENT",
+      "derived": true
+    },
+    {
+      "id": "MALWARE_FAMILY_STRAIN:family-shai-hulud->strain-hades-shai-hulud",
+      "source": "family-shai-hulud",
+      "target": "strain-hades-shai-hulud",
+      "type": "HAS_STRAIN",
+      "derived": true
+    },
+    {
+      "id": "MALWARE_FAMILY_STRAIN:family-shai-hulud->strain-ironworm",
+      "source": "family-shai-hulud",
+      "target": "strain-ironworm",
+      "type": "HAS_STRAIN",
+      "derived": true
+    },
+    {
+      "id": "MALWARE_FAMILY_STRAIN:family-shai-hulud->strain-miasma",
+      "source": "family-shai-hulud",
+      "target": "strain-miasma",
+      "type": "HAS_STRAIN",
+      "derived": true
+    },
+    {
+      "id": "MALWARE_FAMILY_STRAIN:family-shai-hulud->strain-mini-shai-hulud",
+      "source": "family-shai-hulud",
+      "target": "strain-mini-shai-hulud",
+      "type": "HAS_STRAIN",
+      "derived": true
+    },
+    {
+      "id": "MALWARE_FAMILY_STRAIN:family-shai-hulud->strain-shai-hulud",
+      "source": "family-shai-hulud",
+      "target": "strain-shai-hulud",
+      "type": "HAS_STRAIN",
+      "derived": true
+    },
+    {
+      "id": "MALWARE_FAMILY_STRAIN:family-shai-hulud->strain-shai-hulud-2",
+      "source": "family-shai-hulud",
+      "target": "strain-shai-hulud-2",
+      "type": "HAS_STRAIN",
+      "derived": true
+    },
+    {
       "id": "PACKAGE_RELEASE:pkg-golang-github-com-boltdb-go-bolt->release-golang-github-com-boltdb-go-bolt-v1-3-1",
       "source": "pkg-golang-github-com-boltdb-go-bolt",
       "target": "release-golang-github-com-boltdb-go-bolt-v1-3-1",
@@ -8783,6 +9081,27 @@
       "type": "SOURCE_ARTIFACT_DIVERGENCE",
       "evidence_tier": null,
       "source_refs": []
+    },
+    {
+      "id": "STRAIN_INCIDENT:strain-mini-shai-hulud->incident-SC-2026-MINI-SHAI-HULUD",
+      "source": "strain-mini-shai-hulud",
+      "target": "incident-SC-2026-MINI-SHAI-HULUD",
+      "type": "STRAIN_INCIDENT",
+      "derived": true
+    },
+    {
+      "id": "STRAIN_INCIDENT:strain-shai-hulud->incident-SC-2025-NPM-SHAI-HULUD",
+      "source": "strain-shai-hulud",
+      "target": "incident-SC-2025-NPM-SHAI-HULUD",
+      "type": "STRAIN_INCIDENT",
+      "derived": true
+    },
+    {
+      "id": "STRAIN_INCIDENT:strain-shai-hulud-2->incident-SC-2025-SHAI-HULUD-2",
+      "source": "strain-shai-hulud-2",
+      "target": "incident-SC-2025-SHAI-HULUD-2",
+      "type": "STRAIN_INCIDENT",
+      "derived": true
     },
     {
       "id": "USED_BUILD_SYSTEM:incident-SC-2020-OCTOPUS-SCANNER->build-netbeans-netbeans-project-build-process",
@@ -9255,6 +9574,44 @@
       "type": "USES_ACCOUNT",
       "evidence_tier": null,
       "source_refs": []
+    },
+    {
+      "id": "VARIANT_OF:strain-ironworm->strain-mini-shai-hulud",
+      "source": "strain-ironworm",
+      "target": "strain-mini-shai-hulud",
+      "type": "VARIANT_OF",
+      "evidence_class": "suspected",
+      "confidence": "suspected",
+      "relation_kind": "cosmetic_clone",
+      "mutation_delta": [
+        "Rust ELF payload",
+        "preinstall hook",
+        "cosmetic fork"
+      ],
+      "source_refs": [
+        "ref-stepsecurity-mini-shai"
+      ],
+      "fork_event_id": "fork-mini-shai-source-release",
+      "summary": "IronWorm is a suspected sibling clone over the released base rather than a confirmed descendant."
+    },
+    {
+      "id": "VARIANT_OF:strain-miasma->strain-mini-shai-hulud",
+      "source": "strain-miasma",
+      "target": "strain-mini-shai-hulud",
+      "type": "VARIANT_OF",
+      "evidence_class": "suspected",
+      "confidence": "suspected",
+      "relation_kind": "playbook_adoption",
+      "mutation_delta": [
+        "binding.gyp install evasion",
+        "per-infection encryption",
+        "AI coding-agent prompt injection"
+      ],
+      "source_refs": [
+        "ref-stepsecurity-mini-shai"
+      ],
+      "fork_event_id": "fork-mini-shai-source-release",
+      "summary": "Miasma is treated as a suspected fork from the released framework unless stronger code-overlap or researcher-attestation evidence lands."
     }
   ]
 }

--- a/site/public/supply-chain-graph.json
+++ b/site/public/supply-chain-graph.json
@@ -6930,8 +6930,8 @@
       "source": "strain-hades-shai-hulud",
       "target": "strain-miasma",
       "type": "EVOLVED_FROM",
-      "evidence_class": "confirmed",
-      "confidence": "confirmed",
+      "evidence_class": "suspected",
+      "confidence": "suspected",
       "relation_kind": "evolution",
       "mutation_delta": [
         "moved to PyPI",
@@ -6942,7 +6942,7 @@
         "ref-stepsecurity-mini-shai"
       ],
       "fork_event_id": null,
-      "summary": "Hades is modeled as an evolution of Miasma in the worked example."
+      "summary": "Hades is modeled as a suspected evolution of Miasma pending explicit code-overlap or researcher-attestation evidence."
     },
     {
       "id": "EVOLVED_FROM:strain-mini-shai-hulud->strain-shai-hulud-2",

--- a/site/public/supply-chain-malware-families-stix.json
+++ b/site/public/supply-chain-malware-families-stix.json
@@ -1,11 +1,11 @@
 {
   "type": "bundle",
-  "id": "bundle--26e0d902-ae34-4885-9be7-2ff88b77b8a7",
+  "id": "bundle--26e0d902-ae34-4b88-95be-72ff88b77b8a",
   "objects": [
     {
       "type": "malware",
       "spec_version": "2.1",
-      "id": "malware--316777e0-9649-4c41-8359-04ddccf4c401",
+      "id": "malware--316777e0-9649-46c4-9835-904ddccf4c40",
       "created": "2026-06-22T00:00:00.000Z",
       "modified": "2026-06-22T00:00:00.000Z",
       "name": "Shai-Hulud",
@@ -31,7 +31,7 @@
     {
       "type": "malware",
       "spec_version": "2.1",
-      "id": "malware--b8054347-f268-4af8-9d0d-b2470e6a5c49",
+      "id": "malware--b8054347-f268-40af-8dd0-db2470e6a5c4",
       "created": "2026-06-22T00:00:00.000Z",
       "modified": "2026-06-22T00:00:00.000Z",
       "name": "Shai-Hulud 2.0",
@@ -57,7 +57,7 @@
     {
       "type": "malware",
       "spec_version": "2.1",
-      "id": "malware--e151d7d5-1daa-463a-8bfc-787baf1ab83d",
+      "id": "malware--e151d7d5-1daa-4963-acbf-c787baf1ab83",
       "created": "2026-06-22T00:00:00.000Z",
       "modified": "2026-06-22T00:00:00.000Z",
       "name": "Mini Shai-Hulud",
@@ -83,7 +83,7 @@
     {
       "type": "malware",
       "spec_version": "2.1",
-      "id": "malware--6805f78e-c6d4-4cd0-87d9-812326ab065a",
+      "id": "malware--6805f78e-c6d4-45cd-847d-9812326ab065",
       "created": "2026-06-22T00:00:00.000Z",
       "modified": "2026-06-22T00:00:00.000Z",
       "name": "Miasma",
@@ -109,7 +109,7 @@
     {
       "type": "malware",
       "spec_version": "2.1",
-      "id": "malware--12a7c86a-3854-42c0-bf11-40d886d24753",
+      "id": "malware--12a7c86a-3854-412c-8bf1-140d886d2475",
       "created": "2026-06-22T00:00:00.000Z",
       "modified": "2026-06-22T00:00:00.000Z",
       "name": "Hades",
@@ -135,7 +135,7 @@
     {
       "type": "malware",
       "spec_version": "2.1",
-      "id": "malware--98cd4d95-60cd-4e1c-a94c-f5435d65ac97",
+      "id": "malware--98cd4d95-60cd-41e1-8e94-cf5435d65ac9",
       "created": "2026-06-22T00:00:00.000Z",
       "modified": "2026-06-22T00:00:00.000Z",
       "name": "IronWorm",
@@ -161,12 +161,12 @@
     {
       "type": "relationship",
       "spec_version": "2.1",
-      "id": "relationship--1853fccf-516c-4e11-ae96-e3ca4bdc9499",
+      "id": "relationship--1853fccf-516c-41e1-92e9-6e3ca4bdc949",
       "created": "2026-06-22T00:00:00.000Z",
       "modified": "2026-06-22T00:00:00.000Z",
       "relationship_type": "derived-from",
-      "source_ref": "malware--b8054347-f268-4af8-9d0d-b2470e6a5c49",
-      "target_ref": "malware--316777e0-9649-4c41-8359-04ddccf4c401",
+      "source_ref": "malware--b8054347-f268-40af-8dd0-db2470e6a5c4",
+      "target_ref": "malware--316777e0-9649-46c4-9835-904ddccf4c40",
       "description": "The second wave retained the Shai-Hulud worm playbook while increasing scale and propagation speed.",
       "external_references": [
         {
@@ -184,12 +184,12 @@
     {
       "type": "relationship",
       "spec_version": "2.1",
-      "id": "relationship--dc367265-47eb-48a2-bfb0-0920d7da6efa",
+      "id": "relationship--dc367265-47eb-438a-abfb-00920d7da6ef",
       "created": "2026-06-22T00:00:00.000Z",
       "modified": "2026-06-22T00:00:00.000Z",
       "relationship_type": "derived-from",
-      "source_ref": "malware--e151d7d5-1daa-463a-8bfc-787baf1ab83d",
-      "target_ref": "malware--b8054347-f268-4af8-9d0d-b2470e6a5c49",
+      "source_ref": "malware--e151d7d5-1daa-4963-acbf-c787baf1ab83",
+      "target_ref": "malware--b8054347-f268-40af-8dd0-db2470e6a5c4",
       "description": "Mini Shai-Hulud is modeled as the industrialized cross-ecosystem evolution of the Shai-Hulud worm pattern.",
       "external_references": [
         {
@@ -212,12 +212,12 @@
     {
       "type": "relationship",
       "spec_version": "2.1",
-      "id": "relationship--33934301-00d0-4b34-b27d-2a780a2d68e6",
+      "id": "relationship--33934301-00d0-47b3-8327-d2a780a2d68e",
       "created": "2026-06-22T00:00:00.000Z",
       "modified": "2026-06-22T00:00:00.000Z",
       "relationship_type": "variant-of",
-      "source_ref": "malware--6805f78e-c6d4-4cd0-87d9-812326ab065a",
-      "target_ref": "malware--e151d7d5-1daa-463a-8bfc-787baf1ab83d",
+      "source_ref": "malware--6805f78e-c6d4-45cd-847d-9812326ab065",
+      "target_ref": "malware--e151d7d5-1daa-4963-acbf-c787baf1ab83",
       "description": "Miasma is treated as a suspected fork from the released framework unless stronger code-overlap or researcher-attestation evidence lands.",
       "external_references": [
         {
@@ -236,12 +236,12 @@
     {
       "type": "relationship",
       "spec_version": "2.1",
-      "id": "relationship--ffa41d5e-553b-4060-9555-94754ab79362",
+      "id": "relationship--ffa41d5e-553b-4006-8155-594754ab7936",
       "created": "2026-06-22T00:00:00.000Z",
       "modified": "2026-06-22T00:00:00.000Z",
       "relationship_type": "derived-from",
-      "source_ref": "malware--12a7c86a-3854-42c0-bf11-40d886d24753",
-      "target_ref": "malware--6805f78e-c6d4-4cd0-87d9-812326ab065a",
+      "source_ref": "malware--12a7c86a-3854-412c-8bf1-140d886d2475",
+      "target_ref": "malware--6805f78e-c6d4-45cd-847d-9812326ab065",
       "description": "Hades is modeled as an evolution of Miasma in the worked example.",
       "external_references": [
         {
@@ -260,12 +260,12 @@
     {
       "type": "relationship",
       "spec_version": "2.1",
-      "id": "relationship--bb0547c7-20b1-4881-9bdb-b8c9546e22bc",
+      "id": "relationship--bb0547c7-20b1-4988-91bd-bb8c9546e22b",
       "created": "2026-06-22T00:00:00.000Z",
       "modified": "2026-06-22T00:00:00.000Z",
       "relationship_type": "variant-of",
-      "source_ref": "malware--98cd4d95-60cd-4e1c-a94c-f5435d65ac97",
-      "target_ref": "malware--e151d7d5-1daa-463a-8bfc-787baf1ab83d",
+      "source_ref": "malware--98cd4d95-60cd-41e1-8e94-cf5435d65ac9",
+      "target_ref": "malware--e151d7d5-1daa-4963-acbf-c787baf1ab83",
       "description": "IronWorm is a suspected sibling clone over the released base rather than a confirmed descendant.",
       "external_references": [
         {

--- a/site/public/supply-chain-malware-families-stix.json
+++ b/site/public/supply-chain-malware-families-stix.json
@@ -1,11 +1,11 @@
 {
   "type": "bundle",
-  "id": "bundle--26e0d902-ae34-4b88-95be-72ff88b77b8a",
+  "id": "bundle--b5fdf18c-8281-589d-88b5-dc9acf0f300e",
   "objects": [
     {
       "type": "malware",
       "spec_version": "2.1",
-      "id": "malware--316777e0-9649-46c4-9835-904ddccf4c40",
+      "id": "malware--4dcf112f-c450-5c25-bc0e-fd6d7854a1dc",
       "created": "2026-06-22T00:00:00.000Z",
       "modified": "2026-06-22T00:00:00.000Z",
       "name": "Shai-Hulud",
@@ -31,7 +31,7 @@
     {
       "type": "malware",
       "spec_version": "2.1",
-      "id": "malware--b8054347-f268-40af-8dd0-db2470e6a5c4",
+      "id": "malware--9aa902e2-9675-58ea-b82c-28a2b61ee284",
       "created": "2026-06-22T00:00:00.000Z",
       "modified": "2026-06-22T00:00:00.000Z",
       "name": "Shai-Hulud 2.0",
@@ -57,7 +57,7 @@
     {
       "type": "malware",
       "spec_version": "2.1",
-      "id": "malware--e151d7d5-1daa-4963-acbf-c787baf1ab83",
+      "id": "malware--3355581c-d6ee-5b61-8ef2-8307e00edc00",
       "created": "2026-06-22T00:00:00.000Z",
       "modified": "2026-06-22T00:00:00.000Z",
       "name": "Mini Shai-Hulud",
@@ -83,7 +83,7 @@
     {
       "type": "malware",
       "spec_version": "2.1",
-      "id": "malware--6805f78e-c6d4-45cd-847d-9812326ab065",
+      "id": "malware--3b01f136-c08a-5e7d-94da-3019f1987e5c",
       "created": "2026-06-22T00:00:00.000Z",
       "modified": "2026-06-22T00:00:00.000Z",
       "name": "Miasma",
@@ -109,7 +109,7 @@
     {
       "type": "malware",
       "spec_version": "2.1",
-      "id": "malware--12a7c86a-3854-412c-8bf1-140d886d2475",
+      "id": "malware--3f28802d-c9f4-5fe9-8120-c9134fc8fc56",
       "created": "2026-06-22T00:00:00.000Z",
       "modified": "2026-06-22T00:00:00.000Z",
       "name": "Hades",
@@ -135,7 +135,7 @@
     {
       "type": "malware",
       "spec_version": "2.1",
-      "id": "malware--98cd4d95-60cd-41e1-8e94-cf5435d65ac9",
+      "id": "malware--f84fd04c-3f4e-5222-bd13-376c10f86827",
       "created": "2026-06-22T00:00:00.000Z",
       "modified": "2026-06-22T00:00:00.000Z",
       "name": "IronWorm",
@@ -161,12 +161,12 @@
     {
       "type": "relationship",
       "spec_version": "2.1",
-      "id": "relationship--1853fccf-516c-41e1-92e9-6e3ca4bdc949",
+      "id": "relationship--d3cae7eb-cee6-56fa-9647-14b835abf55f",
       "created": "2026-06-22T00:00:00.000Z",
       "modified": "2026-06-22T00:00:00.000Z",
       "relationship_type": "derived-from",
-      "source_ref": "malware--b8054347-f268-40af-8dd0-db2470e6a5c4",
-      "target_ref": "malware--316777e0-9649-46c4-9835-904ddccf4c40",
+      "source_ref": "malware--9aa902e2-9675-58ea-b82c-28a2b61ee284",
+      "target_ref": "malware--4dcf112f-c450-5c25-bc0e-fd6d7854a1dc",
       "description": "The second wave retained the Shai-Hulud worm playbook while increasing scale and propagation speed.",
       "external_references": [
         {
@@ -184,12 +184,12 @@
     {
       "type": "relationship",
       "spec_version": "2.1",
-      "id": "relationship--dc367265-47eb-438a-abfb-00920d7da6ef",
+      "id": "relationship--49ed629b-4d72-5267-bde5-b596d01cf63f",
       "created": "2026-06-22T00:00:00.000Z",
       "modified": "2026-06-22T00:00:00.000Z",
       "relationship_type": "derived-from",
-      "source_ref": "malware--e151d7d5-1daa-4963-acbf-c787baf1ab83",
-      "target_ref": "malware--b8054347-f268-40af-8dd0-db2470e6a5c4",
+      "source_ref": "malware--3355581c-d6ee-5b61-8ef2-8307e00edc00",
+      "target_ref": "malware--9aa902e2-9675-58ea-b82c-28a2b61ee284",
       "description": "Mini Shai-Hulud is modeled as the industrialized cross-ecosystem evolution of the Shai-Hulud worm pattern.",
       "external_references": [
         {
@@ -212,12 +212,12 @@
     {
       "type": "relationship",
       "spec_version": "2.1",
-      "id": "relationship--33934301-00d0-47b3-8327-d2a780a2d68e",
+      "id": "relationship--ac8685c2-a3b9-5150-b60f-91d2b227dc78",
       "created": "2026-06-22T00:00:00.000Z",
       "modified": "2026-06-22T00:00:00.000Z",
       "relationship_type": "variant-of",
-      "source_ref": "malware--6805f78e-c6d4-45cd-847d-9812326ab065",
-      "target_ref": "malware--e151d7d5-1daa-4963-acbf-c787baf1ab83",
+      "source_ref": "malware--3b01f136-c08a-5e7d-94da-3019f1987e5c",
+      "target_ref": "malware--3355581c-d6ee-5b61-8ef2-8307e00edc00",
       "description": "Miasma is treated as a suspected fork from the released framework unless stronger code-overlap or researcher-attestation evidence lands.",
       "external_references": [
         {
@@ -236,12 +236,12 @@
     {
       "type": "relationship",
       "spec_version": "2.1",
-      "id": "relationship--ffa41d5e-553b-4006-8155-594754ab7936",
+      "id": "relationship--1d94091f-7807-5df1-a6f4-eab82ccff2ad",
       "created": "2026-06-22T00:00:00.000Z",
       "modified": "2026-06-22T00:00:00.000Z",
       "relationship_type": "derived-from",
-      "source_ref": "malware--12a7c86a-3854-412c-8bf1-140d886d2475",
-      "target_ref": "malware--6805f78e-c6d4-45cd-847d-9812326ab065",
+      "source_ref": "malware--3f28802d-c9f4-5fe9-8120-c9134fc8fc56",
+      "target_ref": "malware--3b01f136-c08a-5e7d-94da-3019f1987e5c",
       "description": "Hades is modeled as an evolution of Miasma in the worked example.",
       "external_references": [
         {
@@ -260,12 +260,12 @@
     {
       "type": "relationship",
       "spec_version": "2.1",
-      "id": "relationship--bb0547c7-20b1-4988-91bd-bb8c9546e22b",
+      "id": "relationship--e70d4886-9937-564c-814a-5cb766a1f91d",
       "created": "2026-06-22T00:00:00.000Z",
       "modified": "2026-06-22T00:00:00.000Z",
       "relationship_type": "variant-of",
-      "source_ref": "malware--98cd4d95-60cd-41e1-8e94-cf5435d65ac9",
-      "target_ref": "malware--e151d7d5-1daa-4963-acbf-c787baf1ab83",
+      "source_ref": "malware--f84fd04c-3f4e-5222-bd13-376c10f86827",
+      "target_ref": "malware--3355581c-d6ee-5b61-8ef2-8307e00edc00",
       "description": "IronWorm is a suspected sibling clone over the released base rather than a confirmed descendant.",
       "external_references": [
         {

--- a/site/public/supply-chain-malware-families-stix.json
+++ b/site/public/supply-chain-malware-families-stix.json
@@ -1,0 +1,285 @@
+{
+  "type": "bundle",
+  "id": "bundle--26e0d902-ae34-4885-9be7-2ff88b77b8a7",
+  "objects": [
+    {
+      "type": "malware",
+      "spec_version": "2.1",
+      "id": "malware--316777e0-9649-4c41-8359-04ddccf4c401",
+      "created": "2026-06-22T00:00:00.000Z",
+      "modified": "2026-06-22T00:00:00.000Z",
+      "name": "Shai-Hulud",
+      "is_family": false,
+      "malware_types": [
+        "trojan"
+      ],
+      "aliases": [
+        "Shai Hulud"
+      ],
+      "first_seen": "2025-09-16T00:00:00.000Z",
+      "description": "Created the family template: developer token theft, public exfiltration repositories, and automated republishing into other npm packages.",
+      "external_references": [
+        {
+          "source_name": "Threatpedia",
+          "external_id": "strain-shai-hulud",
+          "url": "https://threatpedia.wiki/supply-chain/malware-families/family-shai-hulud/#strain-shai-hulud"
+        }
+      ],
+      "x_threatpedia_family_id": "family-shai-hulud",
+      "x_threatpedia_lineage_confidence": "origin"
+    },
+    {
+      "type": "malware",
+      "spec_version": "2.1",
+      "id": "malware--b8054347-f268-4af8-9d0d-b2470e6a5c49",
+      "created": "2026-06-22T00:00:00.000Z",
+      "modified": "2026-06-22T00:00:00.000Z",
+      "name": "Shai-Hulud 2.0",
+      "is_family": false,
+      "malware_types": [
+        "trojan"
+      ],
+      "aliases": [
+        "Shai Hulud 2.0"
+      ],
+      "first_seen": "2025-11-24T00:00:00.000Z",
+      "description": "Expanded the original playbook into a larger wave while retaining token theft and automated republishing.",
+      "external_references": [
+        {
+          "source_name": "Threatpedia",
+          "external_id": "strain-shai-hulud-2",
+          "url": "https://threatpedia.wiki/supply-chain/malware-families/family-shai-hulud/#strain-shai-hulud-2"
+        }
+      ],
+      "x_threatpedia_family_id": "family-shai-hulud",
+      "x_threatpedia_lineage_confidence": "confirmed"
+    },
+    {
+      "type": "malware",
+      "spec_version": "2.1",
+      "id": "malware--e151d7d5-1daa-463a-8bfc-787baf1ab83d",
+      "created": "2026-06-22T00:00:00.000Z",
+      "modified": "2026-06-22T00:00:00.000Z",
+      "name": "Mini Shai-Hulud",
+      "is_family": false,
+      "malware_types": [
+        "trojan"
+      ],
+      "aliases": [
+        "Mini Shai Hulud"
+      ],
+      "first_seen": "2026-05-11T00:00:00.000Z",
+      "description": "Shifted the worm from static-token theft toward CI/CD trusted-publishing abuse, OIDC token extraction, and cross-ecosystem package propagation.",
+      "external_references": [
+        {
+          "source_name": "Threatpedia",
+          "external_id": "strain-mini-shai-hulud",
+          "url": "https://threatpedia.wiki/supply-chain/malware-families/family-shai-hulud/#strain-mini-shai-hulud"
+        }
+      ],
+      "x_threatpedia_family_id": "family-shai-hulud",
+      "x_threatpedia_lineage_confidence": "confirmed"
+    },
+    {
+      "type": "malware",
+      "spec_version": "2.1",
+      "id": "malware--6805f78e-c6d4-4cd0-87d9-812326ab065a",
+      "created": "2026-06-22T00:00:00.000Z",
+      "modified": "2026-06-22T00:00:00.000Z",
+      "name": "Miasma",
+      "is_family": false,
+      "malware_types": [
+        "trojan"
+      ],
+      "aliases": [
+        "The Spreading Blight"
+      ],
+      "first_seen": "2026-06-01T00:00:00.000Z",
+      "description": "Added per-infection encryption, binding.gyp execution, and AI-assistant prompt-injection behavior while retaining the released Mini Shai-Hulud playbook.",
+      "external_references": [
+        {
+          "source_name": "Threatpedia",
+          "external_id": "strain-miasma",
+          "url": "https://threatpedia.wiki/supply-chain/malware-families/family-shai-hulud/#strain-miasma"
+        }
+      ],
+      "x_threatpedia_family_id": "family-shai-hulud",
+      "x_threatpedia_lineage_confidence": "suspected"
+    },
+    {
+      "type": "malware",
+      "spec_version": "2.1",
+      "id": "malware--12a7c86a-3854-42c0-bf11-40d886d24753",
+      "created": "2026-06-22T00:00:00.000Z",
+      "modified": "2026-06-22T00:00:00.000Z",
+      "name": "Hades",
+      "is_family": false,
+      "malware_types": [
+        "trojan"
+      ],
+      "aliases": [
+        "Hades Shai-Hulud lineage strain"
+      ],
+      "first_seen": "2026-06-06T00:00:00.000Z",
+      "description": "Carried Miasma behavior into PyPI and added Artifactory-focused reconnaissance.",
+      "external_references": [
+        {
+          "source_name": "Threatpedia",
+          "external_id": "strain-hades-shai-hulud",
+          "url": "https://threatpedia.wiki/supply-chain/malware-families/family-shai-hulud/#strain-hades-shai-hulud"
+        }
+      ],
+      "x_threatpedia_family_id": "family-shai-hulud",
+      "x_threatpedia_lineage_confidence": "confirmed"
+    },
+    {
+      "type": "malware",
+      "spec_version": "2.1",
+      "id": "malware--98cd4d95-60cd-4e1c-a94c-f5435d65ac97",
+      "created": "2026-06-22T00:00:00.000Z",
+      "modified": "2026-06-22T00:00:00.000Z",
+      "name": "IronWorm",
+      "is_family": false,
+      "malware_types": [
+        "trojan"
+      ],
+      "aliases": [
+        "Iron Worm"
+      ],
+      "first_seen": "2026-06-06T00:00:00.000Z",
+      "description": "A suspected cosmetic clone over the released base, with a Rust ELF payload and preinstall execution.",
+      "external_references": [
+        {
+          "source_name": "Threatpedia",
+          "external_id": "strain-ironworm",
+          "url": "https://threatpedia.wiki/supply-chain/malware-families/family-shai-hulud/#strain-ironworm"
+        }
+      ],
+      "x_threatpedia_family_id": "family-shai-hulud",
+      "x_threatpedia_lineage_confidence": "suspected"
+    },
+    {
+      "type": "relationship",
+      "spec_version": "2.1",
+      "id": "relationship--1853fccf-516c-4e11-ae96-e3ca4bdc9499",
+      "created": "2026-06-22T00:00:00.000Z",
+      "modified": "2026-06-22T00:00:00.000Z",
+      "relationship_type": "derived-from",
+      "source_ref": "malware--b8054347-f268-4af8-9d0d-b2470e6a5c49",
+      "target_ref": "malware--316777e0-9649-4c41-8359-04ddccf4c401",
+      "description": "The second wave retained the Shai-Hulud worm playbook while increasing scale and propagation speed.",
+      "external_references": [
+        {
+          "source_name": "Threatpedia",
+          "external_id": "ref-microsoft-shai-hulud-2"
+        }
+      ],
+      "x_threatpedia_relation_kind": "descendant",
+      "x_threatpedia_confidence": "confirmed",
+      "x_threatpedia_mutation_delta": [
+        "scale",
+        "faster propagation"
+      ]
+    },
+    {
+      "type": "relationship",
+      "spec_version": "2.1",
+      "id": "relationship--dc367265-47eb-48a2-bfb0-0920d7da6efa",
+      "created": "2026-06-22T00:00:00.000Z",
+      "modified": "2026-06-22T00:00:00.000Z",
+      "relationship_type": "derived-from",
+      "source_ref": "malware--e151d7d5-1daa-463a-8bfc-787baf1ab83d",
+      "target_ref": "malware--b8054347-f268-4af8-9d0d-b2470e6a5c49",
+      "description": "Mini Shai-Hulud is modeled as the industrialized cross-ecosystem evolution of the Shai-Hulud worm pattern.",
+      "external_references": [
+        {
+          "source_name": "Threatpedia",
+          "external_id": "ref-socket-tanstack-mini-shai"
+        },
+        {
+          "source_name": "Threatpedia",
+          "external_id": "ref-stepsecurity-mini-shai"
+        }
+      ],
+      "x_threatpedia_relation_kind": "evolution",
+      "x_threatpedia_confidence": "confirmed",
+      "x_threatpedia_mutation_delta": [
+        "added PyPI",
+        "added trusted publishing",
+        "OIDC token theft"
+      ]
+    },
+    {
+      "type": "relationship",
+      "spec_version": "2.1",
+      "id": "relationship--33934301-00d0-4b34-b27d-2a780a2d68e6",
+      "created": "2026-06-22T00:00:00.000Z",
+      "modified": "2026-06-22T00:00:00.000Z",
+      "relationship_type": "variant-of",
+      "source_ref": "malware--6805f78e-c6d4-4cd0-87d9-812326ab065a",
+      "target_ref": "malware--e151d7d5-1daa-463a-8bfc-787baf1ab83d",
+      "description": "Miasma is treated as a suspected fork from the released framework unless stronger code-overlap or researcher-attestation evidence lands.",
+      "external_references": [
+        {
+          "source_name": "Threatpedia",
+          "external_id": "ref-stepsecurity-mini-shai"
+        }
+      ],
+      "x_threatpedia_relation_kind": "playbook_adoption",
+      "x_threatpedia_confidence": "suspected",
+      "x_threatpedia_mutation_delta": [
+        "binding.gyp install evasion",
+        "per-infection encryption",
+        "AI coding-agent prompt injection"
+      ]
+    },
+    {
+      "type": "relationship",
+      "spec_version": "2.1",
+      "id": "relationship--ffa41d5e-553b-4060-9555-94754ab79362",
+      "created": "2026-06-22T00:00:00.000Z",
+      "modified": "2026-06-22T00:00:00.000Z",
+      "relationship_type": "derived-from",
+      "source_ref": "malware--12a7c86a-3854-42c0-bf11-40d886d24753",
+      "target_ref": "malware--6805f78e-c6d4-4cd0-87d9-812326ab065a",
+      "description": "Hades is modeled as an evolution of Miasma in the worked example.",
+      "external_references": [
+        {
+          "source_name": "Threatpedia",
+          "external_id": "ref-stepsecurity-mini-shai"
+        }
+      ],
+      "x_threatpedia_relation_kind": "evolution",
+      "x_threatpedia_confidence": "confirmed",
+      "x_threatpedia_mutation_delta": [
+        "moved to PyPI",
+        "Artifactory reconnaissance",
+        "broader propagation"
+      ]
+    },
+    {
+      "type": "relationship",
+      "spec_version": "2.1",
+      "id": "relationship--bb0547c7-20b1-4881-9bdb-b8c9546e22bc",
+      "created": "2026-06-22T00:00:00.000Z",
+      "modified": "2026-06-22T00:00:00.000Z",
+      "relationship_type": "variant-of",
+      "source_ref": "malware--98cd4d95-60cd-4e1c-a94c-f5435d65ac97",
+      "target_ref": "malware--e151d7d5-1daa-463a-8bfc-787baf1ab83d",
+      "description": "IronWorm is a suspected sibling clone over the released base rather than a confirmed descendant.",
+      "external_references": [
+        {
+          "source_name": "Threatpedia",
+          "external_id": "ref-stepsecurity-mini-shai"
+        }
+      ],
+      "x_threatpedia_relation_kind": "cosmetic_clone",
+      "x_threatpedia_confidence": "suspected",
+      "x_threatpedia_mutation_delta": [
+        "Rust ELF payload",
+        "preinstall hook",
+        "cosmetic fork"
+      ]
+    }
+  ]
+}

--- a/site/public/supply-chain-malware-families-stix.json
+++ b/site/public/supply-chain-malware-families-stix.json
@@ -130,7 +130,7 @@
         }
       ],
       "x_threatpedia_family_id": "family-shai-hulud",
-      "x_threatpedia_lineage_confidence": "confirmed"
+      "x_threatpedia_lineage_confidence": "suspected"
     },
     {
       "type": "malware",
@@ -246,7 +246,7 @@
       "external_references": [
         {
           "source_name": "Threatpedia",
-          "external_id": "ref-stepsecurity-mini-shai"
+          "external_id": "ref-stepsecurity-hades-campaign"
         }
       ],
       "x_threatpedia_relation_kind": "evolution",

--- a/site/public/supply-chain-malware-families-stix.json
+++ b/site/public/supply-chain-malware-families-stix.json
@@ -242,7 +242,7 @@
       "relationship_type": "derived-from",
       "source_ref": "malware--3f28802d-c9f4-5fe9-8120-c9134fc8fc56",
       "target_ref": "malware--3b01f136-c08a-5e7d-94da-3019f1987e5c",
-      "description": "Hades is modeled as an evolution of Miasma in the worked example.",
+      "description": "Hades is modeled as a suspected evolution of Miasma pending explicit code-overlap or researcher-attestation evidence.",
       "external_references": [
         {
           "source_name": "Threatpedia",
@@ -250,7 +250,7 @@
         }
       ],
       "x_threatpedia_relation_kind": "evolution",
-      "x_threatpedia_confidence": "confirmed",
+      "x_threatpedia_confidence": "suspected",
       "x_threatpedia_mutation_delta": [
         "moved to PyPI",
         "Artifactory reconnaissance",

--- a/site/public/supply-chain-malware-families-stix.json
+++ b/site/public/supply-chain-malware-families-stix.json
@@ -11,7 +11,7 @@
       "name": "Shai-Hulud",
       "is_family": false,
       "malware_types": [
-        "trojan"
+        "worm"
       ],
       "aliases": [
         "Shai Hulud"
@@ -37,7 +37,7 @@
       "name": "Shai-Hulud 2.0",
       "is_family": false,
       "malware_types": [
-        "trojan"
+        "worm"
       ],
       "aliases": [
         "Shai Hulud 2.0"
@@ -63,7 +63,7 @@
       "name": "Mini Shai-Hulud",
       "is_family": false,
       "malware_types": [
-        "trojan"
+        "worm"
       ],
       "aliases": [
         "Mini Shai Hulud"
@@ -89,7 +89,7 @@
       "name": "Miasma",
       "is_family": false,
       "malware_types": [
-        "trojan"
+        "worm"
       ],
       "aliases": [
         "The Spreading Blight"
@@ -115,7 +115,7 @@
       "name": "Hades",
       "is_family": false,
       "malware_types": [
-        "trojan"
+        "worm"
       ],
       "aliases": [
         "Hades Shai-Hulud lineage strain"
@@ -141,7 +141,7 @@
       "name": "IronWorm",
       "is_family": false,
       "malware_types": [
-        "trojan"
+        "worm"
       ],
       "aliases": [
         "Iron Worm"

--- a/site/public/supply-chain-search-index.json
+++ b/site/public/supply-chain-search-index.json
@@ -4241,7 +4241,8 @@
       "strain-ironworm",
       "IronWorm",
       "Iron Worm"
-    ]
+    ],
+    "href": "/supply-chain/malware-families/family-shai-hulud/"
   },
   {
     "id": "strain-hades-shai-hulud",
@@ -4257,7 +4258,8 @@
       "Shai Hulud",
       "Shai-Hulud worm family",
       "Mini Shai-Hulud"
-    ]
+    ],
+    "href": "/supply-chain/malware-families/family-shai-hulud/#strain-hades-shai-hulud"
   },
   {
     "id": "strain-ironworm",
@@ -4273,7 +4275,8 @@
       "Shai Hulud",
       "Shai-Hulud worm family",
       "Mini Shai-Hulud"
-    ]
+    ],
+    "href": "/supply-chain/malware-families/family-shai-hulud/#strain-ironworm"
   },
   {
     "id": "strain-miasma",
@@ -4289,7 +4292,8 @@
       "Shai Hulud",
       "Shai-Hulud worm family",
       "Mini Shai-Hulud"
-    ]
+    ],
+    "href": "/supply-chain/malware-families/family-shai-hulud/#strain-miasma"
   },
   {
     "id": "strain-mini-shai-hulud",
@@ -4307,7 +4311,8 @@
       "Shai-Hulud",
       "Shai Hulud",
       "Shai-Hulud worm family"
-    ]
+    ],
+    "href": "/supply-chain/malware-families/family-shai-hulud/#strain-mini-shai-hulud"
   },
   {
     "id": "strain-shai-hulud",
@@ -4322,7 +4327,8 @@
       "SC-2025-NPM-SHAI-HULUD",
       "Shai-Hulud worm family",
       "Mini Shai-Hulud"
-    ]
+    ],
+    "href": "/supply-chain/malware-families/family-shai-hulud/#strain-shai-hulud"
   },
   {
     "id": "strain-shai-hulud-2",
@@ -4339,7 +4345,8 @@
       "Shai Hulud",
       "Shai-Hulud worm family",
       "Mini Shai-Hulud"
-    ]
+    ],
+    "href": "/supply-chain/malware-families/family-shai-hulud/#strain-shai-hulud-2"
   },
   {
     "id": "org-3cx",

--- a/site/public/supply-chain-search-index.json
+++ b/site/public/supply-chain-search-index.json
@@ -4217,6 +4217,131 @@
     ]
   },
   {
+    "id": "family-shai-hulud",
+    "type": "malware_family",
+    "displayName": "Shai-Hulud",
+    "aliases": [
+      "family-shai-hulud",
+      "Shai Hulud",
+      "Shai-Hulud worm family",
+      "Mini Shai-Hulud",
+      "A self-propagating supply-chain worm family spanning npm, PyPI, and RubyGems activity, modeled as genealogy rather than infection propagation.",
+      "strain-shai-hulud",
+      "strain-shai-hulud-2",
+      "Shai-Hulud 2.0",
+      "Shai Hulud 2.0",
+      "strain-mini-shai-hulud",
+      "Mini Shai Hulud",
+      "strain-miasma",
+      "Miasma",
+      "The Spreading Blight",
+      "strain-hades-shai-hulud",
+      "Hades",
+      "Hades Shai-Hulud lineage strain",
+      "strain-ironworm",
+      "IronWorm",
+      "Iron Worm"
+    ]
+  },
+  {
+    "id": "strain-hades-shai-hulud",
+    "type": "malware_strain",
+    "displayName": "Hades",
+    "aliases": [
+      "strain-hades-shai-hulud",
+      "Hades Shai-Hulud lineage strain",
+      "PyPI move with Artifactory-focused reconnaissance and broader propagation.",
+      "Carried Miasma behavior into PyPI and added Artifactory-focused reconnaissance.",
+      "PyPI",
+      "Shai-Hulud",
+      "Shai Hulud",
+      "Shai-Hulud worm family",
+      "Mini Shai-Hulud"
+    ]
+  },
+  {
+    "id": "strain-ironworm",
+    "type": "malware_strain",
+    "displayName": "IronWorm",
+    "aliases": [
+      "strain-ironworm",
+      "Iron Worm",
+      "Rust ELF payload delivered through a preinstall hook.",
+      "A suspected cosmetic clone over the released base, with a Rust ELF payload and preinstall execution.",
+      "npm",
+      "Shai-Hulud",
+      "Shai Hulud",
+      "Shai-Hulud worm family",
+      "Mini Shai-Hulud"
+    ]
+  },
+  {
+    "id": "strain-miasma",
+    "type": "malware_strain",
+    "displayName": "Miasma",
+    "aliases": [
+      "strain-miasma",
+      "The Spreading Blight",
+      "binding.gyp install-time evasion, per-infection encryption, and prompt-injection targeting AI coding agents.",
+      "Added per-infection encryption, binding.gyp execution, and AI-assistant prompt-injection behavior while retaining the released Mini Shai-Hulud playbook.",
+      "npm",
+      "Shai-Hulud",
+      "Shai Hulud",
+      "Shai-Hulud worm family",
+      "Mini Shai-Hulud"
+    ]
+  },
+  {
+    "id": "strain-mini-shai-hulud",
+    "type": "malware_strain",
+    "displayName": "Mini Shai-Hulud",
+    "aliases": [
+      "strain-mini-shai-hulud",
+      "Mini Shai Hulud",
+      "Trusted publishing and OIDC token abuse across multiple package ecosystems.",
+      "Shifted the worm from static-token theft toward CI/CD trusted-publishing abuse, OIDC token extraction, and cross-ecosystem package propagation.",
+      "npm",
+      "PyPI",
+      "RubyGems",
+      "SC-2026-MINI-SHAI-HULUD",
+      "Shai-Hulud",
+      "Shai Hulud",
+      "Shai-Hulud worm family"
+    ]
+  },
+  {
+    "id": "strain-shai-hulud",
+    "type": "malware_strain",
+    "displayName": "Shai-Hulud",
+    "aliases": [
+      "strain-shai-hulud",
+      "Shai Hulud",
+      "Origin strain: self-replicating npm worm with token theft and auto-republish behavior.",
+      "Created the family template: developer token theft, public exfiltration repositories, and automated republishing into other npm packages.",
+      "npm",
+      "SC-2025-NPM-SHAI-HULUD",
+      "Shai-Hulud worm family",
+      "Mini Shai-Hulud"
+    ]
+  },
+  {
+    "id": "strain-shai-hulud-2",
+    "type": "malware_strain",
+    "displayName": "Shai-Hulud 2.0",
+    "aliases": [
+      "strain-shai-hulud-2",
+      "Shai Hulud 2.0",
+      "Second wave with broader package reach and faster propagation.",
+      "Expanded the original playbook into a larger wave while retaining token theft and automated republishing.",
+      "npm",
+      "SC-2025-SHAI-HULUD-2",
+      "Shai-Hulud",
+      "Shai Hulud",
+      "Shai-Hulud worm family",
+      "Mini Shai-Hulud"
+    ]
+  },
+  {
     "id": "org-3cx",
     "type": "organization",
     "displayName": "3CX",

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -879,10 +879,12 @@ function buildFamilyPhylogenyModel(data, family) {
   ]);
   const edgeInputs = (family.lineage_edges || []).map((edge) => ({
     ...edge,
-    external_refs: (edge.external_refs || []).map((ref) => ({
-      ...ref,
-      source: sourceById.get(ref.source_ref),
-    })),
+    external_refs: Array.isArray(edge.external_refs)
+      ? edge.external_refs.map((ref) => ({
+          ...ref,
+          source: sourceById.get(ref?.source_ref),
+        }))
+      : [],
   }));
   const edges = edgeInputs.map((edge) => lineageEdgePath(edge, nodeById, forkById)).filter(Boolean);
   const parentByChild = {};

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -841,12 +841,12 @@ function lineageEdgePath(edge, nodeById, forkById) {
   const fork = edge.fork_event_id ? forkById.get(edge.fork_event_id) : null;
   const startOffset = from.kind === 'fork' ? 14 : 86;
   const endOffset = to.kind === 'fork' ? 14 : 86;
-  const x1 = Number(from.layout?.x || 0) + startOffset;
-  const y1 = Number(from.layout?.y || 0);
-  const x2 = Number(to.layout?.x || 0) - endOffset;
-  const y2 = Number(to.layout?.y || 0);
+  const x1 = Number(from.layout?.x ?? 0) + startOffset;
+  const y1 = Number(from.layout?.y ?? 0);
+  const x2 = Number(to.layout?.x ?? 0) - endOffset;
+  const y2 = Number(to.layout?.y ?? 0);
   const mx = fork ? Number(fork.layout?.x ?? (x1 + x2) / 2) : (x1 + x2) / 2;
-  const labelY = fork ? ((y1 + y2) / 2) + 56 : (y1 + y2) / 2 - (Math.abs(y2 - y1) > 40 ? 0 : 14);
+  const labelY = fork ? Number(fork.layout?.y ?? 0) + 56 : (y1 + y2) / 2 - (Math.abs(y2 - y1) > 40 ? 0 : 14);
   return {
     ...edge,
     id: `${edge.source}->${edge.target}`,
@@ -872,8 +872,11 @@ function buildFamilyPhylogenyModel(data, family) {
     kind: 'fork',
     references: (event.source_refs || []).map((sourceId) => sourceById.get(sourceId)).filter(Boolean),
   }));
-  const nodeById = new Map(strains.map((strain) => [strain.id, strain]));
   const forkById = new Map(forks.map((event) => [event.id, event]));
+  const nodeById = new Map([
+    ...strains.map((strain) => [strain.id, strain]),
+    ...forks.map((event) => [event.id, event]),
+  ]);
   const edgeInputs = (family.lineage_edges || []).map((edge) => ({
     ...edge,
     external_refs: (edge.external_refs || []).map((ref) => ({
@@ -882,7 +885,11 @@ function buildFamilyPhylogenyModel(data, family) {
     })),
   }));
   const edges = edgeInputs.map((edge) => lineageEdgePath(edge, nodeById, forkById)).filter(Boolean);
-  const parentByChild = Object.fromEntries(edgeInputs.map((edge) => [edge.source, edge.target]));
+  const parentByChild = {};
+  edgeInputs.forEach((edge) => {
+    if (!parentByChild[edge.source]) parentByChild[edge.source] = [];
+    parentByChild[edge.source].push(edge.target);
+  });
   return {
     strains,
     forks,

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -1110,7 +1110,7 @@ export function getSupplyChainMalwareFamilyPage(id, data = loadSupplyChainData()
     when: [
       strain.first_seen,
       (strain.ecosystems || []).join(' + '),
-      strain.lineage_confidence === 'origin' ? 'origin' : strain.lineage_confidence,
+      strain.lineage_confidence,
     ].filter(Boolean).join(' · '),
     kept: strain.retained_features || [],
     mutation: strain.mutation_summary,

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -1124,7 +1124,7 @@ export function getSupplyChainMalwareFamilyPage(id, data = loadSupplyChainData()
     phylogeny,
     strainComparisonRows,
     changelogRows,
-    relatedIncidents: familyIncidentLinks(data, phylogeny.strains.flatMap((strain) => strain.incident_ids || [])),
+    relatedIncidents: familyIncidentLinks(data, Array.from(new Set(phylogeny.strains.flatMap((strain) => strain.incident_ids || [])))),
     seo: {
       title: `Supply Chain Malware Family: ${family.name}`,
       description,

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -888,7 +888,7 @@ function buildFamilyPhylogenyModel(data, family) {
     forks,
     edges,
     parentByChild,
-    ticks: [
+    ticks: Array.isArray(family.timeline_ticks) && family.timeline_ticks.length > 0 ? family.timeline_ticks : [
       { label: 'Sep 2025', x: 90 },
       { label: 'Dec 2025', x: 330 },
       { label: 'May 2026', x: 565 },

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -35,6 +35,7 @@ const incidentPath = path.join(repoRoot, 'data/supply-chain-incidents/incidents.
 const relationshipPath = path.join(repoRoot, 'data/supply-chain-relationships/relationships.json');
 const entityDir = path.join(repoRoot, 'data/supply-chain-entities');
 const candidateQueuePath = path.join(repoRoot, '.github/pipeline/supply-chain-candidates/latest.json');
+const malwareFamilyPath = path.join(repoRoot, 'data/supply-chain-malware-families/families.json');
 let cachedData = null;
 
 export const SUPPLY_CHAIN_ENTITY_TYPES = [
@@ -190,6 +191,7 @@ export function loadSupplyChainData() {
   if (cachedData) return cachedData;
   const incidents = readJson(incidentPath);
   const relationships = readJson(relationshipPath);
+  const malwareFamilies = readJson(malwareFamilyPath);
   const entities = Object.fromEntries(
     Object.entries(allEntityFiles).map(([key, filename]) => [key, readJson(path.join(entityDir, filename))])
   );
@@ -201,7 +203,7 @@ export function loadSupplyChainData() {
     });
   });
   const incidentByNodeId = new Map(incidents.map((incident) => [`incident-${incident.id}`, incident]));
-  cachedData = { incidents, relationships, entities, entityById, incidentByNodeId, candidateQueue };
+  cachedData = { incidents, relationships, malwareFamilies, entities, entityById, incidentByNodeId, candidateQueue };
   return cachedData;
 }
 
@@ -213,6 +215,9 @@ export function validateSupplyChainPageData(data = loadSupplyChainData()) {
     const targetExists = validIncidentNodes.has(relationship.target) || data.entityById.has(relationship.target);
     if (!sourceExists) errors.push(`relationships[${index}].source unknown: ${relationship.source}`);
     if (!targetExists) errors.push(`relationships[${index}].target unknown: ${relationship.target}`);
+  });
+  (data.malwareFamilies || []).forEach((family, index) => {
+    if (!family?.id || !family.id.startsWith('family-')) errors.push(`malwareFamilies[${index}].id invalid: ${family?.id}`);
   });
   return errors;
 }
@@ -629,6 +634,9 @@ function buildGraphHeroModel(data) {
   const graphCorpus = {
     incidents: incidents.filter((incident) => incident && typeof incident === 'object' && typeof incident.id === 'string'),
     relationships: relationships.filter((relationship) => relationship && typeof relationship === 'object'),
+    malwareFamilies: Array.isArray(data.malwareFamilies)
+      ? data.malwareFamilies.filter((family) => family && typeof family === 'object' && typeof family.id === 'string')
+      : [],
     entities: Object.fromEntries(
       Object.entries(entities).map(([key, collection]) => [
         key,
@@ -803,6 +811,91 @@ function buildDwellTimeline(data) {
       disclosedPercent: barPercent,
     };
   });
+}
+
+function sourceByIdForFamily(family) {
+  return new Map((family.sources || []).map((source) => [source.id, source]));
+}
+
+function familyIncidentLinks(data, incidentIds = []) {
+  return incidentIds
+    .map((id) => data.incidents.find((incident) => incident.id === id))
+    .filter(Boolean)
+    .map((incident) => ({
+      href: `/supply-chain/incidents/${incident.id}/`,
+      label: incident.title,
+      id: incident.id,
+      type: 'STRAIN_INCIDENT',
+      entityType: 'Supply Chain Incident',
+      context: incidentSortDate(incident),
+    }))
+    .sort(compareDateDesc);
+}
+
+function lineageEdgePath(edge, nodeById, forkById) {
+  const source = nodeById.get(edge.source);
+  const target = nodeById.get(edge.target);
+  if (!source || !target) return null;
+  const from = target;
+  const to = source;
+  const fork = edge.fork_event_id ? forkById.get(edge.fork_event_id) : null;
+  const startOffset = from.kind === 'fork' ? 14 : 86;
+  const endOffset = to.kind === 'fork' ? 14 : 86;
+  const x1 = Number(from.layout?.x || 0) + startOffset;
+  const y1 = Number(from.layout?.y || 0);
+  const x2 = Number(to.layout?.x || 0) - endOffset;
+  const y2 = Number(to.layout?.y || 0);
+  const mx = fork ? Number(fork.layout?.x || (x1 + x2) / 2) : (x1 + x2) / 2;
+  const labelY = fork ? ((y1 + y2) / 2) + 56 : (y1 + y2) / 2 - (Math.abs(y2 - y1) > 40 ? 0 : 14);
+  return {
+    ...edge,
+    id: `${edge.source}->${edge.target}`,
+    displaySource: target,
+    displayTarget: source,
+    path: `M ${x1} ${y1} C ${mx} ${y1}, ${mx} ${y2}, ${x2} ${y2}`,
+    labelX: mx,
+    labelY,
+    label: (edge.mutation_delta || []).join(' · '),
+    references: (edge.external_refs || []).map((ref) => ref.source).filter(Boolean),
+  };
+}
+
+function buildFamilyPhylogenyModel(data, family) {
+  const sourceById = sourceByIdForFamily(family);
+  const strains = (family.strains || []).map((strain) => ({
+    ...strain,
+    kind: 'strain',
+    incidents: familyIncidentLinks(data, strain.incident_ids || []),
+  }));
+  const forks = (family.fork_events || []).map((event) => ({
+    ...event,
+    kind: 'fork',
+    references: (event.source_refs || []).map((sourceId) => sourceById.get(sourceId)).filter(Boolean),
+  }));
+  const nodeById = new Map(strains.map((strain) => [strain.id, strain]));
+  const forkById = new Map(forks.map((event) => [event.id, event]));
+  const edgeInputs = (family.lineage_edges || []).map((edge) => ({
+    ...edge,
+    external_refs: (edge.external_refs || []).map((ref) => ({
+      ...ref,
+      source: sourceById.get(ref.source_ref),
+    })),
+  }));
+  const edges = edgeInputs.map((edge) => lineageEdgePath(edge, nodeById, forkById)).filter(Boolean);
+  const parentByChild = Object.fromEntries(edgeInputs.map((edge) => [edge.source, edge.target]));
+  return {
+    strains,
+    forks,
+    edges,
+    parentByChild,
+    ticks: [
+      { label: 'Sep 2025', x: 90 },
+      { label: 'Dec 2025', x: 330 },
+      { label: 'May 2026', x: 565 },
+      { label: 'Jun 1-5', x: 905 },
+      { label: 'Jun 6+', x: 1110 },
+    ],
+  };
 }
 
 export function getSupplyChainIndexModel(data = loadSupplyChainData()) {
@@ -996,6 +1089,60 @@ export function getSupplyChainEntityPage(collectionKey, id, data = loadSupplyCha
   };
 }
 
+export function getSupplyChainMalwareFamilyPage(id, data = loadSupplyChainData()) {
+  const family = (data.malwareFamilies || []).find((item) => item.id === id);
+  if (!family) return null;
+  const description = family.summary;
+  const phylogeny = buildFamilyPhylogenyModel(data, family);
+  const strainComparisonRows = phylogeny.strains.map((strain) => ({
+    id: strain.id,
+    generation: strain.name,
+    firstSeen: strain.first_seen,
+    ecosystems: (strain.ecosystems || []).join(' · '),
+    keyMutation: strain.key_mutation,
+    provenanceAbuse: strain.provenance_abuse,
+    attribution: strain.attribution?.label || 'Unknown',
+    confidence: strain.lineage_confidence,
+  }));
+  const changelogRows = phylogeny.strains.map((strain) => ({
+    id: strain.id,
+    title: strain.name,
+    when: [
+      strain.first_seen,
+      (strain.ecosystems || []).join(' + '),
+      strain.lineage_confidence === 'origin' ? 'origin' : strain.lineage_confidence,
+    ].filter(Boolean).join(' · '),
+    kept: strain.retained_features || [],
+    mutation: strain.mutation_summary,
+    confidence: strain.lineage_confidence,
+  }));
+  return {
+    kind: 'malware-family',
+    title: family.name,
+    family,
+    graphHero: buildGraphHeroModel(data),
+    phylogeny,
+    strainComparisonRows,
+    changelogRows,
+    relatedIncidents: familyIncidentLinks(data, phylogeny.strains.flatMap((strain) => strain.incident_ids || [])),
+    seo: {
+      title: `Supply Chain Malware Family: ${family.name}`,
+      description,
+      canonicalPath: `/supply-chain/malware-families/${family.id}/`,
+      ogTitle: `${family.name} lineage - Threatpedia Supply Chain`,
+      ogDescription: description,
+      jsonLd: {
+        '@context': 'https://schema.org',
+        '@type': 'TechArticle',
+        headline: `${family.name} malware-family lineage`,
+        description,
+        url: `https://threatpedia.wiki/supply-chain/malware-families/${family.id}/`,
+        about: phylogeny.strains.map((strain) => ({ '@type': 'Thing', name: strain.name })),
+      },
+    },
+  };
+}
+
 export function getSupplyChainRoutes(options = {}) {
   const enabled = options.enabled ?? isSupplyChainPagesEnabled(options.env);
   if (!enabled) return [];
@@ -1020,6 +1167,12 @@ export function getSupplyChainRoutes(options = {}) {
       });
     });
   });
+  (data.malwareFamilies || []).forEach((family) => {
+    routes.push({
+      slug: `malware-families/${family.id}`,
+      page: getSupplyChainMalwareFamilyPage(family.id, data),
+    });
+  });
   return routes;
 }
 
@@ -1028,6 +1181,7 @@ export function pageFromSlug(slug, data = loadSupplyChainData()) {
   const [segment, id] = slug.split('/');
   if (segment === 'explore') return getSupplyChainExploreModel(data);
   if (segment === 'incidents') return getSupplyChainIncidentPage(id, data);
+  if (segment === 'malware-families') return getSupplyChainMalwareFamilyPage(id, data);
   const entityType = routeEntityBySegment[segment];
   if (!entityType) return null;
   return getSupplyChainEntityPage(entityType.key, id, data);

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -845,7 +845,7 @@ function lineageEdgePath(edge, nodeById, forkById) {
   const y1 = Number(from.layout?.y || 0);
   const x2 = Number(to.layout?.x || 0) - endOffset;
   const y2 = Number(to.layout?.y || 0);
-  const mx = fork ? Number(fork.layout?.x || (x1 + x2) / 2) : (x1 + x2) / 2;
+  const mx = fork ? Number(fork.layout?.x ?? (x1 + x2) / 2) : (x1 + x2) / 2;
   const labelY = fork ? ((y1 + y2) / 2) + 56 : (y1 + y2) / 2 - (Math.abs(y2 - y1) > 40 ? 0 : 14);
   return {
     ...edge,

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -897,13 +897,7 @@ function buildFamilyPhylogenyModel(data, family) {
     forks,
     edges,
     parentByChild,
-    ticks: Array.isArray(family.timeline_ticks) && family.timeline_ticks.length > 0 ? family.timeline_ticks : [
-      { label: 'Sep 2025', x: 90 },
-      { label: 'Dec 2025', x: 330 },
-      { label: 'May 2026', x: 565 },
-      { label: 'Jun 1-5', x: 905 },
-      { label: 'Jun 6+', x: 1110 },
-    ],
+    ticks: Array.isArray(family.timeline_ticks) ? family.timeline_ticks : [],
   };
 }
 

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -51,6 +51,17 @@ const graphHero = page.kind === 'index'
   ? page.graphHero
   : page.kind === 'explore'
   ? page.graphHero
+  : page.kind === 'malware-family'
+  ? {
+      ...page.graphHero,
+      eyebrow: 'Malware Family Lineage',
+      title: page.family.name,
+      summary: page.family.summary,
+      status: 'Lineage view',
+      nodeCount: page.graphHero?.nodeCount,
+      relationshipCount: page.graphHero?.relationshipCount,
+      latestIncident: page.graphHero?.latestIncident,
+    }
   : {
       ...page.graphHero,
       eyebrow: page.kind === 'incident' ? 'Supply Chain Incident' : page.entityType,
@@ -63,8 +74,8 @@ const graphHero = page.kind === 'index'
       relationshipCount: page.graphHero?.relationshipCount,
       latestIncident: page.graphHero?.latestIncident,
     };
-const graphSelectionType = page.kind === 'incident' ? 'incident' : page.kind === 'entity' ? page.entityType.toLowerCase() : page.kind === 'explore' ? 'preserve' : 'overview';
-const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.kind === 'entity' ? page.entity.id : page.kind === 'explore' ? 'current' : 'recent';
+const graphSelectionType = page.kind === 'incident' ? 'incident' : page.kind === 'entity' ? page.entityType.toLowerCase() : page.kind === 'malware-family' ? 'malware_family' : page.kind === 'explore' ? 'preserve' : 'overview';
+const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.kind === 'entity' ? page.entity.id : page.kind === 'malware-family' ? page.family.id : page.kind === 'explore' ? 'current' : 'recent';
 ---
 
 <Base
@@ -196,10 +207,12 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
         <p id="supply-chain-title" class="graph-context-title">Focused Graph View</p>
       )}
       <p class="lede">
-        {page.kind === 'index'
+      {page.kind === 'index'
           ? graphHero.summary
           : page.kind === 'explore'
           ? 'Search, pan, zoom, and cross-filter the persistent Supply Chain graph.'
+          : page.kind === 'malware-family'
+          ? 'Trace malware strain genealogy separately from infection propagation, with confidence and mutation deltas visible on each edge.'
           : `The persistent graph is framed to this ${page.kind === 'incident' ? 'incident' : page.entityType.toLowerCase()} while the canonical page heading and details continue below.`}
       </p>
       <div class="hero-meta" aria-label="Supply Chain graph summary">
@@ -675,9 +688,234 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
       <EntityList title="Connected Entities" items={page.connectedEntities} />
     </article>
   )}
+
+  {page.kind === 'malware-family' && (
+    <article class="supply-chain-page malware-family-page">
+      <header class="sc-header">
+        <p class="eyebrow">Supply Chain / Malware Family</p>
+        <h1>{page.family.name}: a worm family, traced</h1>
+        <p class="lede">{page.family.summary}</p>
+      </header>
+
+      <section class="sc-section lineage-section" aria-labelledby="lineage-title">
+        <div class="section-heading">
+          <p class="eyebrow">Actor at root · time left to right · mutation on each edge</p>
+          <h2 id="lineage-title">Phylogeny</h2>
+        </div>
+        <div class="lineage-stage-wrap">
+          <div
+            class="lineage-stage"
+            data-lineage-stage
+            data-lineage-parents={JSON.stringify(page.phylogeny.parentByChild)}
+          >
+            <svg class="lineage-edges" viewBox="0 0 1180 560" preserveAspectRatio="none" aria-hidden="true">
+              {page.phylogeny.edges.map((edge) => (
+                <path
+                  d={edge.path}
+                  data-lineage-edge={`${edge.target}->${edge.source}`}
+                  class={`lineage-edge lineage-${edge.confidence}`}
+                />
+              ))}
+            </svg>
+            <div class="lineage-axis"></div>
+            {page.phylogeny.ticks.map((tick) => (
+              <div class="lineage-tick" style={`left:${tick.x}px`}>{tick.label}</div>
+            ))}
+            {page.phylogeny.edges.map((edge) => (
+              <div
+                class="lineage-edge-label"
+                data-lineage-edge-label={`${edge.target}->${edge.source}`}
+                style={`left:${edge.labelX}px;top:${edge.labelY}px`}
+              >
+                {edge.label}
+              </div>
+            ))}
+            {page.phylogeny.forks.map((event) => (
+              <div
+                id={event.id}
+                class="lineage-fork"
+                style={`left:${event.layout.x}px;top:${event.layout.y}px`}
+              >
+                <div class="lineage-fork-diamond"></div>
+                <strong>{event.name}</strong>
+                <span>{event.date}</span>
+              </div>
+            ))}
+            {page.phylogeny.strains.map((strain) => (
+              <button
+                id={strain.id}
+                type="button"
+                class={`lineage-node severity-${strain.severity || 'medium'} lineage-node-${strain.lineage_confidence}`}
+                style={`left:${strain.layout.x}px;top:${strain.layout.y}px`}
+                data-lineage-node={strain.id}
+                data-lineage-name={strain.name}
+                data-lineage-meta={`${strain.first_seen} · ${(strain.ecosystems || []).join(' · ')}`}
+                data-lineage-confidence={titleCase(strain.lineage_confidence)}
+                data-lineage-detail={strain.mutation_summary}
+              >
+                <strong>{strain.name}</strong>
+                <span>{strain.first_seen} · {(strain.ecosystems || []).join(' · ')}</span>
+                <em>{strain.key_mutation}</em>
+                <b>{titleCase(strain.lineage_confidence)}</b>
+              </button>
+            ))}
+          </div>
+        </div>
+        <div class="lineage-legend" aria-label="Lineage legend">
+          <span><i class="legend-solid"></i> confirmed descent</span>
+          <span><i class="legend-dashed"></i> suspected / cosmetic fork</span>
+          <span><i class="legend-fork"></i> source-release fork event</span>
+          <span>EVOLVED_FROM is genealogy; SEEDED_BY remains infection path.</span>
+        </div>
+        <div class="lineage-detail" data-lineage-detail>
+          <strong>Hover a strain</strong>
+          <span>Targets and incidents live one layer down; this page traces family genealogy.</span>
+        </div>
+      </section>
+
+      <section class="sc-section">
+        <div class="section-heading">
+          <p class="eyebrow">Analyst consumable</p>
+          <h2>Strain Comparison</h2>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Generation</th>
+                <th>First Seen</th>
+                <th>Ecosystems</th>
+                <th>Key Mutation / Novelty</th>
+                <th>Provenance Abuse</th>
+                <th>Attributed</th>
+                <th>Lineage</th>
+              </tr>
+            </thead>
+            <tbody>
+              {page.strainComparisonRows.map((row) => (
+                <tr>
+                  <td><a href={`#${row.id}`}>{row.generation}</a></td>
+                  <td class="mono">{row.firstSeen}</td>
+                  <td>{row.ecosystems}</td>
+                  <td>{row.keyMutation}</td>
+                  <td>{row.provenanceAbuse}</td>
+                  <td class="mono">{row.attribution}</td>
+                  <td><span class={`lineage-pill lineage-pill-${row.confidence}`}>{titleCase(row.confidence)}</span></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="sc-section">
+        <div class="section-heading">
+          <p class="eyebrow">What stayed, what mutated</p>
+          <h2>Family Changelog</h2>
+        </div>
+        <div class="lineage-changelog">
+          {page.changelogRows.map((row) => (
+            <article class={`lineage-change lineage-change-${row.confidence}`}>
+              <h3>{row.title}</h3>
+              <span>{row.when}</span>
+              {row.kept.length > 0 && <p><b>Kept:</b> {row.kept.join(', ')}.</p>}
+              <p><b>Mutated:</b> {row.mutation}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section class="sc-section lineage-discipline">
+        <div class="section-heading">
+          <p class="eyebrow">Why the grading matters</p>
+          <h2>Genealogy, Not Infection</h2>
+        </div>
+        <p>
+          Confirmed descent requires code overlap or explicit researcher attestation. Suspected and cosmetic forks stay dashed, and the source-release fork event remains visible because public code makes look-alikes harder to attribute.
+        </p>
+        <p>
+          This page separates <strong>EVOLVED_FROM</strong>, meaning strain genealogy, from <strong>SEEDED_BY</strong>, meaning one compromise enabled another.
+        </p>
+      </section>
+
+      <EntityList title="Related Incidents" items={page.relatedIncidents} />
+
+      <section class="sc-section">
+        <h2>Family Sources</h2>
+        <ul class="reference-list">
+          {page.family.sources.map((source) => (
+            <li>
+              <a href={source.url} target="_blank" rel="noopener noreferrer">{source.title}</a>
+              <span>{source.publisher} · {source.published_at}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </article>
+  )}
 </Base>
 
 <script type="module" src="/js/supply-chain-graph-core.js"></script>
+<script is:inline>
+  (() => {
+    const stage = document.querySelector('[data-lineage-stage]');
+    if (!stage) return;
+    const detail = document.querySelector('[data-lineage-detail]');
+    const parents = JSON.parse(stage.dataset.lineageParents || '{}');
+    const nodes = Array.from(stage.querySelectorAll('[data-lineage-node]'));
+    const edges = Array.from(stage.querySelectorAll('[data-lineage-edge]'));
+    const labels = Array.from(stage.querySelectorAll('[data-lineage-edge-label]'));
+
+    const ancestry = (id) => {
+      const chain = [];
+      let current = id;
+      while (current) {
+        chain.push(current);
+        current = parents[current];
+      }
+      return chain;
+    };
+
+    const clear = () => {
+      nodes.forEach((node) => node.classList.remove('is-lit', 'is-dim'));
+      edges.forEach((edge) => edge.classList.remove('is-lit', 'is-dim'));
+      labels.forEach((label) => label.classList.remove('is-lit'));
+      if (detail) {
+        detail.innerHTML = '<strong>Hover a strain</strong><span>Targets and incidents live one layer down; this page traces family genealogy.</span>';
+      }
+    };
+
+    const focusLineage = (button) => {
+      const chain = ancestry(button.dataset.lineageNode);
+      const activeNodes = new Set(chain);
+      const activeEdges = new Set();
+      for (let index = 0; index < chain.length - 1; index += 1) {
+        activeEdges.add(`${chain[index + 1]}->${chain[index]}`);
+      }
+      nodes.forEach((node) => {
+        const active = activeNodes.has(node.dataset.lineageNode);
+        node.classList.toggle('is-lit', active);
+        node.classList.toggle('is-dim', !active);
+      });
+      edges.forEach((edge) => {
+        const active = activeEdges.has(edge.dataset.lineageEdge);
+        edge.classList.toggle('is-lit', active);
+        edge.classList.toggle('is-dim', !active);
+      });
+      labels.forEach((label) => label.classList.toggle('is-lit', activeEdges.has(label.dataset.lineageEdgeLabel)));
+      if (detail) {
+        detail.innerHTML = `<strong>${button.dataset.lineageName}</strong><span>${button.dataset.lineageMeta} · ${button.dataset.lineageConfidence}</span><p>${button.dataset.lineageDetail}</p>`;
+      }
+    };
+
+    nodes.forEach((node) => {
+      node.addEventListener('mouseenter', () => focusLineage(node));
+      node.addEventListener('focus', () => focusLineage(node));
+      node.addEventListener('click', () => focusLineage(node));
+    });
+    stage.addEventListener('mouseleave', clear);
+  })();
+</script>
 
 <style>
   .supply-chain-page {
@@ -1943,6 +2181,335 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
     font-family: var(--font-mono);
     font-size: 0.72rem;
     font-style: normal;
+  }
+
+  .malware-family-page {
+    max-width: 1240px;
+  }
+
+  .lineage-stage-wrap {
+    overflow-x: auto;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: radial-gradient(130% 100% at 75% 0%, #0e141b, #070a0e);
+  }
+
+  .lineage-stage {
+    position: relative;
+    width: 1180px;
+    height: 560px;
+    margin: 0 auto;
+  }
+
+  .lineage-edges {
+    position: absolute;
+    inset: 0;
+    width: 1180px;
+    height: 560px;
+    pointer-events: none;
+  }
+
+  .lineage-edge {
+    fill: none;
+    stroke-width: 2;
+  }
+
+  .lineage-confirmed {
+    stroke: #2f6a3a;
+  }
+
+  .lineage-suspected {
+    stroke: #7a5418;
+    stroke-dasharray: 5 4;
+  }
+
+  .lineage-edge.is-lit {
+    stroke: var(--amber);
+  }
+
+  .lineage-edge.is-dim {
+    opacity: 0.36;
+  }
+
+  .lineage-axis {
+    position: absolute;
+    right: 0;
+    bottom: 14px;
+    left: 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, var(--border) 8%, var(--border) 92%, transparent);
+  }
+
+  .lineage-tick {
+    position: absolute;
+    bottom: 18px;
+    transform: translateX(-50%);
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.63rem;
+    letter-spacing: 0.1em;
+  }
+
+  .lineage-node {
+    position: absolute;
+    display: grid;
+    gap: 5px;
+    width: 172px;
+    transform: translate(-50%, -50%);
+    border: 1px solid var(--border);
+    border-left-width: 3px;
+    border-radius: 5px;
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    padding: 9px 11px 10px;
+    text-align: left;
+  }
+
+  .lineage-node:hover,
+  .lineage-node:focus-visible,
+  .lineage-node.is-lit {
+    border-color: var(--amber);
+    box-shadow: 0 0 0 1px var(--amber), 0 0 22px rgba(232, 160, 32, 0.18);
+    outline: none;
+  }
+
+  .lineage-node.is-dim {
+    opacity: 0.32;
+  }
+
+  .lineage-node strong {
+    color: var(--white);
+    font-size: 0.86rem;
+    line-height: 1.15;
+  }
+
+  .lineage-node span {
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.59rem;
+    letter-spacing: 0.04em;
+  }
+
+  .lineage-node em {
+    color: var(--text);
+    font-size: 0.7rem;
+    font-style: normal;
+    line-height: 1.25;
+  }
+
+  .lineage-node b,
+  .lineage-pill {
+    width: max-content;
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.54rem;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    padding: 2px 6px;
+    text-transform: uppercase;
+  }
+
+  .lineage-node-origin b,
+  .lineage-pill-origin {
+    border-color: var(--amber);
+    color: var(--amber);
+  }
+
+  .lineage-node-confirmed b,
+  .lineage-pill-confirmed {
+    border-color: #2f6a3a;
+    color: #7fd18c;
+  }
+
+  .lineage-node-suspected b,
+  .lineage-pill-suspected {
+    border-color: #7a5418;
+    color: var(--severity-high);
+  }
+
+  .lineage-fork {
+    position: absolute;
+    transform: translate(-50%, -50%);
+    text-align: center;
+  }
+
+  .lineage-fork-diamond {
+    width: 22px;
+    height: 22px;
+    margin: 0 auto 10px;
+    transform: rotate(45deg);
+    border: 2px solid var(--amber);
+    background: var(--surface);
+    box-shadow: 0 0 16px rgba(232, 160, 32, 0.25);
+  }
+
+  .lineage-fork strong,
+  .lineage-fork span {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 0.56rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .lineage-fork strong {
+    color: var(--amber);
+  }
+
+  .lineage-fork span {
+    color: var(--muted);
+    margin-top: 3px;
+  }
+
+  .lineage-edge-label {
+    position: absolute;
+    max-width: 150px;
+    transform: translate(-50%, -50%);
+    border-radius: 3px;
+    background: rgba(7, 10, 14, 0.82);
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.56rem;
+    line-height: 1.3;
+    padding: 2px 6px;
+    pointer-events: none;
+    text-align: center;
+  }
+
+  .lineage-edge-label.is-lit {
+    color: var(--white);
+  }
+
+  .lineage-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    align-items: center;
+    margin-top: 12px;
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.63rem;
+    letter-spacing: 0.04em;
+  }
+
+  .lineage-legend span {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .legend-solid,
+  .legend-dashed {
+    display: inline-block;
+    width: 34px;
+    border-top: 2px solid #7fd18c;
+  }
+
+  .legend-dashed {
+    border-color: var(--severity-high);
+    border-top-style: dashed;
+  }
+
+  .legend-fork {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    transform: rotate(45deg);
+    border: 2px solid var(--amber);
+  }
+
+  .lineage-detail {
+    display: grid;
+    gap: 4px;
+    min-height: 58px;
+    margin-top: 14px;
+    border: 1px solid var(--border);
+    border-left: 2px solid var(--amber);
+    border-radius: 0 5px 5px 0;
+    background: var(--surface);
+    padding: 13px 15px;
+  }
+
+  .lineage-detail strong {
+    color: var(--white);
+    font-family: var(--font-serif);
+    font-size: 1rem;
+  }
+
+  .lineage-detail span {
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.64rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .lineage-detail p {
+    margin: 0;
+  }
+
+  .lineage-changelog {
+    border-left: 1px solid var(--border);
+    margin-left: 8px;
+  }
+
+  .lineage-change {
+    position: relative;
+    padding: 0 0 20px 26px;
+  }
+
+  .lineage-change::before {
+    content: '';
+    position: absolute;
+    top: 4px;
+    left: -5px;
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    background: var(--amber);
+    box-shadow: 0 0 0 3px var(--bg);
+  }
+
+  .lineage-change-suspected::before {
+    background: var(--severity-high);
+  }
+
+  .lineage-change h3 {
+    margin: 0;
+    color: var(--white);
+    font-size: 0.95rem;
+  }
+
+  .lineage-change > span {
+    display: block;
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.63rem;
+    letter-spacing: 0.06em;
+    margin: 2px 0 7px;
+    text-transform: uppercase;
+  }
+
+  .lineage-change p,
+  .lineage-discipline p {
+    color: var(--text);
+    line-height: 1.55;
+    margin: 4px 0;
+  }
+
+  .lineage-change b {
+    color: var(--amber);
+  }
+
+  .lineage-discipline {
+    border: 1px solid rgba(160, 106, 16, 0.8);
+    border-radius: 6px;
+    background: rgba(232, 160, 32, 0.05);
+    padding: 16px;
   }
 
   @media (max-width: 820px) {

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -865,6 +865,20 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
     const nodes = Array.from(stage.querySelectorAll('[data-lineage-node]'));
     const edges = Array.from(stage.querySelectorAll('[data-lineage-edge]'));
     const labels = Array.from(stage.querySelectorAll('[data-lineage-edge-label]'));
+    const renderDetail = (title, meta, body) => {
+      if (!detail) return;
+      const titleEl = document.createElement('strong');
+      titleEl.textContent = title;
+      const metaEl = document.createElement('span');
+      metaEl.textContent = meta;
+      if (body) {
+        const bodyEl = document.createElement('p');
+        bodyEl.textContent = body;
+        detail.replaceChildren(titleEl, metaEl, bodyEl);
+      } else {
+        detail.replaceChildren(titleEl, metaEl);
+      }
+    };
 
     const ancestry = (id) => {
       const chain = [];
@@ -880,9 +894,7 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
       nodes.forEach((node) => node.classList.remove('is-lit', 'is-dim'));
       edges.forEach((edge) => edge.classList.remove('is-lit', 'is-dim'));
       labels.forEach((label) => label.classList.remove('is-lit'));
-      if (detail) {
-        detail.innerHTML = '<strong>Hover a strain</strong><span>Targets and incidents live one layer down; this page traces family genealogy.</span>';
-      }
+      renderDetail('Hover a strain', 'Targets and incidents live one layer down; this page traces family genealogy.');
     };
 
     const focusLineage = (button) => {
@@ -903,9 +915,11 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
         edge.classList.toggle('is-dim', !active);
       });
       labels.forEach((label) => label.classList.toggle('is-lit', activeEdges.has(label.dataset.lineageEdgeLabel)));
-      if (detail) {
-        detail.innerHTML = `<strong>${button.dataset.lineageName}</strong><span>${button.dataset.lineageMeta} · ${button.dataset.lineageConfidence}</span><p>${button.dataset.lineageDetail}</p>`;
-      }
+      renderDetail(
+        button.dataset.lineageName || 'Unknown strain',
+        `${button.dataset.lineageMeta || 'unknown'} · ${button.dataset.lineageConfidence || 'unknown'}`,
+        button.dataset.lineageDetail || ''
+      );
     };
 
     nodes.forEach((node) => {

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -882,10 +882,15 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
 
     const ancestry = (id) => {
       const chain = [];
-      let current = id;
-      while (current) {
+      const stack = [id];
+      const seen = new Set();
+      while (stack.length > 0) {
+        const current = stack.pop();
+        if (!current || seen.has(current)) continue;
+        seen.add(current);
         chain.push(current);
-        current = parents[current];
+        const lineageParents = Array.isArray(parents[current]) ? parents[current] : [parents[current]].filter(Boolean);
+        stack.push(...lineageParents);
       }
       return chain;
     };
@@ -901,9 +906,10 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
       const chain = ancestry(button.dataset.lineageNode);
       const activeNodes = new Set(chain);
       const activeEdges = new Set();
-      for (let index = 0; index < chain.length - 1; index += 1) {
-        activeEdges.add(`${chain[index + 1]}->${chain[index]}`);
-      }
+      chain.forEach((child) => {
+        const lineageParents = Array.isArray(parents[child]) ? parents[child] : [parents[child]].filter(Boolean);
+        lineageParents.forEach((parent) => activeEdges.add(`${child}->${parent}`));
+      });
       nodes.forEach((node) => {
         const active = activeNodes.has(node.dataset.lineageNode);
         node.classList.toggle('is-lit', active);

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -712,7 +712,7 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
               {page.phylogeny.edges.map((edge) => (
                 <path
                   d={edge.path}
-                  data-lineage-edge={`${edge.target}->${edge.source}`}
+                  data-lineage-edge={`${edge.source}->${edge.target}`}
                   class={`lineage-edge lineage-${edge.confidence}`}
                 />
               ))}
@@ -724,7 +724,7 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
             {page.phylogeny.edges.map((edge) => (
               <div
                 class="lineage-edge-label"
-                data-lineage-edge-label={`${edge.target}->${edge.source}`}
+                data-lineage-edge-label={`${edge.source}->${edge.target}`}
                 style={`left:${edge.labelX}px;top:${edge.labelY}px`}
               >
                 {edge.label}

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -106,6 +106,8 @@ class SupplyChainGraphTests(unittest.TestCase):
         malformed[0]["strains"][0]["incident_ids"] = "SC-2025-NPM-SHAI-HULUD"
         malformed[0]["fork_events"] = {"id": "fork-not-a-list"}
         malformed[0]["lineage_edges"][2]["suspected_reason"] = "   "
+        malformed[0]["lineage_edges"][2]["external_refs"][0] = "not-an-object"
+        malformed[0]["sources"].append(copy.deepcopy(malformed[0]["sources"][0]))
 
         errors = validator.validate_malware_families(
             malformed,
@@ -118,10 +120,35 @@ class SupplyChainGraphTests(unittest.TestCase):
         self.assertIn("strain-shai-hulud.first_seen: expected YYYY-MM-DD or YYYY-MM", errors)
         self.assertIn("strain-shai-hulud.incident_ids: expected list", errors)
         self.assertIn("family-shai-hulud.fork_events: expected list", errors)
+        self.assertIn("family-shai-hulud.sources[4].id: duplicate source id 'ref-wiz-shai-hulud'", errors)
+        self.assertIn(
+            "family-shai-hulud.lineage_edges[2].external_refs[0]: expected object",
+            errors,
+        )
         self.assertIn(
             "family-shai-hulud.lineage_edges[2].suspected_reason: suspected edges must explain uncertainty",
             errors,
         )
+
+    def test_malware_family_validator_allows_single_strain_without_lineage_edges(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        entities_by_type = validator.load_entities(ENTITY_DIR)
+        entity_ids = {entity["id"] for entities in entities_by_type.values() for entity in entities}
+        raw_incident_ids = validator.collect_raw_incident_ids(corpus)
+        malware_families = load_json(MALWARE_FAMILY_PATH)
+        single_strain = copy.deepcopy(malware_families)
+        single_strain[0]["strains"] = single_strain[0]["strains"][:1]
+        single_strain[0]["fork_events"] = []
+        single_strain[0].pop("lineage_edges", None)
+
+        errors = validator.validate_malware_families(
+            single_strain,
+            raw_incident_ids=raw_incident_ids,
+            entity_ids=entity_ids,
+        )
+
+        self.assertNotIn("family-shai-hulud.lineage_edges: expected non-empty list", errors)
+        self.assertEqual(errors, [])
 
     def test_builder_extracts_expected_entities(self) -> None:
         graph = builder.build_graph(load_json(CORPUS_PATH))

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -104,6 +104,7 @@ class SupplyChainGraphTests(unittest.TestCase):
         malformed[0]["associated_actor_ids"] = "actor-teampcp"
         malformed[0]["strains"][0]["first_seen"] = "2025-99-99"
         malformed[0]["strains"][0]["incident_ids"] = "SC-2025-NPM-SHAI-HULUD"
+        malformed[0]["strains"][0]["layout"] = {"x": "left"}
         malformed[0]["fork_events"] = {"id": "fork-not-a-list"}
         malformed[0]["lineage_edges"][2]["suspected_reason"] = "   "
         malformed[0]["lineage_edges"][2]["external_refs"][0] = "not-an-object"
@@ -119,6 +120,8 @@ class SupplyChainGraphTests(unittest.TestCase):
         self.assertIn("family-shai-hulud.associated_actor_ids: expected list", errors)
         self.assertIn("strain-shai-hulud.first_seen: expected YYYY-MM-DD or YYYY-MM", errors)
         self.assertIn("strain-shai-hulud.incident_ids: expected list", errors)
+        self.assertIn("strain-shai-hulud.layout.x: expected number", errors)
+        self.assertIn("strain-shai-hulud.layout.y: expected number", errors)
         self.assertIn("family-shai-hulud.fork_events: expected list", errors)
         self.assertIn("family-shai-hulud.sources[4].id: duplicate source id 'ref-wiz-shai-hulud'", errors)
         self.assertIn(
@@ -129,6 +132,17 @@ class SupplyChainGraphTests(unittest.TestCase):
             "family-shai-hulud.lineage_edges[2].suspected_reason: suspected edges must explain uncertainty",
             errors,
         )
+
+        malformed_event = copy.deepcopy(malware_families)
+        malformed_event[0]["fork_events"][0]["layout"] = {"y": "middle"}
+        event_errors = validator.validate_malware_families(
+            malformed_event,
+            raw_incident_ids=raw_incident_ids,
+            entity_ids=entity_ids,
+        )
+
+        self.assertIn("fork-mini-shai-source-release.layout.x: expected number", event_errors)
+        self.assertIn("fork-mini-shai-source-release.layout.y: expected number", event_errors)
 
     def test_malware_family_validator_allows_single_strain_without_lineage_edges(self) -> None:
         corpus = load_json(CORPUS_PATH)

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -126,7 +126,7 @@ class SupplyChainGraphTests(unittest.TestCase):
             entity_ids=entity_ids,
         )
 
-        self.assertIn("family-shai-hulud.timeline_ticks: expected list", errors)
+        self.assertIn("family-shai-hulud.timeline_ticks: expected non-empty list", errors)
         self.assertIn("family-shai-hulud.associated_actor_ids: expected list", errors)
         self.assertIn("strain-shai-hulud.first_seen: expected YYYY-MM-DD or YYYY-MM", errors)
         self.assertIn("strain-shai-hulud.incident_ids: expected list", errors)

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -141,7 +141,7 @@ class SupplyChainGraphTests(unittest.TestCase):
         self.assertIn("family-shai-hulud.sources[0].publisher: expected non-empty string", errors)
         self.assertIn("family-shai-hulud.sources[0].url: expected valid HTTP/HTTPS URL", errors)
         self.assertIn("family-shai-hulud.sources[0].published_at: expected YYYY-MM-DD or YYYY-MM", errors)
-        self.assertIn("family-shai-hulud.sources[4].id: duplicate source id 'ref-wiz-shai-hulud'", errors)
+        self.assertIn("family-shai-hulud.sources[5].id: duplicate source id 'ref-wiz-shai-hulud'", errors)
         self.assertIn(
             "family-shai-hulud.lineage_edges[2].external_refs[0]: expected object",
             errors,

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -54,7 +54,7 @@ class SupplyChainGraphTests(unittest.TestCase):
     def test_malware_family_lineage_validates_and_rejects_cycles(self) -> None:
         corpus = load_json(CORPUS_PATH)
         entities_by_type = validator.load_entities(ENTITY_DIR)
-        entity_ids = {entity["id"] for entities in entities_by_type.values() for entity in entities}
+        actor_ids = {entity["id"] for entity in entities_by_type["actors"]}
         raw_incident_ids = validator.collect_raw_incident_ids(corpus)
         malware_families = load_json(MALWARE_FAMILY_PATH)
 
@@ -62,7 +62,7 @@ class SupplyChainGraphTests(unittest.TestCase):
             validator.validate_malware_families(
                 malware_families,
                 raw_incident_ids=raw_incident_ids,
-                entity_ids=entity_ids,
+                actor_ids=actor_ids,
             ),
             [],
         )
@@ -88,7 +88,7 @@ class SupplyChainGraphTests(unittest.TestCase):
                 for error in validator.validate_malware_families(
                     cyclic,
                     raw_incident_ids=raw_incident_ids,
-                    entity_ids=entity_ids,
+                    actor_ids=actor_ids,
                 )
             )
         )
@@ -96,7 +96,7 @@ class SupplyChainGraphTests(unittest.TestCase):
     def test_malware_family_validator_rejects_invalid_dates_and_non_list_fields(self) -> None:
         corpus = load_json(CORPUS_PATH)
         entities_by_type = validator.load_entities(ENTITY_DIR)
-        entity_ids = {entity["id"] for entities in entities_by_type.values() for entity in entities}
+        actor_ids = {entity["id"] for entity in entities_by_type["actors"]}
         raw_incident_ids = validator.collect_raw_incident_ids(corpus)
         malware_families = load_json(MALWARE_FAMILY_PATH)
         malformed = copy.deepcopy(malware_families)
@@ -132,7 +132,7 @@ class SupplyChainGraphTests(unittest.TestCase):
         errors = validator.validate_malware_families(
             malformed,
             raw_incident_ids=raw_incident_ids,
-            entity_ids=entity_ids,
+            actor_ids=actor_ids,
         )
 
         self.assertIn("family-shai-hulud.timeline_ticks: expected non-empty list", errors)
@@ -141,6 +141,18 @@ class SupplyChainGraphTests(unittest.TestCase):
         self.assertIn("family-shai-hulud.first_seen: expected YYYY-MM-DD or YYYY-MM", errors)
         self.assertIn("family-shai-hulud.aliases[3]: expected non-empty string", errors)
         self.assertIn("family-shai-hulud.associated_actor_ids: expected list", errors)
+        non_actor_family = copy.deepcopy(malware_families)
+        non_actor_family[0]["root_actor_id"] = "org-npm"
+        non_actor_family[0]["associated_actor_ids"] = ["org-npm"]
+        non_actor_family[0]["strains"][0]["attribution"]["actor_id"] = "org-npm"
+        non_actor_errors = validator.validate_malware_families(
+            non_actor_family,
+            raw_incident_ids=raw_incident_ids,
+            actor_ids=actor_ids,
+        )
+        self.assertIn("family-shai-hulud.root_actor_id: unknown actor id 'org-npm'", non_actor_errors)
+        self.assertIn("family-shai-hulud.associated_actor_ids[0]: unknown actor id 'org-npm'", non_actor_errors)
+        self.assertIn("strain-shai-hulud.attribution.actor_id: unknown actor id 'org-npm'", non_actor_errors)
         self.assertIn("strain-shai-hulud.first_seen: expected YYYY-MM-DD or YYYY-MM", errors)
         self.assertIn("strain-shai-hulud.ecosystems[1]: expected non-empty string", errors)
         self.assertIn("strain-shai-hulud.aliases[1]: expected non-empty string", errors)
@@ -151,7 +163,7 @@ class SupplyChainGraphTests(unittest.TestCase):
         self.assertIn("strain-shai-hulud.layout.x: expected number", errors)
         self.assertIn("strain-shai-hulud.layout.y: expected number", errors)
         self.assertIn("strain-shai-hulud.severity: expected low, medium, high, or critical", errors)
-        self.assertIn("strain-shai-hulud.attribution.actor_id: unknown actor/entity id 'actor-does-not-exist'", errors)
+        self.assertIn("strain-shai-hulud.attribution.actor_id: unknown actor id 'actor-does-not-exist'", errors)
         self.assertIn("strain-shai-hulud.attribution.label: expected non-empty string", errors)
         self.assertIn("strain-shai-hulud.attribution.confidence: expected unknown, suspected, likely, or confirmed", errors)
         self.assertIn("family-shai-hulud.fork_events: expected list", errors)
@@ -176,7 +188,7 @@ class SupplyChainGraphTests(unittest.TestCase):
         evidence_errors = validator.validate_malware_families(
             suspected_evidence_only,
             raw_incident_ids=raw_incident_ids,
-            entity_ids=entity_ids,
+            actor_ids=actor_ids,
         )
         self.assertIn(
             "family-shai-hulud.lineage_edges[0].suspected_reason: suspected edges must explain uncertainty",
@@ -189,7 +201,7 @@ class SupplyChainGraphTests(unittest.TestCase):
         event_errors = validator.validate_malware_families(
             malformed_event,
             raw_incident_ids=raw_incident_ids,
-            entity_ids=entity_ids,
+            actor_ids=actor_ids,
         )
 
         self.assertIn("fork-mini-shai-source-release.name: expected non-empty string", event_errors)
@@ -207,15 +219,15 @@ class SupplyChainGraphTests(unittest.TestCase):
         unhashable_errors = validator.validate_malware_families(
             unhashable_refs,
             raw_incident_ids=raw_incident_ids,
-            entity_ids=entity_ids,
+            actor_ids=actor_ids,
         )
 
         self.assertIn(
-            "family-shai-hulud.root_actor_id: unknown actor/entity id ['actor-shai-hulud-operator']",
+            "family-shai-hulud.root_actor_id: unknown actor id ['actor-shai-hulud-operator']",
             unhashable_errors,
         )
         self.assertIn(
-            "strain-shai-hulud.attribution.actor_id: unknown actor/entity id {'id': 'actor-teampcp'}",
+            "strain-shai-hulud.attribution.actor_id: unknown actor id {'id': 'actor-teampcp'}",
             unhashable_errors,
         )
         self.assertIn(
@@ -242,7 +254,7 @@ class SupplyChainGraphTests(unittest.TestCase):
     def test_malware_family_validator_allows_single_strain_without_lineage_edges(self) -> None:
         corpus = load_json(CORPUS_PATH)
         entities_by_type = validator.load_entities(ENTITY_DIR)
-        entity_ids = {entity["id"] for entities in entities_by_type.values() for entity in entities}
+        actor_ids = {entity["id"] for entity in entities_by_type["actors"]}
         raw_incident_ids = validator.collect_raw_incident_ids(corpus)
         malware_families = load_json(MALWARE_FAMILY_PATH)
         single_strain = copy.deepcopy(malware_families)
@@ -253,7 +265,7 @@ class SupplyChainGraphTests(unittest.TestCase):
         errors = validator.validate_malware_families(
             single_strain,
             raw_incident_ids=raw_incident_ids,
-            entity_ids=entity_ids,
+            actor_ids=actor_ids,
         )
 
         self.assertNotIn("family-shai-hulud.lineage_edges: expected non-empty list", errors)

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -100,6 +100,10 @@ class SupplyChainGraphTests(unittest.TestCase):
         raw_incident_ids = validator.collect_raw_incident_ids(corpus)
         malware_families = load_json(MALWARE_FAMILY_PATH)
         malformed = copy.deepcopy(malware_families)
+        malformed[0]["schema_version"] = ""
+        malformed[0]["summary"] = ""
+        malformed[0]["first_seen"] = "2025-99"
+        malformed[0]["aliases"].append(" ")
         malformed[0]["timeline_ticks"] = "not-a-list"
         malformed[0]["associated_actor_ids"] = "actor-teampcp"
         malformed[0]["sources"][0]["title"] = ""
@@ -107,6 +111,10 @@ class SupplyChainGraphTests(unittest.TestCase):
         malformed[0]["sources"][0]["url"] = "ftp://example.test/report"
         malformed[0]["sources"][0]["published_at"] = "2025-13"
         malformed[0]["strains"][0]["first_seen"] = "2025-99-99"
+        malformed[0]["strains"][0]["aliases"].append("")
+        malformed[0]["strains"][0]["key_mutation"] = ""
+        malformed[0]["strains"][0]["provenance_abuse"] = ""
+        malformed[0]["strains"][0]["retained_features"].append(" ")
         malformed[0]["strains"][0]["incident_ids"] = "SC-2025-NPM-SHAI-HULUD"
         malformed[0]["strains"][0]["layout"] = {"x": "left"}
         malformed[0]["strains"][0]["severity"] = "severe"
@@ -127,8 +135,16 @@ class SupplyChainGraphTests(unittest.TestCase):
         )
 
         self.assertIn("family-shai-hulud.timeline_ticks: expected non-empty list", errors)
+        self.assertIn("family-shai-hulud.schema_version: expected non-empty string", errors)
+        self.assertIn("family-shai-hulud.summary: expected non-empty string", errors)
+        self.assertIn("family-shai-hulud.first_seen: expected YYYY-MM-DD or YYYY-MM", errors)
+        self.assertIn("family-shai-hulud.aliases[3]: expected non-empty string", errors)
         self.assertIn("family-shai-hulud.associated_actor_ids: expected list", errors)
         self.assertIn("strain-shai-hulud.first_seen: expected YYYY-MM-DD or YYYY-MM", errors)
+        self.assertIn("strain-shai-hulud.aliases[1]: expected non-empty string", errors)
+        self.assertIn("strain-shai-hulud.key_mutation: expected non-empty string", errors)
+        self.assertIn("strain-shai-hulud.provenance_abuse: expected non-empty string", errors)
+        self.assertIn("strain-shai-hulud.retained_features[0]: expected non-empty string", errors)
         self.assertIn("strain-shai-hulud.incident_ids: expected list", errors)
         self.assertIn("strain-shai-hulud.layout.x: expected number", errors)
         self.assertIn("strain-shai-hulud.layout.y: expected number", errors)

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -111,6 +111,7 @@ class SupplyChainGraphTests(unittest.TestCase):
         malformed[0]["sources"][0]["url"] = "ftp://example.test/report"
         malformed[0]["sources"][0]["published_at"] = "2025-13"
         malformed[0]["strains"][0]["first_seen"] = "2025-99-99"
+        malformed[0]["strains"][0]["ecosystems"].append(" ")
         malformed[0]["strains"][0]["aliases"].append("")
         malformed[0]["strains"][0]["key_mutation"] = ""
         malformed[0]["strains"][0]["provenance_abuse"] = ""
@@ -141,6 +142,7 @@ class SupplyChainGraphTests(unittest.TestCase):
         self.assertIn("family-shai-hulud.aliases[3]: expected non-empty string", errors)
         self.assertIn("family-shai-hulud.associated_actor_ids: expected list", errors)
         self.assertIn("strain-shai-hulud.first_seen: expected YYYY-MM-DD or YYYY-MM", errors)
+        self.assertIn("strain-shai-hulud.ecosystems[1]: expected non-empty string", errors)
         self.assertIn("strain-shai-hulud.aliases[1]: expected non-empty string", errors)
         self.assertIn("strain-shai-hulud.key_mutation: expected non-empty string", errors)
         self.assertIn("strain-shai-hulud.provenance_abuse: expected non-empty string", errors)

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -151,6 +151,20 @@ class SupplyChainGraphTests(unittest.TestCase):
             errors,
         )
 
+        suspected_evidence_only = copy.deepcopy(malware_families)
+        suspected_evidence_only[0]["lineage_edges"][0]["confidence"] = "confirmed"
+        suspected_evidence_only[0]["lineage_edges"][0]["evidence_class"] = "suspected"
+        suspected_evidence_only[0]["lineage_edges"][0]["suspected_reason"] = ""
+        evidence_errors = validator.validate_malware_families(
+            suspected_evidence_only,
+            raw_incident_ids=raw_incident_ids,
+            entity_ids=entity_ids,
+        )
+        self.assertIn(
+            "family-shai-hulud.lineage_edges[0].suspected_reason: suspected edges must explain uncertainty",
+            evidence_errors,
+        )
+
         malformed_event = copy.deepcopy(malware_families)
         malformed_event[0]["fork_events"][0]["name"] = ""
         malformed_event[0]["fork_events"][0]["layout"] = {"y": "middle"}

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -102,9 +102,19 @@ class SupplyChainGraphTests(unittest.TestCase):
         malformed = copy.deepcopy(malware_families)
         malformed[0]["timeline_ticks"] = "not-a-list"
         malformed[0]["associated_actor_ids"] = "actor-teampcp"
+        malformed[0]["sources"][0]["title"] = ""
+        malformed[0]["sources"][0]["publisher"] = ""
+        malformed[0]["sources"][0]["url"] = "ftp://example.test/report"
+        malformed[0]["sources"][0]["published_at"] = "2025-13"
         malformed[0]["strains"][0]["first_seen"] = "2025-99-99"
         malformed[0]["strains"][0]["incident_ids"] = "SC-2025-NPM-SHAI-HULUD"
         malformed[0]["strains"][0]["layout"] = {"x": "left"}
+        malformed[0]["strains"][0]["severity"] = "severe"
+        malformed[0]["strains"][0]["attribution"] = {
+            "actor_id": "actor-does-not-exist",
+            "label": "",
+            "confidence": "high",
+        }
         malformed[0]["fork_events"] = {"id": "fork-not-a-list"}
         malformed[0]["lineage_edges"][2]["suspected_reason"] = "   "
         malformed[0]["lineage_edges"][2]["external_refs"][0] = "not-an-object"
@@ -122,7 +132,15 @@ class SupplyChainGraphTests(unittest.TestCase):
         self.assertIn("strain-shai-hulud.incident_ids: expected list", errors)
         self.assertIn("strain-shai-hulud.layout.x: expected number", errors)
         self.assertIn("strain-shai-hulud.layout.y: expected number", errors)
+        self.assertIn("strain-shai-hulud.severity: expected low, medium, high, or critical", errors)
+        self.assertIn("strain-shai-hulud.attribution.actor_id: unknown actor/entity id 'actor-does-not-exist'", errors)
+        self.assertIn("strain-shai-hulud.attribution.label: expected non-empty string", errors)
+        self.assertIn("strain-shai-hulud.attribution.confidence: expected unknown, suspected, likely, or confirmed", errors)
         self.assertIn("family-shai-hulud.fork_events: expected list", errors)
+        self.assertIn("family-shai-hulud.sources[0].title: expected non-empty string", errors)
+        self.assertIn("family-shai-hulud.sources[0].publisher: expected non-empty string", errors)
+        self.assertIn("family-shai-hulud.sources[0].url: expected valid HTTP/HTTPS URL", errors)
+        self.assertIn("family-shai-hulud.sources[0].published_at: expected YYYY-MM-DD or YYYY-MM", errors)
         self.assertIn("family-shai-hulud.sources[4].id: duplicate source id 'ref-wiz-shai-hulud'", errors)
         self.assertIn(
             "family-shai-hulud.lineage_edges[2].external_refs[0]: expected object",
@@ -134,6 +152,7 @@ class SupplyChainGraphTests(unittest.TestCase):
         )
 
         malformed_event = copy.deepcopy(malware_families)
+        malformed_event[0]["fork_events"][0]["name"] = ""
         malformed_event[0]["fork_events"][0]["layout"] = {"y": "middle"}
         event_errors = validator.validate_malware_families(
             malformed_event,
@@ -141,6 +160,7 @@ class SupplyChainGraphTests(unittest.TestCase):
             entity_ids=entity_ids,
         )
 
+        self.assertIn("fork-mini-shai-source-release.name: expected non-empty string", event_errors)
         self.assertIn("fork-mini-shai-source-release.layout.x: expected number", event_errors)
         self.assertIn("fork-mini-shai-source-release.layout.y: expected number", event_errors)
 

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -194,6 +194,49 @@ class SupplyChainGraphTests(unittest.TestCase):
         self.assertIn("fork-mini-shai-source-release.layout.x: expected number", event_errors)
         self.assertIn("fork-mini-shai-source-release.layout.y: expected number", event_errors)
 
+        unhashable_refs = copy.deepcopy(malware_families)
+        unhashable_refs[0]["root_actor_id"] = ["actor-shai-hulud-operator"]
+        unhashable_refs[0]["strains"][0]["attribution"]["actor_id"] = {"id": "actor-teampcp"}
+        unhashable_refs[0]["fork_events"][0]["source_refs"] = [{"id": "ref-stepsecurity-mini-shai"}]
+        unhashable_refs[0]["lineage_edges"][0]["source"] = ["strain-shai-hulud-2"]
+        unhashable_refs[0]["lineage_edges"][0]["target"] = {"id": "strain-shai-hulud"}
+        unhashable_refs[0]["lineage_edges"][0]["external_refs"][0]["source_ref"] = ["ref-wiz-shai-hulud"]
+        unhashable_refs[0]["lineage_edges"][0]["fork_event_id"] = {"id": "fork-mini-shai-source-release"}
+        unhashable_errors = validator.validate_malware_families(
+            unhashable_refs,
+            raw_incident_ids=raw_incident_ids,
+            entity_ids=entity_ids,
+        )
+
+        self.assertIn(
+            "family-shai-hulud.root_actor_id: unknown actor/entity id ['actor-shai-hulud-operator']",
+            unhashable_errors,
+        )
+        self.assertIn(
+            "strain-shai-hulud.attribution.actor_id: unknown actor/entity id {'id': 'actor-teampcp'}",
+            unhashable_errors,
+        )
+        self.assertIn(
+            "fork-mini-shai-source-release.source_refs[0]: unknown family source ref {'id': 'ref-stepsecurity-mini-shai'}",
+            unhashable_errors,
+        )
+        self.assertIn(
+            "family-shai-hulud.lineage_edges[0].source: unknown strain id ['strain-shai-hulud-2']",
+            unhashable_errors,
+        )
+        self.assertIn(
+            "family-shai-hulud.lineage_edges[0].target: unknown strain id {'id': 'strain-shai-hulud'}",
+            unhashable_errors,
+        )
+        self.assertIn(
+            "family-shai-hulud.lineage_edges[0].external_refs[0].source_ref: unknown family source ref ['ref-wiz-shai-hulud']",
+            unhashable_errors,
+        )
+        self.assertIn(
+            "family-shai-hulud.lineage_edges[0].fork_event_id: unknown fork event {'id': 'fork-mini-shai-source-release'}",
+            unhashable_errors,
+        )
+
     def test_malware_family_validator_allows_single_strain_without_lineage_edges(self) -> None:
         corpus = load_json(CORPUS_PATH)
         entities_by_type = validator.load_entities(ENTITY_DIR)

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -11,6 +11,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 CORPUS_PATH = REPO_ROOT / "data" / "supply-chain-incidents" / "incidents.json"
 ENTITY_DIR = REPO_ROOT / "data" / "supply-chain-entities"
 RELATIONSHIP_PATH = REPO_ROOT / "data" / "supply-chain-relationships" / "relationships.json"
+MALWARE_FAMILY_PATH = REPO_ROOT / "data" / "supply-chain-malware-families" / "families.json"
 
 
 def load_module(name: str, path: Path):
@@ -46,8 +47,51 @@ class SupplyChainGraphTests(unittest.TestCase):
         corpus = load_json(CORPUS_PATH)
         entities_by_type = validator.load_entities(ENTITY_DIR)
         relationships = load_json(RELATIONSHIP_PATH)
+        malware_families = load_json(MALWARE_FAMILY_PATH)
 
-        self.assertEqual(validator.validate_graph(corpus, entities_by_type, relationships), [])
+        self.assertEqual(validator.validate_graph(corpus, entities_by_type, relationships, malware_families), [])
+
+    def test_malware_family_lineage_validates_and_rejects_cycles(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        entities_by_type = validator.load_entities(ENTITY_DIR)
+        entity_ids = {entity["id"] for entities in entities_by_type.values() for entity in entities}
+        raw_incident_ids = validator.collect_raw_incident_ids(corpus)
+        malware_families = load_json(MALWARE_FAMILY_PATH)
+
+        self.assertEqual(
+            validator.validate_malware_families(
+                malware_families,
+                raw_incident_ids=raw_incident_ids,
+                entity_ids=entity_ids,
+            ),
+            [],
+        )
+
+        cyclic = copy.deepcopy(malware_families)
+        cyclic[0]["lineage_edges"].append(
+            {
+                "source": "strain-shai-hulud",
+                "target": "strain-hades-shai-hulud",
+                "type": "EVOLVED_FROM",
+                "evidence_class": "confirmed",
+                "confidence": "confirmed",
+                "relation_kind": "evolution",
+                "mutation_delta": ["cycle fixture"],
+                "external_refs": [{"source_ref": "ref-wiz-shai-hulud"}],
+                "summary": "Fixture edge that creates a lineage cycle.",
+            }
+        )
+
+        self.assertTrue(
+            any(
+                "EVOLVED_FROM cycle detected" in error
+                for error in validator.validate_malware_families(
+                    cyclic,
+                    raw_incident_ids=raw_incident_ids,
+                    entity_ids=entity_ids,
+                )
+            )
+        )
 
     def test_builder_extracts_expected_entities(self) -> None:
         graph = builder.build_graph(load_json(CORPUS_PATH))

--- a/tests/test_supply_chain_graph.py
+++ b/tests/test_supply_chain_graph.py
@@ -93,6 +93,36 @@ class SupplyChainGraphTests(unittest.TestCase):
             )
         )
 
+    def test_malware_family_validator_rejects_invalid_dates_and_non_list_fields(self) -> None:
+        corpus = load_json(CORPUS_PATH)
+        entities_by_type = validator.load_entities(ENTITY_DIR)
+        entity_ids = {entity["id"] for entities in entities_by_type.values() for entity in entities}
+        raw_incident_ids = validator.collect_raw_incident_ids(corpus)
+        malware_families = load_json(MALWARE_FAMILY_PATH)
+        malformed = copy.deepcopy(malware_families)
+        malformed[0]["timeline_ticks"] = "not-a-list"
+        malformed[0]["associated_actor_ids"] = "actor-teampcp"
+        malformed[0]["strains"][0]["first_seen"] = "2025-99-99"
+        malformed[0]["strains"][0]["incident_ids"] = "SC-2025-NPM-SHAI-HULUD"
+        malformed[0]["fork_events"] = {"id": "fork-not-a-list"}
+        malformed[0]["lineage_edges"][2]["suspected_reason"] = "   "
+
+        errors = validator.validate_malware_families(
+            malformed,
+            raw_incident_ids=raw_incident_ids,
+            entity_ids=entity_ids,
+        )
+
+        self.assertIn("family-shai-hulud.timeline_ticks: expected list", errors)
+        self.assertIn("family-shai-hulud.associated_actor_ids: expected list", errors)
+        self.assertIn("strain-shai-hulud.first_seen: expected YYYY-MM-DD or YYYY-MM", errors)
+        self.assertIn("strain-shai-hulud.incident_ids: expected list", errors)
+        self.assertIn("family-shai-hulud.fork_events: expected list", errors)
+        self.assertIn(
+            "family-shai-hulud.lineage_edges[2].suspected_reason: suspected edges must explain uncertainty",
+            errors,
+        )
+
     def test_builder_extracts_expected_entities(self) -> None:
         graph = builder.build_graph(load_json(CORPUS_PATH))
 


### PR DESCRIPTION
## Summary
- Add JSON-backed supply-chain malware family lineage primitives for Shai-Hulud
- Add EVOLVED_FROM / VARIANT_OF validation, DAG checks, graph/search payload support, and STIX output
- Add a dedicated malware-family lineage route with phylogeny, strain comparison table, changelog, and source list

## Verification
- python3 scripts/validate_supply_chain_graph.py
- node scripts/build-supply-chain-graph.mjs --check
- python3 -m unittest tests.test_supply_chain_graph
- node scripts/test-supply-chain-pages.mjs
- npm --prefix site run build
- ENABLE_SUPPLY_CHAIN_PAGES=true npm --prefix site run build
- Playwright/Chrome smoke check for desktop and mobile lineage rendering

## Notes
- Distinguishes genealogy EVOLVED_FROM / VARIANT_OF from infection-path SEEDED_BY.
- Suspected lineage edges require an uncertainty reason and render dashed in the phylogeny.
