### PR TITLE
fix(pipeline): preserve VulnCheck evidence semantics

### DIFF
--- a/.github/workflows/supply-chain-live-discovery.yml
+++ b/.github/workflows/supply-chain-live-discovery.yml
@@ -206,22 +206,22 @@ jobs:
 
             const top = (queue.candidates || []).slice(0, 10);
             let body = '## Supply Chain B1 candidate queue\n\n';
-            body += 'This PR updates the live Supply Chain discovery/classification queue. It is candidate review only: no article tasks, no drafts, and no corpus records are created by this lane.\\n\\n';
-            body += `Review requested: @MahdiHedhli @dangermouse-bot @ernestpenfold-bot.\\n\\n`;
-            body += `Summary: ${queue.summary.candidates_emitted} emitted candidates, ${queue.summary.current_candidates} current, ${queue.summary.matched_existing} matched existing corpus subjects.\\n`;
-            body += `Currency: latest corpus ${queue.currency.latest_corpus_incident_at || 'unknown'}, latest discovery ${queue.currency.latest_discovery_signal_at || 'none'}, pending ${queue.currency.pending_candidate_count}.\\n\\n`;
-            body += '| Rank | Class | Intent | Subject | Title | Sources |\\n';
-            body += '|---:|---|---|---|---|---|\\n';
+            body += 'This PR updates the live Supply Chain discovery/classification queue. It is candidate review only: no article tasks, no drafts, and no corpus records are created by this lane.\n\n';
+            body += `Review requested: @MahdiHedhli @dangermouse-bot @ernestpenfold-bot.\n\n`;
+            body += `Summary: ${queue.summary.candidates_emitted} emitted candidates, ${queue.summary.current_candidates} current, ${queue.summary.matched_existing} matched existing corpus subjects.\n`;
+            body += `Currency: latest corpus ${queue.currency.latest_corpus_incident_at || 'unknown'}, latest discovery ${queue.currency.latest_discovery_signal_at || 'none'}, pending ${queue.currency.pending_candidate_count}.\n\n`;
+            body += '| Rank | Class | Intent | Subject | Title | Sources |\n';
+            body += '|---:|---|---|---|---|---|\n';
             for (const candidate of top) {
-              const title = String(candidate.title || '').replace(/\\|/g, '\\\\|').slice(0, 100);
+              const title = String(candidate.title || '').replace(/\|/g, '\\|').slice(0, 100);
               const subject = `\`${String(candidate.canonicalSubjectId || '').replace(/`/g, '')}\``;
-              body += `| ${candidate.rank} | ${candidate.classification.leadClass} | ${candidate.classification.workIntent} | ${subject} | ${title} | ${candidate.sources.join(', ')} |\\n`;
+              body += `| ${candidate.rank} | ${candidate.classification.leadClass} | ${candidate.classification.workIntent} | ${subject} | ${title} | ${candidate.sources.join(', ')} |\n`;
             }
