### PR TITLE
[codex] Fix live discovery PR body script

### DIFF
--- a/.github/workflows/supply-chain-live-discovery.yml
+++ b/.github/workflows/supply-chain-live-discovery.yml
@@ -172,7 +172,8 @@ jobs:
             body += '|---:|---|---|---|---|---|\\n';
             for (const candidate of top) {
               const title = String(candidate.title || '').replace(/\\|/g, '\\\\|').slice(0, 100);
-              body += `| ${candidate.rank} | ${candidate.classification.leadClass} | ${candidate.classification.workIntent} | \\`${candidate.canonicalSubjectId}\\` | ${title} | ${candidate.sources.join(', ')} |\\n`;
+              const subject = `\`${String(candidate.canonicalSubjectId || '').replace(/`/g, '')}\``;
+              body += `| ${candidate.rank} | ${candidate.classification.leadClass} | ${candidate.classification.workIntent} | ${subject} | ${title} | ${candidate.sources.join(', ')} |\\n`;
             }
             body += '\\n### Guardrails\\n\\n';
             body += '- `drafting_enabled=false` and `auto_drafting_allowed=false` are validated.\\n';


### PR DESCRIPTION
## Summary
- fix the Supply Chain live discovery workflow PR-body builder so the inline `actions/github-script` JavaScript parses
- avoid the escaped-backtick/template-literal syntax failure that currently kills the workflow after it commits the candidate queue branch

## Root cause
The workflow tried to emit a Markdown code span inside a JavaScript template literal as `\`${candidate.canonicalSubjectId}\``, which closes the template literal before `${...}` and throws `SyntaxError: Unexpected identifier '$'`.

## Validation
- `git diff --check`
- extracted `.github/workflows/supply-chain-live-discovery.yml` `script: |` block and compiled it with `new AsyncFunction(...)` to match `actions/github-script` behavior

## Follow-up after merge
- rerun `Supply Chain: Live Discovery` with `execute=true` and confirm `Create or update candidate queue PR` succeeds.