### PR TITLE
Fix pipeline orchestration backpressure

### DIFF
--- a/.github/workflows/pipeline-discovery.yml
+++ b/.github/workflows/pipeline-discovery.yml
@@ -437,11 +437,36 @@ jobs:
               | awk '!/\/latest\.json$/ { count += 1 } END { print count + 0 }'
           }
 
-          curl --retry 3 --retry-all-errors --retry-delay 2 --connect-timeout 10 --max-time 30 -sSf \
-            -H "Authorization: token ${GH_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${REPO}/pulls?state=open&per_page=100" \
-            > "$OPEN_PREFILL_JSON"
+          echo '[]' > "$OPEN_PREFILL_JSON"
+          OPEN_PREFILL_PAGE=1
+          while true; do
+            PAGE_JSON="${OPEN_PREFILL_JSON%.json}-page-${OPEN_PREFILL_PAGE}.json"
+            curl --retry 3 --retry-all-errors --retry-delay 2 --connect-timeout 10 --max-time 30 -sSf \
+              -H "Authorization: token ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${REPO}/pulls?state=open&per_page=100&page=${OPEN_PREFILL_PAGE}" \
+              > "$PAGE_JSON"
+            PAGE_COUNT="$(python3 - "$OPEN_PREFILL_JSON" "$PAGE_JSON" <<'PY'
+          import json
+          import sys
+          combined_path, page_path = sys.argv[1], sys.argv[2]
+          with open(combined_path, encoding='utf-8') as handle:
+              combined = json.load(handle)
+          with open(page_path, encoding='utf-8') as handle:
+              page = json.load(handle)
+          if not isinstance(combined, list) or not isinstance(page, list):
+              raise SystemExit('GitHub open pull request response must be a JSON array')
+          combined.extend(page)
+          with open(combined_path, 'w', encoding='utf-8') as handle:
+              json.dump(combined, handle)
+          print(len(page))
+          PY
+            )"
+            if [ "$PAGE_COUNT" -lt 100 ]; then
+              break
+            fi
+            OPEN_PREFILL_PAGE=$((OPEN_PREFILL_PAGE + 1))
+          done
 
           mapfile -t OPEN_PREFILL_BRANCHES < <(python3 - "$OPEN_PREFILL_JSON" "$BASE_BRANCH" <<'PY'
           import json

--- a/.github/workflows/pipeline-discovery.yml
+++ b/.github/workflows/pipeline-discovery.yml
@@ -437,7 +437,7 @@ jobs:
               | awk '!/\/latest\.json$/ { count += 1 } END { print count + 0 }'
           }
 
-          curl -sSf \
+          curl --retry 3 --retry-all-errors --retry-delay 2 --connect-timeout 10 --max-time 30 -sSf \
             -H "Authorization: token ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${REPO}/pulls?state=open&per_page=100" \
@@ -459,12 +459,23 @@ jobs:
           PY
           )
 
+          FETCHED_PREFILL_BRANCHES=()
           : > "$SEEN_PREFILL_PATHS"
           for candidate_branch in "${OPEN_PREFILL_BRANCHES[@]}"; do
-            git fetch origin "refs/heads/${candidate_branch}:refs/remotes/origin/${candidate_branch}" >/dev/null 2>&1 || continue
+            if ! git fetch origin "refs/heads/${candidate_branch}:refs/remotes/origin/${candidate_branch}" >/dev/null 2>&1; then
+              echo "::warning::Could not fetch open VulnCheck prefill branch ${candidate_branch}; pausing intake because global backlog state is incomplete."
+              continue
+            fi
+            FETCHED_PREFILL_BRANCHES+=("$candidate_branch")
             git diff --name-only origin/main..."origin/${candidate_branch}" -- '.github/pipeline/source-packets/vulncheck-kev/*.json' \
               >> "$SEEN_PREFILL_PATHS"
           done
+
+          if [ "${#FETCHED_PREFILL_BRANCHES[@]}" -ne "${#OPEN_PREFILL_BRANCHES[@]}" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "branch=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           sort -u "$SEEN_PREFILL_PATHS" -o "$SEEN_PREFILL_PATHS"
 
           TOTAL_PENDING_PREFILLS="$(awk '!/\/latest\.json$/ { count += 1 } END { print count + 0 }' "$SEEN_PREFILL_PATHS")"
@@ -476,7 +487,7 @@ jobs:
           fi
 
           SELECTED_BRANCH=""
-          for candidate_branch in "${OPEN_PREFILL_BRANCHES[@]}"; do
+          for candidate_branch in "${FETCHED_PREFILL_BRANCHES[@]}"; do
             PENDING_PREFILLS="$(branch_prefill_count "origin/${candidate_branch}")"
             if [ "$PENDING_PREFILLS" -lt "$PENDING_CAP" ]; then
               SELECTED_BRANCH="$candidate_branch"

--- a/.github/workflows/pipeline-discovery.yml
+++ b/.github/workflows/pipeline-discovery.yml
@@ -66,6 +66,10 @@ env:
   DISCOVERY_LABEL: pipeline/discovery
   VULNCHECK_PREFILL_BRANCH_PREFIX: pipeline/vulncheck-prefill
 
+concurrency:
+  group: pipeline-discovery-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   discover:
     runs-on: ubuntu-latest
@@ -269,7 +273,7 @@ jobs:
                   bucket: candidate.recency_bucket || '—',
                   date: candidate.vulncheck_exploitation_signal?.date_added || '—',
                   score: candidate.priority_score ?? null,
-                  officialCisa: !!candidate.official_cisa_kev?.listed,
+                  cisaDatePresent: !!prefill.key_dates?.cisa_kev_added_at_from_vulncheck_record,
                   canary: !!candidate.vulncheck_exploitation_signal?.reported_exploited_by_vulncheck_canaries,
                   vendor: product.vendor || '—',
                   product: product.product || '—',
@@ -344,7 +348,7 @@ jobs:
               for (const packet of packets) {
                 const cveCell = packet.cves.length > 0 ? packet.cves.map(cve => `\`${cve}\``).join(', ') : '—';
                 const artifact = packet.path.replace(/^\.\//, '');
-                body += `| ${cveCell} | ${packet.date} | ${packet.bucket} | ${packet.score == null ? '—' : packet.score} | ${packet.officialCisa ? '✓' : '—'} | ${packet.canary ? '✓' : '—'} | ${`${packet.vendor} / ${packet.product}`.replace(/\|/g, '\\|')} | \`${artifact}\` |\n`;
+                body += `| ${cveCell} | ${packet.date} | ${packet.bucket} | ${packet.score == null ? '—' : packet.score} | ${packet.cisaDatePresent ? '✓' : '—'} | ${packet.canary ? '✓' : '—'} | ${`${packet.vendor} / ${packet.product}`.replace(/\|/g, '\\|')} | \`${artifact}\` |\n`;
               }
               body += `\n`;
             }
@@ -455,9 +459,24 @@ jobs:
           PY
           )
 
