### PR TITLE
Add grounded drafting packet pipeline

### DIFF
--- a/.github/pipeline/source-packets/README.md
+++ b/.github/pipeline/source-packets/README.md
@@ -1,9 +1,9 @@
-# Zero-Day Source Packet Pilot
+# Source Packets and Grounded Drafting
 
-This pilot adds a deterministic source packet stage before zero-day drafting:
+Source packets are Threatpedia's evidence contract before drafting:
 
 ```
-task JSON -> source packet -> deterministic preflight -> article draft -> validator -> PR -> review gate
+task/candidate approval -> source packet -> deterministic preflight -> grounded draft -> fidelity check -> validator -> PR -> review gate
 ```
 
 The source packet is an evidence contract. A drafter should not add factual
@@ -14,12 +14,55 @@ claims beyond `claims[]` unless the packet is updated and preflight is rerun.
 - `schema/source-packet-1.schema.json` defines the versioned packet shape.
 - `scripts/build-source-packet.mjs` builds a conservative packet from one
   zero-day task JSON.
+- `scripts/build-grounded-source-packet.mjs` builds a B2 grounded packet from
+  an explicitly approved B1 supply-chain candidate.
 - `scripts/preflight-source-packet.mjs` validates one packet and returns
   pass/fail, errors, warnings, and a normalized summary.
+- `scripts/draft-grounded-article.mjs` generates a conservative draft from
+  packet claims only.
+- `scripts/check-grounded-draft.mjs` verifies claim-marker and source-URL
+  fidelity for a grounded draft.
 - `scripts/vulncheck-kev-intake.mjs` emits recent-first VulnCheck KEV
   prioritization/source-packet-prefill artifacts in dry-run or live mode.
 - `fixtures/zero-day-valid-packet.json` is a passing fixture.
 - `fixtures/zero-day-invalid-packet.json` is an intentionally failing fixture.
+
+## B2 Grounded Candidate Drafting
+
+B2 consumes B1 candidate-queue entries only after explicit human or EP approval.
+The candidate queue remains non-drafting state (`draftingAllowed: false`); the
+approval is recorded in the grounded packet.
+
+Sample fixture-backed flow:
+
+```bash
+node scripts/build-grounded-source-packet.mjs \
+  --queue tests/fixtures/grounded_drafting/candidate_queue.json \
+  --candidate-id SC-CAND-1234abcd5678ef90 \
+  --approved-by KernelK \
+  --approval-ref fixture-approval \
+  --fixtures-dir tests/fixtures/grounded_drafting/sources \
+  --out /tmp/grounded-packet.json
+
+node scripts/preflight-source-packet.mjs /tmp/grounded-packet.json
+node scripts/draft-grounded-article.mjs --packet /tmp/grounded-packet.json --out /tmp/grounded-draft.md
+node scripts/check-grounded-draft.mjs --packet /tmp/grounded-packet.json --draft /tmp/grounded-draft.md
+```
+
+The grounded path supports the approved archetype lanes:
+`incident`, `zero-day`, `campaign`, `threat-actor`, and `malware-family`.
+Drafting is packet-only:
+
+- source fetch/extraction failures fail closed unless an operator deliberately
+  uses `--allow-fetch-failures`;
+- every substantive draft sentence must carry a packet claim marker;
+- every draft URL must come from packet sources;
+- placeholder or source-recovery URLs are hard failures;
+- facts absent from `claims[]` are omitted or left as packet uncertainties.
+
+This path does not make every B1 candidate draftable. Candidate approval,
+source sufficiency, packet preflight, and grounded-draft fidelity must all pass
+before an article PR is opened.
 
 ## VulnCheck KEV Prefill
 
@@ -64,7 +107,7 @@ article tasks by themselves and do not satisfy drafting source sufficiency.
 
 ## Preflight Coverage
 
-The pilot preflight checks:
+Preflight checks:
 
 - source sufficiency, URL dedupe, and source refs
 - date shape and source-backed date claims
@@ -78,7 +121,7 @@ The pilot preflight checks:
 
 ## Pilot Metrics
 
-Record these per zero-day PR during the pilot:
+Record these per source-packet-backed PR:
 
 - preflight errors caught before drafting
 - validator failures after drafting
@@ -91,8 +134,9 @@ Record these per zero-day PR during the pilot:
 
 ## Limitations
 
-- The builder does not fetch source URLs.
-- The builder does not call a model.
+- `scripts/build-source-packet.mjs` remains the legacy zero-day task packet
+  builder and does not fetch source URLs.
+- The B2 grounded builder fetches/extracts sources but does not call a model.
 - Publisher and source-type classification is URL-derived and conservative.
 - A passing packet does not mean the future article is merge-ready; it only
   means the drafter has a bounded evidence contract to draft from.

--- a/.github/pipeline/source-packets/schema/source-packet-1.schema.json
+++ b/.github/pipeline/source-packets/schema/source-packet-1.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://threatpedia.wiki/schemas/source-packet-1.schema.json",
-  "title": "Threatpedia zero-day source packet v1",
+  "title": "Threatpedia source packet v1",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -31,8 +31,8 @@
   "properties": {
     "schema_version": { "const": "source-packet/1" },
     "task_id": { "type": "string", "pattern": "^TASK-[0-9]{4}-[0-9]{4}$" },
-    "lane": { "const": "zero-day" },
-    "source_packet_id": { "type": "string", "pattern": "^sp-TASK-[0-9]{4}-[0-9]{4}$" },
+    "lane": { "type": "string", "enum": ["zero-day", "incident", "campaign", "threat-actor", "malware-family"] },
+    "source_packet_id": { "type": "string", "pattern": "^sp-(TASK-[0-9]{4}-[0-9]{4}|SC-CAND-[a-f0-9]{16})$" },
     "created_at": { "type": "string", "format": "date-time" },
     "source_packet_status": { "type": "string", "enum": ["draft", "preflight_passed", "preflight_failed"] },
     "output_target": {
@@ -45,6 +45,45 @@
         "pr": { "type": "boolean" }
       }
     },
+    "candidate": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "candidate_id": { "type": "string" },
+        "canonical_subject_id": { "type": "string" },
+        "proposed_archetype": { "type": "string" }
+      }
+    },
+    "approval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["approved_by", "approval_ref", "approved_at", "scope"],
+      "properties": {
+        "approved_by": { "type": "string", "minLength": 1 },
+        "approval_ref": { "type": "string", "minLength": 1 },
+        "approved_at": { "type": "string", "format": "date-time" },
+        "scope": { "type": "string", "minLength": 1 }
+      }
+    },
+    "grounding_contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "drafting_mode",
+        "disallow_model_memory",
+        "disallow_placeholder_urls",
+        "require_claim_markers",
+        "require_source_url_parity"
+      ],
+      "properties": {
+        "drafting_mode": { "const": "packet_claims_only" },
+        "disallow_model_memory": { "type": "boolean" },
+        "disallow_placeholder_urls": { "type": "boolean" },
+        "require_claim_markers": { "type": "boolean" },
+        "require_source_url_parity": { "type": "boolean" },
+        "generation_must_fail_on_fetch_error": { "type": "boolean" }
+      }
+    },
     "primary_sources": {
       "type": "array",
       "items": { "$ref": "#/$defs/source" }
@@ -52,6 +91,10 @@
     "supporting_sources": {
       "type": "array",
       "items": { "$ref": "#/$defs/source" }
+    },
+    "source_extracts": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/sourceExtract" }
     },
     "source_quality": {
       "type": "object",
@@ -94,7 +137,6 @@
     },
     "cves": {
       "type": "array",
-      "minItems": 1,
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -256,6 +298,19 @@
         },
         "role": { "type": "string", "enum": ["primary", "supporting"] },
         "notes": { "type": "string", "minLength": 1 }
+      }
+    },
+    "sourceExtract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_id", "status", "title", "extracted_at", "extracted_text"],
+      "properties": {
+        "source_id": { "type": "string", "pattern": "^src-[0-9]+$" },
+        "status": { "type": "string", "enum": ["ok", "failed"] },
+        "title": { "type": ["string", "null"] },
+        "extracted_at": { "type": "string", "format": "date-time" },
+        "extracted_text": { "type": "string" },
+        "error": { "type": "string" }
       }
     }
   }

--- a/.github/workflows/supply-chain-live-discovery.yml
+++ b/.github/workflows/supply-chain-live-discovery.yml
@@ -177,7 +177,7 @@ jobs:
             body += '\\n### Guardrails\\n\\n';
             body += '- `drafting_enabled=false` and `auto_drafting_allowed=false` are validated.\\n';
             body += '- `kevStatusDerived` is dispatch-cycle output, not authored truth.\\n';
