### PR TITLE
Add discovered KEV drafting tasks

### DIFF
--- a/.github/pipeline/tasks/TASK-2026-0383.json
+++ b/.github/pipeline/tasks/TASK-2026-0383.json
@@ -1,0 +1,83 @@
+{
+  "task_id": "TASK-2026-0383",
+  "stage": "draft",
+  "type": "zero-day",
+  "priority": "P0",
+  "status": "pending",
+  "created": "2026-06-23T19:53:54.897Z",
+  "updated": "2026-06-23T19:53:54.897Z",
+  "source": "auto_discovery",
+  "submitted_by": "pipeline-discovery",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "Lantronix EDS5000 Code Injection Vulnerability (CVE-2025-67038)",
+    "sources": [
+      "https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+      "https://nvd.nist.gov/vuln/detail/CVE-2025-67038",
+      "https://ltrxdev.atlassian.net/wiki/spaces/LTRXTS/pages/2538438657/Latest+Firmware+for+the+EDS5000+series+EDS5008+EDS5016+EDS5032"
+    ],
+    "candidate_data": {
+      "cve": "CVE-2025-67038",
+      "cves": [
+        "CVE-2025-67038"
+      ],
+      "exploitId": "TP-EXP-2025-0008",
+      "type": "Command Injection",
+      "platform": "Lantronix EDS5000",
+      "severity": "critical",
+      "cisaKev": true,
+      "disclosedDate": "2026-06-23",
+      "cwes": [
+        "CWE-78",
+        "CWE-94"
+      ],
+      "knownRansomwareUse": false
+    },
+    "notes": "CISA KEV entry added 2026-06-23. Required action by 2026-06-26. CVSS 3.1: 9.8 (CRITICAL). Discovery score: 100/100 (auto-certify eligible)."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 5,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 100"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/zero-days/lantronix-eds5000-cve-2025-67038.md",
+    "branch": "pipeline/TASK-2026-0383",
+    "pr": true
+  },
+  "discovery": {
+    "feed": "CISA_KEV",
+    "score": 100,
+    "auto_certify": true,
+    "cvss": {
+      "score": 9.8,
+      "severity": "CRITICAL",
+      "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "version": "3.1"
+    },
+    "discovered_at": "2026-06-23T19:53:54.897Z"
+  },
+  "history": [
+    {
+      "timestamp": "2026-06-23T19:53:54.897Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "pipeline-discovery",
+      "note": "Auto-discovered from CISA KEV (score: 100)"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0383.json
+++ b/.github/pipeline/tasks/TASK-2026-0383.json
@@ -43,7 +43,7 @@
   "acceptance_criteria": {
     "frontmatter_valid": true,
     "min_sources": 3,
-    "min_h2_sections": 5,
+    "min_h2_sections": 7,
     "min_mitre_mappings": 1,
     "review_status": "draft_ai",
     "schema_validation": "pass",

--- a/.github/pipeline/tasks/TASK-2026-0383.json
+++ b/.github/pipeline/tasks/TASK-2026-0383.json
@@ -29,7 +29,6 @@
       "cisaKev": true,
       "disclosedDate": "2026-06-23",
       "cwes": [
-        "CWE-78",
         "CWE-94"
       ],
       "knownRansomwareUse": false

--- a/.github/pipeline/tasks/TASK-2026-0384.json
+++ b/.github/pipeline/tasks/TASK-2026-0384.json
@@ -1,0 +1,82 @@
+{
+  "task_id": "TASK-2026-0384",
+  "stage": "draft",
+  "type": "zero-day",
+  "priority": "P0",
+  "status": "pending",
+  "created": "2026-06-23T19:53:54.898Z",
+  "updated": "2026-06-23T19:53:54.898Z",
+  "source": "auto_discovery",
+  "submitted_by": "pipeline-discovery",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "Ubiquiti UniFi OS Improper Input Validation Vulnerability (CVE-2026-34910)",
+    "sources": [
+      "https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+      "https://nvd.nist.gov/vuln/detail/CVE-2026-34910",
+      "https://community.ui.com/releases/Security-Advisory-Bulletin-064-064/84811c09-4cf4-42ab-bd61-cc994445963b"
+    ],
+    "candidate_data": {
+      "cve": "CVE-2026-34910",
+      "cves": [
+        "CVE-2026-34910"
+      ],
+      "exploitId": "TP-EXP-2026-0326",
+      "type": "Command Injection",
+      "platform": "Ubiquiti UniFi OS",
+      "severity": "critical",
+      "cisaKev": true,
+      "disclosedDate": "2026-06-23",
+      "cwes": [
+        "CWE-20"
+      ],
+      "knownRansomwareUse": false
+    },
+    "notes": "CISA KEV entry added 2026-06-23. Required action by 2026-06-26. CVSS 3.1: 10 (CRITICAL). Discovery score: 100/100 (auto-certify eligible)."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 5,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 100"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/zero-days/ubiquiti-unifi-os-cve-2026-34910.md",
+    "branch": "pipeline/TASK-2026-0384",
+    "pr": true
+  },
+  "discovery": {
+    "feed": "CISA_KEV",
+    "score": 100,
+    "auto_certify": true,
+    "cvss": {
+      "score": 10,
+      "severity": "CRITICAL",
+      "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+      "version": "3.1"
+    },
+    "discovered_at": "2026-06-23T19:53:54.898Z"
+  },
+  "history": [
+    {
+      "timestamp": "2026-06-23T19:53:54.898Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "pipeline-discovery",
+      "note": "Auto-discovered from CISA KEV (score: 100)"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0384.json
+++ b/.github/pipeline/tasks/TASK-2026-0384.json
@@ -23,7 +23,7 @@
         "CVE-2026-34910"
       ],
       "exploitId": "TP-EXP-2026-0326",
-      "type": "Command Injection",
+      "type": "Improper Input Validation",
       "platform": "Ubiquiti UniFi OS",
       "severity": "critical",
       "cisaKev": true,

--- a/.github/pipeline/tasks/TASK-2026-0384.json
+++ b/.github/pipeline/tasks/TASK-2026-0384.json
@@ -42,7 +42,7 @@
   "acceptance_criteria": {
     "frontmatter_valid": true,
     "min_sources": 3,
-    "min_h2_sections": 5,
+    "min_h2_sections": 7,
     "min_mitre_mappings": 1,
     "review_status": "draft_ai",
     "schema_validation": "pass",

--- a/.github/pipeline/tasks/TASK-2026-0385.json
+++ b/.github/pipeline/tasks/TASK-2026-0385.json
@@ -1,0 +1,82 @@
+{
+  "task_id": "TASK-2026-0385",
+  "stage": "draft",
+  "type": "zero-day",
+  "priority": "P0",
+  "status": "pending",
+  "created": "2026-06-23T19:53:54.898Z",
+  "updated": "2026-06-23T19:53:54.898Z",
+  "source": "auto_discovery",
+  "submitted_by": "pipeline-discovery",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "Ubiquiti UniFi OS Path Traversal Vulnerability (CVE-2026-34909)",
+    "sources": [
+      "https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+      "https://nvd.nist.gov/vuln/detail/CVE-2026-34909",
+      "https://community.ui.com/releases/Security-Advisory-Bulletin-064-064/84811c09-4cf4-42ab-bd61-cc994445963b"
+    ],
+    "candidate_data": {
+      "cve": "CVE-2026-34909",
+      "cves": [
+        "CVE-2026-34909"
+      ],
+      "exploitId": "TP-EXP-2026-0327",
+      "type": "Path Traversal",
+      "platform": "Ubiquiti UniFi OS",
+      "severity": "critical",
+      "cisaKev": true,
+      "disclosedDate": "2026-06-23",
+      "cwes": [
+        "CWE-22"
+      ],
+      "knownRansomwareUse": false
+    },
+    "notes": "CISA KEV entry added 2026-06-23. Required action by 2026-06-26. CVSS 3.1: 10 (CRITICAL). Discovery score: 100/100 (auto-certify eligible)."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 5,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 100"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/zero-days/ubiquiti-unifi-os-cve-2026-34909.md",
+    "branch": "pipeline/TASK-2026-0385",
+    "pr": true
+  },
+  "discovery": {
+    "feed": "CISA_KEV",
+    "score": 100,
+    "auto_certify": true,
+    "cvss": {
+      "score": 10,
+      "severity": "CRITICAL",
+      "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+      "version": "3.1"
+    },
+    "discovered_at": "2026-06-23T19:53:54.898Z"
+  },
+  "history": [
+    {
+      "timestamp": "2026-06-23T19:53:54.898Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "pipeline-discovery",
+      "note": "Auto-discovered from CISA KEV (score: 100)"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0385.json
+++ b/.github/pipeline/tasks/TASK-2026-0385.json
@@ -42,7 +42,7 @@
   "acceptance_criteria": {
     "frontmatter_valid": true,
     "min_sources": 3,
-    "min_h2_sections": 5,
+    "min_h2_sections": 7,
     "min_mitre_mappings": 1,
     "review_status": "draft_ai",
     "schema_validation": "pass",

--- a/.github/pipeline/tasks/TASK-2026-0386.json
+++ b/.github/pipeline/tasks/TASK-2026-0386.json
@@ -1,0 +1,82 @@
+{
+  "task_id": "TASK-2026-0386",
+  "stage": "draft",
+  "type": "zero-day",
+  "priority": "P0",
+  "status": "pending",
+  "created": "2026-06-23T19:53:54.898Z",
+  "updated": "2026-06-23T19:53:54.898Z",
+  "source": "auto_discovery",
+  "submitted_by": "pipeline-discovery",
+  "locked_by": null,
+  "locked_at": null,
+  "input": {
+    "topic": "Ubiquiti UniFi OS Improper Access Control Vulnerability (CVE-2026-34908)",
+    "sources": [
+      "https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+      "https://nvd.nist.gov/vuln/detail/CVE-2026-34908",
+      "https://community.ui.com/releases/Security-Advisory-Bulletin-064-064/84811c09-4cf4-42ab-bd61-cc994445963b"
+    ],
+    "candidate_data": {
+      "cve": "CVE-2026-34908",
+      "cves": [
+        "CVE-2026-34908"
+      ],
+      "exploitId": "TP-EXP-2026-0328",
+      "type": "Unclassified",
+      "platform": "Ubiquiti UniFi OS",
+      "severity": "critical",
+      "cisaKev": true,
+      "disclosedDate": "2026-06-23",
+      "cwes": [
+        "CWE-284"
+      ],
+      "knownRansomwareUse": false
+    },
+    "notes": "CISA KEV entry added 2026-06-23. Required action by 2026-06-26. CVSS 3.1: 10 (CRITICAL). Discovery score: 100/100 (auto-certify eligible)."
+  },
+  "specs": [
+    "DATA-STANDARDS-v1.0.md",
+    "EDITORIAL-WORKFLOW-SPEC.md §14A"
+  ],
+  "acceptance_criteria": {
+    "frontmatter_valid": true,
+    "min_sources": 3,
+    "min_h2_sections": 5,
+    "min_mitre_mappings": 1,
+    "review_status": "draft_ai",
+    "schema_validation": "pass",
+    "astro_build": true
+  },
+  "depends_on": [],
+  "preconditions": [
+    "editorial queue depth < 100"
+  ],
+  "output": {
+    "file_pattern": "site/src/content/zero-days/ubiquiti-unifi-os-cve-2026-34908.md",
+    "branch": "pipeline/TASK-2026-0386",
+    "pr": true
+  },
+  "discovery": {
+    "feed": "CISA_KEV",
+    "score": 100,
+    "auto_certify": true,
+    "cvss": {
+      "score": 10,
+      "severity": "CRITICAL",
+      "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+      "version": "3.1"
+    },
+    "discovered_at": "2026-06-23T19:53:54.898Z"
+  },
+  "history": [
+    {
+      "timestamp": "2026-06-23T19:53:54.898Z",
+      "action": "created",
+      "from": "none",
+      "to": "pending",
+      "agent": "pipeline-discovery",
+      "note": "Auto-discovered from CISA KEV (score: 100)"
+    }
+  ]
+}

--- a/.github/pipeline/tasks/TASK-2026-0386.json
+++ b/.github/pipeline/tasks/TASK-2026-0386.json
@@ -42,7 +42,7 @@
   "acceptance_criteria": {
     "frontmatter_valid": true,
     "min_sources": 3,
-    "min_h2_sections": 5,
+    "min_h2_sections": 7,
     "min_mitre_mappings": 1,
     "review_status": "draft_ai",
     "schema_validation": "pass",

--- a/.github/pipeline/tasks/TASK-2026-0386.json
+++ b/.github/pipeline/tasks/TASK-2026-0386.json
@@ -23,7 +23,7 @@
         "CVE-2026-34908"
       ],
       "exploitId": "TP-EXP-2026-0328",
-      "type": "Unclassified",
+      "type": "Improper Access Control",
       "platform": "Ubiquiti UniFi OS",
       "severity": "critical",
       "cisaKev": true,

--- a/scripts/pipeline-discover.mjs
+++ b/scripts/pipeline-discover.mjs
@@ -26,6 +26,7 @@ import { XMLParser } from 'fast-xml-parser';
 import yaml from 'js-yaml';
 import { loadPipelineConfig } from './pipeline-config.mjs';
 import { PIPELINE_TASK_FILE_NAME_PATTERN, PIPELINE_TASK_FILE_PATH_RE } from './pipeline-task-patterns.mjs';
+import { SCHEMA_REQUIRED_H2_BY_TYPE } from './pipeline-schema.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -1168,7 +1169,7 @@ function buildZeroDayTask(candidate, taskId, exploitId) {
     acceptance_criteria: {
       frontmatter_valid: true,
       min_sources: 3,
-      min_h2_sections: 5,
+      min_h2_sections: SCHEMA_REQUIRED_H2_BY_TYPE['zero-day'].length,
       min_mitre_mappings: 1,
       review_status: 'draft_ai',
       schema_validation: 'pass',


### PR DESCRIPTION
## Summary
- split from oversized PR #1274
- adds four pending auto-discovery drafting tasks for recent CISA KEV zero-day candidates
- keeps task changes separate from VulnCheck source-packet artifacts

## Validation
- `node scripts/validate-pipeline-tasks.mjs --files-file /tmp/pr1274-task-files.txt --new-files-file /tmp/pr1274-new-task-files.txt` PASS
- `git diff --check` PASS

## Review
@MahdiHedhli @dangermouse-bot @ernestpenfold-bot

@codex review
/gemini review
/review-gate