+          : > "$SEEN_PREFILL_PATHS"
+          for candidate_branch in "${OPEN_PREFILL_BRANCHES[@]}"; do
+            git fetch origin "refs/heads/${candidate_branch}:refs/remotes/origin/${candidate_branch}" >/dev/null 2>&1 || continue
+            git diff --name-only origin/main..."origin/${candidate_branch}" -- '.github/pipeline/source-packets/vulncheck-kev/*.json' \
+              >> "$SEEN_PREFILL_PATHS"
+          done
+          sort -u "$SEEN_PREFILL_PATHS" -o "$SEEN_PREFILL_PATHS"
+
+          TOTAL_PENDING_PREFILLS="$(awk '!/\/latest\.json$/ { count += 1 } END { print count + 0 }' "$SEEN_PREFILL_PATHS")"
+          if [ "$TOTAL_PENDING_PREFILLS" -ge "$PENDING_CAP" ]; then
+            echo "::notice::VulnCheck source-packet queue is at global capacity (${TOTAL_PENDING_PREFILLS}/${PENDING_CAP}); pausing intake until an open prefill PR is merged or closed."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "branch=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           SELECTED_BRANCH=""
           for candidate_branch in "${OPEN_PREFILL_BRANCHES[@]}"; do
-            git fetch origin "$candidate_branch"
             PENDING_PREFILLS="$(branch_prefill_count "origin/${candidate_branch}")"
             if [ "$PENDING_PREFILLS" -lt "$PENDING_CAP" ]; then
               SELECTED_BRANCH="$candidate_branch"
@@ -473,23 +492,17 @@ jobs:
           elif git ls-remote --exit-code --heads origin "$BASE_BRANCH" >/dev/null 2>&1 \
               && ! printf '%s\n' "${OPEN_PREFILL_BRANCHES[@]}" | grep -qx "$BASE_BRANCH"; then
             echo "No open VulnCheck PR on ${BASE_BRANCH}; resetting reusable branch to origin/main."
+            git fetch origin "refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}"
             git checkout -B "$BASE_BRANCH" origin/main
-            git push --force-with-lease origin "$BASE_BRANCH"
           elif [ "${#OPEN_PREFILL_BRANCHES[@]}" -gt 0 ]; then
-            BRANCH="${BASE_BRANCH}-${GITHUB_RUN_ID}"
-            echo "All open VulnCheck prefill PRs are full; rolling over to ${BRANCH}."
-            git checkout -B "$BRANCH" origin/main
+            echo "::warning::Open VulnCheck prefill PRs exist but none has capacity; pausing instead of creating another backlog PR."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "branch=" >> "$GITHUB_OUTPUT"
+            exit 0
           else
             echo "Creating reusable VulnCheck prefill branch ${BASE_BRANCH}."
             git checkout -B "$BASE_BRANCH" origin/main
           fi
-
-          : > "$SEEN_PREFILL_PATHS"
-          for candidate_branch in "${OPEN_PREFILL_BRANCHES[@]}"; do
-            git fetch origin "$candidate_branch" >/dev/null 2>&1 || continue
-            git diff --name-only origin/main..."origin/${candidate_branch}" -- '.github/pipeline/source-packets/vulncheck-kev/*.json' \
-              >> "$SEEN_PREFILL_PATHS"
-          done
 
           SEEN_PREFILL_CVES="$(python3 - "$SEEN_PREFILL_PATHS" <<'PY'
           import re
@@ -504,22 +517,14 @@ jobs:
           PY
           )"
 
-          PENDING_PREFILLS="$(branch_prefill_count HEAD)"
-          HEADROOM=$((PENDING_CAP - PENDING_PREFILLS))
-          if [ "$HEADROOM" -le 0 ]; then
-            BRANCH="${BASE_BRANCH}-${GITHUB_RUN_ID}"
-            echo "Active VulnCheck branch is full; rolling over to ${BRANCH}."
-            git checkout -B "$BRANCH" origin/main
-            PENDING_PREFILLS=0
-            HEADROOM="$PENDING_CAP"
-          fi
+          HEADROOM=$((PENDING_CAP - TOTAL_PENDING_PREFILLS))
 
           RUN_LIMIT="$PER_RUN_LIMIT"
           if [ "$RUN_LIMIT" -gt "$HEADROOM" ]; then
             RUN_LIMIT="$HEADROOM"
           fi
 
-          echo "VulnCheck KEV source-packet headroom on ${BRANCH}: ${PENDING_PREFILLS}/${PENDING_CAP}; running intake with --max-candidates ${RUN_LIMIT}."
+          echo "VulnCheck KEV global source-packet headroom: ${TOTAL_PENDING_PREFILLS}/${PENDING_CAP}; using ${BRANCH} with --max-candidates ${RUN_LIMIT}."
           SEEN_ARGS=()
           if [ -n "$SEEN_PREFILL_CVES" ]; then
             SEEN_ARGS=(--seen-cves "$SEEN_PREFILL_CVES")
@@ -579,7 +584,7 @@ jobs:
                   bucket: candidate.recency_bucket || '—',
                   date: candidate.vulncheck_exploitation_signal?.date_added || '—',
                   score: candidate.priority_score ?? null,
-                  officialCisa: !!candidate.official_cisa_kev?.listed,
+                  cisaDatePresent: !!prefill.key_dates?.cisa_kev_added_at_from_vulncheck_record,
                   canary: !!candidate.vulncheck_exploitation_signal?.reported_exploited_by_vulncheck_canaries,
                   vendor: product.vendor || '—',
                   product: product.product || '—',
@@ -598,14 +603,14 @@ jobs:
             let body = `## VulnCheck KEV Source-Packet Prefill Batch\n\n`;
             body += `This PR stages a bounded VulnCheck KEV source-packet prefill batch from \`${BRANCH}\` for review before landing on \`main\`.\n\n`;
             body += `These are prioritization/source-packet artifacts only. They do not create article drafts, do not mark official CISA KEV membership, and require prominent VulnCheck KEV attribution if surfaced.\n`;