-            body += '\\n### Guardrails\\n\\n';
-            body += '- `drafting_enabled=false` and `auto_drafting_allowed=false` are validated.\\n';
-            body += '- `kevStatusDerived` is dispatch-cycle output, not authored truth.\\n';
-            body += '- B2 grounded drafting may consume approved candidates only through source-packet preflight and grounded-draft fidelity checks.\\n';
-            body += '\\n@codex review\\n/gemini review\\n';
+            body += '\n### Guardrails\n\n';
+            body += '- `drafting_enabled=false` and `auto_drafting_allowed=false` are validated.\n';
+            body += '- `kevStatusDerived` is dispatch-cycle output, not authored truth.\n';
+            body += '- B2 grounded drafting may consume approved candidates only through source-packet preflight and grounded-draft fidelity checks.\n';
+            body += '\n@codex review\n/gemini review\n';
 
             const existing = await github.rest.pulls.list({
               owner,

--- a/scripts/test-pipeline-orchestration-contracts.mjs
+++ b/scripts/test-pipeline-orchestration-contracts.mjs
@@ -16,6 +16,9 @@ assert.ok(supplyChainWorkflow.includes('PREVIOUS_PACKET_DIR="$RUNNER_TEMP/supply
 assert.ok(supplyChainWorkflow.includes('git diff --name-only --diff-filter=A origin/main..."origin/${BRANCH}"'));
 assert.ok(supplyChainWorkflow.includes('git cat-file -e "origin/main:${packet_path}"'));
 assert.ok(supplyChainWorkflow.includes('cp -R "$PREVIOUS_PACKET_DIR"/. "$VULNCHECK_PACKET_DIR"/'));
+assert.ok(supplyChainWorkflow.includes("replace(/\\|/g, '\\\\|')"));
+assert.ok(supplyChainWorkflow.includes("body += '\\n### Guardrails\\n\\n'"));
+assert.ok(!supplyChainWorkflow.includes("body += '\\\\n### Guardrails"));
 
 assert.match(discoveryWorkflow, /TOTAL_PENDING_PREFILLS/);
 assert.match(discoveryWorkflow, /"\$TOTAL_PENDING_PREFILLS" -ge "\$PENDING_CAP"/);

--- a/scripts/test-vulncheck-kev-intake.mjs
+++ b/scripts/test-vulncheck-kev-intake.mjs
@@ -75,7 +75,7 @@ assert.equal(result.candidates[0].recency_bucket, 'recent');
 assert.equal(result.candidates[1].cves[0], 'CVE-2026-0001');
 assert.equal(result.candidates[1].recency_bucket, 'backlog');
 assert.equal(result.candidates[0].drafting_allowed, false);
-assert.equal(result.candidates[0].official_cisa_kev.listed, false);
+assert.equal(result.candidates[0].official_cisa_kev.listed, null);
 assert.equal(result.candidates[0].official_cisa_kev.date_added, null);
 assert.equal(
   result.candidates[0].official_cisa_kev.status_source,
@@ -181,10 +181,156 @@ const correctedProduct = buildRecentIntake({
 
 assert.equal(correctedProduct.candidates[0].vendorProject, 'Red Hat');
 assert.equal(correctedProduct.candidates[0].product, 'cockpit');
+assert.equal(
+  correctedProduct.candidates[0].vulnerabilityName,
+  'Cockpit: unauthenticated remote code execution due to SSH command-line argument injection',
+);
 assert.equal(correctedProduct.candidates[0].source_packet_prefill.affected_products[0].vendor, 'Red Hat');
 assert.equal(correctedProduct.candidates[0].source_packet_prefill.affected_products[0].product, 'cockpit');
 assert.equal(correctedProduct.candidates[0].source_packet_prefill.preserved_vulncheck_fields.vendorProject, 'Red Hat');
 assert.equal(correctedProduct.candidates[0].source_packet_prefill.preserved_vulncheck_fields.product, 'cockpit');
+assert.equal(
+  correctedProduct.candidates[0].source_packet_prefill.preserved_vulncheck_fields.vulnerabilityName,
+  'Cockpit: unauthenticated remote code execution due to SSH command-line argument injection',
+);
+assert.ok(
+  correctedProduct.candidates[0].source_packet_prefill.supporting_sources.some(
+    source => source.url === 'https://www.cve.org/CVERecord?id=CVE-2026-4631'
+      && source.id.startsWith('src-cve-normalization-')
+      && !source.notes.includes('VulnCheck observed'),
+  ),
+);
+assert.ok(
+  correctedProduct.candidates[0].source_packet_prefill.affected_products[0].source_refs.some(
+    sourceRef => sourceRef.startsWith('src-cve-normalization-'),
+  ),
+);
+const correctedSourcesById = new Map(
+  correctedProduct.candidates[0].source_packet_prefill.supporting_sources.map(source => [source.id, source]),
+);
+const correctedCvesById = new Map(
+  correctedProduct.candidates[0].source_packet_prefill.cves.map(cve => [cve.id, cve]),
+);
+for (const cve of correctedCvesById.values()) {
+  assert.ok(cve.source_refs.every(sourceRef => typeof sourceRef === 'string' && sourceRef.length > 0));
+}
+assert.ok(
+  correctedCvesById.get('CVE-2026-4631').source_refs.some(
+    sourceRef => correctedSourcesById.get(sourceRef)?.url.endsWith('CVE-2026-4631'),
+  ),
+);
+assert.ok(
+  correctedCvesById.get('CVE-2025-12352').source_refs.every(
+    sourceRef => !correctedSourcesById.get(sourceRef)?.url.endsWith('CVE-2026-4631'),
+  ),
+);
+
+const reportedEvidenceFixture = [
+  { url: ' HTTPS://cyber.gov.au/example-alert ', date_added: '2026-07-09T00:00:00Z' },
+  { url: 'https://www.cve.org/CVERecord?id=CVE-2026-31843', date_added: '2026-07-09T00:00:00Z' },
+  { url: 'https://nvd.nist.gov/vuln/detail/CVE-2026-31843', date_added: '2026-07-09T00:00:00Z' },
+  { url: 'https://www.ncsc.gov.uk/example-alert', date_added: '2026-07-09T00:00:00Z' },
+  { url: 'https://cyber.gc.ca/example-alert', date_added: '2026-07-09T00:00:00Z' },
+  { url: 'https://www.bsi.bund.de/example-alert', date_added: '2026-07-09T00:00:00Z' },
+  { url: 'https://www.ncsc.govt.nz/example-alert', date_added: '2026-07-09T00:00:00Z' },
+  { url: 'https://cyber.example.gov.scot/example-alert', date_added: '2026-07-09T00:00:00Z' },
+  { url: 'https://cert.ssi.gouv.fr/example-alert', date_added: '2026-07-09T00:00:00Z' },
+  { url: 'https://example.gc.ca/example-alert', date_added: '2026-07-09T00:00:00Z' },
+  { url: 'https://example.gob.mx/example-alert', date_added: '2026-07-09T00:00:00Z' },
+  { url: 'https://example.go.jp/example-alert', date_added: '2026-07-09T00:00:00Z' },
+  { url: 'https://example.gv.at/example-alert', date_added: '2026-07-09T00:00:00Z' },
+];
+
+const evidenceClassified = buildRecentIntake({
+  data: [
+    {
+      vendorProject: null,
+      product: null,
+      vulnerabilityName: 'pay-uz remote code execution',
+      shortDescription: 'The goodoneuz/pay-uz package allows unauthenticated remote code execution.',
+      required_action: 'Patch.',
+      knownRansomwareCampaignUse: 'Unknown',
+      cve: ['CVE-2026-31843'],
+      cwes: [],
+      vulncheck_xdb: [],
+      vulncheck_reported_exploitation: reportedEvidenceFixture,
+      reported_exploited_by_vulncheck_canaries: false,
+      date_added: '2026-07-09T00:00:00Z',
+    },
+  ],
+}, {
+  lookbackDays: 30,
+  maxCandidates: 1,
+  asOf: '2026-07-09',
+  seenCves: new Set(),
+});
+
+const classifiedCandidate = evidenceClassified.candidates[0];
+assert.equal(classifiedCandidate.vendorProject, 'goodoneuz');
+assert.equal(classifiedCandidate.product, 'pay-uz');
+assert.equal(classifiedCandidate.vulncheck_exploitation_signal.reported_exploitation_count, 11);
+assert.deepEqual(classifiedCandidate.vulncheck_exploitation_signal.evidence_urls, [
+  'https://cyber.gov.au/example-alert',
+  'https://www.ncsc.gov.uk/example-alert',
+  'https://cyber.gc.ca/example-alert',
+  'https://www.bsi.bund.de/example-alert',
+  'https://www.ncsc.govt.nz/example-alert',
+  'https://cyber.example.gov.scot/example-alert',
+  'https://cert.ssi.gouv.fr/example-alert',
+  'https://example.gc.ca/example-alert',
+  'https://example.gob.mx/example-alert',
+  'https://example.go.jp/example-alert',
+  'https://example.gv.at/example-alert',
+]);
+assert.ok(classifiedCandidate.priority_reasons.includes('11 VulnCheck reported exploitation reference(s)'));
+assert.equal(classifiedCandidate.source_packet_prefill.source_quality.has_government_source, true);
+assert.equal(classifiedCandidate.source_packet_prefill.source_quality.has_primary_source, false);
+assert.ok(
+  classifiedCandidate.source_packet_prefill.supporting_sources.some(
+    source => source.url.includes('cve.org/CVERecord') && source.notes.includes('not counted as exploitation evidence'),
+  ),
+);
+assert.ok(
+  classifiedCandidate.source_packet_prefill.supporting_sources.some(
+    source => source.publisher === 'National Vulnerability Database' && source.source_type === 'database',
+  ),
+);
+const classifiedSourcesById = new Map(
+  classifiedCandidate.source_packet_prefill.supporting_sources.map(source => [source.id, source]),
+);
+assert.ok(
+  classifiedCandidate.source_packet_prefill.affected_products[0].source_refs.some(
+    sourceRef => classifiedSourcesById.get(sourceRef)?.url.endsWith('CVE-2026-31843'),
+  ),
+);
+for (const publisher of [
+  'National Cyber Security Centre',
+  'Canadian Centre for Cyber Security',
+  'Federal Office for Information Security',
+  'National Cyber Security Centre New Zealand',
+]) {
+  assert.ok(
+    classifiedCandidate.source_packet_prefill.supporting_sources.some(
+      source => source.publisher === publisher && source.source_type === 'government',
+    ),
+  );
+}
+assert.ok(
+  classifiedCandidate.source_packet_prefill.supporting_sources.some(
+    source => source.publisher === 'cyber.example.gov.scot' && source.source_type === 'government',
+  ),
+);
+for (const publisher of ['cert.ssi.gouv.fr', 'example.gc.ca', 'example.gob.mx', 'example.go.jp', 'example.gv.at']) {
+  assert.ok(
+    classifiedCandidate.source_packet_prefill.supporting_sources.some(
+      source => source.publisher === publisher && source.source_type === 'government',
+    ),
+  );
+}
+assert.deepEqual(
+  classifiedCandidate.source_packet_prefill.preserved_vulncheck_fields.vulncheck_reported_exploitation,
+  reportedEvidenceFixture,
+);
 
 const escapedMetadata = buildRecentIntake({
   data: [

--- a/scripts/vulncheck-kev-intake.mjs
+++ b/scripts/vulncheck-kev-intake.mjs
@@ -30,14 +30,22 @@ const DEFAULT_CANDIDATE_INDEX_PATH = '.github/pipeline/source-packets/vulncheck-
 const DEFAULT_SIBLING_LIMIT = 4;
 const CVE_RE = /\bCVE-\d{4}-\d{4,}\b/gi;
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const GOVERNMENT_COUNTRY_DOMAIN_RE = /(^|\.)(?:gov|govt|gouv|gc|gob|go|gv)\.(?:scot|wales|cymru|[a-z]{2})$/;
 const PRODUCT_NORMALIZATION_BY_CVE = new Map([
   ['CVE-2025-12352', { vendorProject: 'rocketgenius', product: 'gravityforms' }],
   ['CVE-2026-6433', { vendorProject: 'custom_css_js_php_project', product: 'custom_css_js_php' }],
+  ['CVE-2026-31843', {
+    vendorProject: 'goodoneuz',
+    product: 'pay-uz',
+    sourceUrl: 'https://www.cve.org/CVERecord?id=CVE-2026-31843',
+  }],
   // VulnCheck currently carries unrelated GNU/grub2 fields; Red Hat's CVE
   // record identifies the affected package as Cockpit.
   ['CVE-2026-4631', {
     vendorProject: 'Red Hat',
     product: 'cockpit',
+    vulnerabilityName: 'Cockpit: unauthenticated remote code execution due to SSH command-line argument injection',
+    sourceUrl: 'https://www.cve.org/CVERecord?id=CVE-2026-4631',
     overrideExisting: true,
   }],
 ]);
@@ -509,13 +517,139 @@ function siblingKey(candidate) {
   ].join(':');
 }
 
+function parsedHttpUrl(value) {
+  if (typeof value !== 'string') return null;
+  try {
+    const parsed = new URL(value);
+    return ['http:', 'https:'].includes(parsed.protocol) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function isCveIdentityUrl(value) {
+  const parsed = parsedHttpUrl(value);
+  if (!parsed) return false;
+  const host = parsed.hostname.toLowerCase();
+  const pathname = parsed.pathname.toLowerCase();
+  return ((host === 'cve.org' || host.endsWith('.cve.org') || host === 'cve.mitre.org')
+      && (pathname.includes('cverecord') || pathname.includes('/cgi-bin/cvename.cgi')))
+    || ((host === 'nvd.nist.gov' || host.endsWith('.nvd.nist.gov')) && pathname.startsWith('/vuln/detail/'));
+}
+
+function reportedExploitationEntriesFor(record) {
+  return (Array.isArray(record?.vulncheck_reported_exploitation) ? record.vulncheck_reported_exploitation : [])
+    .filter(item => parsedHttpUrl(item?.url) && !isCveIdentityUrl(item.url));
+}
+
+function cveIdentityEntriesFor(record) {
+  return (Array.isArray(record?.vulncheck_reported_exploitation) ? record.vulncheck_reported_exploitation : [])
+    .filter(item => parsedHttpUrl(item?.url) && isCveIdentityUrl(item.url));
+}
+
+function isGovernmentHost(host) {
+  return host === 'cisa.gov'
+    || host.endsWith('.cisa.gov')
+    || host.endsWith('.gov')
+    || GOVERNMENT_COUNTRY_DOMAIN_RE.test(host);
+}
+
+function sourceMetadataForUrl(value) {
+  const parsed = parsedHttpUrl(value);
+  if (!parsed) return { publisher: 'Other', source_type: 'other' };
+  const host = parsed.hostname.toLowerCase();
+  if (host === 'cve.org' || host.endsWith('.cve.org') || host === 'cve.mitre.org') {
+    return { publisher: 'CVE Program', source_type: 'database' };
+  }
+  if (host === 'nvd.nist.gov' || host.endsWith('.nvd.nist.gov')) {
+    return { publisher: 'National Vulnerability Database', source_type: 'database' };
+  }
+  if (host === 'cyber.gov.au' || host.endsWith('.cyber.gov.au')) {
+    return { publisher: 'Australian Cyber Security Centre', source_type: 'government' };
+  }
+  if (host === 'cisa.gov' || host.endsWith('.cisa.gov')) {
+    return { publisher: 'Cybersecurity and Infrastructure Security Agency', source_type: 'government' };
+  }
+  if (host === 'ncsc.gov.uk' || host.endsWith('.ncsc.gov.uk')) {
+    return { publisher: 'National Cyber Security Centre', source_type: 'government' };
+  }
+  if (host === 'cyber.gc.ca' || host.endsWith('.cyber.gc.ca')) {
+    return { publisher: 'Canadian Centre for Cyber Security', source_type: 'government' };
+  }
+  if (host === 'bsi.bund.de' || host.endsWith('.bsi.bund.de')) {
+    return { publisher: 'Federal Office for Information Security', source_type: 'government' };
+  }
+  if (host === 'ncsc.govt.nz' || host.endsWith('.ncsc.govt.nz')) {
+    return { publisher: 'National Cyber Security Centre New Zealand', source_type: 'government' };
+  }
+  if (isGovernmentHost(host)) return { publisher: host, source_type: 'government' };
+  return { publisher: host || 'Other', source_type: 'other' };
+}
+
+function supportingSourcesFor(record, dateAdded) {
+  const sources = [{
+    id: 'src-vulncheck-kev',
+    publisher: 'VulnCheck',
+    url: 'https://api.vulncheck.com/v3/backup/vulncheck-kev',
+    published_at: dateAdded,
+    source_type: 'vendor',
+    role: 'supporting',
+    notes: 'VulnCheck KEV community backup record; prominent VulnCheck KEV attribution required when data is surfaced.',
+  }];
+  const seen = new Set(sources.map(source => source.url));
+
+  const appendEntries = (entries, idPrefix, notes, options = {}) => {
+    for (const item of entries) {
+      const url = parsedHttpUrl(item?.url)?.toString();
+      if (!url || seen.has(url)) continue;
+      seen.add(url);
+      const metadata = sourceMetadataForUrl(url);
+      sources.push({
+        id: `${idPrefix}-${sources.length}`,
+        publisher: metadata.publisher,
+        url,
+        published_at: null,
+        source_type: metadata.source_type,
+        role: 'supporting',
+        notes: options.observedByVulnCheck === false
+          ? notes
+          : `${notes} VulnCheck observed this reference on ${normalizeDate(item?.date_added) || 'an unknown date'}.`,
+      });
+    }
+  };
+
+  appendEntries(
+    reportedExploitationEntriesFor(record),
+    'src-vulncheck-exploitation',
+    'Direct URL carried by VulnCheck as reported exploitation evidence; independently verify before publication.',
+  );
+  appendEntries(
+    cveIdentityEntriesFor(record),
+    'src-vulncheck-cve-identity',
+    'CVE identity provenance carried by VulnCheck; not counted as exploitation evidence.',
+  );
+  const normalizationEntries = uniqueStrings(record?.cve)
+    .map(cve => PRODUCT_NORMALIZATION_BY_CVE.get(cve)?.sourceUrl)
+    .filter(Boolean)
+    .map(url => ({ url, date_added: null }));
+  appendEntries(
+    normalizationEntries,
+    'src-cve-normalization',
+    'Authoritative CVE Program provenance for normalized product or vulnerability metadata; not exploitation evidence.',
+    { observedByVulnCheck: false },
+  );
+  return sources;
+}
+
 function sourceRefsFor(record) {
   const urls = [];
-  for (const item of Array.isArray(record.vulncheck_reported_exploitation) ? record.vulncheck_reported_exploitation : []) {
-    if (typeof item?.url === 'string' && item.url.startsWith('http')) urls.push(item.url);
+  for (const item of reportedExploitationEntriesFor(record)) {
+    const url = parsedHttpUrl(item?.url)?.toString();
+    if (url) urls.push(url);
   }
   for (const item of xdbEntriesFor(record)) {
-    if (typeof item?.xdb_url === 'string' && item.xdb_url.startsWith('http')) urls.push(item.xdb_url);
+    const url = parsedHttpUrl(item?.xdb_url)?.toString();
+    if (url) urls.push(url);
   }
   return uniqueStrings(urls);
 }
@@ -538,7 +672,7 @@ function exploitTypes(record) {
 function priorityScore(record, addedDate, recencyBucket) {
   let score = 0;
   const reasons = [];
-  const reported = Array.isArray(record.vulncheck_reported_exploitation) ? record.vulncheck_reported_exploitation.length : 0;
+  const reported = reportedExploitationEntriesFor(record).length;
   const xdb = xdbEntriesFor(record).length;
 
   if (addedDate) {
@@ -596,6 +730,7 @@ function normalizeKnownProductFields(record) {
       ...cleaned,
       vendorProject: forcedNormalization.vendorProject,
       product: forcedNormalization.product,
+      vulnerabilityName: forcedNormalization.vulnerabilityName || cleaned.vulnerabilityName,
     };
   }
   const cves = uniqueStrings(record?.cve);
@@ -606,6 +741,7 @@ function normalizeKnownProductFields(record) {
       ...cleaned,
       vendorProject: cleaned.vendorProject || normalized.vendorProject,
       product: cleaned.product || normalized.product,
+      vulnerabilityName: cleaned.vulnerabilityName || normalized.vulnerabilityName,
     };
   }
   return cleaned;
@@ -621,6 +757,31 @@ function makePrefill(rawRecord) {
   const dueDate = normalizeDate(record.dueDate);
   const dateAdded = normalizeDate(record.date_added);
   const vulncheckSourceId = 'src-vulncheck-kev';
+  const supportingSources = supportingSourcesFor(rawRecord, dateAdded);
+  const sourceIdByUrl = new Map(supportingSources.map(source => [source.url, source.id]));
+  const identitySourceRefsByCve = new Map(cves.map(cve => [cve, []]));
+  for (const item of cveIdentityEntriesFor(rawRecord)) {
+    const url = parsedHttpUrl(item?.url)?.toString();
+    const sourceId = sourceIdByUrl.get(url);
+    if (!sourceId) continue;
+    const referencedCves = new Set(extractCvesFromText(url));
+    for (const cve of cves) {
+      if (referencedCves.has(cve)) identitySourceRefsByCve.get(cve).push(sourceId);
+    }
+  }
+  const normalizationSourceRefForCve = new Map(cves.map((cve) => {
+    const sourceUrl = parsedHttpUrl(PRODUCT_NORMALIZATION_BY_CVE.get(cve)?.sourceUrl)?.toString();
+    return [cve, sourceIdByUrl.get(sourceUrl) || null];
+  }));
+  const cveSourceRefsFor = cve => uniqueStrings([
+    vulncheckSourceId,
+    ...(identitySourceRefsByCve.get(cve) || []),
+    normalizationSourceRefForCve.get(cve),
+  ].filter(Boolean));
+  const productSourceRefs = uniqueStrings([
+    vulncheckSourceId,
+    ...[...normalizationSourceRefForCve.values()].filter(Boolean),
+  ]);
 
   return {
     status: 'prefill_only',
@@ -631,19 +792,9 @@ function makePrefill(rawRecord) {
       vulncheck_role: 'non-authoritative exploitation signal and supporting source',
       instruction: 'Do not draft or apply official KEV labeling from VulnCheck alone; verify CISA KEV membership against CISA before publication.',
     },
-    supporting_sources: [
-      {
-        id: vulncheckSourceId,
-        publisher: 'VulnCheck',
-        url: 'https://api.vulncheck.com/v3/backup/vulncheck-kev',
-        published_at: dateAdded,
-        source_type: 'vendor',
-        role: 'supporting',
-        notes: 'VulnCheck KEV community backup record; prominent VulnCheck KEV attribution required when data is surfaced.',
-      },
-    ],
+    supporting_sources: supportingSources,
     source_quality: {
-      has_government_source: false,
+      has_government_source: supportingSources.some(source => source.source_type === 'government'),
       has_vendor_source: true,
       has_primary_source: false,
       source_sufficiency: 'needs_human_review',
@@ -658,15 +809,15 @@ function makePrefill(rawRecord) {
         vendor: String(record.vendorProject || 'Unknown'),
         product: String(record.product || 'Unknown'),
         versions: 'unknown',
-        source_refs: [vulncheckSourceId],
+        source_refs: productSourceRefs,
       },
     ],
-    cves: cves.map(id => ({ id, source_refs: [vulncheckSourceId] })),
+    cves: cves.map(id => ({ id, source_refs: cveSourceRefsFor(id) })),
     cwes: cwes.map(id => ({ id, name: 'Unknown', source_refs: [vulncheckSourceId] })),
     preserved_vulncheck_fields: {
       vendorProject: forcedNormalization ? record.vendorProject : normalizeVulnCheckText(rawRecord.vendorProject) || null,
       product: forcedNormalization ? record.product : normalizeVulnCheckText(rawRecord.product) || null,
-      vulnerabilityName: normalizeVulnCheckText(rawRecord.vulnerabilityName) || null,
+      vulnerabilityName: forcedNormalization ? record.vulnerabilityName : normalizeVulnCheckText(rawRecord.vulnerabilityName) || null,
       shortDescription: normalizeVulnCheckText(rawRecord.shortDescription) || null,
       required_action: rawRecord.required_action || null,
       knownRansomwareCampaignUse: rawRecord.knownRansomwareCampaignUse || null,
@@ -714,7 +865,7 @@ function toCandidate(record, seenCves, recencyBucket = 'recent') {
     priority_reasons: priority.reasons,
     official_cisa_kev: {
       status_source: 'not inferred from VulnCheck; verify CISA KEV membership against CISA before official labeling',
-      listed: false,
+      listed: null,
       date_added: null,
       due_date: null,
     },
@@ -724,7 +875,7 @@ function toCandidate(record, seenCves, recencyBucket = 'recent') {
       date_added: addedDate,
       known_ransomware_campaign_use: record.knownRansomwareCampaignUse || 'Unknown',
       reported_exploited_by_vulncheck_canaries: record.reported_exploited_by_vulncheck_canaries === true,
-      reported_exploitation_count: Array.isArray(record.vulncheck_reported_exploitation) ? record.vulncheck_reported_exploitation.length : 0,
+      reported_exploitation_count: reportedExploitationEntriesFor(record).length,
       xdb_count: xdbEntriesFor(record).length,
       xdb_exploit_types: exploitTypes(record),
       evidence_urls: sourceRefsFor(record),


### PR DESCRIPTION
## Summary

- represent unverified CISA KEV membership as unknown rather than an authoritative negative
- exclude CVE identity records from exploitation counts, scoring, and evidence URLs while retaining them as provenance
- normalize the two reviewer-flagged product/name anomalies from current CVE Program records
- classify direct government evidence references without treating feed-carried URLs as publication-ready primary sources
- render generated Supply Chain PR bodies with real newlines and only escape actual pipe characters

Fixes the generator defects blocking #1417.

## Validation

- `npm --prefix scripts test`
- workflow YAML parse
- `git diff --check`
- 30-record regression replay against #1417 artifacts

@codex review
/gemini review
@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated candidate-queue PR markdown so line breaks and pipe characters render correctly.
  * Improved VulnCheck KEV intake by enhancing URL provenance classification, expanding CVE normalization (including vulnerability-name overrides and additional CVE mappings), refining evidence/supporting-source generation, and adjusting evidence counting and prefilling.
  * Updated KEV listing status to return `null` instead of `false`.
* **Tests**
  * Expanded workflow and intake contract tests to cover the new escaping, normalization behavior, supporting-source contents, and filtered exploitation-evidence counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->