-            body += '- B2 grounded drafting remains the first sprint that may consume approved candidates for generation.\\n';
+            body += '- B2 grounded drafting may consume approved candidates only through source-packet preflight and grounded-draft fidelity checks.\\n';
             body += '\\n@codex review\\n/gemini review\\n';
 
             const existing = await github.rest.pulls.list({

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -187,6 +187,18 @@ discovery queues are open, validated, and stable.
      before drafting. The packet is a source-backed evidence contract; the
      draft should use packet `claims[]` and avoid `not_supported[]` items unless
      the packet is updated and preflight is rerun.
+   - **B2 grounded candidate drafting:** approved B1 supply-chain candidates
+     may be consumed only through
+     `node scripts/build-grounded-source-packet.mjs --queue <queue.json> --candidate-id <id> --approved-by <operator> --approval-ref <ref> --out <packet.json>`,
+     followed by `node scripts/preflight-source-packet.mjs <packet.json>`,
+     `node scripts/draft-grounded-article.mjs --packet <packet.json> --out <draft.md>`,
+     and `node scripts/check-grounded-draft.mjs --packet <packet.json> --draft <draft.md>`.
+     The B1 queue remains `draftingAllowed: false`; approval is recorded in
+     the B2 packet. The grounded drafter must write only from packet claims and
+     packet source URLs. Placeholder URLs, unmarked factual sentences, and URLs
+     absent from the packet are fidelity failures. Supported archetype lanes are
+     `incident`, `zero-day`, `campaign`, `threat-actor`, and `malware-family`.
+     B2 does not authorize B3-scale backfill until a sample passes fidelity QA.
    - **VulnCheck KEV prefill:** operators may run
      `node scripts/vulncheck-kev-intake.mjs --dry-run --out <artifact.json>`
      to inspect VulnCheck KEV candidates before selecting or enriching zero-day

--- a/docs/supply-chain-live-discovery.md
+++ b/docs/supply-chain-live-discovery.md
@@ -108,3 +108,27 @@ node scripts/supply-chain-live-discovery.mjs --check --queue-path .github/pipeli
 ```
 
 The queue check fails if any candidate permits drafting, omits required classifier fields, stores KEV status as authored truth, or duplicates candidate IDs.
+
+## B2 Consumption
+
+B1 queue entries can feed drafting only after an explicit approval is recorded
+in a grounded source packet. Do not flip `draftingAllowed` in the queue.
+
+```bash
+node scripts/build-grounded-source-packet.mjs \
+  --queue .github/pipeline/supply-chain-candidates/latest.json \
+  --candidate-id <SC-CAND-...> \
+  --approved-by <operator-or-reviewer> \
+  --approval-ref <issue-pr-or-review-ref> \
+  --out /tmp/grounded-packet.json
+
+node scripts/preflight-source-packet.mjs /tmp/grounded-packet.json
+node scripts/draft-grounded-article.mjs --packet /tmp/grounded-packet.json --out /tmp/grounded-draft.md
+node scripts/check-grounded-draft.mjs --packet /tmp/grounded-packet.json --draft /tmp/grounded-draft.md
+```
+
+The grounded packet builder fetches and extracts the cited candidate sources
+before drafting. It fails closed on fetch failures by default. The draft checker
+rejects placeholder URLs, URLs not present in the packet, and substantive draft
+sentences without packet claim markers. These checks are the B2 safety boundary;
+the B1 queue by itself never authorizes article generation.

--- a/scripts/build-grounded-source-packet.mjs
+++ b/scripts/build-grounded-source-packet.mjs
@@ -1,0 +1,333 @@
+#!/usr/bin/env node
+/**
+ * Build a grounded source packet from an approved B1 candidate.
+ *
+ * This is the B2 path. It requires an explicit approval selector and fetches
+ * source text before marking the packet sufficient for drafting. It never
+ * mutates the B1 candidate queue and never creates article drafts by itself.
+ */
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  candidateById,
+  claim,
+  extractIds,
+  extractSource,
+  laneForCandidate,
+  readJson,
+  repoPath,
+  safeTitle,
+  SECTION_MAP,
+  uniqueStrings,
+  writeJson,
+} from './grounded-drafting-lib.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function usage() {
+  console.log([
+    'Usage:',
+    '  node scripts/build-grounded-source-packet.mjs --queue <queue.json> --candidate-id <id> --approved-by <name> --approval-ref <ref> --out <packet.json> [--fixtures-dir <dir>]',
+    '',
+    'The queue candidate must remain candidate-review only; B2 approval is recorded in the packet, not the queue.',
+  ].join('\n'));
+}
+
+function parseArgs(argv = process.argv) {
+  const args = {
+    queue: null,
+    candidateId: null,
+    approvedBy: null,
+    approvalRef: null,
+    out: null,
+    fixturesDir: null,
+    createdAt: null,
+    allowFetchFailures: false,
+  };
+  for (let i = 2; i < argv.length; i += 1) {
+    const token = argv[i];
+    const next = argv[i + 1];
+    switch (token) {
+      case '--queue':
+        if (!next) throw new Error('Missing value for --queue');
+        args.queue = next;
+        i += 1;
+        break;
+      case '--candidate-id':
+        if (!next) throw new Error('Missing value for --candidate-id');
+        args.candidateId = next;
+        i += 1;
+        break;
+      case '--approved-by':
+        if (!next) throw new Error('Missing value for --approved-by');
+        args.approvedBy = next;
+        i += 1;
+        break;
+      case '--approval-ref':
+        if (!next) throw new Error('Missing value for --approval-ref');
+        args.approvalRef = next;
+        i += 1;
+        break;
+      case '--out':
+        if (!next) throw new Error('Missing value for --out');
+        args.out = next;
+        i += 1;
+        break;
+      case '--fixtures-dir':
+        if (!next) throw new Error('Missing value for --fixtures-dir');
+        args.fixturesDir = next;
+        i += 1;
+        break;
+      case '--created-at':
+        if (!next) throw new Error('Missing value for --created-at');
+        args.createdAt = next;
+        i += 1;
+        break;
+      case '--allow-fetch-failures':
+        args.allowFetchFailures = true;
+        break;
+      case '--help':
+      case '-h':
+        usage();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${token}`);
+    }
+  }
+  for (const field of ['queue', 'candidateId', 'approvedBy', 'approvalRef', 'out']) {
+    if (!args[field]) throw new Error(`--${field.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`)} is required`);
+  }
+  return args;
+}
+
+function sourceRefsForAll(sources) {
+  return sources.map((source) => source.id);
+}
+
+function sourceRefsByRole(sources, roles) {
+  const wanted = new Set(roles);
+  const refs = sources.filter((source) => wanted.has(source.role) || wanted.has(source.source_type)).map((source) => source.id);
+  return refs.length ? refs : sourceRefsForAll(sources);
+}
+
+function affectedProducts(candidate, sources) {
+  const sourceRefs = sourceRefsByRole(sources, ['primary', 'database', 'vendor', 'research']);
+  const products = [];
+  const subject = candidate.canonicalSubjectId || '';
+  if (subject.startsWith('pkg:')) {
+    products.push({
+      vendor: 'Unknown',
+      product: subject,
+      versions: 'unknown',
+      source_refs: sourceRefs,
+    });
+  }
+  for (const pkg of candidate.matchedEntityHints?.packages || []) {
+    products.push({
+      vendor: 'Unknown',
+      product: pkg.name || pkg.id,
+      versions: 'unknown',
+      source_refs: sourceRefs,
+    });
+  }
+  if (products.length === 0) {
+    products.push({
+      vendor: 'Unknown',
+      product: candidate.title || candidate.canonicalSubjectId,
+      versions: 'unknown',
+      source_refs: sourceRefs,
+    });
+  }
+  return products;
+}
+
+function outputPatternForLane(lane, candidateId) {
+  const section = SECTION_MAP[lane];
+  if (!section) throw new Error(`Unsupported grounded drafting lane: ${lane}`);
+  if (lane === 'malware-family') {
+    return `.github/pipeline/grounded-drafts/${section}/${candidateId}.md`;
+  }
+  return `site/src/content/${section}/${candidateId}.md`;
+}
+
+function candidateClaims(candidate, sources, extracts) {
+  const claims = [];
+  const primaryRefs = sourceRefsByRole(sources, ['primary', 'database', 'vendor', 'research']);
+  const allRefs = sourceRefsForAll(sources);
+  claim(claims, `${safeTitle(candidate.title)} is the candidate subject approved for grounded drafting.`, 'other', primaryRefs, 'summary');
+  if (candidate.summary) claim(claims, candidate.summary, 'other', primaryRefs, 'summary', 'medium');
+  if (candidate.canonicalSubjectId) claim(claims, `The canonical subject identifier is ${candidate.canonicalSubjectId}.`, 'other', primaryRefs, 'frontmatter');
+  if (candidate.classification?.leadClass) claim(claims, `The candidate is classified as ${candidate.classification.leadClass}.`, 'other', allRefs, 'summary', 'medium');
+  if (candidate.classification?.workIntent) claim(claims, `The classifier work intent is ${candidate.classification.workIntent}.`, 'other', allRefs, 'summary', 'medium');
+  if (candidate.classification?.effectiveActiveStatus && candidate.classification.effectiveActiveStatus !== 'none') {
+    claim(claims, `The classifier effective active status is ${candidate.classification.effectiveActiveStatus}.`, 'exploitation', primaryRefs, 'summary', 'medium');
+  }
+  for (const actor of candidate.matchedEntityHints?.actors || []) {
+    claim(claims, `The candidate text connects to existing actor ${actor.name || actor.id}.`, 'attribution', allRefs, 'summary', 'low');
+  }
+  for (const campaign of candidate.matchedEntityHints?.campaigns || []) {
+    claim(claims, `The candidate text connects to existing campaign ${campaign.name || campaign.id}.`, 'attribution', allRefs, 'summary', 'low');
+  }
+  for (const extract of extracts.filter((item) => item.status === 'ok')) {
+    const text = extract.extracted_text;
+    const firstSentence = text.split(/(?<=[.!?])\s+/).find((sentence) => sentence.length >= 40 && sentence.length <= 280);
+    if (firstSentence) claim(claims, firstSentence, 'other', [extract.source_id], 'technical-analysis', 'medium');
+  }
+  return claims;
+}
+
+export async function buildGroundedPacket(args) {
+  const queue = readJson(repoRoot, args.queue);
+  const candidate = candidateById(queue, args.candidateId);
+  if (!candidate) throw new Error(`Candidate ${args.candidateId} not found in ${args.queue}`);
+  if (candidate.queueAction !== 'candidate_review') throw new Error(`Candidate ${candidate.candidateId} is not in candidate_review state`);
+  if (candidate.draftingAllowed !== false) throw new Error('B1 candidate queue must remain draftingAllowed=false; approval belongs in the B2 packet');
+
+  const sourceUrls = uniqueStrings(candidate.sourceRefs || []);
+  if (sourceUrls.length === 0) throw new Error(`Candidate ${candidate.candidateId} has no sourceRefs`);
+
+  const extracted = await Promise.all(sourceUrls.map((url, index) => extractSource(url, `src-${index + 1}`, {
+    root: repoRoot,
+    fixturesDir: args.fixturesDir,
+  })));
+  const sources = extracted.map((item) => item.source);
+  const extracts = extracted.map((item) => item.extract);
+  const failed = extracts.filter((extract) => extract.status !== 'ok');
+  if (failed.length && !args.allowFetchFailures) {
+    throw new Error(`Source extraction failed for ${failed.map((item) => item.source_id).join(', ')}; rerun only after sources can be fetched or fixture-backed`);
+  }
+
+  const lane = laneForCandidate(candidate);
+  const allText = [candidate.title, candidate.summary, candidate.canonicalSubjectId, extracts.map((item) => item.extracted_text)].flat().join('\n');
+  const ids = extractIds(allText);
+  const primarySources = sources.filter((source) => source.role === 'primary');
+  const supportingSources = sources.filter((source) => source.role !== 'primary');
+  const successfulExtractRefs = extracts.filter((extract) => extract.status === 'ok').map((extract) => extract.source_id);
+  const claims = candidateClaims(candidate, sources, extracts);
+  const createdAt = args.createdAt || new Date().toISOString();
+
+  return {
+    schema_version: 'source-packet/1',
+    task_id: `TASK-${createdAt.slice(0, 4)}-${String(Number.parseInt(candidate.candidateId?.slice(-4) || '0', 16) % 10000).padStart(4, '0')}`,
+    lane,
+    source_packet_id: `sp-${candidate.candidateId}`,
+    created_at: createdAt,
+    source_packet_status: 'draft',
+    candidate: {
+      candidate_id: candidate.candidateId,
+      canonical_subject_id: candidate.canonicalSubjectId,
+      proposed_archetype: candidate.proposedArchetype,
+      classification: candidate.classification,
+      rank: candidate.rank,
+      rank_reasons: candidate.rankReasons || [],
+    },
+    approval: {
+      approved_by: args.approvedBy,
+      approval_ref: args.approvalRef,
+      approved_at: createdAt,
+      scope: 'grounded_draft_sample_or_candidate',
+    },
+    grounding_contract: {
+      drafting_mode: 'packet_claims_only',
+      disallow_model_memory: true,
+      disallow_placeholder_urls: true,
+      require_claim_markers: true,
+      require_source_url_parity: true,
+      generation_must_fail_on_fetch_error: !args.allowFetchFailures,
+    },
+    output_target: {
+      file_pattern: outputPatternForLane(lane, candidate.candidateId),
+      branch: null,
+      pr: true,
+    },
+    primary_sources: primarySources,
+    supporting_sources: supportingSources,
+    source_extracts: extracts,
+    source_quality: {
+      has_government_source: sources.some((source) => source.source_type === 'government'),
+      has_vendor_source: sources.some((source) => source.source_type === 'vendor'),
+      has_primary_source: primarySources.length > 0,
+      source_sufficiency: primarySources.length > 0 && successfulExtractRefs.length > 0 && claims.length > 0 ? 'sufficient' : 'insufficient',
+    },
+    key_dates: {
+      disclosed_at: null,
+      published_at: candidate.firstSeenAt ? candidate.firstSeenAt.slice(0, 10) : null,
+      patched_at: null,
+      kev_added_at: null,
+      exploited_before_disclosure: 'unknown',
+      date_uncertainties: ['Candidate queue data does not establish all article timeline dates.'],
+    },
+    affected_products: affectedProducts(candidate, sources),
+    cves: ids.cves.map((id) => ({ id, source_refs: sourceRefsByRole(sources, ['database', 'government', 'vendor', 'primary']) })),
+    cwes: [],
+    kev_status: {
+      in_kev: candidate.classification?.kevStatusDerived ? true : false,
+      source_refs: candidate.classification?.kevStatusDerived ? sourceRefsByRole(sources, ['government', 'database', 'primary']) : [],
+    },
+    exploit_status: {
+      known_exploited: candidate.classification?.effectiveActiveStatus !== 'none',
+      source_refs: candidate.classification?.effectiveActiveStatus !== 'none' ? sourceRefsByRole(sources, ['database', 'research', 'vendor', 'primary']) : [],
+      notes: candidate.classification?.effectiveActiveStatus !== 'none'
+        ? 'Known-exploitation or malware signal is limited to classifier-backed source data in this packet.'
+        : 'No effective active-exploitation signal is present in the candidate classification.',
+    },
+    claims,
+    uncertainties: [
+      {
+        topic: 'source packet scope',
+        reason: 'This packet is built from a candidate queue item and fetched sources only.',
+        drafting_instruction: 'Do not add facts, dates, attribution, or impact figures unless they are represented in claims with source_refs.',
+      },
+      {
+        topic: 'date and patch status',
+        reason: 'The candidate queue and fetched source extracts do not establish every timeline or remediation date required for publication.',
+        drafting_instruction: 'Do not claim disclosure, publication, patch, or remediation dates unless a packet claim states the date with source_refs.',
+      },
+      {
+        topic: 'exploit timing',
+        reason: 'The candidate classification can indicate active signal without establishing exploitation timing relative to disclosure.',
+        drafting_instruction: 'Do not claim exploitation timing, pre-disclosure exploitation, or campaign dwell time unless a packet claim states it with source_refs.',
+      },
+    ],
+    not_supported: [
+      {
+        claim: 'Any fact not present in claims[]',
+        reason: 'B2 grounded drafting forbids model-memory additions and placeholder source recovery.',
+      },
+    ],
+    mitre_candidates: [],
+    drafting_notes: [
+      'Draft strictly from claims[] and source_extracts[].',
+      'Every substantive article sentence must carry a claim marker.',
+      'Do not introduce URLs outside primary_sources/supporting_sources.',
+    ],
+    preflight: {
+      status: 'not_run',
+      errors: [],
+      warnings: [],
+    },
+  };
+}
+
+async function run() {
+  const args = parseArgs();
+  const packet = await buildGroundedPacket(args);
+  writeJson(repoRoot, args.out, packet);
+  process.stdout.write(`${JSON.stringify({
+    status: 'PASS',
+    packet: repoPath(repoRoot, args.out),
+    candidate_id: packet.candidate.candidate_id,
+    lane: packet.lane,
+    sources: packet.primary_sources.length + packet.supporting_sources.length,
+    claims: packet.claims.length,
+  }, null, 2)}\n`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  run().catch((error) => {
+    console.error(`[build-grounded-source-packet] ERROR: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/check-grounded-draft.mjs
+++ b/scripts/check-grounded-draft.mjs
@@ -16,7 +16,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 const URL_RE = /https?:\/\/[^\s\])"'<>]+/g;
 const CLAIM_MARKER_RE = /<!--\s*claims?:\s*([a-zA-Z0-9\-\s]+)\s*-->/g;
 const PLACEHOLDER_RE = /(FIXME|VERIFY URL|SOURCE RECOVERY|placeholder URL|example\.com\/placeholder|TBD source)/i;