-            body += `When the active VulnCheck prefill PR reaches the configured pending cap, scheduled discovery rolls over to a separate PR instead of overfilling the current one.\n\n`;
+            body += `Scheduled discovery pauses at the configured global pending cap, so review backlog cannot create additional prefill PRs.\n\n`;
             body += `Review requested: @MahdiHedhli @dangermouse-bot @ernestpenfold-bot.\n\n`;
             body += `| CVE | Date added | Bucket | Score | CISA date present | Canary signal | Vendor / product | Artifact |\n`;
             body += `|---|---|---|---:|:-:|:-:|---|---|\n`;
             for (const packet of packets) {
               const cveCell = packet.cves.length > 0 ? packet.cves.map(cve => `\`${cve}\``).join(', ') : '—';
               const artifact = packet.path.replace(/^\.\//, '');
-              body += `| ${cveCell} | ${packet.date} | ${packet.bucket} | ${packet.score == null ? '—' : packet.score} | ${packet.officialCisa ? '✓' : '—'} | ${packet.canary ? '✓' : '—'} | ${`${packet.vendor} / ${packet.product}`.replace(/\|/g, '\\|')} | \`${artifact}\` |\n`;
+              body += `| ${cveCell} | ${packet.date} | ${packet.bucket} | ${packet.score == null ? '—' : packet.score} | ${packet.cisaDatePresent ? '✓' : '—'} | ${packet.canary ? '✓' : '—'} | ${`${packet.vendor} / ${packet.product}`.replace(/\|/g, '\\|')} | \`${artifact}\` |\n`;
             }
             body += `\n---\n\n`;
             body += `_Last updated: ${new Date().toISOString()} · Run [${context.runId}](${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}) · See [docs/PIPELINE.md](${context.serverUrl}/${owner}/${repo}/blob/main/docs/PIPELINE.md) for the end-to-end flow._\n`;

--- a/.github/workflows/pipeline-review-gate.yml
+++ b/.github/workflows/pipeline-review-gate.yml
@@ -32,7 +32,7 @@ jobs:
       (
         github.event_name == 'pull_request_review' &&
         contains(
-          fromJSON('["chatgpt-codex-connector", "chatgpt-codex-connector[bot]", "gemini-code-assist", "gemini-code-assist[bot]", "dangermouse-bot", "ernestpenfold-bot"]'),
+          fromJSON('["chatgpt-codex-connector", "chatgpt-codex-connector[bot]", "gemini-code-assist", "gemini-code-assist[bot]", "coderabbitai", "coderabbitai[bot]", "dangermouse-bot", "ernestpenfold-bot"]'),
           github.event.review.user.login
         )
       ) ||

--- a/.github/workflows/supply-chain-live-discovery.yml
+++ b/.github/workflows/supply-chain-live-discovery.yml
@@ -67,6 +67,9 @@ jobs:
           set -euo pipefail
           BRANCH="${DISCOVERY_BRANCH}"
           PREVIOUS_QUEUE="$RUNNER_TEMP/supply-chain-previous-queue.json"
+          PREVIOUS_PACKET_DIR="$RUNNER_TEMP/supply-chain-previous-vulncheck-packets"
+          VULNCHECK_PACKET_DIR=".github/pipeline/source-packets/vulncheck-kev"
+          PRESERVED_PACKET_COUNT=0
           REMOTE_HEAD=""
 
           git fetch origin main
@@ -79,10 +82,27 @@ jobs:
               "https://api.github.com/repos/${REPO}/pulls?state=open&head=${OWNER}:${BRANCH}&per_page=5" \
               | python3 -c 'import sys,json; print(len(json.loads(sys.stdin.read(), strict=False)))')
 
-            if [ "$OPEN_PRS" != "0" ] \
-                && git cat-file -e "origin/${BRANCH}:${QUEUE_PATH}" 2>/dev/null; then
-              git show "origin/${BRANCH}:${QUEUE_PATH}" > "$PREVIOUS_QUEUE"
-              echo "Preserving the pending candidate queue while rebuilding from current main."
+            if [ "$OPEN_PRS" != "0" ]; then
+              if git cat-file -e "origin/${BRANCH}:${QUEUE_PATH}" 2>/dev/null; then
+                git show "origin/${BRANCH}:${QUEUE_PATH}" > "$PREVIOUS_QUEUE"
+                echo "Preserving the pending candidate queue while rebuilding from current main."
+              fi
+
+              mkdir -p "$PREVIOUS_PACKET_DIR"
+              while IFS= read -r packet_path; do
+                [ -n "$packet_path" ] || continue
+                if git cat-file -e "origin/main:${packet_path}" 2>/dev/null; then
+                  continue
+                fi
+                relative_path="${packet_path#${VULNCHECK_PACKET_DIR}/}"
+                mkdir -p "$PREVIOUS_PACKET_DIR/$(dirname "$relative_path")"
+                git show "origin/${BRANCH}:${packet_path}" > "$PREVIOUS_PACKET_DIR/$relative_path"
+                PRESERVED_PACKET_COUNT=$((PRESERVED_PACKET_COUNT + 1))
+              done < <(
+                git diff --name-only --diff-filter=A origin/main..."origin/${BRANCH}" -- "${VULNCHECK_PACKET_DIR}/*.json" \
+                  | awk '!/\/latest\.json$/'
+              )
+              echo "Preserving ${PRESERVED_PACKET_COUNT} branch-only VulnCheck source packets."
             fi
           fi
 
@@ -92,6 +112,10 @@ jobs:
           if [ -s "$PREVIOUS_QUEUE" ]; then
             mkdir -p "$(dirname "$QUEUE_PATH")"
             cp "$PREVIOUS_QUEUE" "$QUEUE_PATH"
+          fi
+          if [ "$PRESERVED_PACKET_COUNT" -gt 0 ]; then
+            mkdir -p "$VULNCHECK_PACKET_DIR"
+            cp -R "$PREVIOUS_PACKET_DIR"/. "$VULNCHECK_PACKET_DIR"/
           fi
           echo "DISCOVERY_REMOTE_HEAD=${REMOTE_HEAD}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/supply-chain-live-discovery.yml
+++ b/.github/workflows/supply-chain-live-discovery.yml
@@ -23,6 +23,10 @@ env:
   DISCOVERY_LABEL: pipeline/supply-chain-discovery
   QUEUE_PATH: .github/pipeline/supply-chain-candidates/latest.json
 
+concurrency:
+  group: supply-chain-live-discovery-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   discover:
     runs-on: ubuntu-latest
@@ -62,24 +66,34 @@ jobs:
         run: |
           set -euo pipefail
           BRANCH="${DISCOVERY_BRANCH}"
+          PREVIOUS_QUEUE="$RUNNER_TEMP/supply-chain-previous-queue.json"
+          REMOTE_HEAD=""
+
+          git fetch origin main
           if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git fetch origin "refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
