### PR TITLE
[codex] Add supply-chain graph zoom controls and lineage card

### DIFF
--- a/scripts/test-supply-chain-pages.mjs
+++ b/scripts/test-supply-chain-pages.mjs
@@ -51,6 +51,7 @@ const disabledRoutes = getSupplyChainRoutes({ enabled: false, data });
 assert.equal(disabledRoutes.length, 0, 'feature flag disabled should generate no routes');
 
 const routes = getSupplyChainRoutes({ enabled: true, data });
+const indexModel = getSupplyChainIndexModel(data);
 const routeUrls = new Set(routes.map(routeUrl));
 assert.ok(routeUrls.has('/supply-chain/'), 'index route should be generated');
 assert.ok(routeUrls.has('/supply-chain/explore/'), 'explore route should be generated');
@@ -62,6 +63,15 @@ assert.ok(routeUrls.has('/supply-chain/repositories/repo-github-com-codecov-code
 assert.ok(routeUrls.has('/supply-chain/organizations/org-codecov/'), 'organization route should be generated');
 assert.ok(routeUrls.has('/supply-chain/maintainers/maintainer-jia-tan/'), 'maintainer route should be generated');
 assert.ok(routeUrls.has('/supply-chain/malware-families/family-shai-hulud/'), 'malware-family lineage route should be generated');
+assert.ok(
+  indexModel.lineageViews.some((view) =>
+    view.id === 'family-shai-hulud' &&
+    view.href === '/supply-chain/malware-families/family-shai-hulud/' &&
+    view.command.graphType === 'malware_family' &&
+    view.strainCount > 0
+  ),
+  'index model should expose malware-family lineage views with graph commands'
+);
 const shaiHuludFamily = getSupplyChainMalwareFamilyPage('family-shai-hulud', data);
 assert.equal(shaiHuludFamily.kind, 'malware-family', 'malware-family page model should use dedicated kind');
 assert.ok(
@@ -101,11 +111,24 @@ assert.ok(
     supplyChainRouteSource.includes('data-sc-explore-exit') &&
     supplyChainRouteSource.includes('class="sc-explore-rail"') &&
     supplyChainRouteSource.includes('class="graph-search-pill"') &&
+    supplyChainRouteSource.includes('data-sc-graph-zoom="in"') &&
+    supplyChainRouteSource.includes('data-sc-graph-zoom="out"') &&
+    supplyChainRouteSource.includes('aria-label="Zoom graph in"') &&
+    supplyChainRouteSource.includes('aria-label="Zoom graph out"') &&
     supplyChainRouteSource.includes('aria-label="Search graph"') &&
     supplyChainRouteSource.includes('title="Full screen"') &&
     supplyChainRouteSource.includes('aria-label="Toggle full screen"') &&
     supplyChainRouteSource.includes('title="Exit full screen"'),
   'route should expose full-screen explore controls on the persisted graph island'
+);
+assert.ok(
+  supplyChainRouteSource.includes('Lineage Views') &&
+    supplyChainRouteSource.includes('Malware Families') &&
+    supplyChainRouteSource.includes('class="lineage-view-card"') &&
+    supplyChainRouteSource.includes('data-graph-type={family.command.graphType}') &&
+    supplyChainRouteSource.includes('.lineage-view-grid') &&
+    supplyChainRouteSource.includes('.lineage-view-card'),
+  'index route should expose malware-family lineage cards from the standard Supply Chain page'
 );
 assert.ok(
   supplyChainRouteSource.includes(':global(body.sc-explore-active)') &&
@@ -239,6 +262,17 @@ assert.ok(
   supplyChainGraphSource.includes('if (entry.href)') &&
     supplyChainGraphSource.includes('window.location.href = entry.href'),
   'graph search should navigate entries with explicit hrefs before graph-selection fallback'
+);
+assert.ok(
+  supplyChainGraphSource.includes('const CAMERA_Z_MIN = 0.22') &&
+    supplyChainGraphSource.includes('const CAMERA_Z_MAX = 3.4') &&
+    supplyChainGraphSource.includes('data-sc-graph-zoom') &&
+    supplyChainGraphSource.includes('zoomAt(event.clientX, event.clientY, zoomFactor)') &&
+    supplyChainGraphSource.includes('startPinchGesture()') &&
+    supplyChainGraphSource.includes('updatePinchGesture()') &&
+    supplyChainGraphSource.includes('screenToWorldAtCamera') &&
+    supplyChainGraphSource.includes('cameraForAnchoredZoom'),
+  'graph runtime should support visible zoom controls, cursor-anchored wheel zoom, and pinch zoom'
 );
 const generatedStixBundle = buildMalwareFamilyStixBundle(data);
 assert.deepEqual(malwareFamilyStixPayload, generatedStixBundle, 'malware-family STIX bundle should be generated from the same data object');

--- a/site/public/js/supply-chain-graph-core.js
+++ b/site/public/js/supply-chain-graph-core.js
@@ -10,6 +10,9 @@ const INCIDENT_LABEL_Z = 1.48;
 const DEEP_LABEL_Z = 1.95;
 const TECHNIQUE_Z_THRESHOLD = 1.45;
 const ALL_INCIDENT_Z_THRESHOLD = 1.72;
+const CAMERA_Z_MIN = 0.22;
+const CAMERA_Z_MAX = 3.4;
+const CAMERA_Z_STEP = 1.28;
 const RECENT_WINDOW_DAYS = 183;
 const REST_NODE_BUDGET = 40;
 const SEVERITY_COLORS = {
@@ -730,6 +733,8 @@ class SupplyChainGraph {
     this.focusReflow = false;
     this.keyboardNodeId = null;
     this.drag = null;
+    this.activePointers = new Map();
+    this.pinch = null;
     this.reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     this.gl = this.canvas.getContext('webgl2', { antialias: true }) || this.canvas.getContext('webgl', { antialias: true });
     if (!this.gl) throw new Error('WebGL is not available');
@@ -810,6 +815,12 @@ class SupplyChainGraph {
     this.resizeObserver.observe(this.root);
     this.canvas.addEventListener('pointerdown', (event) => {
       this.canvas.setPointerCapture(event.pointerId);
+      this.activePointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+      if (this.activePointers.size >= 2) {
+        this.drag = null;
+        this.startPinchGesture();
+        return;
+      }
       this.drag = {
         pointerId: event.pointerId,
         x: event.clientX,
@@ -820,6 +831,14 @@ class SupplyChainGraph {
       };
     });
     this.canvas.addEventListener('pointermove', (event) => {
+      if (this.activePointers.has(event.pointerId)) {
+        this.activePointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+      }
+      if (this.pinch && this.activePointers.size >= 2) {
+        event.preventDefault();
+        this.updatePinchGesture();
+        return;
+      }
       if (!this.drag) {
         const node = this.pick(event.clientX, event.clientY);
         const nextHover = node?.id || null;
@@ -842,18 +861,26 @@ class SupplyChainGraph {
       this.hoverNodeId = null;
       this.lastLabelKey = '';
     });
-    this.canvas.addEventListener('pointerup', (event) => {
+    const endPointer = (event) => {
       const drag = this.drag;
+      this.activePointers.delete(event.pointerId);
+      if (this.pinch) {
+        if (this.activePointers.size >= 2) this.startPinchGesture();
+        else this.pinch = null;
+        this.drag = null;
+        return;
+      }
       this.drag = null;
       if (!drag || drag.moved) return;
       const node = this.pick(event.clientX, event.clientY);
       if (node) this.selectNode(node);
-    });
+    };
+    this.canvas.addEventListener('pointerup', endPointer);
+    this.canvas.addEventListener('pointercancel', endPointer);
     this.canvas.addEventListener('wheel', (event) => {
       event.preventDefault();
       const zoomFactor = Math.exp(-event.deltaY * 0.001);
-      this.setCameraTarget({ ...this.targetCamera, z: clamp(this.targetCamera.z * zoomFactor, 0.22, 3.4) });
-      this.ensureSemanticBloom();
+      this.zoomAt(event.clientX, event.clientY, zoomFactor);
     }, { passive: false });
     this.reflowButton?.addEventListener('click', () => {
       if (this.selection?.type !== 'technique') return;
@@ -868,6 +895,13 @@ class SupplyChainGraph {
         event.preventDefault();
         event.stopPropagation();
         this.openSearchPalette(searchTarget);
+        return;
+      }
+      const zoomTarget = event.target.closest('[data-sc-graph-zoom]');
+      if (zoomTarget) {
+        event.preventDefault();
+        const direction = zoomTarget.dataset.scGraphZoom;
+        this.zoomFromControl(direction === 'out' ? 1 / CAMERA_Z_STEP : CAMERA_Z_STEP);
         return;
       }
       const exploreLink = event.target.closest('[data-sc-explore-enter], [data-sc-explore-exit]');
@@ -1289,7 +1323,7 @@ class SupplyChainGraph {
   }
 
   setCameraTarget(target, immediate = false) {
-    const z = clamp(target.z, 0.22, 3.4);
+    const z = clamp(target.z, CAMERA_Z_MIN, CAMERA_Z_MAX);
     const halfWidth = this.viewport.width / z / 2;
     const halfHeight = this.viewport.height / z / 2;
     const bounds = this.activeBounds();
@@ -1301,12 +1335,81 @@ class SupplyChainGraph {
     if (immediate || this.reduceMotion) this.camera = { ...this.targetCamera };
   }
 
-  screenToWorld(clientX, clientY) {
+  screenToWorldAtCamera(clientX, clientY, camera = this.camera) {
     const rect = this.canvas.getBoundingClientRect();
     return {
-      x: (clientX - rect.left - this.viewport.width / 2) / this.camera.z + this.camera.cx,
-      y: (clientY - rect.top - this.viewport.height / 2) / this.camera.z + this.camera.cy,
+      x: (clientX - rect.left - this.viewport.width / 2) / camera.z + camera.cx,
+      y: (clientY - rect.top - this.viewport.height / 2) / camera.z + camera.cy,
     };
+  }
+
+  screenToWorld(clientX, clientY) {
+    return this.screenToWorldAtCamera(clientX, clientY);
+  }
+
+  cameraForAnchoredZoom(clientX, clientY, nextZ, camera = this.targetCamera) {
+    const rect = this.canvas.getBoundingClientRect();
+    const z = clamp(nextZ, CAMERA_Z_MIN, CAMERA_Z_MAX);
+    const world = this.screenToWorldAtCamera(clientX, clientY, camera);
+    const dx = clientX - rect.left - this.viewport.width / 2;
+    const dy = clientY - rect.top - this.viewport.height / 2;
+    return {
+      cx: world.x - dx / z,
+      cy: world.y - dy / z,
+      z,
+    };
+  }
+
+  zoomAt(clientX, clientY, factor, camera = this.targetCamera) {
+    if (!Number.isFinite(factor) || factor <= 0) return;
+    this.setCameraTarget(this.cameraForAnchoredZoom(clientX, clientY, camera.z * factor, camera));
+    this.ensureSemanticBloom();
+  }
+
+  zoomFromControl(factor) {
+    const rect = this.canvas.getBoundingClientRect();
+    this.zoomAt(rect.left + rect.width / 2, rect.top + rect.height / 2, factor);
+    this.root.focus({ preventScroll: true });
+  }
+
+  pointerPair() {
+    return Array.from(this.activePointers.values()).slice(0, 2);
+  }
+
+  pinchMetrics() {
+    const [a, b] = this.pointerPair();
+    if (!a || !b) return null;
+    return {
+      distance: Math.max(1, Math.hypot(b.x - a.x, b.y - a.y)),
+      centerX: (a.x + b.x) / 2,
+      centerY: (a.y + b.y) / 2,
+    };
+  }
+
+  startPinchGesture() {
+    const metrics = this.pinchMetrics();
+    if (!metrics) return;
+    const startCamera = { ...this.targetCamera };
+    this.pinch = {
+      ...metrics,
+      startCamera,
+      startWorld: this.screenToWorldAtCamera(metrics.centerX, metrics.centerY, startCamera),
+    };
+  }
+
+  updatePinchGesture() {
+    const metrics = this.pinchMetrics();
+    if (!metrics || !this.pinch) return;
+    const rect = this.canvas.getBoundingClientRect();
+    const z = clamp(this.pinch.startCamera.z * (metrics.distance / this.pinch.distance), CAMERA_Z_MIN, CAMERA_Z_MAX);
+    const dx = metrics.centerX - rect.left - this.viewport.width / 2;
+    const dy = metrics.centerY - rect.top - this.viewport.height / 2;
+    this.setCameraTarget({
+      cx: this.pinch.startWorld.x - dx / z,
+      cy: this.pinch.startWorld.y - dy / z,
+      z,
+    });
+    this.ensureSemanticBloom();
   }
 
   worldToScreen(node) {

--- a/site/src/lib/supplyChainPages.mjs
+++ b/site/src/lib/supplyChainPages.mjs
@@ -924,6 +924,25 @@ export function getSupplyChainIndexModel(data = loadSupplyChainData()) {
       summary: incident.summary,
     }))
     .sort(compareTitle);
+  const lineageViews = (Array.isArray(data.malwareFamilies) ? data.malwareFamilies : [])
+    .filter((family) => family && typeof family.id === 'string')
+    .map((family) => {
+      const strains = Array.isArray(family.strains) ? family.strains : [];
+      const ecosystems = Array.from(
+        new Set(strains.flatMap((strain) => (Array.isArray(strain.ecosystems) ? strain.ecosystems : [])))
+      ).sort((a, b) => String(a).localeCompare(String(b)));
+      return {
+        id: family.id,
+        title: family.name || family.id,
+        summary: family.summary || '',
+        href: `/supply-chain/malware-families/${family.id}/`,
+        strainCount: strains.length,
+        edgeCount: Array.isArray(family.lineage_edges) ? family.lineage_edges.length : 0,
+        ecosystems,
+        command: { type: 'select-entity', value: family.id, graphType: 'malware_family' },
+      };
+    })
+    .sort(compareTitle);
 
   return {
     kind: 'index',
@@ -934,6 +953,7 @@ export function getSupplyChainIndexModel(data = loadSupplyChainData()) {
     attackVectorBars: buildAttackVectorBars(data),
     attributionRows: buildAttributionRows(data),
     dwellTimeline: buildDwellTimeline(data),
+    lineageViews,
     featuredIncidents,
     entitySummaries: entitySummaryDefinitions.map((summary) => ({
       ...summary,

--- a/site/src/pages/supply-chain/[...slug].astro
+++ b/site/src/pages/supply-chain/[...slug].astro
@@ -109,6 +109,24 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
         <span class="graph-search-label" aria-hidden="true">Search</span>
         <span class="graph-search-shortcut" aria-hidden="true">⌘K / /</span>
       </button>
+      <button
+        class="graph-icon-button"
+        type="button"
+        data-sc-graph-zoom="in"
+        aria-label="Zoom graph in"
+        title="Zoom in"
+      >
+        <span aria-hidden="true">+</span>
+      </button>
+      <button
+        class="graph-icon-button"
+        type="button"
+        data-sc-graph-zoom="out"
+        aria-label="Zoom graph out"
+        title="Zoom out"
+      >
+        <span aria-hidden="true">-</span>
+      </button>
       {isExplore ? (
         <a
           class="graph-icon-button"
@@ -439,6 +457,37 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
           </article>
         ))}
       </section>
+
+      {page.lineageViews.length > 0 && (
+        <section class="sc-section lineage-views-section">
+          <div class="section-heading">
+            <p class="eyebrow">Lineage Views</p>
+            <h2>Malware Families</h2>
+          </div>
+          <div class="lineage-view-grid">
+            {page.lineageViews.map((family) => (
+              <a
+                class="lineage-view-card"
+                href={family.href}
+                data-graph-command={family.command.type}
+                data-graph-value={family.command.value}
+                data-graph-type={family.command.graphType}
+                data-graph-target-type={family.command.graphType}
+                data-graph-target-value={family.command.value}
+              >
+                <span>Malware Family</span>
+                <strong>{family.title}</strong>
+                <p>{family.summary}</p>
+                <div class="lineage-view-meta">
+                  <b>{family.strainCount} strains</b>
+                  <b>{family.edgeCount} lineage edges</b>
+                  {family.ecosystems.length > 0 && <b>{family.ecosystems.join(' / ')}</b>}
+                </div>
+              </a>
+            ))}
+          </div>
+        </section>
+      )}
 
       <section class="sc-section">
         <div class="section-heading">
@@ -1148,6 +1197,12 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
     stroke-width: 1.65;
   }
 
+  .graph-icon-button span {
+    color: currentColor;
+    font-size: 1rem;
+    line-height: 1;
+  }
+
   .graph-search-label {
     color: var(--text);
   }
@@ -1788,6 +1843,67 @@ const graphSelectionValue = page.kind === 'incident' ? page.incident.id : page.k
     margin-bottom: 30px;
     padding-bottom: 20px;
     border-bottom: 1px solid var(--border);
+  }
+
+  .lineage-view-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 14px;
+  }
+
+  .lineage-view-card {
+    display: grid;
+    gap: 9px;
+    min-height: 190px;
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--amber);
+    border-radius: 4px;
+    background: var(--surface);
+    color: var(--text);
+    padding: 16px;
+    text-decoration: none;
+  }
+
+  .lineage-view-card:hover,
+  .lineage-view-card:focus-visible {
+    border-color: rgba(232, 160, 32, 0.72);
+    box-shadow: 0 0 0 1px rgba(232, 160, 32, 0.16), 0 12px 30px rgba(0, 0, 0, 0.24);
+    outline: none;
+  }
+
+  .lineage-view-card > span,
+  .lineage-view-meta {
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .lineage-view-card > span {
+    color: var(--amber);
+  }
+
+  .lineage-view-card strong {
+    color: var(--white);
+    font-family: var(--font-serif);
+    font-size: 1.25rem;
+    line-height: 1.1;
+  }
+
+  .lineage-view-card p {
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  .lineage-view-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    color: var(--muted);
+  }
+
+  .lineage-view-meta b {
+    font-weight: 500;
   }
 
   .eyebrow {


### PR DESCRIPTION
## Summary
- add visible + / - graph zoom controls wired into the existing persistent graph instance
- make wheel zoom cursor-anchored and add two-pointer pinch zoom for touch devices
- expose Malware Families / Lineage Views from the standard /supply-chain/ index, linking to the Shai-Hulud lineage page
- extend supply-chain page tests to cover zoom controls and index lineage cards

## Validation
- `git diff --check`
- `node scripts/test-supply-chain-pages.mjs`
- `node scripts/build-supply-chain-graph.mjs --check`
- `python3 scripts/validate_supply_chain_graph.py`
- `python3 -m unittest tests.test_supply_chain_graph`
- `ENABLE_SUPPLY_CHAIN_PAGES=true npm --prefix site run build`
- Playwright desktop/mobile browser verification: /supply-chain/ lineage card visible, zoom in/out buttons change camera scale, wheel zoom changes camera scale, graph canvas screenshot nonblank
- Playwright mobile touch verification: two-touch pinch spread changed camera z from 0.279 to 1.024

## Notes
- Build still emits existing campaign corpus warnings for campaigns with fewer than two related incidents; build exits cleanly.
- Temp Playwright install was outside the repo under /tmp; no package files changed.