-const FRONTMATTER_RE = /^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/;
+const FRONTMATTER_RE = /^---[ \t]*\r?\n[\s\S]*?\r?\n---[ \t]*\r?\n([\s\S]*)$/;
 
 function usage() {
   console.log([
@@ -68,8 +68,8 @@ function allSources(packet) {
 }
 
 function bodyWithoutFrontmatter(text) {
-  const match = String(text).match(FRONTMATTER_RE);
-  return match ? text.slice(match[0].length) : text;
+  const match = String(text || '').match(FRONTMATTER_RE);
+  return match ? match[1] : text;
 }
 
 function claimIdsFromMarker(line) {

--- a/scripts/check-grounded-draft.mjs
+++ b/scripts/check-grounded-draft.mjs
@@ -16,6 +16,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 const URL_RE = /https?:\/\/[^\s\])"'<>]+/g;
 const CLAIM_MARKER_RE = /<!--\s*claims?:\s*([a-zA-Z0-9\-\s]+)\s*-->/g;
 const PLACEHOLDER_RE = /(FIXME|VERIFY URL|SOURCE RECOVERY|placeholder URL|example\.com\/placeholder|TBD source)/i;
+const FRONTMATTER_RE = /^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/;
 
 function usage() {
   console.log([
@@ -67,9 +68,8 @@ function allSources(packet) {
 }
 
 function bodyWithoutFrontmatter(text) {
-  if (!text.startsWith('---\n')) return text;
-  const end = text.indexOf('\n---', 4);
-  return end === -1 ? text : text.slice(end + 4);
+  const match = String(text).match(FRONTMATTER_RE);
+  return match ? text.slice(match[0].length) : text;
 }
 
 function claimIdsFromMarker(line) {

--- a/scripts/check-grounded-draft.mjs
+++ b/scripts/check-grounded-draft.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * Fidelity gate for B2 grounded drafts.
+ *
+ * Fails if a draft includes placeholder source recovery markers, URLs outside
+ * the packet, claim IDs outside the packet, or substantive body lines without
+ * packet claim markers.
+ */
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { readFileSync } from 'node:fs';
+import { readJson } from './grounded-drafting-lib.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const URL_RE = /https?:\/\/[^\s\])"'<>]+/g;
+const CLAIM_MARKER_RE = /<!--\s*claims?:\s*([a-zA-Z0-9\-\s]+)\s*-->/g;
+const PLACEHOLDER_RE = /(FIXME|VERIFY URL|SOURCE RECOVERY|placeholder URL|example\.com\/placeholder|TBD source)/i;
+
+function usage() {
+  console.log([
+    'Usage:',
+    '  node scripts/check-grounded-draft.mjs --packet <packet.json> --draft <draft.md> [--json-out <report.json>]',
+  ].join('\n'));
+}
+
+function parseArgs(argv = process.argv) {
+  const args = { packet: null, draft: null, jsonOut: null };
+  for (let i = 2; i < argv.length; i += 1) {
+    const token = argv[i];
+    const next = argv[i + 1];
+    switch (token) {
+      case '--packet':
+        if (!next) throw new Error('Missing value for --packet');
+        args.packet = next;
+        i += 1;
+        break;
+      case '--draft':
+        if (!next) throw new Error('Missing value for --draft');
+        args.draft = next;
+        i += 1;
+        break;
+      case '--json-out':
+        if (!next) throw new Error('Missing value for --json-out');
+        args.jsonOut = next;
+        i += 1;
+        break;
+      case '--help':
+      case '-h':
+        usage();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${token}`);
+    }
+  }
+  if (!args.packet) throw new Error('--packet is required');
+  if (!args.draft) throw new Error('--draft is required');
+  return args;
+}
+
+function allSources(packet) {
+  return [
+    ...(Array.isArray(packet.primary_sources) ? packet.primary_sources : []),
+    ...(Array.isArray(packet.supporting_sources) ? packet.supporting_sources : []),
+  ];
+}
+
+function bodyWithoutFrontmatter(text) {
+  if (!text.startsWith('---\n')) return text;
+  const end = text.indexOf('\n---', 4);
+  return end === -1 ? text : text.slice(end + 4);
+}
+
+function claimIdsFromMarker(line) {
+  const ids = [];
+  for (const match of line.matchAll(CLAIM_MARKER_RE)) {
+    ids.push(...match[1].split(/\s+/).map((item) => item.trim()).filter(Boolean));
+  }
+  return ids;
+}
+
+function isSubstantiveLine(line, inSources) {
+  const trimmed = line.trim();
+  if (!trimmed) return false;
+  if (trimmed.startsWith('---')) return false;
+  if (trimmed.startsWith('##')) return false;
+  if (trimmed.startsWith('<!--') && trimmed.endsWith('-->')) return false;
+  if (inSources && /^\d+\.\s+\[/.test(trimmed)) return false;
+  if (/^\|?\s*:?-{3,}:?\s*\|/.test(trimmed)) return false;
+  return /[A-Za-z0-9]/.test(trimmed);
+}
+
+export function checkGroundedDraft(packet, draftText) {
+  const errors = [];
+  const warnings = [];
+  const sourceUrls = new Set(allSources(packet).map((source) => source.url));
+  const packetClaimIds = new Set((packet.claims || []).map((claim) => claim.claim_id));
+  const draftUrls = [...draftText.matchAll(URL_RE)].map((match) => match[0].replace(/[.,;:]$/, ''));
+  for (const url of draftUrls) {
+    if (!sourceUrls.has(url)) errors.push({ path: '$.draft.urls', message: `draft URL is not in packet sources: ${url}` });
+  }
+  if (PLACEHOLDER_RE.test(draftText)) {
+    errors.push({ path: '$.draft', message: 'placeholder/FIXME source text is forbidden in grounded drafts' });
+  }
+
+  const referencedClaimIds = new Set();
+  const body = bodyWithoutFrontmatter(draftText);
+  let inSources = false;
+  for (const [index, line] of body.split(/\r?\n/).entries()) {
+    if (/^##\s+Sources\s*&\s*References\b/i.test(line.trim())) inSources = true;
+    const lineClaimIds = claimIdsFromMarker(line);
+    for (const claimId of lineClaimIds) {
+      referencedClaimIds.add(claimId);
+      if (!packetClaimIds.has(claimId)) errors.push({ path: `$.draft.lines[${index + 1}]`, message: `unknown packet claim marker ${claimId}` });
+    }
+    if (isSubstantiveLine(line, inSources) && lineClaimIds.length === 0) {
+      errors.push({ path: `$.draft.lines[${index + 1}]`, message: 'substantive draft line is missing packet claim marker' });
+    }
+  }
+
+  for (const claim of packet.claims || []) {
+    if (!referencedClaimIds.has(claim.claim_id)) {
+      warnings.push({ path: `$.claims.${claim.claim_id}`, message: 'packet claim is not referenced in draft body' });
+    }
+  }
+
+  return {
+    pass: errors.length === 0,
+    status: errors.length === 0 ? 'pass' : 'fail',
+    errors,
+    warnings,
+    summary: {
+      packet_claims: packetClaimIds.size,
+      referenced_claims: referencedClaimIds.size,
+      packet_urls: sourceUrls.size,
+      draft_urls: draftUrls.length,
+    },
+  };
+}
+
+function format(result) {
+  const lines = [
+    '## Grounded Draft Fidelity',
+    '',
+    result.pass ? ':white_check_mark: Grounded draft fidelity passed.' : `:x: Grounded draft fidelity failed with ${result.errors.length} error(s).`,
+    '',
+    `Packet claims: ${result.summary.packet_claims}`,
+    `Referenced claims: ${result.summary.referenced_claims}`,
+    `Packet URLs: ${result.summary.packet_urls}`,
+    `Draft URLs: ${result.summary.draft_urls}`,
+    '',
+  ];
+  if (result.errors.length) {
+    lines.push('### Errors');
+    for (const error of result.errors) lines.push(`- ${error.path}: ${error.message}`);
+    lines.push('');
+  }
+  if (result.warnings.length) {
+    lines.push('### Warnings');
+    for (const warning of result.warnings) lines.push(`- ${warning.path}: ${warning.message}`);
+    lines.push('');
+  }
+  return `${lines.join('\n').trim()}\n`;
+}
+
+async function run() {
+  const args = parseArgs();
+  const packet = readJson(repoRoot, args.packet);
+  const draftText = readFileSync(path.resolve(repoRoot, args.draft), 'utf8');
+  const result = checkGroundedDraft(packet, draftText);
+  if (args.jsonOut) {
+    const { writeText } = await import('./grounded-drafting-lib.mjs');
+    writeText(repoRoot, args.jsonOut, `${JSON.stringify(result, null, 2)}\n`);
+  }
+  process.stdout.write(format(result));
+  if (!result.pass) process.exit(1);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  run().catch((error) => {
+    console.error(`[check-grounded-draft] ERROR: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/check-grounded-draft.mjs
+++ b/scripts/check-grounded-draft.mjs
@@ -91,6 +91,14 @@ function isSubstantiveLine(line, inSources) {
   return /[A-Za-z0-9]/.test(trimmed);
 }
 
+function sentenceCount(text) {
+  return String(text || '')
+    .trim()
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.trim())
+    .filter(Boolean).length;
+}
+
 export function checkGroundedDraft(packet, draftText) {
   const errors = [];
   const warnings = [];
@@ -114,8 +122,15 @@ export function checkGroundedDraft(packet, draftText) {
       referencedClaimIds.add(claimId);
       if (!packetClaimIds.has(claimId)) errors.push({ path: `$.draft.lines[${index + 1}]`, message: `unknown packet claim marker ${claimId}` });
     }
-    if (isSubstantiveLine(line, inSources) && lineClaimIds.length === 0) {
-      errors.push({ path: `$.draft.lines[${index + 1}]`, message: 'substantive draft line is missing packet claim marker' });
+    if (isSubstantiveLine(line, inSources)) {
+      if (lineClaimIds.length === 0) {
+        errors.push({ path: `$.draft.lines[${index + 1}]`, message: 'substantive draft line is missing packet claim marker' });
+      } else {
+        const unmarkedText = line.replace(CLAIM_MARKER_RE, '').trim();
+        if (sentenceCount(unmarkedText) > lineClaimIds.length) {
+          errors.push({ path: `$.draft.lines[${index + 1}]`, message: 'substantive draft sentence is missing packet claim marker' });
+        }
+      }
     }
   }
 

--- a/scripts/draft-grounded-article.mjs
+++ b/scripts/draft-grounded-article.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+/**
+ * Deterministic grounded drafter.
+ *
+ * This is intentionally not a model call. It turns a passing B2 source packet
+ * into a conservative draft where every substantive sentence is tied to packet
+ * claim IDs and every URL comes from packet sources.
+ */
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  markdownEscape,
+  numericId,
+  readJson,
+  safeTitle,
+  slugPart,
+  writeText,
+  yamlString,
+} from './grounded-drafting-lib.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function usage() {
+  console.log([
+    'Usage:',
+    '  node scripts/draft-grounded-article.mjs --packet <packet.json> --out <draft.md> [--created-at <YYYY-MM-DD>]',
+    '',
+    'The draft is generated only from packet claims and packet source URLs.',
+  ].join('\n'));
+}
+
+function parseArgs(argv = process.argv) {
+  const args = { packet: null, out: null, createdAt: null };
+  for (let i = 2; i < argv.length; i += 1) {
+    const token = argv[i];
+    const next = argv[i + 1];
+    switch (token) {
+      case '--packet':
+        if (!next) throw new Error('Missing value for --packet');
+        args.packet = next;
+        i += 1;
+        break;
+      case '--out':
+        if (!next) throw new Error('Missing value for --out');
+        args.out = next;
+        i += 1;
+        break;
+      case '--created-at':
+        if (!next) throw new Error('Missing value for --created-at');
+        args.createdAt = next;
+        i += 1;
+        break;
+      case '--help':
+      case '-h':
+        usage();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${token}`);
+    }
+  }
+  if (!args.packet) throw new Error('--packet is required');
+  if (!args.out) throw new Error('--out is required');
+  return args;
+}
+
+function allSources(packet) {
+  return [
+    ...(Array.isArray(packet.primary_sources) ? packet.primary_sources : []),
+    ...(Array.isArray(packet.supporting_sources) ? packet.supporting_sources : []),
+  ];
+}
+
+function sourceFrontmatter(source) {
+  const publisherType = source.source_type === 'database' ? 'research' : source.source_type === 'other' ? 'community' : source.source_type;
+  return [
+    '  - url: ' + yamlString(source.url),
+    '    publisher: ' + yamlString(source.publisher),
+    '    publisherType: ' + publisherType,
+    '    reliability: ' + (source.role === 'primary' ? 'R1' : 'R2'),
+    '    publicationDate: ' + yamlString(source.published_at || new Date().toISOString().slice(0, 10)),
+    '    archived: false',
+  ].join('\n');
+}
+
+function frontmatter(packet, createdAt) {
+  const title = safeTitle(packet.claims?.[0]?.claim || packet.candidate?.canonical_subject_id || 'Grounded Threatpedia Draft');
+  const tags = ['grounded-draft', packet.lane, 'supply-chain'].filter(Boolean);
+  const sources = allSources(packet).map(sourceFrontmatter).join('\n');
+  const date = packet.key_dates?.disclosed_at || packet.key_dates?.published_at || createdAt;
+  const base = [
+    '---',
+  ];
+
+  if (packet.lane === 'campaign') {
+    base.push(
+      `campaignId: ${yamlString(`TP-CAMP-${createdAt.slice(0, 4)}-${numericId(packet.source_packet_id, Number(createdAt.slice(0, 4))).slice(-4)}`)}`,
+      `title: ${yamlString(title)}`,
+      `startDate: ${yamlString(date)}`,
+      'ongoing: false',
+      'attackType: "Supply Chain"',
+      'severity: medium',
+      'sector: "Technology"',
+      'geography: "Global"',
+      'reviewStatus: "draft_ai"',
+      'confidenceGrade: C',
+      'generatedBy: "ai_ingestion"',
+      `generatedDate: ${createdAt}`,
+      'tags:',
+      ...tags.map((tag) => `  - ${yamlString(tag)}`),
+      'sources:',
+      sources,
+      'mitreMappings: []',
+    );
+  } else if (packet.lane === 'threat-actor') {
+    base.push(
+      `name: ${yamlString(title)}`,
+      'aliases: []',
+      'affiliation: "Unknown"',
+      'motivation: "Unknown"',
+      'status: unknown',
+      'country: "Unknown"',
+      'attributionConfidence: A6',
+      'reviewStatus: "draft_ai"',
+      'generatedBy: "ai_ingestion"',
+      `generatedDate: ${createdAt}`,
+      'tags:',
+      ...tags.map((tag) => `  - ${yamlString(tag)}`),
+      'sources:',
+      sources,
+      'mitreMappings: []',
+    );
+  } else if (packet.lane === 'zero-day') {
+    base.push(
+      `cveId: ${yamlString(packet.cves?.[0]?.id || packet.candidate?.canonical_subject_id || 'CVE-0000-0000')}`,
+      `title: ${yamlString(title)}`,
+      `discoveredDate: ${yamlString(date)}`,
+      'publishedDate: null',
+      'vendor: "Unknown"',
+      'product: "Unknown"',
+      'severity: medium',
+      'reviewStatus: "draft_ai"',
+      'confidenceGrade: C',
+      'generatedBy: "ai_ingestion"',
+      `generatedDate: ${createdAt}`,
+      'tags:',
+      ...tags.map((tag) => `  - ${yamlString(tag)}`),
+      'sources:',
+      sources,
+      'mitreMappings: []',
+    );
+  } else {
+    base.push(
+      `eventId: ${yamlString(numericId(packet.source_packet_id, Number(createdAt.slice(0, 4))))}`,
+      `title: ${yamlString(title)}`,
+      `date: ${createdAt}`,
+      'attackType: "Supply Chain"',
+      'severity: medium',
+      'sector: "Technology"',
+      'geography: "Global"',
+      'threatActor: "Unknown"',
+      'attributionConfidence: A6',
+      'reviewStatus: "draft_ai"',
+      'confidenceGrade: C',
+      'generatedBy: "ai_ingestion"',
+      `generatedDate: ${createdAt}`,
+      'tags:',
+      ...tags.map((tag) => `  - ${yamlString(tag)}`),
+      'sources:',
+      sources,
+      'mitreMappings: []',
+    );
+  }
+
+  base.push('---', '');
+  return base.join('\n');
+}
+
+function claimLine(claim) {
+  return `<!-- claims: ${claim.claim_id} --> ${claim.claim}`;
+}
+
+function groupedClaims(packet) {
+  const groups = new Map();
+  for (const claim of packet.claims || []) {
+    const section = claim.article_section || 'summary';
+    if (!groups.has(section)) groups.set(section, []);
+    groups.get(section).push(claim);
+  }
+  return groups;
+}
+
+function body(packet) {
+  const groups = groupedClaims(packet);
+  const summaryClaims = groups.get('summary') || packet.claims?.slice(0, 2) || [];
+  const technicalClaims = groups.get('technical-analysis') || [];
+  const timelineClaims = groups.get('timeline') || [];
+  const summaryClaimIds = new Set(summaryClaims.map((claim) => claim.claim_id));
+  const technicalClaimIds = new Set(technicalClaims.map((claim) => claim.claim_id));
+  const timelineClaimIds = new Set(timelineClaims.map((claim) => claim.claim_id));
+  const supportingClaims = (packet.claims || []).filter((claim) =>
+    !summaryClaimIds.has(claim.claim_id)
+    && !technicalClaimIds.has(claim.claim_id)
+    && !timelineClaimIds.has(claim.claim_id)
+  );
+  const findingClaims = [...technicalClaims, ...supportingClaims];
+  const sourceRows = allSources(packet)
+    .map((source, index) => `${index + 1}. [${markdownEscape(source.publisher)}](${source.url}) — ${markdownEscape(source.publisher)}, ${source.published_at || 'accessed during packet assembly'}`)
+    .join('\n');
+
+  const lines = [
+    '## Executive Summary',
+    '',
+    ...(summaryClaims.length ? summaryClaims.map(claimLine) : ['<!-- claims: claim-1 --> This draft has no additional executive-summary facts beyond the packet subject.']),
+    '',
+    '## Source-Grounded Findings',
+    '',
+    ...(findingClaims.length ? findingClaims.map(claimLine) : (packet.claims || []).map(claimLine)),
+    '',
+    '## Timeline',
+    '',
+    ...(timelineClaims.length ? timelineClaims.map(claimLine) : ['<!-- claims: claim-1 --> The source packet does not establish a complete public timeline.']),
+    '',
+    '## Open Questions',
+    '',
+    ...((packet.uncertainties || []).map((item) => `<!-- claims: ${packet.claims?.[0]?.claim_id || 'claim-1'} --> ${item.drafting_instruction}`)),
+    '',
+    '## Sources & References',
+    '',
+    sourceRows,
+    '',
+  ];
+  return lines.join('\n');
+}
+
+export function draftFromPacket(packet, { createdAt = new Date().toISOString().slice(0, 10) } = {}) {
+  if (packet?.grounding_contract?.drafting_mode !== 'packet_claims_only') {
+    throw new Error('Packet is missing packet_claims_only grounding contract');
+  }
+  if (!Array.isArray(packet.claims) || packet.claims.length === 0) {
+    throw new Error('Packet has no claims to draft from');
+  }
+  return frontmatter(packet, createdAt) + body(packet);
+}
+
+async function run() {
+  const args = parseArgs();
+  const packet = readJson(repoRoot, args.packet);
+  const draft = draftFromPacket(packet, { createdAt: args.createdAt || new Date().toISOString().slice(0, 10) });
+  writeText(repoRoot, args.out, draft);
+  process.stdout.write(`${JSON.stringify({
+    status: 'PASS',
+    output: path.resolve(repoRoot, args.out),
+    lane: packet.lane,
+    claims: packet.claims.length,
+    slug: slugPart(packet.claims[0]?.claim || packet.source_packet_id),
+  }, null, 2)}\n`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  run().catch((error) => {
+    console.error(`[draft-grounded-article] ERROR: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/draft-grounded-article.mjs
+++ b/scripts/draft-grounded-article.mjs
@@ -84,6 +84,11 @@ function sourceFrontmatter(source) {
   ].join('\n');
 }
 
+function firstAffectedProduct(packet) {
+  const product = Array.isArray(packet.affected_products) ? packet.affected_products[0] : null;
+  return product?.product || product?.vendor || 'Unknown';
+}
+
 function frontmatter(packet, createdAt) {
   const title = safeTitle(packet.claims?.[0]?.claim || packet.candidate?.canonical_subject_id || 'Grounded Threatpedia Draft');
   const tags = ['grounded-draft', packet.lane, 'supply-chain'].filter(Boolean);
@@ -98,7 +103,7 @@ function frontmatter(packet, createdAt) {
       `campaignId: ${yamlString(`TP-CAMP-${createdAt.slice(0, 4)}-${numericId(packet.source_packet_id, Number(createdAt.slice(0, 4))).slice(-4)}`)}`,
       `title: ${yamlString(title)}`,
       `startDate: ${yamlString(date)}`,
-      'ongoing: false',
+      'ongoing: true',
       'attackType: "Supply Chain"',
       'severity: medium',
       'sector: "Technology"',
@@ -133,15 +138,16 @@ function frontmatter(packet, createdAt) {
     );
   } else if (packet.lane === 'zero-day') {
     base.push(
-      `cveId: ${yamlString(packet.cves?.[0]?.id || packet.candidate?.canonical_subject_id || 'CVE-0000-0000')}`,
       `title: ${yamlString(title)}`,
-      `discoveredDate: ${yamlString(date)}`,
-      'publishedDate: null',
-      'vendor: "Unknown"',
-      'product: "Unknown"',
+      `cve: ${yamlString(packet.cves?.[0]?.id || packet.candidate?.canonical_subject_id || 'CVE-0000-0000')}`,
+      'type: "Vulnerability"',
+      `platform: ${yamlString(firstAffectedProduct(packet))}`,
       'severity: medium',
+      'status: unknown',
+      'isZeroDay: true',
+      `disclosedDate: ${yamlString(date)}`,
+      `cisaKev: ${packet.kev_status?.in_kev ? 'true' : 'false'}`,
       'reviewStatus: "draft_ai"',
-      'confidenceGrade: C',
       'generatedBy: "ai_ingestion"',
       `generatedDate: ${createdAt}`,
       'tags:',

--- a/scripts/draft-grounded-article.mjs
+++ b/scripts/draft-grounded-article.mjs
@@ -73,7 +73,13 @@ function allSources(packet) {
 }
 
 function sourceFrontmatter(source) {
-  const publisherType = source.source_type === 'database' ? 'research' : source.source_type === 'other' ? 'community' : source.source_type;
+  const publisherType = source.source_type === 'database'
+    ? 'research'
+    : source.source_type === 'news'
+      ? 'media'
+      : source.source_type === 'other'
+        ? 'community'
+        : source.source_type;
   return [
     '  - url: ' + yamlString(source.url),
     '    publisher: ' + yamlString(source.publisher),
@@ -89,6 +95,20 @@ function firstAffectedProduct(packet) {
   return product?.product || product?.vendor || 'Unknown';
 }
 
+function mitreFrontmatter(packet) {
+  const included = (Array.isArray(packet.mitre_candidates) ? packet.mitre_candidates : [])
+    .filter((candidate) => candidate.include_in_article && candidate.technique_id);
+  if (included.length === 0) return [];
+  return [
+    'mitreMappings:',
+    ...included.flatMap((candidate) => [
+      `  - techniqueId: ${yamlString(candidate.technique_id)}`,
+      `    techniqueName: ${yamlString(candidate.technique_name)}`,
+      ...(candidate.tactic ? [`    tactic: ${yamlString(candidate.tactic)}`] : []),
+    ]),
+  ];
+}
+
 function frontmatter(packet, createdAt) {
   const title = safeTitle(packet.claims?.[0]?.claim || packet.candidate?.canonical_subject_id || 'Grounded Threatpedia Draft');
   const tags = ['grounded-draft', packet.lane, 'supply-chain'].filter(Boolean);
@@ -99,6 +119,10 @@ function frontmatter(packet, createdAt) {
   ];
 
   if (packet.lane === 'campaign') {
+    const mitreMappings = mitreFrontmatter(packet);
+    if (mitreMappings.length === 0) {
+      throw new Error('campaign packets require at least one included MITRE mapping to generate schema-valid frontmatter');
+    }
     base.push(
       `campaignId: ${yamlString(`TP-CAMP-${createdAt.slice(0, 4)}-${numericId(packet.source_packet_id, Number(createdAt.slice(0, 4))).slice(-4)}`)}`,
       `title: ${yamlString(title)}`,
@@ -116,7 +140,7 @@ function frontmatter(packet, createdAt) {
       ...tags.map((tag) => `  - ${yamlString(tag)}`),
       'sources:',
       sources,
-      'mitreMappings: []',
+      ...mitreMappings,
     );
   } else if (packet.lane === 'threat-actor') {
     base.push(
@@ -160,7 +184,7 @@ function frontmatter(packet, createdAt) {
     base.push(
       `eventId: ${yamlString(numericId(packet.source_packet_id, Number(createdAt.slice(0, 4))))}`,
       `title: ${yamlString(title)}`,
-      `date: ${createdAt}`,
+      `date: ${yamlString(date)}`,
       'attackType: "Supply Chain"',
       'severity: medium',
       'sector: "Technology"',

--- a/scripts/draft-grounded-article.mjs
+++ b/scripts/draft-grounded-article.mjs
@@ -18,6 +18,7 @@ import {
   writeText,
   yamlString,
 } from './grounded-drafting-lib.mjs';
+import { SCHEMA_REQUIRED_H2_BY_TYPE } from './pipeline-schema.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -72,14 +73,18 @@ function allSources(packet) {
   ];
 }
 
+function publisherTypeForSource(source) {
+  const publisher = String(source.publisher || '').toLowerCase();
+  const url = String(source.url || '').toLowerCase();
+  if (publisher.includes('cybersecurity and infrastructure security agency') || url.includes('cisa.gov')) return 'government';
+  if (source.source_type === 'database') return 'research';
+  if (source.source_type === 'news') return 'media';
+  if (source.source_type === 'other') return 'community';
+  return source.source_type;
+}
+
 function sourceFrontmatter(source) {
-  const publisherType = source.source_type === 'database'
-    ? 'research'
-    : source.source_type === 'news'
-      ? 'media'
-      : source.source_type === 'other'
-        ? 'community'
-        : source.source_type;
+  const publisherType = publisherTypeForSource(source);
   return [
     '  - url: ' + yamlString(source.url),
     '    publisher: ' + yamlString(source.publisher),
@@ -88,6 +93,17 @@ function sourceFrontmatter(source) {
     '    publicationDate: ' + yamlString(source.published_at || new Date().toISOString().slice(0, 10)),
     '    archived: false',
   ].join('\n');
+}
+
+function assertCampaignSourceReadiness(packet) {
+  const sources = allSources(packet);
+  const governmentSources = sources.filter((source) => publisherTypeForSource(source) === 'government');
+  if (sources.length < 3) {
+    throw new Error('Campaign grounded drafts require at least three packet sources for the live campaign schema');
+  }
+  if (governmentSources.length === 0) {
+    throw new Error('Campaign grounded drafts require at least one government source for the live campaign schema');
+  }
 }
 
 function firstAffectedProduct(packet) {
@@ -140,6 +156,7 @@ function frontmatter(packet, createdAt) {
   ];
 
   if (packet.lane === 'campaign') {
+    assertCampaignSourceReadiness(packet);
     base.push(
       `campaignId: ${yamlString(`TP-CAMP-${createdAt.slice(0, 4)}-${numericId(packet.source_packet_id, Number(createdAt.slice(0, 4))).slice(-4)}`)}`,
       `title: ${yamlString(title)}`,
@@ -224,8 +241,16 @@ function frontmatter(packet, createdAt) {
   return base.join('\n');
 }
 
+function splitSentences(text) {
+  const cleaned = String(text || '').trim();
+  if (!cleaned) return [];
+  return cleaned.split(/(?<=[.!?])\s+/).map((sentence) => sentence.trim()).filter(Boolean);
+}
+
 function claimLine(claim) {
-  return `<!-- claims: ${claim.claim_id} --> ${claim.claim}`;
+  const sentences = splitSentences(claim.claim);
+  if (sentences.length === 0) return `<!-- claims: ${claim.claim_id} -->`;
+  return sentences.map((sentence) => `<!-- claims: ${claim.claim_id} --> ${sentence}`).join('\n');
 }
 
 function groupedClaims(packet) {
@@ -238,46 +263,73 @@ function groupedClaims(packet) {
   return groups;
 }
 
+function claimLines(claims) {
+  return claims.flatMap((claim) => claimLine(claim).split('\n'));
+}
+
+function fallbackLine(packet, text) {
+  return `<!-- claims: ${packet.claims?.[0]?.claim_id || 'claim-1'} --> ${text}`;
+}
+
+function sectionContent(packet, heading, claimSets) {
+  if (heading === 'Sources & References') {
+    const sourceRows = allSources(packet)
+      .map((source, index) => `${index + 1}. [${markdownEscape(source.publisher)}](${source.url}) — ${markdownEscape(source.publisher)}, ${source.published_at || 'accessed during packet assembly'}`);
+    return sourceRows.length ? sourceRows : [fallbackLine(packet, 'The source packet did not include source rows for this draft.')];
+  }
+  if (/timeline/i.test(heading)) {
+    return claimSets.timeline.length ? claimLines(claimSets.timeline) : [fallbackLine(packet, 'The source packet does not establish a complete public timeline.')];
+  }
+  if (/summary|severity/i.test(heading)) {
+    return claimSets.summary.length ? claimLines(claimSets.summary) : [fallbackLine(packet, 'The source packet establishes only the approved candidate subject.')];
+  }
+  if (/technical|attack chain|exploit chain|mitre|capabilities/i.test(heading)) {
+    return claimSets.findings.length ? claimLines(claimSets.findings) : claimLines(packet.claims || []);
+  }
+  if (/attribution|campaign/i.test(heading)) {
+    return claimSets.attribution.length ? claimLines(claimSets.attribution) : [fallbackLine(packet, 'The packet does not establish additional attribution beyond the candidate classification.')];
+  }
+  if (/remediation|impact|detection|indicators|open questions/i.test(heading)) {
+    const uncertaintyLines = (packet.uncertainties || []).map((item) => fallbackLine(packet, item.drafting_instruction));
+    return uncertaintyLines.length ? uncertaintyLines : [fallbackLine(packet, 'The packet does not establish additional guidance for this section.')];
+  }
+  return claimLines(packet.claims || []);
+}
+
 function body(packet) {
   const groups = groupedClaims(packet);
   const summaryClaims = groups.get('summary') || packet.claims?.slice(0, 2) || [];
   const technicalClaims = groups.get('technical-analysis') || [];
   const timelineClaims = groups.get('timeline') || [];
+  const attributionClaims = groups.get('attribution') || (packet.claims || []).filter((claim) => claim.claim_type === 'attribution');
   const summaryClaimIds = new Set(summaryClaims.map((claim) => claim.claim_id));
   const technicalClaimIds = new Set(technicalClaims.map((claim) => claim.claim_id));
   const timelineClaimIds = new Set(timelineClaims.map((claim) => claim.claim_id));
+  const attributionClaimIds = new Set(attributionClaims.map((claim) => claim.claim_id));
   const supportingClaims = (packet.claims || []).filter((claim) =>
     !summaryClaimIds.has(claim.claim_id)
     && !technicalClaimIds.has(claim.claim_id)
     && !timelineClaimIds.has(claim.claim_id)
+    && !attributionClaimIds.has(claim.claim_id)
   );
   const findingClaims = [...technicalClaims, ...supportingClaims];
-  const sourceRows = allSources(packet)
-    .map((source, index) => `${index + 1}. [${markdownEscape(source.publisher)}](${source.url}) — ${markdownEscape(source.publisher)}, ${source.published_at || 'accessed during packet assembly'}`)
-    .join('\n');
-
-  const lines = [
-    '## Executive Summary',
-    '',
-    ...(summaryClaims.length ? summaryClaims.map(claimLine) : ['<!-- claims: claim-1 --> This draft has no additional executive-summary facts beyond the packet subject.']),
-    '',
-    '## Source-Grounded Findings',
-    '',
-    ...(findingClaims.length ? findingClaims.map(claimLine) : (packet.claims || []).map(claimLine)),
-    '',
-    '## Timeline',
-    '',
-    ...(timelineClaims.length ? timelineClaims.map(claimLine) : ['<!-- claims: claim-1 --> The source packet does not establish a complete public timeline.']),
-    '',
-    '## Open Questions',
-    '',
-    ...((packet.uncertainties || []).map((item) => `<!-- claims: ${packet.claims?.[0]?.claim_id || 'claim-1'} --> ${item.drafting_instruction}`)),
-    '',
-    '## Sources & References',
-    '',
-    sourceRows,
-    '',
+  const headings = SCHEMA_REQUIRED_H2_BY_TYPE[packet.lane] || [
+    'Executive Summary',
+    'Source-Grounded Findings',
+    'Timeline',
+    'Open Questions',
+    'Sources & References',
   ];
+  const claimSets = {
+    summary: summaryClaims,
+    findings: findingClaims,
+    timeline: timelineClaims,
+    attribution: attributionClaims,
+  };
+  const lines = [];
+  for (const heading of headings) {
+    lines.push(`## ${heading}`, '', ...sectionContent(packet, heading, claimSets), '');
+  }
   return lines.join('\n');
 }
 

--- a/scripts/draft-grounded-article.mjs
+++ b/scripts/draft-grounded-article.mjs
@@ -95,16 +95,37 @@ function firstAffectedProduct(packet) {
   return product?.product || product?.vendor || 'Unknown';
 }
 
-function mitreFrontmatter(packet) {
-  const included = (Array.isArray(packet.mitre_candidates) ? packet.mitre_candidates : [])
-    .filter((candidate) => candidate.include_in_article && candidate.technique_id);
-  if (included.length === 0) return [];
+function mappingConfidence(value) {
+  if (value === 'high') return 'confirmed';
+  if (value === 'medium') return 'probable';
+  return 'possible';
+}
+
+function includedMitreMappings(packet) {
+  return (Array.isArray(packet.mitre_candidates) ? packet.mitre_candidates : [])
+    .filter((mapping) => mapping?.include_in_article === true && mapping.technique_id)
+    .map((mapping) => ({
+      techniqueId: mapping.technique_id,
+      techniqueName: mapping.technique_name,
+      tactic: mapping.tactic,
+      confidence: mappingConfidence(mapping.confidence),
+    }));
+}
+
+function mitreFrontmatter(packet, { required = false } = {}) {
+  const mappings = includedMitreMappings(packet);
+  if (required && mappings.length === 0) {
+    throw new Error('Campaign grounded drafts require at least one packet-backed MITRE mapping marked include_in_article=true');
+  }
+  if (mappings.length === 0) return ['mitreMappings: []'];
   return [
     'mitreMappings:',
-    ...included.flatMap((candidate) => [
-      `  - techniqueId: ${yamlString(candidate.technique_id)}`,
-      `    techniqueName: ${yamlString(candidate.technique_name)}`,
-      ...(candidate.tactic ? [`    tactic: ${yamlString(candidate.tactic)}`] : []),
+    ...mappings.flatMap((mapping) => [
+      `  - techniqueId: ${yamlString(mapping.techniqueId)}`,
+      `    techniqueName: ${yamlString(mapping.techniqueName)}`,
+      `    tactic: ${yamlString(mapping.tactic)}`,
+      `    confidence: ${mapping.confidence}`,
+      '    evidence: "Included from grounded source packet MITRE candidates."',
     ]),
   ];
 }
@@ -119,10 +140,6 @@ function frontmatter(packet, createdAt) {
   ];
 
   if (packet.lane === 'campaign') {
-    const mitreMappings = mitreFrontmatter(packet);
-    if (mitreMappings.length === 0) {
-      throw new Error('campaign packets require at least one included MITRE mapping to generate schema-valid frontmatter');
-    }
     base.push(
       `campaignId: ${yamlString(`TP-CAMP-${createdAt.slice(0, 4)}-${numericId(packet.source_packet_id, Number(createdAt.slice(0, 4))).slice(-4)}`)}`,
       `title: ${yamlString(title)}`,
@@ -140,7 +157,7 @@ function frontmatter(packet, createdAt) {
       ...tags.map((tag) => `  - ${yamlString(tag)}`),
       'sources:',
       sources,
-      ...mitreMappings,
+      ...mitreFrontmatter(packet, { required: true }),
     );
   } else if (packet.lane === 'threat-actor') {
     base.push(
@@ -158,7 +175,7 @@ function frontmatter(packet, createdAt) {
       ...tags.map((tag) => `  - ${yamlString(tag)}`),
       'sources:',
       sources,
-      'mitreMappings: []',
+      ...mitreFrontmatter(packet),
     );
   } else if (packet.lane === 'zero-day') {
     base.push(
@@ -178,13 +195,13 @@ function frontmatter(packet, createdAt) {
       ...tags.map((tag) => `  - ${yamlString(tag)}`),
       'sources:',
       sources,
-      'mitreMappings: []',
+      ...mitreFrontmatter(packet),
     );
   } else {
     base.push(
       `eventId: ${yamlString(numericId(packet.source_packet_id, Number(createdAt.slice(0, 4))))}`,
       `title: ${yamlString(title)}`,
-      `date: ${yamlString(date)}`,
+      `date: ${date}`,
       'attackType: "Supply Chain"',
       'severity: medium',
       'sector: "Technology"',
@@ -199,7 +216,7 @@ function frontmatter(packet, createdAt) {
       ...tags.map((tag) => `  - ${yamlString(tag)}`),
       'sources:',
       sources,
-      'mitreMappings: []',
+      ...mitreFrontmatter(packet),
     );
   }
 

--- a/scripts/grounded-drafting-lib.mjs
+++ b/scripts/grounded-drafting-lib.mjs
@@ -1,0 +1,247 @@
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+export const LANES = new Set(['incident', 'zero-day', 'campaign', 'threat-actor', 'malware-family']);
+export const SOURCE_TYPES = new Set(['government', 'vendor', 'database', 'research', 'news', 'other']);
+export const PRIMARY_SOURCE_TYPES = new Set(['government', 'vendor', 'database', 'research']);
+export const CLAIM_TYPES = new Set(['date', 'product', 'vulnerability', 'exploitation', 'impact', 'mitigation', 'attribution', 'other']);
+export const SECTION_MAP = {
+  incident: 'incidents',
+  'zero-day': 'zero-days',
+  campaign: 'campaigns',
+  'threat-actor': 'threat-actors',
+  'malware-family': 'supply-chain-malware-families',
+};
+
+const HTML_TAG_RE = /<[^>]+>/g;
+const WHITESPACE_RE = /\s+/g;
+const CVE_RE = /\bCVE-\d{4}-\d{4,}\b/gi;
+const GHSA_RE = /\bGHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}\b/gi;
+const OSV_RE = /\b(?:MAL|PYSEC|GO)-\d{4}-[A-Z0-9-]+\b/gi;
+const FETCH_TIMEOUT_MS = 15000;
+
+export function repoPath(root, relativeOrAbsolutePath) {
+  return path.isAbsolute(relativeOrAbsolutePath)
+    ? relativeOrAbsolutePath
+    : path.resolve(root, relativeOrAbsolutePath);
+}
+
+export function readJson(root, relativeOrAbsolutePath) {
+  return JSON.parse(readFileSync(repoPath(root, relativeOrAbsolutePath), 'utf8'));
+}
+
+export function writeJson(root, relativeOrAbsolutePath, value) {
+  const abs = repoPath(root, relativeOrAbsolutePath);
+  mkdirSync(path.dirname(abs), { recursive: true });
+  writeFileSync(abs, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function writeText(root, relativeOrAbsolutePath, value) {
+  const abs = repoPath(root, relativeOrAbsolutePath);
+  mkdirSync(path.dirname(abs), { recursive: true });
+  writeFileSync(abs, value);
+}
+
+export function normalizeWhitespace(value) {
+  return String(value || '').replace(WHITESPACE_RE, ' ').trim();
+}
+
+export function slugPart(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9@._/-]+/g, '-')
+    .replace(/[\/@._]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 90);
+}
+
+export function sha(value, len = 12) {
+  return createHash('sha256').update(String(value)).digest('hex').slice(0, len);
+}
+
+export function uniqueStrings(values) {
+  const seen = new Set();
+  return (Array.isArray(values) ? values.flat(Infinity) : [values])
+    .filter((value) => value !== null && value !== undefined)
+    .map((value) => String(value).trim())
+    .filter(Boolean)
+    .filter((value) => {
+      const key = value.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+}
+
+export function isoDate(value) {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : new Date(parsed).toISOString().slice(0, 10);
+}
+
+export function classifySource(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { publisher: 'Unknown', source_type: 'other' };
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (host === 'cisa.gov' || host.endsWith('.cisa.gov')) return { publisher: 'CISA', source_type: 'government' };
+  if (host === 'nist.gov' || host.endsWith('.nist.gov')) return { publisher: 'NIST', source_type: 'database' };
+  if (host === 'osv.dev' || host.endsWith('.osv.dev')) return { publisher: 'OSV.dev', source_type: 'database' };
+  if (host === 'github.com' && parsed.pathname.startsWith('/advisories')) return { publisher: 'GitHub Advisory Database', source_type: 'database' };
+  if (host === 'github.com' || host.endsWith('.github.com')) return { publisher: 'GitHub', source_type: 'research' };
+  if (host === 'npmjs.com' || host.endsWith('.npmjs.com') || host === 'registry.npmjs.org') return { publisher: 'npm Registry', source_type: 'database' };
+  if (host === 'pypi.org' || host.endsWith('.pypi.org')) return { publisher: 'PyPI', source_type: 'database' };
+  if (host === 'microsoft.com' || host.endsWith('.microsoft.com')) return { publisher: 'Microsoft', source_type: 'vendor' };
+  if (host === 'google.com' || host.endsWith('.google.com')) return { publisher: 'Google', source_type: 'vendor' };
+  if (host === 'socket.dev' || host.endsWith('.socket.dev')) return { publisher: 'Socket', source_type: 'research' };
+  if (host === 'snyk.io' || host.endsWith('.snyk.io')) return { publisher: 'Snyk', source_type: 'research' };
+  if (host === 'wiz.io' || host.endsWith('.wiz.io')) return { publisher: 'Wiz', source_type: 'research' };
+  if (host === 'trendmicro.com' || host.endsWith('.trendmicro.com')) return { publisher: 'Trend Micro', source_type: 'vendor' };
+  if (host === 'thehackernews.com' || host.endsWith('.thehackernews.com')) return { publisher: 'The Hacker News', source_type: 'news' };
+  return { publisher: parsed.hostname, source_type: 'other' };
+}
+
+export function sourceFixtureName(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return `${sha(url)}.txt`;
+  }
+  const stem = slugPart(`${parsed.hostname}${parsed.pathname}`) || sha(url);
+  return `${stem}.txt`;
+}
+
+function stripHtml(text) {
+  return String(text || '')
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(HTML_TAG_RE, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>');
+}
+
+function extractTitle(rawText) {
+  const titleMatch = String(rawText || '').match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  return titleMatch ? normalizeWhitespace(stripHtml(titleMatch[1])) : null;
+}
+
+export async function fetchSourceText(url, { fixturesDir = null, root = process.cwd() } = {}) {
+  if (fixturesDir) {
+    const fixturePath = repoPath(root, path.join(fixturesDir, sourceFixtureName(url)));
+    if (!existsSync(fixturePath)) throw new Error(`missing source fixture ${fixturePath}`);
+    return readFileSync(fixturePath, 'utf8');
+  }
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'text/html, text/plain, application/json, */*',
+      'User-Agent': 'threatpedia-grounded-drafting/1.0 (+https://threatpedia.wiki)',
+    },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!response.ok) throw new Error(`${url} returned ${response.status} ${response.statusText}`);
+  return response.text();
+}
+
+export async function extractSource(url, sourceId, options = {}) {
+  const classification = classifySource(url);
+  try {
+    const raw = await fetchSourceText(url, options);
+    const extractedText = normalizeWhitespace(stripHtml(raw)).slice(0, 5000);
+    return {
+      source: {
+        id: sourceId,
+        publisher: classification.publisher,
+        url,
+        published_at: null,
+        source_type: classification.source_type,
+        role: PRIMARY_SOURCE_TYPES.has(classification.source_type) ? 'primary' : 'supporting',
+        notes: 'Fetched and extracted by the grounded source-packet builder.',
+      },
+      extract: {
+        source_id: sourceId,
+        status: 'ok',
+        title: extractTitle(raw),
+        extracted_at: new Date().toISOString(),
+        extracted_text: extractedText,
+      },
+    };
+  } catch (error) {
+    return {
+      source: {
+        id: sourceId,
+        publisher: classification.publisher,
+        url,
+        published_at: null,
+        source_type: classification.source_type,
+        role: PRIMARY_SOURCE_TYPES.has(classification.source_type) ? 'primary' : 'supporting',
+        notes: `Fetch failed: ${error.message}`,
+      },
+      extract: {
+        source_id: sourceId,
+        status: 'failed',
+        title: null,
+        extracted_at: new Date().toISOString(),
+        extracted_text: '',
+        error: error.message,
+      },
+    };
+  }
+}
+
+export function extractIds(text) {
+  const joined = String(text || '');
+  return {
+    cves: uniqueStrings(joined.match(CVE_RE) || []).map((id) => id.toUpperCase()),
+    ghsas: uniqueStrings(joined.match(GHSA_RE) || []).map((id) => id.toUpperCase()),
+    osvIds: uniqueStrings(joined.match(OSV_RE) || []).map((id) => id.toUpperCase()),
+  };
+}
+
+export function candidateById(queue, candidateId) {
+  const candidates = Array.isArray(queue?.candidates) ? queue.candidates : [];
+  return candidates.find((candidate) => candidate?.candidateId === candidateId || candidate?.canonicalSubjectId === candidateId);
+}
+
+export function laneForCandidate(candidate) {
+  const lane = String(candidate?.proposedArchetype || 'incident');
+  return LANES.has(lane) ? lane : 'incident';
+}
+
+export function claim(claims, claimText, type, sourceRefs, articleSection = 'summary', confidence = 'high') {
+  const cleaned = normalizeWhitespace(claimText);
+  const refs = uniqueStrings(sourceRefs);
+  if (!cleaned || refs.length === 0) return;
+  claims.push({
+    claim_id: `claim-${claims.length + 1}`,
+    claim: cleaned,
+    claim_type: CLAIM_TYPES.has(type) ? type : 'other',
+    source_refs: refs,
+    confidence,
+    article_section: articleSection,
+  });
+}
+
+export function safeTitle(value) {
+  return normalizeWhitespace(value).replace(/["<>]/g, '').slice(0, 100) || 'Untitled Threatpedia Draft';
+}
+
+export function markdownEscape(value) {
+  return String(value || '').replace(/\|/g, '\\|').trim();
+}
+
+export function yamlString(value) {
+  return `"${String(value || '').replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+export function numericId(seed, year = new Date().getUTCFullYear()) {
+  const value = Number.parseInt(sha(seed, 8), 16) % 9000 + 1000;
+  return `TP-${year}-${String(value).padStart(4, '0')}`;
+}

--- a/scripts/grounded-drafting-lib.mjs
+++ b/scripts/grounded-drafting-lib.mjs
@@ -89,9 +89,9 @@ export function classifySource(url) {
     return { publisher: 'Unknown', source_type: 'other' };
   }
   const host = parsed.hostname.toLowerCase();
-  if (host === 'cisa.gov' || host.endsWith('.cisa.gov')) return { publisher: 'CISA', source_type: 'database' };
+  if (host === 'cisa.gov' || host.endsWith('.cisa.gov')) return { publisher: 'Cybersecurity and Infrastructure Security Agency', source_type: 'database' };
+  if (host === 'nist.gov' || host.endsWith('.nist.gov')) return { publisher: 'National Vulnerability Database', source_type: 'database' };
   if (host === 'cve.org' || host.endsWith('.cve.org') || host === 'cve.mitre.org') return { publisher: 'CVE Program', source_type: 'database' };
-  if (host === 'nist.gov' || host.endsWith('.nist.gov')) return { publisher: 'NIST', source_type: 'database' };
   if (host === 'osv.dev' || host.endsWith('.osv.dev')) return { publisher: 'OSV.dev', source_type: 'database' };
   if (host === 'github.com' && parsed.pathname.startsWith('/advisories')) return { publisher: 'GitHub Advisory Database', source_type: 'database' };
   if (host === 'github.com' || host.endsWith('.github.com')) return { publisher: 'GitHub', source_type: 'research' };

--- a/scripts/grounded-drafting-lib.mjs
+++ b/scripts/grounded-drafting-lib.mjs
@@ -89,7 +89,8 @@ export function classifySource(url) {
     return { publisher: 'Unknown', source_type: 'other' };
   }
   const host = parsed.hostname.toLowerCase();
-  if (host === 'cisa.gov' || host.endsWith('.cisa.gov')) return { publisher: 'CISA', source_type: 'government' };
+  if (host === 'cisa.gov' || host.endsWith('.cisa.gov')) return { publisher: 'CISA', source_type: 'database' };
+  if (host === 'cve.org' || host.endsWith('.cve.org') || host === 'cve.mitre.org') return { publisher: 'CVE Program', source_type: 'database' };
   if (host === 'nist.gov' || host.endsWith('.nist.gov')) return { publisher: 'NIST', source_type: 'database' };
   if (host === 'osv.dev' || host.endsWith('.osv.dev')) return { publisher: 'OSV.dev', source_type: 'database' };
   if (host === 'github.com' && parsed.pathname.startsWith('/advisories')) return { publisher: 'GitHub Advisory Database', source_type: 'database' };

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -7,7 +7,7 @@
     "check:supply-chain-preview": "node check_supply_chain_preview.mjs",
     "check:supply-chain-public-readiness": "node check_supply_chain_public_readiness.mjs",
     "social:share-x": "node social-share-x.mjs",
-    "test": "node test-vulncheck-kev-intake.mjs && node test-supply-chain-live-discovery.mjs && node test-pipeline-dispatcher-stall.cjs && node test-adversary-schema-foundation.mjs"
+    "test": "node test-vulncheck-kev-intake.mjs && node test-supply-chain-live-discovery.mjs && node test-grounded-drafting.mjs && node test-pipeline-dispatcher-stall.cjs && node test-adversary-schema-foundation.mjs"
   },
   "keywords": [],
   "author": "",

--- a/scripts/preflight-source-packet.mjs
+++ b/scripts/preflight-source-packet.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Deterministic preflight for source-packet/1 zero-day packets.
+ * Deterministic preflight for source-packet/1 packets.
  */
 
 import { dirname, resolve } from 'node:path';
@@ -20,6 +20,7 @@ const SOURCE_TYPES = new Set(['government', 'vendor', 'database', 'research', 'n
 const SOURCE_ROLES = new Set(['primary', 'supporting']);
 const SUFFICIENCY = new Set(['sufficient', 'insufficient', 'needs_human_review']);
 const SOURCE_PACKET_STATUSES = new Set(['draft', 'preflight_passed', 'preflight_failed']);
+const LANES = new Set(['zero-day', 'incident', 'campaign', 'threat-actor', 'malware-family']);
 const PREFLIGHT_STATUSES = new Set(['not_run', 'pass', 'fail']);
 const CONFIDENCE = new Set(['high', 'medium', 'low']);
 const CLAIM_TYPES = new Set(['date', 'product', 'vulnerability', 'exploitation', 'impact', 'mitigation', 'attribution', 'other']);
@@ -180,10 +181,13 @@ function validatePreflight(packet) {
     return report(packet, errors, warnings);
   }
 
+  const lane = packet.lane;
+  const isZeroDay = lane === 'zero-day';
+
   if (packet.schema_version !== 'source-packet/1') add(errors, 'schema_version must be source-packet/1', '$.schema_version');
   if (!/^TASK-\d{4}-\d{4}$/.test(packet.task_id || '')) add(errors, 'task_id must match TASK-YYYY-NNNN', '$.task_id');
-  if (packet.lane !== 'zero-day') add(errors, 'lane must be zero-day for this pilot', '$.lane');
-  if (!/^sp-TASK-\d{4}-\d{4}$/.test(packet.source_packet_id || '')) add(errors, 'source_packet_id must match sp-TASK-YYYY-NNNN', '$.source_packet_id');
+  if (!LANES.has(lane)) add(errors, 'lane is invalid', '$.lane');
+  if (!/^sp-(?:TASK-\d{4}-\d{4}|SC-CAND-[a-f0-9]{16})$/.test(packet.source_packet_id || '')) add(errors, 'source_packet_id must match sp-TASK-YYYY-NNNN or sp-SC-CAND-<16 hex>', '$.source_packet_id');
   if (!ISO_RE.test(packet.created_at || '') || Number.isNaN(Date.parse(packet.created_at))) add(errors, 'created_at must be an ISO timestamp', '$.created_at');
   if (!SOURCE_PACKET_STATUSES.has(packet.source_packet_status)) add(errors, 'source_packet_status is invalid', '$.source_packet_status');
 
@@ -225,7 +229,7 @@ function validatePreflight(packet) {
   if (new Set(sourceUrls).size !== sourceUrls.length) add(errors, 'source URLs must be deduped', '$.primary_sources');
 
   const hasGovernmentOrVendorOrDatabase = sources.some(source => ['government', 'vendor', 'database'].includes(source?.source_type));
-  if (!hasGovernmentOrVendorOrDatabase) add(errors, 'zero-day packets need at least one government, vendor, or database source', '$.source_quality');
+  if (isZeroDay && !hasGovernmentOrVendorOrDatabase) add(errors, 'zero-day packets need at least one government, vendor, or database source', '$.source_quality');
 
   if (!isObject(packet.source_quality)) {
     add(errors, 'source_quality is required', '$.source_quality');
@@ -236,6 +240,53 @@ function validatePreflight(packet) {
     if (!SUFFICIENCY.has(packet.source_quality.source_sufficiency)) add(errors, 'source_sufficiency is invalid', '$.source_quality.source_sufficiency');
     if (!packet.source_quality.has_primary_source) add(errors, 'has_primary_source must be true for drafting readiness', '$.source_quality.has_primary_source');
     if (packet.source_quality.source_sufficiency !== 'sufficient') add(errors, 'source_sufficiency must be sufficient for drafting readiness', '$.source_quality.source_sufficiency');
+  }
+
+  if (packet.source_extracts !== undefined) {
+    if (!Array.isArray(packet.source_extracts)) {
+      add(errors, 'source_extracts must be an array when present', '$.source_extracts');
+    } else {
+      const okExtracts = packet.source_extracts.filter(extract => extract?.status === 'ok');
+      if (packet.grounding_contract?.drafting_mode === 'packet_claims_only' && okExtracts.length === 0) {
+        add(errors, 'grounded drafting packets need at least one successful source extract', '$.source_extracts');
+      }
+      packet.source_extracts.forEach((extract, index) => {
+        const path = `$.source_extracts[${index}]`;
+        if (!isObject(extract)) {
+          add(errors, 'source_extract must be an object', path);
+          return;
+        }
+        if (!sourceIds.has(extract.source_id)) add(errors, `unknown source_id ${JSON.stringify(extract.source_id)}`, `${path}.source_id`);
+        if (!['ok', 'failed'].includes(extract.status)) add(errors, 'status must be ok or failed', `${path}.status`);
+        if (!ISO_RE.test(extract.extracted_at || '') || Number.isNaN(Date.parse(extract.extracted_at))) add(errors, 'extracted_at must be an ISO timestamp', `${path}.extracted_at`);
+        if (extract.status === 'ok' && !isString(extract.extracted_text)) add(errors, 'ok extracts require extracted_text', `${path}.extracted_text`);
+        if (extract.status === 'failed' && !isString(extract.error)) add(errors, 'failed extracts require error', `${path}.error`);
+      });
+    }
+  }
+
+  if (packet.approval !== undefined) {
+    if (!isObject(packet.approval)) {
+      add(errors, 'approval must be an object when present', '$.approval');
+    } else {
+      for (const field of ['approved_by', 'approval_ref', 'approved_at', 'scope']) {
+        if (!isString(packet.approval[field])) add(errors, `${field} is required`, `$.approval.${field}`);
+      }
+      if (packet.approval.approved_at && (!ISO_RE.test(packet.approval.approved_at) || Number.isNaN(Date.parse(packet.approval.approved_at)))) {
+        add(errors, 'approved_at must be an ISO timestamp', '$.approval.approved_at');
+      }
+    }
+  }
+
+  if (packet.grounding_contract !== undefined) {
+    if (!isObject(packet.grounding_contract)) {
+      add(errors, 'grounding_contract must be an object when present', '$.grounding_contract');
+    } else {
+      if (packet.grounding_contract.drafting_mode !== 'packet_claims_only') add(errors, 'drafting_mode must be packet_claims_only', '$.grounding_contract.drafting_mode');
+      for (const field of ['disallow_model_memory', 'disallow_placeholder_urls', 'require_claim_markers', 'require_source_url_parity']) {
+        if (!isBool(packet.grounding_contract[field])) add(errors, `${field} must be boolean`, `$.grounding_contract.${field}`);
+      }
+    }
   }
 
   if (!isObject(packet.key_dates)) {
@@ -269,8 +320,8 @@ function validatePreflight(packet) {
     });
   }
 
-  if (!Array.isArray(packet.cves) || packet.cves.length === 0) {
-    add(errors, 'at least one CVE is required', '$.cves');
+  if (!Array.isArray(packet.cves) || (isZeroDay && packet.cves.length === 0)) {
+    add(errors, isZeroDay ? 'at least one CVE is required' : 'cves must be an array', '$.cves');
   } else {
     packet.cves.forEach((cve, index) => {
       const path = `$.cves[${index}]`;

--- a/scripts/preflight-source-packet.mjs
+++ b/scripts/preflight-source-packet.mjs
@@ -242,6 +242,9 @@ function validatePreflight(packet) {
     if (packet.source_quality.source_sufficiency !== 'sufficient') add(errors, 'source_sufficiency must be sufficient for drafting readiness', '$.source_quality.source_sufficiency');
   }
 
+  if (packet.grounding_contract?.drafting_mode === 'packet_claims_only' && packet.source_extracts === undefined) {
+    add(errors, 'grounded drafting packets need at least one successful source extract', '$.source_extracts');
+  }
   if (packet.source_extracts !== undefined) {
     if (!Array.isArray(packet.source_extracts)) {
       add(errors, 'source_extracts must be an array when present', '$.source_extracts');

--- a/scripts/supply-chain-live-discovery.mjs
+++ b/scripts/supply-chain-live-discovery.mjs
@@ -1072,7 +1072,7 @@ export function classifyLeads(rawLeads, { config, corpusIndex, now, previousQueu
       rankReasons: ranking.rankReasons,
       queueAction: 'candidate_review',
       draftingAllowed: false,
-      autoDraftingBlockedReason: 'B1 discovery/classification stops at candidate queue; grounded drafting is not implemented in this sprint.',
+      autoDraftingBlockedReason: 'B1 discovery/classification stops at candidate queue; B2 grounded drafting requires explicit approval, source-packet preflight, and fidelity check.',
       ...(previousManualOverride ? { manualOverride: previousManualOverride } : {}),
     });
   }

--- a/scripts/test-grounded-drafting.mjs
+++ b/scripts/test-grounded-drafting.mjs
@@ -48,6 +48,7 @@ async function testGroundedPacketDraftAndFidelityPass() {
     runNode(['scripts/preflight-source-packet.mjs', packetPath]);
     const draft = draftFromPacket(packet, { createdAt: '2026-06-22' });
     writeFileSync(draftPath, draft);
+    assert.match(draft, /\ndate: 2026-06-21\n/);
     const fidelity = checkGroundedDraft(packet, draft);
     assert.equal(fidelity.pass, true);
     assert.equal(fidelity.errors.length, 0);
@@ -176,9 +177,20 @@ async function testDraftFrontmatterMatchesLiveSchema() {
       createdAt: '2026-06-22T00:00:00Z',
       allowFetchFailures: false,
     });
+    assert.throws(() => draftFromPacket(campaignPacket, { createdAt: '2026-06-22' }), /Campaign grounded drafts require at least one packet-backed MITRE mapping/);
+    campaignPacket.mitre_candidates = [{
+      technique_id: 'T1195',
+      technique_name: 'Supply Chain Compromise',
+      tactic: 'Initial Access',
+      source_refs: ['src-1'],
+      confidence: 'medium',
+      include_in_article: true,
+    }];
     const campaignDraft = draftFromPacket(campaignPacket, { createdAt: '2026-06-22' });
     assert.match(campaignDraft, /\nongoing: true\n/);
     assert.doesNotMatch(campaignDraft, /\nendDate:/);
+    assert.match(campaignDraft, /\nmitreMappings:\n/);
+    assert.match(campaignDraft, /techniqueId: "T1195"/);
 
     const zeroDayQueue = structuredClone(baseQueue);
     zeroDayQueue.candidates[0].proposedArchetype = 'zero-day';
@@ -208,9 +220,27 @@ async function testDraftFrontmatterMatchesLiveSchema() {
   }
 }
 
+async function testNewsSourceMapsToMediaPublisherType() {
+  const packet = await buildGroundedPacket({
+    queue: queuePath,
+    candidateId: 'SC-CAND-1234abcd5678ef90',
+    approvedBy: 'KernelK',
+    approvalRef: 'fixture-approval',
+    out: path.join(tmpdir(), 'unused.json'),
+    fixturesDir,
+    createdAt: '2026-06-22T00:00:00Z',
+    allowFetchFailures: false,
+  });
+  packet.primary_sources[0].source_type = 'news';
+  const draft = draftFromPacket(packet, { createdAt: '2026-06-22' });
+  assert.match(draft, /\n\s+publisherType: media\n/);
+  assert.doesNotMatch(draft, /\n\s+publisherType: news\n/);
+}
+
 await testGroundedPacketDraftAndFidelityPass();
 await testOutputTargetsUseCollectionNames();
 await testDraftFrontmatterMatchesLiveSchema();
+await testNewsSourceMapsToMediaPublisherType();
 testCliRequiresExplicitApproval();
 await testFidelityRejectsInventedUrl();
 await testFidelityRejectsUnmarkedClaimLine();

--- a/scripts/test-grounded-drafting.mjs
+++ b/scripts/test-grounded-drafting.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'node:url';
 import { buildGroundedPacket } from './build-grounded-source-packet.mjs';
 import { draftFromPacket } from './draft-grounded-article.mjs';
 import { checkGroundedDraft } from './check-grounded-draft.mjs';
-import { readJson, writeJson } from './grounded-drafting-lib.mjs';
+import { classifySource, readJson, writeJson } from './grounded-drafting-lib.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const queuePath = 'tests/fixtures/grounded_drafting/candidate_queue.json';
@@ -94,6 +94,36 @@ async function testFidelityRejectsUnmarkedClaimLine() {
   assert.equal(fidelity.pass, false);
   assert.ok(fidelity.errors.some((error) => error.message.includes('missing packet claim marker')));
   assert.ok(packet.candidates.length > 0);
+}
+
+function testFidelityHandlesCrlfFrontmatter() {
+  const draft = [
+    '---',
+    'title: "fixture"',
+    '---',
+    '',
+    '## Executive Summary',
+    '<!-- claims: claim-1 --> This line is grounded.',
+    '',
+  ].join('\r\n');
+  const fidelity = checkGroundedDraft({ claims: [{ claim_id: 'claim-1' }], primary_sources: [], supporting_sources: [] }, draft);
+  assert.equal(fidelity.pass, true);
+  assert.equal(fidelity.errors.length, 0);
+}
+
+function testOfficialAdvisorySourceClassification() {
+  assert.deepEqual(classifySource('https://www.cisa.gov/known-exploited-vulnerabilities-catalog'), {
+    publisher: 'Cybersecurity and Infrastructure Security Agency',
+    source_type: 'database',
+  });
+  assert.deepEqual(classifySource('https://nvd.nist.gov/vuln/detail/CVE-2026-12345'), {
+    publisher: 'National Vulnerability Database',
+    source_type: 'database',
+  });
+  assert.deepEqual(classifySource('https://www.cve.org/CVERecord?id=CVE-2026-12345'), {
+    publisher: 'CVE Program',
+    source_type: 'database',
+  });
 }
 
 async function testOutputTargetsUseCollectionNames() {
@@ -184,4 +214,6 @@ await testDraftFrontmatterMatchesLiveSchema();
 testCliRequiresExplicitApproval();
 await testFidelityRejectsInventedUrl();
 await testFidelityRejectsUnmarkedClaimLine();
+testFidelityHandlesCrlfFrontmatter();
+testOfficialAdvisorySourceClassification();
 console.log('Grounded drafting tests passed');

--- a/scripts/test-grounded-drafting.mjs
+++ b/scripts/test-grounded-drafting.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildGroundedPacket } from './build-grounded-source-packet.mjs';
+import { draftFromPacket } from './draft-grounded-article.mjs';
+import { checkGroundedDraft } from './check-grounded-draft.mjs';
+import { readJson, writeJson } from './grounded-drafting-lib.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const queuePath = 'tests/fixtures/grounded_drafting/candidate_queue.json';
+const fixturesDir = 'tests/fixtures/grounded_drafting/sources';
+
+function runNode(args) {
+  return execFileSync(process.execPath, args, { cwd: repoRoot, encoding: 'utf8' });
+}
+
+async function testGroundedPacketDraftAndFidelityPass() {
+  const tempDir = mkdtempSync(path.join(tmpdir(), 'threatpedia-b2-'));
+  try {
+    const packetPath = path.join(tempDir, 'packet.json');
+    const draftPath = path.join(tempDir, 'draft.md');
+    const packet = await buildGroundedPacket({
+      queue: queuePath,
+      candidateId: 'SC-CAND-1234abcd5678ef90',
+      approvedBy: 'KernelK',
+      approvalRef: 'fixture-approval',
+      out: packetPath,
+      fixturesDir,
+      createdAt: '2026-06-22T00:00:00Z',
+      allowFetchFailures: false,
+    });
+    writeJson(repoRoot, packetPath, packet);
+
+    assert.equal(packet.lane, 'incident');
+    assert.equal(packet.approval.approved_by, 'KernelK');
+    assert.equal(packet.grounding_contract.drafting_mode, 'packet_claims_only');
+    assert.equal(packet.source_quality.source_sufficiency, 'sufficient');
+    assert.ok(packet.source_extracts.every((extract) => extract.status === 'ok'));
+    assert.ok(packet.claims.length >= 5);
+    assert.equal(packet.output_target.file_pattern, 'site/src/content/incidents/SC-CAND-1234abcd5678ef90.md');
+    assert.ok(packet.uncertainties.some((item) => item.topic.includes('date')));
+    assert.ok(packet.uncertainties.some((item) => item.topic.includes('exploit')));
+
+    runNode(['scripts/preflight-source-packet.mjs', packetPath]);
+    const draft = draftFromPacket(packet, { createdAt: '2026-06-22' });
+    writeFileSync(draftPath, draft);
+    const fidelity = checkGroundedDraft(packet, draft);
+    assert.equal(fidelity.pass, true);
+    assert.equal(fidelity.errors.length, 0);
+    runNode(['scripts/check-grounded-draft.mjs', '--packet', packetPath, '--draft', draftPath]);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function testCliRequiresExplicitApproval() {
+  const result = spawnSync(process.execPath, [
+    'scripts/build-grounded-source-packet.mjs',
+    '--queue', queuePath,
+    '--candidate-id', 'SC-CAND-1234abcd5678ef90',
+    '--approval-ref', 'fixture-approval',
+    '--out', path.join(tmpdir(), 'no-approval-packet.json'),
+    '--fixtures-dir', fixturesDir,
+  ], { cwd: repoRoot, encoding: 'utf8' });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /approved-by is required/);
+}
+
+async function testFidelityRejectsInventedUrl() {
+  const packet = await buildGroundedPacket({
+    queue: queuePath,
+    candidateId: 'SC-CAND-1234abcd5678ef90',
+    approvedBy: 'KernelK',
+    approvalRef: 'fixture-approval',
+    out: path.join(tmpdir(), 'unused.json'),
+    fixturesDir,
+    createdAt: '2026-06-22T00:00:00Z',
+    allowFetchFailures: false,
+  });
+  const draft = `${draftFromPacket(packet, { createdAt: '2026-06-22' })}\n<!-- claims: claim-1 --> Invented URL https://invented.example.invalid/report\n`;
+  const fidelity = checkGroundedDraft(packet, draft);
+  assert.equal(fidelity.pass, false);
+  assert.ok(fidelity.errors.some((error) => error.message.includes('draft URL is not in packet sources')));
+}
+
+async function testFidelityRejectsUnmarkedClaimLine() {
+  const packet = readJson(repoRoot, queuePath);
+  const draft = '---\ntitle: "bad"\n---\n\n## Executive Summary\nThis line has no claim marker.\n';
+  const fidelity = checkGroundedDraft({ claims: [{ claim_id: 'claim-1' }], primary_sources: [], supporting_sources: [] }, draft);
+  assert.equal(fidelity.pass, false);
+  assert.ok(fidelity.errors.some((error) => error.message.includes('missing packet claim marker')));
+  assert.ok(packet.candidates.length > 0);
+}
+
+async function testOutputTargetsUseCollectionNames() {
+  const baseQueue = readJson(repoRoot, queuePath);
+  const tempDir = mkdtempSync(path.join(tmpdir(), 'threatpedia-b2-lanes-'));
+  try {
+    const cases = [
+      ['zero-day', 'site/src/content/zero-days/SC-CAND-1234abcd5678ef90.md'],
+      ['campaign', 'site/src/content/campaigns/SC-CAND-1234abcd5678ef90.md'],
+      ['threat-actor', 'site/src/content/threat-actors/SC-CAND-1234abcd5678ef90.md'],
+      ['malware-family', '.github/pipeline/grounded-drafts/supply-chain-malware-families/SC-CAND-1234abcd5678ef90.md'],
+    ];
+    for (const [proposedArchetype, expectedPattern] of cases) {
+      const queue = structuredClone(baseQueue);
+      queue.candidates[0].proposedArchetype = proposedArchetype;
+      const queueFile = path.join(tempDir, `${proposedArchetype}.json`);
+      writeJson(repoRoot, queueFile, queue);
+      const packet = await buildGroundedPacket({
+        queue: queueFile,
+        candidateId: 'SC-CAND-1234abcd5678ef90',
+        approvedBy: 'KernelK',
+        approvalRef: 'fixture-approval',
+        out: path.join(tempDir, `${proposedArchetype}-packet.json`),
+        fixturesDir,
+        createdAt: '2026-06-22T00:00:00Z',
+        allowFetchFailures: false,
+      });
+      assert.equal(packet.output_target.file_pattern, expectedPattern);
+    }
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+await testGroundedPacketDraftAndFidelityPass();
+await testOutputTargetsUseCollectionNames();
+testCliRequiresExplicitApproval();
+await testFidelityRejectsInventedUrl();
+await testFidelityRejectsUnmarkedClaimLine();
+console.log('Grounded drafting tests passed');

--- a/scripts/test-grounded-drafting.mjs
+++ b/scripts/test-grounded-drafting.mjs
@@ -71,6 +71,30 @@ function testCliRequiresExplicitApproval() {
   assert.match(result.stderr, /approved-by is required/);
 }
 
+async function testPreflightRequiresGroundedSourceExtracts() {
+  const tempDir = mkdtempSync(path.join(tmpdir(), 'threatpedia-b2-preflight-'));
+  try {
+    const packetPath = path.join(tempDir, 'packet-without-extracts.json');
+    const packet = await buildGroundedPacket({
+      queue: queuePath,
+      candidateId: 'SC-CAND-1234abcd5678ef90',
+      approvedBy: 'KernelK',
+      approvalRef: 'fixture-approval',
+      out: packetPath,
+      fixturesDir,
+      createdAt: '2026-06-22T00:00:00Z',
+      allowFetchFailures: false,
+    });
+    delete packet.source_extracts;
+    writeJson(repoRoot, packetPath, packet);
+    const result = spawnSync(process.execPath, ['scripts/preflight-source-packet.mjs', packetPath], { cwd: repoRoot, encoding: 'utf8' });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /grounded drafting packets need at least one successful source extract/);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
 async function testFidelityRejectsInventedUrl() {
   const packet = await buildGroundedPacket({
     queue: queuePath,
@@ -242,6 +266,7 @@ await testOutputTargetsUseCollectionNames();
 await testDraftFrontmatterMatchesLiveSchema();
 await testNewsSourceMapsToMediaPublisherType();
 testCliRequiresExplicitApproval();
+await testPreflightRequiresGroundedSourceExtracts();
 await testFidelityRejectsInventedUrl();
 await testFidelityRejectsUnmarkedClaimLine();
 testFidelityHandlesCrlfFrontmatter();

--- a/scripts/test-grounded-drafting.mjs
+++ b/scripts/test-grounded-drafting.mjs
@@ -9,6 +9,7 @@ import { buildGroundedPacket } from './build-grounded-source-packet.mjs';
 import { draftFromPacket } from './draft-grounded-article.mjs';
 import { checkGroundedDraft } from './check-grounded-draft.mjs';
 import { classifySource, readJson, writeJson } from './grounded-drafting-lib.mjs';
+import { SCHEMA_REQUIRED_H2_BY_TYPE } from './pipeline-schema.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const queuePath = 'tests/fixtures/grounded_drafting/candidate_queue.json';
@@ -16,6 +17,23 @@ const fixturesDir = 'tests/fixtures/grounded_drafting/sources';
 
 function runNode(args) {
   return execFileSync(process.execPath, args, { cwd: repoRoot, encoding: 'utf8' });
+}
+
+function bodyH2s(markdown) {
+  return markdown.split(/\r?\n/)
+    .filter((line) => /^##\s+/.test(line))
+    .map((line) => line.replace(/^##\s+/, '').trim());
+}
+
+function addCampaignGovernmentSource(packet) {
+  packet.supporting_sources.push({
+    source_id: 'src-cisa',
+    url: 'https://www.cisa.gov/news-events/alerts/2026/06/21/fixture-alert',
+    publisher: 'Cybersecurity and Infrastructure Security Agency',
+    source_type: 'database',
+    role: 'supporting',
+    published_at: '2026-06-21',
+  });
 }
 
 async function testGroundedPacketDraftAndFidelityPass() {
@@ -49,6 +67,7 @@ async function testGroundedPacketDraftAndFidelityPass() {
     const draft = draftFromPacket(packet, { createdAt: '2026-06-22' });
     writeFileSync(draftPath, draft);
     assert.match(draft, /\ndate: 2026-06-21\n/);
+    assert.deepEqual(bodyH2s(draft), SCHEMA_REQUIRED_H2_BY_TYPE.incident);
     const fidelity = checkGroundedDraft(packet, draft);
     assert.equal(fidelity.pass, true);
     assert.equal(fidelity.errors.length, 0);
@@ -119,6 +138,13 @@ async function testFidelityRejectsUnmarkedClaimLine() {
   assert.equal(fidelity.pass, false);
   assert.ok(fidelity.errors.some((error) => error.message.includes('missing packet claim marker')));
   assert.ok(packet.candidates.length > 0);
+}
+
+function testFidelityRejectsUnmarkedSentence() {
+  const draft = '---\ntitle: "bad"\n---\n\n## Executive Summary\n<!-- claims: claim-1 --> This sentence is grounded. This sentence is not marked.\n';
+  const fidelity = checkGroundedDraft({ claims: [{ claim_id: 'claim-1' }], primary_sources: [], supporting_sources: [] }, draft);
+  assert.equal(fidelity.pass, false);
+  assert.ok(fidelity.errors.some((error) => error.message.includes('missing packet claim marker')));
 }
 
 function testFidelityHandlesCrlfFrontmatter() {
@@ -201,6 +227,8 @@ async function testDraftFrontmatterMatchesLiveSchema() {
       createdAt: '2026-06-22T00:00:00Z',
       allowFetchFailures: false,
     });
+    assert.throws(() => draftFromPacket(campaignPacket, { createdAt: '2026-06-22' }), /Campaign grounded drafts require at least three packet sources/);
+    addCampaignGovernmentSource(campaignPacket);
     assert.throws(() => draftFromPacket(campaignPacket, { createdAt: '2026-06-22' }), /Campaign grounded drafts require at least one packet-backed MITRE mapping/);
     campaignPacket.mitre_candidates = [{
       technique_id: 'T1195',
@@ -215,6 +243,8 @@ async function testDraftFrontmatterMatchesLiveSchema() {
     assert.doesNotMatch(campaignDraft, /\nendDate:/);
     assert.match(campaignDraft, /\nmitreMappings:\n/);
     assert.match(campaignDraft, /techniqueId: "T1195"/);
+    assert.match(campaignDraft, /\n\s+publisherType: government\n/);
+    assert.deepEqual(bodyH2s(campaignDraft), SCHEMA_REQUIRED_H2_BY_TYPE.campaign);
 
     const zeroDayQueue = structuredClone(baseQueue);
     zeroDayQueue.candidates[0].proposedArchetype = 'zero-day';
@@ -239,6 +269,7 @@ async function testDraftFrontmatterMatchesLiveSchema() {
     assert.match(zeroDayDraft, /\nplatform: "Fixture Platform"\n/);
     assert.doesNotMatch(zeroDayDraft, /\ncveId:/);
     assert.doesNotMatch(zeroDayDraft, /\npublishedDate:/);
+    assert.deepEqual(bodyH2s(zeroDayDraft), SCHEMA_REQUIRED_H2_BY_TYPE['zero-day']);
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }
@@ -269,6 +300,7 @@ testCliRequiresExplicitApproval();
 await testPreflightRequiresGroundedSourceExtracts();
 await testFidelityRejectsInventedUrl();
 await testFidelityRejectsUnmarkedClaimLine();
+testFidelityRejectsUnmarkedSentence();
 testFidelityHandlesCrlfFrontmatter();
 testOfficialAdvisorySourceClassification();
 console.log('Grounded drafting tests passed');

--- a/scripts/test-grounded-drafting.mjs
+++ b/scripts/test-grounded-drafting.mjs
@@ -128,8 +128,59 @@ async function testOutputTargetsUseCollectionNames() {
   }
 }
 
+async function testDraftFrontmatterMatchesLiveSchema() {
+  const baseQueue = readJson(repoRoot, queuePath);
+  const tempDir = mkdtempSync(path.join(tmpdir(), 'threatpedia-b2-frontmatter-'));
+  try {
+    const campaignQueue = structuredClone(baseQueue);
+    campaignQueue.candidates[0].proposedArchetype = 'campaign';
+    const campaignQueueFile = path.join(tempDir, 'campaign.json');
+    writeJson(repoRoot, campaignQueueFile, campaignQueue);
+    const campaignPacket = await buildGroundedPacket({
+      queue: campaignQueueFile,
+      candidateId: 'SC-CAND-1234abcd5678ef90',
+      approvedBy: 'KernelK',
+      approvalRef: 'fixture-approval',
+      out: path.join(tempDir, 'campaign-packet.json'),
+      fixturesDir,
+      createdAt: '2026-06-22T00:00:00Z',
+      allowFetchFailures: false,
+    });
+    const campaignDraft = draftFromPacket(campaignPacket, { createdAt: '2026-06-22' });
+    assert.match(campaignDraft, /\nongoing: true\n/);
+    assert.doesNotMatch(campaignDraft, /\nendDate:/);
+
+    const zeroDayQueue = structuredClone(baseQueue);
+    zeroDayQueue.candidates[0].proposedArchetype = 'zero-day';
+    zeroDayQueue.candidates[0].canonicalSubjectId = 'CVE-2026-12345';
+    zeroDayQueue.candidates[0].summary = `${zeroDayQueue.candidates[0].summary} CVE-2026-12345 affects Fixture Platform.`;
+    const zeroDayQueueFile = path.join(tempDir, 'zero-day.json');
+    writeJson(repoRoot, zeroDayQueueFile, zeroDayQueue);
+    const zeroDayPacket = await buildGroundedPacket({
+      queue: zeroDayQueueFile,
+      candidateId: 'SC-CAND-1234abcd5678ef90',
+      approvedBy: 'KernelK',
+      approvalRef: 'fixture-approval',
+      out: path.join(tempDir, 'zero-day-packet.json'),
+      fixturesDir,
+      createdAt: '2026-06-22T00:00:00Z',
+      allowFetchFailures: false,
+    });
+    zeroDayPacket.affected_products[0].product = 'Fixture Platform';
+    const zeroDayDraft = draftFromPacket(zeroDayPacket, { createdAt: '2026-06-22' });
+    assert.match(zeroDayDraft, /\ncve: "CVE-2026-12345"\n/);
+    assert.match(zeroDayDraft, /\ntype: "Vulnerability"\n/);
+    assert.match(zeroDayDraft, /\nplatform: "Fixture Platform"\n/);
+    assert.doesNotMatch(zeroDayDraft, /\ncveId:/);
+    assert.doesNotMatch(zeroDayDraft, /\npublishedDate:/);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
 await testGroundedPacketDraftAndFidelityPass();
 await testOutputTargetsUseCollectionNames();
+await testDraftFrontmatterMatchesLiveSchema();
 testCliRequiresExplicitApproval();
 await testFidelityRejectsInventedUrl();
 await testFidelityRejectsUnmarkedClaimLine();

--- a/scripts/test-supply-chain-live-discovery.mjs
+++ b/scripts/test-supply-chain-live-discovery.mjs
@@ -610,7 +610,7 @@ async function testPendingCandidatesCarryForwardWhenNotRediscovered() {
         rankReasons: ['current lead'],
         queueAction: 'candidate_review',
         draftingAllowed: false,
-        autoDraftingBlockedReason: 'B1 discovery/classification stops at candidate queue; grounded drafting is not implemented in this sprint.',
+        autoDraftingBlockedReason: 'B1 discovery/classification stops at candidate queue; B2 grounded drafting requires explicit approval, source-packet preflight, and fidelity check.',
       }],
     }));
 

--- a/tests/fixtures/grounded_drafting/candidate_queue.json
+++ b/tests/fixtures/grounded_drafting/candidate_queue.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": "threatpedia-supply-chain-candidate-queue/1",
+  "generated_at": "2026-06-22T00:00:00Z",
+  "mode": "dry-run",
+  "drafting_enabled": false,
+  "auto_drafting_allowed": false,
+  "queue_action": "candidate_review_only",
+  "candidates": [
+    {
+      "candidateId": "SC-CAND-1234abcd5678ef90",
+      "canonicalSubjectId": "MAL-2026-GROUNDED-FIXTURE",
+      "subjectType": "incident",
+      "proposedArchetype": "incident",
+      "title": "Fixture npm supply-chain compromise",
+      "summary": "A malicious npm package release attempted credential theft through a package install script.",
+      "sources": ["osv", "vendor-report"],
+      "sourceRefs": [
+        "https://socket.dev/blog/supply-chain-fixture",
+        "https://www.microsoft.com/security/blog/supply-chain-fixture"
+      ],
+      "mergedLeadRefs": ["osv:MAL-2026-GROUNDED-FIXTURE"],
+      "firstSeenAt": "2026-06-21T00:00:00Z",
+      "lastMaterialActivityAt": "2026-06-21T00:00:00Z",
+      "activityBasis": ["advisory_updated"],
+      "entityMatch": "new",
+      "matchedEntityHints": {
+        "actors": [],
+        "campaigns": [],
+        "packages": [
+          {
+            "id": "pkg-npm-event-stream",
+            "name": "event-stream",
+            "ecosystem": "npm"
+          }
+        ],
+        "malwareFamilies": []
+      },
+      "classification": {
+        "leadClass": "current",
+        "leadClassReason": "material activity within 180 days",
+        "workIntent": "create_article",
+        "routingPriority": "p1",
+        "effectiveActiveStatus": "exploited_in_wild",
+        "activeStatus": "exploited_in_wild",
+        "activeStatusExpiresAt": "2026-07-21T00:00:00Z",
+        "needsReverify": false,
+        "kevStatusDerived": null,
+        "kevStatusIsAuthoredTruth": false,
+        "manualOverrideValid": false,
+        "manualOverrideErrors": []
+      },
+      "rank": 74,
+      "rankReasons": ["current lead", "active exploitation or malware signal"],
+      "queueAction": "candidate_review",
+      "draftingAllowed": false,
+      "autoDraftingBlockedReason": "B1 discovery/classification stops at candidate queue; grounded drafting is required."
+    }
+  ]
+}

--- a/tests/fixtures/grounded_drafting/sources/socket-dev-blog-supply-chain-fixture.txt
+++ b/tests/fixtures/grounded_drafting/sources/socket-dev-blog-supply-chain-fixture.txt
@@ -1,0 +1,1 @@
+Fixture Research Report: Researchers observed a malicious npm package release that attempted credential theft during installation. The package used an install script to collect environment tokens from developer workstations. The report identified event-stream as a related ecosystem package for graph correlation.

--- a/tests/fixtures/grounded_drafting/sources/www-microsoft-com-security-blog-supply-chain-fixture.txt
+++ b/tests/fixtures/grounded_drafting/sources/www-microsoft-com-security-blog-supply-chain-fixture.txt
@@ -1,0 +1,1 @@
+Vendor Advisory: The vendor confirmed that the malicious package release was removed from the registry on 2026-06-21. The advisory advised users to rotate exposed registry and source-control credentials after installing the package.


### PR DESCRIPTION
## Summary

Implements Sprint B2 grounded auto-drafting foundation without starting B3:

- adds a B1 approved-candidate -> grounded source-packet builder with source fetch/extract and explicit approval metadata
- expands source-packet v1/preflight from zero-day-only to approved lanes: incident, zero-day, campaign, threat-actor, malware-family
- adds deterministic packet-only draft generation and a fidelity gate that rejects placeholder URLs, non-packet URLs, unknown claim markers, and substantive unmarked lines
- keeps B1 queue candidates non-drafting (`draftingAllowed: false`) and updates the blocked reason to point at the B2 approval/preflight/fidelity gate
- documents the B2 command chain and safety boundary

No B3 backfill was started. This PR does not mass-import corpus records or auto-open drafting from live feeds.

## Sample grounded run

Fixture candidate: `SC-CAND-1234abcd5678ef90`

- lane: `incident`
- sources fetched/extracted: 2
- claims generated: 8
- output target: `site/src/content/incidents/SC-CAND-1234abcd5678ef90.md`
- preflight: PASS
- grounded draft fidelity: PASS
- referenced claims: 8/8
- draft URLs: all from packet sources

## Validation

- `node --check scripts/supply-chain-live-discovery.mjs && node --check scripts/test-supply-chain-live-discovery.mjs && node --check scripts/build-grounded-source-packet.mjs && node --check scripts/draft-grounded-article.mjs && node --check scripts/check-grounded-draft.mjs && node --check scripts/grounded-drafting-lib.mjs && node --check scripts/test-grounded-drafting.mjs` — PASS
- `npm --prefix scripts test` — PASS
- `python3 scripts/validate_supply_chain_incidents.py && python3 scripts/validate_supply_chain_graph.py && node scripts/build-supply-chain-graph.mjs --check && node scripts/test-supply-chain-pages.mjs` — PASS
- `node scripts/preflight-source-packet.mjs .github/pipeline/source-packets/fixtures/zero-day-valid-packet.json` — PASS
- `node -e 'JSON.parse(require("fs").readFileSync(".github/pipeline/source-packets/schema/source-packet-1.schema.json","utf8")); console.log("source packet schema JSON OK")'` — PASS
- `git diff --check` — PASS
- `ENABLE_SUPPLY_CHAIN_PAGES=true npm --prefix site run build` — PASS

Known unrelated warning: enabled site build still emits existing campaign validator warnings for campaigns with fewer than two related incidents; build exits 0.

## Governance

@MahdiHedhli @dangermouse-bot @ernestpenfold-bot please review.

@codex review
/gemini review