+            REMOTE_HEAD="$(git rev-parse "origin/${BRANCH}")"
             OPEN_PRS=$(curl -sSf \
               -H "Authorization: token ${GH_TOKEN}" \
               -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/${REPO}/pulls?state=open&head=${OWNER}:${BRANCH}&per_page=5" \
               | python3 -c 'import sys,json; print(len(json.loads(sys.stdin.read(), strict=False)))')
-            if [ "$OPEN_PRS" = "0" ]; then
-              git fetch origin main
-              git checkout -B "$BRANCH" origin/main
-              git push --force-with-lease origin "$BRANCH"
-            else
-              git fetch origin "$BRANCH"
-              git checkout -B "$BRANCH" "origin/$BRANCH"
-              git merge --no-edit origin/main
+
+            if [ "$OPEN_PRS" != "0" ] \
+                && git cat-file -e "origin/${BRANCH}:${QUEUE_PATH}" 2>/dev/null; then
+              git show "origin/${BRANCH}:${QUEUE_PATH}" > "$PREVIOUS_QUEUE"
+              echo "Preserving the pending candidate queue while rebuilding from current main."
             fi
-          else
-            git checkout -b "$BRANCH"
           fi
+
+          # Generated branches are rebuilt, not merged. Merging two generated
+          # snapshots makes any conflict permanent and wedges every later run.
+          git checkout -B "$BRANCH" origin/main
+          if [ -s "$PREVIOUS_QUEUE" ]; then
+            mkdir -p "$(dirname "$QUEUE_PATH")"
+            cp "$PREVIOUS_QUEUE" "$QUEUE_PATH"
+          fi
+          echo "DISCOVERY_REMOTE_HEAD=${REMOTE_HEAD}" >> "$GITHUB_ENV"
 
       - name: Run VulnCheck KEV source-packet intake
         if: ${{ inputs.execute != 'false' }}
@@ -126,14 +140,18 @@ jobs:
         if: ${{ inputs.execute != 'false' }}
         run: |
           set -euo pipefail
+          LEASE="--force-with-lease=refs/heads/${DISCOVERY_BRANCH}:${DISCOVERY_REMOTE_HEAD:-}"
           git add .github/pipeline/supply-chain-candidates/ .github/pipeline/source-packets/vulncheck-kev/
           if git diff --cached --quiet; then
             echo "No candidate queue changes this run."
+            if [ -n "${DISCOVERY_REMOTE_HEAD:-}" ]; then
+              git push "$LEASE" origin "HEAD:refs/heads/${DISCOVERY_BRANCH}"
+            fi
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git commit -m "chore(pipeline): update supply chain candidate queue $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          git push --force-with-lease origin "${DISCOVERY_BRANCH}"
+          git push "$LEASE" origin "HEAD:refs/heads/${DISCOVERY_BRANCH}"
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
 
       - name: Create or update candidate queue PR

--- a/.github/workflows/supply-chain-live-discovery.yml
+++ b/.github/workflows/supply-chain-live-discovery.yml
@@ -73,7 +73,7 @@ jobs:
           if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
             git fetch origin "refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
             REMOTE_HEAD="$(git rev-parse "origin/${BRANCH}")"
-            OPEN_PRS=$(curl -sSf \
+            OPEN_PRS=$(curl --retry 3 --retry-all-errors --retry-delay 2 --connect-timeout 10 --max-time 30 -sSf \
               -H "Authorization: token ${GH_TOKEN}" \
               -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/${REPO}/pulls?state=open&head=${OWNER}:${BRANCH}&per_page=5" \

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -265,7 +265,7 @@ discovery queues are open, validated, and stable.
      `node scripts/pipeline-review-gate.mjs --pr <number>` against live
      GitHub state for public content, site, and pipeline PRs.
    - The workflow runs automatically for configured AI reviewer PR review
-     events, including Gemini Code Assist, `dangermouse-bot`, or
+     events, including Gemini Code Assist, CodeRabbit, `dangermouse-bot`, or
      `ernestpenfold-bot` review submission and dismissal. It skips worker/human
      review submissions because
      those often record disposition or remediation notes before current-head AI
@@ -367,12 +367,12 @@ same queue/validation path as discovery-generated tasks.
 | Discovery per-run cap | workflow env `LIMIT` → `--limit` | 20 tasks | Workflow input |
 | Discovery lane selection | workflow env `MODE` → `--mode` | `all` | Workflow input |
 | Discovery publishes via | `pipeline/discovery` branch + auto-PR | labeled `pipeline/discovery`, no direct push to `main` | Workflow |
-| VulnCheck source-packet PR rollover | `pipeline-discovery.yml` via `queues.source_packets.max_pending` | 40 branch-only prefills per active prefill PR | `config.yml`; intake shrinks to remaining headroom or rolls over to a separate PR when full |
+| VulnCheck source-packet backpressure | `pipeline-discovery.yml` via `queues.source_packets.max_pending` | 40 unique prefills across all open prefill PRs | `config.yml`; intake shrinks to global headroom and pauses at the cap instead of opening another backlog PR |
 | Supply Chain B1 live queue | `.github/workflows/supply-chain-live-discovery.yml` → `scripts/supply-chain-live-discovery.mjs` | 30-minute cron; writes `.github/pipeline/supply-chain-candidates/latest.json`; no task or draft emission | Workflow + script |
 | Dispatcher publishes via | `pipeline/dispatcher` branch + auto-PR | labeled `pipeline/dispatcher`, no direct push to `main`; skips duplicate `pipeline/ready` Issues when one is already open | Workflow |
 | Task PR validation | `pipeline-validate-tasks.yml` + `scripts/validate-pipeline-tasks.mjs` + `scripts/pipeline-discovery-validation-dispatch.mjs` | Validates changed `.github/pipeline/tasks/*.json`; new task files must use canonical `acceptance_criteria`, pending-state metadata, matching filenames, and valid source URLs; discovery PRs explicitly dispatch validation and fall back to local validation plus a PR-head status if dispatch cannot be observed | Workflow + script |
 | PR batch review | Human merge (not auto-merge) | Nothing lands on `main` without review | Workflow + branch protection |
-| Review readiness gate | `pipeline-review-gate.yml` + `pipeline-review-gate.mjs` | Current-head validation for content PRs, current-head AI second review from Gemini Code Assist, `dangermouse-bot`, or `ernestpenfold-bot`, and zero unresolved current AI review threads from configured reviewer logins. Automated review findings are triaged by severity for remediation priority, but any unresolved current AI review thread keeps the live gate red until fixed, answered, or resolved. Automatic PR-review runs are limited to configured AI reviewer logins; issue-comment runs require `/review-gate` or `/pipeline review-gate` | Live GitHub state |
+| Review readiness gate | `pipeline-review-gate.yml` + `pipeline-review-gate.mjs` | Current-head validation for content PRs, current-head AI second review from Gemini Code Assist, CodeRabbit, `dangermouse-bot`, or `ernestpenfold-bot`, and zero unresolved current AI review threads from configured reviewer logins. Automated review findings are triaged by severity for remediation priority, but any unresolved current AI review thread keeps the live gate red until fixed, answered, or resolved. Automatic PR-review runs are limited to configured AI reviewer logins; issue-comment runs require `/review-gate` or `/pipeline review-gate` | Live GitHub state |
 | Editorial queue backpressure (hysteresis) | `pipeline-dispatcher.yml` (via `scripts/pipeline-config.mjs`); state tracked via labeled GitHub Issue (`pipeline/backpressure`) | Pause at 100 pending · stay paused until queue < 80 (auto-resume + Issue auto-close) | `config.yml` (`queues.editorial.max_pending` / `backpressure_resume`) |
 | Stale-lock timeout | `pipeline-dispatcher.yml` (via `scripts/pipeline-config.mjs`) | 30 minutes | `config.yml` (`scheduling.stale_lock_minutes`) |
 | Ready-Issue stall alert | `pipeline-dispatcher.yml` | Warn after 60 minutes; alert after 180 minutes, or 60 minutes for P0 | `config.yml` (`ready_issue.*`) |

--- a/docs/supply-chain-live-discovery.md
+++ b/docs/supply-chain-live-discovery.md
@@ -90,6 +90,11 @@ node scripts/supply-chain-live-discovery.mjs --check
 
 `.github/workflows/supply-chain-live-discovery.yml` runs every 30 minutes and can be manually dispatched. It opens or updates a PR from `pipeline/supply-chain-live-discovery`, requests review from Kernel K, DangerMouse, and Ernest Penfold, and includes `@codex review` plus `/gemini review`.
 
+Each run rebuilds the generated branch from current `main` under an explicit
+remote-head lease. When an open queue PR exists, the pending candidate queue is
+carried forward before fresh collection. Generated snapshots are never merged
+into each other, so a stale queue cannot permanently wedge later scheduled runs.
+
 The workflow commits only:
 
 - `.github/pipeline/supply-chain-candidates/**`

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -7,7 +7,7 @@
     "check:supply-chain-preview": "node check_supply_chain_preview.mjs",
     "check:supply-chain-public-readiness": "node check_supply_chain_public_readiness.mjs",
     "social:share-x": "node social-share-x.mjs",
-    "test": "node test-vulncheck-kev-intake.mjs && node test-supply-chain-live-discovery.mjs && node test-grounded-drafting.mjs && node test-pipeline-dispatcher-stall.cjs && node test-adversary-schema-foundation.mjs"
+    "test": "node test-vulncheck-kev-intake.mjs && node test-supply-chain-live-discovery.mjs && node test-grounded-drafting.mjs && node test-pipeline-dispatcher-stall.cjs && node test-pipeline-orchestration-contracts.mjs && node test-adversary-schema-foundation.mjs"
   },
   "keywords": [],
   "author": "",

--- a/scripts/pipeline-review-gate.mjs
+++ b/scripts/pipeline-review-gate.mjs
@@ -15,6 +15,8 @@ const DEFAULT_AI_REVIEW_LOGINS = [
   'chatgpt-codex-connector[bot]',
   'gemini-code-assist',
   'gemini-code-assist[bot]',
+  'coderabbitai',
+  'coderabbitai[bot]',
   'dangermouse-bot',
   'ernestpenfold-bot',
 ];

--- a/scripts/supply-chain-live-discovery.mjs
+++ b/scripts/supply-chain-live-discovery.mjs
@@ -707,7 +707,7 @@ async function collectGhsaLeads(config, fixturesDir) {
     });
 }
 
-function collectVulncheckLeads(indexPath) {
+export function collectVulncheckLeads(indexPath) {
   if (!indexPath || !existsSync(path.resolve(repoRoot, indexPath))) return [];
   const index = readJson(indexPath);
   const candidates = Array.isArray(index.candidates)
@@ -720,11 +720,10 @@ function collectVulncheckLeads(indexPath) {
       : null;
     const prefillDates = candidate.source_packet_prefill?.key_dates;
     const cisaAddedAt = prefillDates?.cisa_kev_added_at_from_vulncheck_record
-      || officialKev?.date_added
+      || (officialKev?.listed === true ? officialKev.date_added : null)
       || null;
     const cisaDueAt = prefillDates?.cisa_due_date_from_vulncheck_record
-      || officialKev?.due_date
-      || officialKev?.dueDate
+      || (officialKev?.listed === true ? (officialKev.due_date || officialKev.dueDate) : null)
       || null;
     return vulnerabilityLead({
       source: 'vulncheck-kev',

--- a/scripts/supply-chain-live-discovery.mjs
+++ b/scripts/supply-chain-live-discovery.mjs
@@ -718,6 +718,14 @@ function collectVulncheckLeads(indexPath) {
     const officialKev = candidate.official_cisa_kev && typeof candidate.official_cisa_kev === 'object'
       ? candidate.official_cisa_kev
       : null;
+    const prefillDates = candidate.source_packet_prefill?.key_dates;
+    const cisaAddedAt = prefillDates?.cisa_kev_added_at_from_vulncheck_record
+      || officialKev?.date_added
+      || null;
+    const cisaDueAt = prefillDates?.cisa_due_date_from_vulncheck_record
+      || officialKev?.due_date
+      || officialKev?.dueDate
+      || null;
     return vulnerabilityLead({
       source: 'vulncheck-kev',
       id: cves[0] || candidate.candidate_key,
@@ -733,14 +741,14 @@ function collectVulncheckLeads(indexPath) {
       })),
       databaseSpecific: {
         non_authoritative: true,
-        cisaDatePresent: Boolean(officialKev?.date_added),
+        cisaDatePresent: Boolean(cisaAddedAt),
         reportedExploitedByCanaries: Boolean(candidate.vulncheck_exploitation_signal?.reported_exploited_by_vulncheck_canaries),
       },
-      kev: officialKev ? {
+      kev: cisaAddedAt ? {
         isKev: true,
-        kevAddedAt: officialKev.date_added,
-        kevUpdatedAt: officialKev.date_added,
-        kevDueAt: officialKev.dueDate,
+        kevAddedAt: cisaAddedAt,
+        kevUpdatedAt: cisaAddedAt,
+        kevDueAt: cisaDueAt,
       } : null,
       raw: candidate,
     });

--- a/scripts/test-pipeline-orchestration-contracts.mjs
+++ b/scripts/test-pipeline-orchestration-contracts.mjs
@@ -15,9 +15,13 @@ assert.match(supplyChainWorkflow, /refs\/heads\/\$\{BRANCH\}:refs\/remotes\/orig
 
 assert.match(discoveryWorkflow, /TOTAL_PENDING_PREFILLS/);
 assert.match(discoveryWorkflow, /"\$TOTAL_PENDING_PREFILLS" -ge "\$PENDING_CAP"/);
+assert.match(discoveryWorkflow, /FETCHED_PREFILL_BRANCHES/);
+assert.match(discoveryWorkflow, /global backlog state is incomplete/);
 assert.doesNotMatch(discoveryWorkflow, /\$\{BASE_BRANCH\}-\$\{GITHUB_RUN_ID\}/);
 assert.match(discoveryWorkflow, /pauses at the configured global pending cap/);
 assert.match(discoveryWorkflow, /refs\/heads\/\$\{candidate_branch\}:refs\/remotes\/origin\/\$\{candidate_branch\}/);
+
+assert.match(supplyChainWorkflow, /--retry 3 --retry-all-errors/);
 
 assert.match(reviewGateWorkflow, /coderabbitai/);
 assert.match(reviewGateScript, /'coderabbitai'/);

--- a/scripts/test-pipeline-orchestration-contracts.mjs
+++ b/scripts/test-pipeline-orchestration-contracts.mjs
@@ -12,6 +12,10 @@ assert.doesNotMatch(supplyChainWorkflow, /git merge --no-edit origin\/main/);
 assert.match(supplyChainWorkflow, /DISCOVERY_REMOTE_HEAD/);
 assert.match(supplyChainWorkflow, /--force-with-lease=refs\/heads\/\$\{DISCOVERY_BRANCH\}/);
 assert.match(supplyChainWorkflow, /refs\/heads\/\$\{BRANCH\}:refs\/remotes\/origin\/\$\{BRANCH\}/);
+assert.ok(supplyChainWorkflow.includes('PREVIOUS_PACKET_DIR="$RUNNER_TEMP/supply-chain-previous-vulncheck-packets"'));
+assert.ok(supplyChainWorkflow.includes('git diff --name-only --diff-filter=A origin/main..."origin/${BRANCH}"'));
+assert.ok(supplyChainWorkflow.includes('git cat-file -e "origin/main:${packet_path}"'));
+assert.ok(supplyChainWorkflow.includes('cp -R "$PREVIOUS_PACKET_DIR"/. "$VULNCHECK_PACKET_DIR"/'));
 
 assert.match(discoveryWorkflow, /TOTAL_PENDING_PREFILLS/);
 assert.match(discoveryWorkflow, /"\$TOTAL_PENDING_PREFILLS" -ge "\$PENDING_CAP"/);
@@ -20,6 +24,9 @@ assert.match(discoveryWorkflow, /global backlog state is incomplete/);
 assert.doesNotMatch(discoveryWorkflow, /\$\{BASE_BRANCH\}-\$\{GITHUB_RUN_ID\}/);
 assert.match(discoveryWorkflow, /pauses at the configured global pending cap/);
 assert.match(discoveryWorkflow, /refs\/heads\/\$\{candidate_branch\}:refs\/remotes\/origin\/\$\{candidate_branch\}/);
+assert.ok(discoveryWorkflow.includes('OPEN_PREFILL_PAGE=1'));
+assert.ok(discoveryWorkflow.includes('pulls?state=open&per_page=100&page=${OPEN_PREFILL_PAGE}'));
+assert.ok(discoveryWorkflow.includes('OPEN_PREFILL_PAGE=$((OPEN_PREFILL_PAGE + 1))'));
 
 assert.match(supplyChainWorkflow, /--retry 3 --retry-all-errors/);
 

--- a/scripts/test-pipeline-orchestration-contracts.mjs
+++ b/scripts/test-pipeline-orchestration-contracts.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const supplyChainWorkflow = readFileSync(new URL('../.github/workflows/supply-chain-live-discovery.yml', import.meta.url), 'utf8');
+const discoveryWorkflow = readFileSync(new URL('../.github/workflows/pipeline-discovery.yml', import.meta.url), 'utf8');
+const reviewGateWorkflow = readFileSync(new URL('../.github/workflows/pipeline-review-gate.yml', import.meta.url), 'utf8');
+const reviewGateScript = readFileSync(new URL('./pipeline-review-gate.mjs', import.meta.url), 'utf8');
+
+assert.match(supplyChainWorkflow, /git checkout -B "\$BRANCH" origin\/main/);
+assert.doesNotMatch(supplyChainWorkflow, /git merge --no-edit origin\/main/);
+assert.match(supplyChainWorkflow, /DISCOVERY_REMOTE_HEAD/);
+assert.match(supplyChainWorkflow, /--force-with-lease=refs\/heads\/\$\{DISCOVERY_BRANCH\}/);
+assert.match(supplyChainWorkflow, /refs\/heads\/\$\{BRANCH\}:refs\/remotes\/origin\/\$\{BRANCH\}/);
+
+assert.match(discoveryWorkflow, /TOTAL_PENDING_PREFILLS/);
+assert.match(discoveryWorkflow, /"\$TOTAL_PENDING_PREFILLS" -ge "\$PENDING_CAP"/);
+assert.doesNotMatch(discoveryWorkflow, /\$\{BASE_BRANCH\}-\$\{GITHUB_RUN_ID\}/);
+assert.match(discoveryWorkflow, /pauses at the configured global pending cap/);
+assert.match(discoveryWorkflow, /refs\/heads\/\$\{candidate_branch\}:refs\/remotes\/origin\/\$\{candidate_branch\}/);
+
+assert.match(reviewGateWorkflow, /coderabbitai/);
+assert.match(reviewGateScript, /'coderabbitai'/);
+
+console.log('pipeline orchestration workflow contracts: PASS');

--- a/scripts/test-supply-chain-live-discovery.mjs
+++ b/scripts/test-supply-chain-live-discovery.mjs
@@ -528,8 +528,16 @@ async function testVulncheckKevFeedsDerivedKevStatus() {
           shortDescription: 'A supply-chain exploited package fixture for KEV derivation.',
           vulncheck_date_added: '2026-06-20',
           official_cisa_kev: {
-            date_added: '2026-06-20',
-            dueDate: '2026-07-10',
+            status_source: 'not inferred from VulnCheck; verify CISA KEV membership against CISA before official labeling',
+            listed: false,
+            date_added: null,
+            due_date: null,
+          },
+          source_packet_prefill: {
+            key_dates: {
+              cisa_kev_added_at_from_vulncheck_record: '2026-06-20',
+              cisa_due_date_from_vulncheck_record: '2026-07-10',
+            },
           },
           vulncheck_exploitation_signal: {
             evidence_urls: ['https://example.invalid/vulncheck'],

--- a/scripts/test-supply-chain-live-discovery.mjs
+++ b/scripts/test-supply-chain-live-discovery.mjs
@@ -7,6 +7,7 @@ import {
   buildPurl,
   buildCandidateQueue,
   classifyLeads,
+  collectVulncheckLeads,
   loadCorpusIndex,
   validateCandidateQueue,
 } from './supply-chain-live-discovery.mjs';
@@ -544,8 +545,33 @@ async function testVulncheckKevFeedsDerivedKevStatus() {
             reported_exploited_by_vulncheck_canaries: true,
           },
         },
+        {
+          candidate_key: 'CVE-2026-54321',
+          cves: ['CVE-2026-54321'],
+          vulnerabilityName: 'Stale non-authoritative KEV fixture',
+          shortDescription: 'A supply-chain fixture with an unlisted legacy CISA date.',
+          vulncheck_date_added: '2026-06-20',
+          official_cisa_kev: {
+            listed: false,
+            date_added: '2026-06-19',
+            due_date: '2026-07-09',
+          },
+          vulncheck_exploitation_signal: {
+            evidence_urls: ['https://example.invalid/vulncheck-stale'],
+            reported_exploited_by_vulncheck_canaries: false,
+          },
+        },
       ],
     }));
+
+    const leads = collectVulncheckLeads(vulncheckIndex);
+    const lead = leads.find((item) => item.advisoryId === 'CVE-2026-12345');
+    assert.equal(lead.databaseSpecific.cisaDatePresent, true);
+    assert.equal(lead.kev.kevAddedAt, '2026-06-20');
+    assert.equal(lead.kev.kevDueAt, '2026-07-10');
+    const unlistedLead = leads.find((item) => item.advisoryId === 'CVE-2026-54321');
+    assert.equal(unlistedLead.databaseSpecific.cisaDatePresent, false);
+    assert.equal(unlistedLead.kev, null);
 
     const out = path.join(tempDir, 'queue.json');
     const queue = await buildCandidateQueue({

--- a/scripts/test-vulncheck-kev-intake.mjs
+++ b/scripts/test-vulncheck-kev-intake.mjs
@@ -164,7 +164,7 @@ const correctedProduct = buildRecentIntake({
       shortDescription: 'Cockpit remote login passes user-controlled values to SSH without validation.',
       required_action: 'Patch.',
       knownRansomwareCampaignUse: 'Unknown',
-      cve: ['CVE-2026-4631'],
+      cve: ['CVE-2025-12352', 'CVE-2026-4631'],
       cwes: ['CWE-78'],
       vulncheck_xdb: [],
       vulncheck_reported_exploitation: [],

--- a/scripts/test-vulncheck-kev-intake.mjs
+++ b/scripts/test-vulncheck-kev-intake.mjs
@@ -75,8 +75,12 @@ assert.equal(result.candidates[0].recency_bucket, 'recent');
 assert.equal(result.candidates[1].cves[0], 'CVE-2026-0001');
 assert.equal(result.candidates[1].recency_bucket, 'backlog');
 assert.equal(result.candidates[0].drafting_allowed, false);
-assert.equal(result.candidates[0].official_cisa_kev.listed, true);
-assert.equal(result.candidates[0].official_cisa_kev.date_added, '2026-06-11');
+assert.equal(result.candidates[0].official_cisa_kev.listed, false);
+assert.equal(result.candidates[0].official_cisa_kev.date_added, null);
+assert.equal(result.candidates[0].source_packet_prefill.key_dates.cisa_kev_added_at_from_vulncheck_record, '2026-06-11');
+assert.ok(result.candidates[0].priority_reasons.includes('recent VulnCheck date_added'));
+assert.ok(result.candidates[1].priority_reasons.includes('VulnCheck date_added present'));
+assert.ok(!result.candidates[1].priority_reasons.includes('recent VulnCheck date_added'));
 assert.equal(result.candidates[0].vulncheck_exploitation_signal.non_authoritative, true);
 assert.equal(result.candidates[0].vulncheck_exploitation_signal.xdb_exploit_types[0], 'info-leak');
 assert.equal(result.candidates[0].source_packet_prefill.status, 'prefill_only');
@@ -146,6 +150,65 @@ assert.equal(normalizedPrefill.affected_products[0].vendor, 'rocketgenius');
 assert.equal(normalizedPrefill.affected_products[0].product, 'gravityforms');
 assert.equal(normalizedPrefill.preserved_vulncheck_fields.vendorProject, null);
 assert.equal(normalizedPrefill.preserved_vulncheck_fields.product, null);
+
+const correctedProduct = buildRecentIntake({
+  data: [
+    {
+      vendorProject: 'GNU',
+      product: 'grub2',
+      vulnerabilityName: 'GNU grub2 OS Command Injection',
+      shortDescription: 'Cockpit remote login passes user-controlled values to SSH without validation.',
+      required_action: 'Patch.',
+      knownRansomwareCampaignUse: 'Unknown',
+      cve: ['CVE-2026-4631'],
+      cwes: ['CWE-78'],
+      vulncheck_xdb: [],
+      vulncheck_reported_exploitation: [],
+      reported_exploited_by_vulncheck_canaries: false,
+      date_added: '2026-07-08T00:00:00Z',
+    },
+  ],
+}, {
+  lookbackDays: 30,
+  maxCandidates: 1,
+  asOf: '2026-07-09',
+  seenCves: new Set(),
+});
+
+assert.equal(correctedProduct.candidates[0].vendorProject, 'Red Hat');
+assert.equal(correctedProduct.candidates[0].product, 'cockpit');
+assert.equal(correctedProduct.candidates[0].source_packet_prefill.affected_products[0].vendor, 'Red Hat');
+assert.equal(correctedProduct.candidates[0].source_packet_prefill.affected_products[0].product, 'cockpit');
+assert.equal(correctedProduct.candidates[0].source_packet_prefill.preserved_vulncheck_fields.vendorProject, 'Red Hat');
+assert.equal(correctedProduct.candidates[0].source_packet_prefill.preserved_vulncheck_fields.product, 'cockpit');
+
+const escapedMetadata = buildRecentIntake({
+  data: [
+    {
+      vendorProject: 'icegram',
+      product: 'email_subscribers_\\&_newsletters',
+      vulnerabilityName: 'icegram email_subscribers_\\&_newsletters Missing Authorization',
+      shortDescription: 'Email Subscribers & Newsletters vulnerability.',
+      required_action: 'Patch.',
+      knownRansomwareCampaignUse: 'Unknown',
+      cve: ['CVE-2019-19985'],
+      cwes: [],
+      vulncheck_xdb: [],
+      vulncheck_reported_exploitation: [],
+      reported_exploited_by_vulncheck_canaries: false,
+      date_added: '2019-11-13T00:00:00Z',
+    },
+  ],
+}, {
+  lookbackDays: 30,
+  maxCandidates: 1,
+  asOf: '2026-07-09',
+  seenCves: new Set(),
+});
+
+assert.equal(escapedMetadata.candidates[0].product, 'email_subscribers_&_newsletters');
+assert.equal(escapedMetadata.candidates[0].source_packet_prefill.affected_products[0].product, 'email_subscribers_&_newsletters');
+assert.equal(escapedMetadata.candidates[0].source_packet_prefill.preserved_vulncheck_fields.product, 'email_subscribers_&_newsletters');
 
 const filteredXdb = buildRecentIntake({
   data: [

--- a/scripts/test-vulncheck-kev-intake.mjs
+++ b/scripts/test-vulncheck-kev-intake.mjs
@@ -77,6 +77,10 @@ assert.equal(result.candidates[1].recency_bucket, 'backlog');
 assert.equal(result.candidates[0].drafting_allowed, false);
 assert.equal(result.candidates[0].official_cisa_kev.listed, false);
 assert.equal(result.candidates[0].official_cisa_kev.date_added, null);
+assert.equal(
+  result.candidates[0].official_cisa_kev.status_source,
+  'not inferred from VulnCheck; verify CISA KEV membership against CISA before official labeling',
+);
 assert.equal(result.candidates[0].source_packet_prefill.key_dates.cisa_kev_added_at_from_vulncheck_record, '2026-06-11');
 assert.ok(result.candidates[0].priority_reasons.includes('recent VulnCheck date_added'));
 assert.ok(result.candidates[1].priority_reasons.includes('VulnCheck date_added present'));

--- a/scripts/vulncheck-kev-intake.mjs
+++ b/scripts/vulncheck-kev-intake.mjs
@@ -705,7 +705,7 @@ function toCandidate(record, seenCves, recencyBucket = 'recent') {
     priority_score: priority.score,
     priority_reasons: priority.reasons,
     official_cisa_kev: {
-      status_source: 'cisa_date_added field from VulnCheck record; verify against CISA before official labeling',
+      status_source: 'not inferred from VulnCheck; verify CISA KEV membership against CISA before official labeling',
       listed: false,
       date_added: null,
       due_date: null,

--- a/scripts/vulncheck-kev-intake.mjs
+++ b/scripts/vulncheck-kev-intake.mjs
@@ -590,14 +590,22 @@ function normalizeKnownProductFields(record) {
     vulnerabilityName: normalizeVulnCheckText(record?.vulnerabilityName),
     shortDescription: normalizeVulnCheckText(record?.shortDescription),
   };
+  const forcedNormalization = forcedProductNormalization(record);
+  if (forcedNormalization) {
+    return {
+      ...cleaned,
+      vendorProject: forcedNormalization.vendorProject,
+      product: forcedNormalization.product,
+    };
+  }
   const cves = uniqueStrings(record?.cve);
   for (const cve of cves) {
     const normalized = PRODUCT_NORMALIZATION_BY_CVE.get(cve);
     if (!normalized) continue;
     return {
       ...cleaned,
-      vendorProject: normalized.overrideExisting ? normalized.vendorProject : cleaned.vendorProject || normalized.vendorProject,
-      product: normalized.overrideExisting ? normalized.product : cleaned.product || normalized.product,
+      vendorProject: cleaned.vendorProject || normalized.vendorProject,
+      product: cleaned.product || normalized.product,
     };
   }
   return cleaned;

--- a/scripts/vulncheck-kev-intake.mjs
+++ b/scripts/vulncheck-kev-intake.mjs
@@ -33,6 +33,13 @@ const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const PRODUCT_NORMALIZATION_BY_CVE = new Map([
   ['CVE-2025-12352', { vendorProject: 'rocketgenius', product: 'gravityforms' }],
   ['CVE-2026-6433', { vendorProject: 'custom_css_js_php_project', product: 'custom_css_js_php' }],
+  // VulnCheck currently carries unrelated GNU/grub2 fields; Red Hat's CVE
+  // record identifies the affected package as Cockpit.
+  ['CVE-2026-4631', {
+    vendorProject: 'Red Hat',
+    product: 'cockpit',
+    overrideExisting: true,
+  }],
 ]);
 
 export function usage() {
@@ -528,7 +535,7 @@ function exploitTypes(record) {
   return uniqueStrings(xdbEntriesFor(record).map(item => item?.exploit_type));
 }
 
-function priorityScore(record, addedDate) {
+function priorityScore(record, addedDate, recencyBucket) {
   let score = 0;
   const reasons = [];
   const reported = Array.isArray(record.vulncheck_reported_exploitation) ? record.vulncheck_reported_exploitation.length : 0;
@@ -536,7 +543,7 @@ function priorityScore(record, addedDate) {
 
   if (addedDate) {
     score += 30;
-    reasons.push('recent VulnCheck date_added');
+    reasons.push(recencyBucket === 'recent' ? 'recent VulnCheck date_added' : 'VulnCheck date_added present');
   }
   if (record.cisa_date_added) {
     score += 20;
@@ -562,22 +569,43 @@ function priorityScore(record, addedDate) {
   return { score, reasons };
 }
 
+function normalizeVulnCheckText(value) {
+  if (typeof value !== 'string') return value;
+  return value.replace(/\\([&|])/g, '$1');
+}
+
+function forcedProductNormalization(record) {
+  for (const cve of uniqueStrings(record?.cve)) {
+    const normalized = PRODUCT_NORMALIZATION_BY_CVE.get(cve);
+    if (normalized?.overrideExisting) return normalized;
+  }
+  return null;
+}
+
 function normalizeKnownProductFields(record) {
+  const cleaned = {
+    ...record,
+    vendorProject: normalizeVulnCheckText(record?.vendorProject),
+    product: normalizeVulnCheckText(record?.product),
+    vulnerabilityName: normalizeVulnCheckText(record?.vulnerabilityName),
+    shortDescription: normalizeVulnCheckText(record?.shortDescription),
+  };
   const cves = uniqueStrings(record?.cve);
   for (const cve of cves) {
     const normalized = PRODUCT_NORMALIZATION_BY_CVE.get(cve);
     if (!normalized) continue;
     return {
-      ...record,
-      vendorProject: record.vendorProject || normalized.vendorProject,
-      product: record.product || normalized.product,
+      ...cleaned,
+      vendorProject: normalized.overrideExisting ? normalized.vendorProject : cleaned.vendorProject || normalized.vendorProject,
+      product: normalized.overrideExisting ? normalized.product : cleaned.product || normalized.product,
     };
   }
-  return record;
+  return cleaned;
 }
 
 function makePrefill(rawRecord) {
   const record = normalizeKnownProductFields(rawRecord);
+  const forcedNormalization = forcedProductNormalization(rawRecord);
   const cves = uniqueStrings(record.cve);
   const cwes = uniqueStrings(record.cwes);
   const refs = sourceRefsFor(record);
@@ -628,10 +656,10 @@ function makePrefill(rawRecord) {
     cves: cves.map(id => ({ id, source_refs: [vulncheckSourceId] })),
     cwes: cwes.map(id => ({ id, name: 'Unknown', source_refs: [vulncheckSourceId] })),
     preserved_vulncheck_fields: {
-      vendorProject: rawRecord.vendorProject || null,
-      product: rawRecord.product || null,
-      vulnerabilityName: rawRecord.vulnerabilityName || null,
-      shortDescription: rawRecord.shortDescription || null,
+      vendorProject: forcedNormalization ? record.vendorProject : normalizeVulnCheckText(rawRecord.vendorProject) || null,
+      product: forcedNormalization ? record.product : normalizeVulnCheckText(rawRecord.product) || null,
+      vulnerabilityName: normalizeVulnCheckText(rawRecord.vulnerabilityName) || null,
+      shortDescription: normalizeVulnCheckText(rawRecord.shortDescription) || null,
       required_action: rawRecord.required_action || null,
       knownRansomwareCampaignUse: rawRecord.knownRansomwareCampaignUse || null,
       reported_exploited_by_vulncheck_canaries: rawRecord.reported_exploited_by_vulncheck_canaries === true,
@@ -660,7 +688,7 @@ function toCandidate(record, seenCves, recencyBucket = 'recent') {
   const cves = uniqueStrings(record.cve);
   const addedDate = normalizeDate(record.date_added);
   const seenMatches = cves.filter(cve => seenCves.has(cve));
-  const priority = priorityScore(record, addedDate);
+  const priority = priorityScore(record, addedDate, recencyBucket);
 
   return {
     candidate_key: candidateKey(record),
@@ -678,9 +706,9 @@ function toCandidate(record, seenCves, recencyBucket = 'recent') {
     priority_reasons: priority.reasons,
     official_cisa_kev: {
       status_source: 'cisa_date_added field from VulnCheck record; verify against CISA before official labeling',
-      listed: Boolean(record.cisa_date_added),
-      date_added: normalizeDate(record.cisa_date_added),
-      due_date: normalizeDate(record.dueDate),
+      listed: false,
+      date_added: null,
+      due_date: null,
     },
     vulncheck_exploitation_signal: {
       source: 'VulnCheck KEV',


### PR DESCRIPTION
## What changed

- rebuild the generated Supply Chain discovery branch from current `main` under an explicit remote-head lease while carrying the pending queue forward
- enforce the configured VulnCheck source-packet cap globally across open PRs instead of rolling over into unbounded new PRs
- correct backlog recency wording, non-authoritative CISA status handling, escaped metadata, and the verified CVE-2026-4631 Cockpit product mapping
- allow current-head CodeRabbit reviews to trigger and satisfy the AI review signal while unresolved review threads remain blocking
- add workflow-contract regression coverage and update pipeline documentation

## Root cause

The Supply Chain workflow merged `main` into a long-lived generated branch. Once generated packet snapshots conflicted, every later scheduled run failed at the same merge. The VulnCheck lane treated `max_pending` as a per-PR limit and created another PR whenever one filled, producing 190 unique open prefills against a configured cap of 40.

## Impact

Generated branch refreshes are deterministic and race-guarded, source-packet intake now pauses under review backpressure, and generated packet metadata no longer promotes non-authoritative fields into official claims.

The CVE-2026-4631 correction is grounded in the [NVD record](https://nvd.nist.gov/vuln/detail/CVE-2026-4631), which identifies Cockpit and Red Hat rather than GNU/grub2.

## Validation

- `cd scripts && npm test`
- `node --check` for modified JavaScript modules and tests
- YAML parse plus `bash -n` for every modified workflow shell block
- explicit `--force-with-lease` branch-creation and guarded-replacement simulation against a temporary bare remote
- live open-prefill accounting: 190 unique prefills versus configured cap 40

@coderabbitai review
/gemini review

Review requested: @dangermouse-bot @ernestpenfold-bot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added repo-level workflow concurrency controls for discovery lanes; discovery now enforces a global pending-cap to pause VulnCheck intake when backlog headroom is exhausted.
* **Bug Fixes**
  * Updated VulnCheck KEV/source-packet PR metadata to compute “CISA date present” from KEV-derived timestamps; improved KEV candidate listed/date behavior and intake robustness.
  * Refined discovery branch/queue handling to reliably rebuild from `main` and safely preserve pending queues.
* **Documentation**
  * Updated pipeline docs for global backpressure/pausing and AI reviewer coverage.
* **Tests**
  * Added pipeline orchestration contract tests and expanded KEV intake fixtures/expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->