### PR TITLE
Repair task schema and generated graph validation

### DIFF
--- a/.github/pipeline/schema/task-schema.json
+++ b/.github/pipeline/schema/task-schema.json
@@ -55,7 +55,7 @@
     },
     "source": {
       "type": "string",
-      "enum": ["auto_discovery", "manual_submission", "enrichment", "backfill", "automated_submission", "historical-corpus", "historical_corpus_backlog"],
+      "enum": ["auto_discovery", "promotion", "manual_submission", "enrichment", "backfill", "automated_submission", "historical-corpus", "historical_corpus_backlog"],
       "description": "How this task entered the pipeline"
     },
     "submitted_by": {

--- a/.github/pipeline/schema/task-schema.json
+++ b/.github/pipeline/schema/task-schema.json
@@ -3,7 +3,11 @@
   "title": "Threatpedia Pipeline Task",
   "description": "Schema for pipeline task files. Agent-agnostic: any agent reads this file, reads the referenced specs, and produces the output.",
   "type": "object",
-  "required": ["task_id", "stage", "type", "priority", "status", "input", "acceptance", "output"],
+  "required": ["task_id", "type", "priority", "status", "input", "output"],
+  "anyOf": [
+    { "required": ["acceptance_criteria"] },
+    { "required": ["acceptance"] }
+  ],
   "properties": {
     "task_id": {
       "type": "string",
@@ -12,7 +16,7 @@
     },
     "stage": {
       "type": "string",
-      "enum": ["discovery", "triage", "draft", "validation", "review", "revision", "approval", "publish"],
+      "enum": ["discovery", "triage", "draft", "generation", "validation", "review", "revision", "approval", "publish"],
       "description": "Current pipeline stage"
     },
     "type": {
@@ -27,7 +31,7 @@
     },
     "status": {
       "type": "string",
-      "enum": ["pending", "locked", "complete", "failed", "blocked", "cancelled"],
+      "enum": ["pending", "locked", "pr_open", "complete", "failed", "blocked", "cancelled"],
       "description": "Task execution status"
     },
     "created": {
@@ -51,7 +55,7 @@
     },
     "source": {
       "type": "string",
-      "enum": ["auto_discovery", "manual_submission", "enrichment", "backfill"],
+      "enum": ["auto_discovery", "manual_submission", "enrichment", "backfill", "automated_submission", "historical-corpus", "historical_corpus_backlog"],
       "description": "How this task entered the pipeline"
     },
     "submitted_by": {
@@ -100,15 +104,40 @@
       "items": { "type": "string" },
       "description": "Spec sections the agent must follow. Defaults applied by dispatcher if omitted."
     },
-    "acceptance": {
+    "acceptance_criteria": {
       "type": "object",
-      "description": "Machine-checkable acceptance criteria. Validation Action checks these.",
+      "description": "Canonical machine-checkable acceptance criteria used by current task writers.",
       "properties": {
         "frontmatter_valid": { "type": "boolean", "default": true },
         "min_sources": { "type": "integer", "default": 3 },
         "min_h2_sections": { "type": "integer", "default": 5 },
         "min_mitre_mappings": { "type": "integer", "default": 1 },
-        "review_status": { "type": "string", "default": "draft_ai" },
+        "review_status": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "minItems": 1, "items": { "type": "string" } }
+          ],
+          "default": "draft_ai"
+        },
+        "schema_validation": { "type": "string", "enum": ["pass", "warn"], "default": "pass" },
+        "astro_build": { "type": "boolean", "default": true }
+      }
+    },
+    "acceptance": {
+      "type": "object",
+      "description": "Legacy acceptance criteria retained for existing task compatibility.",
+      "properties": {
+        "frontmatter_valid": { "type": "boolean", "default": true },
+        "min_sources": { "type": "integer", "default": 3 },
+        "min_h2_sections": { "type": "integer", "default": 5 },
+        "min_mitre_mappings": { "type": "integer", "default": 1 },
+        "review_status": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "minItems": 1, "items": { "type": "string" } }
+          ],
+          "default": "draft_ai"
+        },
         "schema_validation": { "type": "string", "enum": ["pass", "warn"], "default": "pass" },
         "build_passes": { "type": "boolean", "default": true }
       }
@@ -136,7 +165,7 @@
           "description": "Git branch name for this task's work"
         },
         "pr": {
-          "type": "boolean",
+          "type": ["boolean", "null"],
           "default": true,
           "description": "Whether to open a PR when draft is complete"
         },

--- a/.github/workflows/pipeline-validate-tasks.yml
+++ b/.github/workflows/pipeline-validate-tasks.yml
@@ -4,8 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize]
     paths:
+      - ".github/pipeline/schema/task-schema.json"
       - ".github/pipeline/tasks/*.json"
       - ".github/workflows/pipeline-validate-tasks.yml"
+      - "scripts/test-pipeline-orchestration-contracts.mjs"
       - "scripts/validate-pipeline-tasks.mjs"
       - "scripts/pipeline-schema.mjs"
   workflow_dispatch:
@@ -40,6 +42,9 @@ jobs:
 
       - name: Install scripts dependencies
         run: cd scripts && npm ci --no-audit --no-fund
+
+      - name: Run orchestration contract tests
+        run: node scripts/test-pipeline-orchestration-contracts.mjs
 
       - name: Identify changed task files
         id: changed

--- a/.github/workflows/supply-chain-live-discovery.yml
+++ b/.github/workflows/supply-chain-live-discovery.yml
@@ -159,13 +159,24 @@ jobs:
           fi
           node scripts/supply-chain-live-discovery.mjs --check --queue-path "$CHECK_PATH"
 
-      - name: Commit candidate queue to branch
+      - name: Regenerate supply-chain public artifacts
+        if: ${{ inputs.execute != 'false' }}
+        run: |
+          set -euo pipefail
+          node scripts/build-supply-chain-graph.mjs
+
+      - name: Commit candidate queue and public artifacts to branch
         id: commit
         if: ${{ inputs.execute != 'false' }}
         run: |
           set -euo pipefail
           LEASE="--force-with-lease=refs/heads/${DISCOVERY_BRANCH}:${DISCOVERY_REMOTE_HEAD:-}"
-          git add .github/pipeline/supply-chain-candidates/ .github/pipeline/source-packets/vulncheck-kev/
+          git add \
+            .github/pipeline/supply-chain-candidates/ \
+            .github/pipeline/source-packets/vulncheck-kev/ \
+            site/public/supply-chain-graph.json \
+            site/public/supply-chain-malware-families-stix.json \
+            site/public/supply-chain-search-index.json
           if git diff --cached --quiet; then
             echo "No candidate queue changes this run."
             if [ -n "${DISCOVERY_REMOTE_HEAD:-}" ]; then
@@ -206,7 +217,7 @@ jobs:
 
             const top = (queue.candidates || []).slice(0, 10);
             let body = '## Supply Chain B1 candidate queue\n\n';
-            body += 'This PR updates the live Supply Chain discovery/classification queue. It is candidate review only: no article tasks, no drafts, and no corpus records are created by this lane.\n\n';
+            body += 'This PR updates the live Supply Chain discovery/classification queue and its deterministic public graph/search artifacts. It is candidate review only: no article tasks, no drafts, and no corpus records are created by this lane.\n\n';
             body += `Review requested: @MahdiHedhli @dangermouse-bot @ernestpenfold-bot.\n\n`;
             body += `Summary: ${queue.summary.candidates_emitted} emitted candidates, ${queue.summary.current_candidates} current, ${queue.summary.matched_existing} matched existing corpus subjects.\n`;
             body += `Currency: latest corpus ${queue.currency.latest_corpus_incident_at || 'unknown'}, latest discovery ${queue.currency.latest_discovery_signal_at || 'none'}, pending ${queue.currency.pending_candidate_count}.\n\n`;

--- a/.github/workflows/supply-chain-live-discovery.yml
+++ b/.github/workflows/supply-chain-live-discovery.yml
@@ -2,7 +2,7 @@ name: "Supply Chain: Live Discovery"
 
 on:
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "17 */6 * * *"
   workflow_dispatch:
     inputs:
       execute:
@@ -67,9 +67,6 @@ jobs:
           set -euo pipefail
           BRANCH="${DISCOVERY_BRANCH}"
           PREVIOUS_QUEUE="$RUNNER_TEMP/supply-chain-previous-queue.json"
-          PREVIOUS_PACKET_DIR="$RUNNER_TEMP/supply-chain-previous-vulncheck-packets"
-          VULNCHECK_PACKET_DIR=".github/pipeline/source-packets/vulncheck-kev"
-          PRESERVED_PACKET_COUNT=0
           REMOTE_HEAD=""
 
           git fetch origin main
@@ -87,22 +84,6 @@ jobs:
                 git show "origin/${BRANCH}:${QUEUE_PATH}" > "$PREVIOUS_QUEUE"
                 echo "Preserving the pending candidate queue while rebuilding from current main."
               fi
-
-              mkdir -p "$PREVIOUS_PACKET_DIR"
-              while IFS= read -r packet_path; do
-                [ -n "$packet_path" ] || continue
-                if git cat-file -e "origin/main:${packet_path}" 2>/dev/null; then
-                  continue
-                fi
-                relative_path="${packet_path#${VULNCHECK_PACKET_DIR}/}"
-                mkdir -p "$PREVIOUS_PACKET_DIR/$(dirname "$relative_path")"
-                git show "origin/${BRANCH}:${packet_path}" > "$PREVIOUS_PACKET_DIR/$relative_path"
-                PRESERVED_PACKET_COUNT=$((PRESERVED_PACKET_COUNT + 1))
-              done < <(
-                git diff --name-only --diff-filter=A origin/main..."origin/${BRANCH}" -- "${VULNCHECK_PACKET_DIR}/*.json" \
-                  | awk '!/\/latest\.json$/'
-              )
-              echo "Preserving ${PRESERVED_PACKET_COUNT} branch-only VulnCheck source packets."
             fi
           fi
 
@@ -113,27 +94,7 @@ jobs:
             mkdir -p "$(dirname "$QUEUE_PATH")"
             cp "$PREVIOUS_QUEUE" "$QUEUE_PATH"
           fi
-          if [ "$PRESERVED_PACKET_COUNT" -gt 0 ]; then
-            mkdir -p "$VULNCHECK_PACKET_DIR"
-            cp -R "$PREVIOUS_PACKET_DIR"/. "$VULNCHECK_PACKET_DIR"/
-          fi
           echo "DISCOVERY_REMOTE_HEAD=${REMOTE_HEAD}" >> "$GITHUB_ENV"
-
-      - name: Run VulnCheck KEV source-packet intake
-        if: ${{ inputs.execute != 'false' }}
-        env:
-          VULNCHECKAPI: ${{ secrets.VULNCHECKAPI }}
-        run: |
-          set -euo pipefail
-          if [ -z "${VULNCHECKAPI:-}" ]; then
-            echo "::warning::VULNCHECKAPI secret is not configured; continuing without fresh VulnCheck lead contribution."
-          else
-            node scripts/vulncheck-kev-intake.mjs \
-              --execute \
-              --max-candidates 30 \
-              --cache "$RUNNER_TEMP/vulncheck-kev-backup.json" \
-              --out "$RUNNER_TEMP/vulncheck-kev-intake-result.json"
-          fi
 
       - name: Run Supply Chain live discovery
         env:
@@ -173,7 +134,6 @@ jobs:
           LEASE="--force-with-lease=refs/heads/${DISCOVERY_BRANCH}:${DISCOVERY_REMOTE_HEAD:-}"
           git add \
             .github/pipeline/supply-chain-candidates/ \
-            .github/pipeline/source-packets/vulncheck-kev/ \
             site/public/supply-chain-graph.json \
             site/public/supply-chain-malware-families-stix.json \
             site/public/supply-chain-search-index.json
@@ -217,7 +177,7 @@ jobs:
 
             const top = (queue.candidates || []).slice(0, 10);
             let body = '## Supply Chain B1 candidate queue\n\n';
-            body += 'This PR updates the live Supply Chain discovery/classification queue and its deterministic public graph/search artifacts. It is candidate review only: no article tasks, no drafts, and no corpus records are created by this lane.\n\n';
+            body += 'This PR updates the live Supply Chain discovery/classification queue from public registry, OSV, and GitHub Advisory signals, then regenerates its deterministic public graph/search artifacts. The existing VulnCheck index on `main` may contribute read-only supplemental signals, but this workflow does not produce VulnCheck packets. It is candidate review only: no article tasks, no drafts, and no corpus records are created by this lane.\n\n';
             body += `Review requested: @MahdiHedhli @dangermouse-bot @ernestpenfold-bot.\n\n`;
             body += `Summary: ${queue.summary.candidates_emitted} emitted candidates, ${queue.summary.current_candidates} current, ${queue.summary.matched_existing} matched existing corpus subjects.\n`;
             body += `Currency: latest corpus ${queue.currency.latest_corpus_incident_at || 'unknown'}, latest discovery ${queue.currency.latest_discovery_signal_at || 'none'}, pending ${queue.currency.pending_candidate_count}.\n\n`;

--- a/.github/workflows/supply-chain-validate.yml
+++ b/.github/workflows/supply-chain-validate.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize]
     paths:
+      - ".github/workflows/supply-chain-live-discovery.yml"
       - ".github/workflows/supply-chain-validate.yml"
       - "data/supply-chain-entities/**"
       - "data/supply-chain-incidents/**"
@@ -19,6 +20,7 @@ on:
       - "scripts/validate_supply_chain_incidents.py"
       - "scripts/test-supply-chain-pages.mjs"
       - "scripts/test-supply-chain-live-discovery.mjs"
+      - "scripts/test-pipeline-orchestration-contracts.mjs"
       - "site/src/lib/supplyChainPages.mjs"
       - "site/public/supply-chain-graph.json"
       - "site/public/supply-chain-malware-families-stix.json"
@@ -43,6 +45,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+
+      - name: Run orchestration contract tests
+        run: node scripts/test-pipeline-orchestration-contracts.mjs
 
       - name: Python syntax
         run: |

--- a/.github/workflows/supply-chain-validate.yml
+++ b/.github/workflows/supply-chain-validate.yml
@@ -46,6 +46,9 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Install script dependencies
+        run: cd scripts && npm ci --no-audit --no-fund
+
       - name: Run orchestration contract tests
         run: node scripts/test-pipeline-orchestration-contracts.mjs
 
@@ -67,10 +70,7 @@ jobs:
         run: python3 -m unittest tests/test_supply_chain_purl.py tests/test_supply_chain_incidents.py tests/test_supply_chain_graph.py
 
       - name: Run live discovery candidate queue test
-        run: |
-          cd scripts
-          npm ci --no-audit --no-fund
-          node test-supply-chain-live-discovery.mjs
+        run: node scripts/test-supply-chain-live-discovery.mjs
 
       - name: Check generated supply-chain artifacts
         run: node scripts/build-supply-chain-graph.mjs --check

--- a/.github/workflows/supply-chain-validate.yml
+++ b/.github/workflows/supply-chain-validate.yml
@@ -7,9 +7,11 @@ on:
       - ".github/workflows/supply-chain-validate.yml"
       - "data/supply-chain-entities/**"
       - "data/supply-chain-incidents/**"
+      - "data/supply-chain-malware-families/**"
       - "data/supply-chain-relationships/**"
       - "docs/supply-chain*.md"
       - ".github/pipeline/supply-chain-candidates/**"
+      - "scripts/build-supply-chain-graph.mjs"
       - "scripts/build_supply_chain_entities.py"
       - "scripts/supply-chain-live-discovery.mjs"
       - "scripts/supply_chain_purl.py"
@@ -18,6 +20,9 @@ on:
       - "scripts/test-supply-chain-pages.mjs"
       - "scripts/test-supply-chain-live-discovery.mjs"
       - "site/src/lib/supplyChainPages.mjs"
+      - "site/public/supply-chain-graph.json"
+      - "site/public/supply-chain-malware-families-stix.json"
+      - "site/public/supply-chain-search-index.json"
       - "tests/test_supply_chain*.py"
       - "tests/fixtures/supply_chain_live_discovery/**"
   workflow_dispatch:
@@ -61,6 +66,9 @@ jobs:
           cd scripts
           npm ci --no-audit --no-fund
           node test-supply-chain-live-discovery.mjs
+
+      - name: Check generated supply-chain artifacts
+        run: node scripts/build-supply-chain-graph.mjs --check
 
       - name: Run page model test
         run: node scripts/test-supply-chain-pages.mjs

--- a/scripts/test-pipeline-orchestration-contracts.mjs
+++ b/scripts/test-pipeline-orchestration-contracts.mjs
@@ -7,6 +7,7 @@ const supplyChainValidationWorkflow = readFileSync(new URL('../.github/workflows
 const discoveryWorkflow = readFileSync(new URL('../.github/workflows/pipeline-discovery.yml', import.meta.url), 'utf8');
 const reviewGateWorkflow = readFileSync(new URL('../.github/workflows/pipeline-review-gate.yml', import.meta.url), 'utf8');
 const reviewGateScript = readFileSync(new URL('./pipeline-review-gate.mjs', import.meta.url), 'utf8');
+const taskValidator = readFileSync(new URL('./validate-pipeline-tasks.mjs', import.meta.url), 'utf8');
 const taskSchema = JSON.parse(readFileSync(new URL('../.github/pipeline/schema/task-schema.json', import.meta.url), 'utf8'));
 
 assert.match(supplyChainWorkflow, /git checkout -B "\$BRANCH" origin\/main/);
@@ -47,10 +48,12 @@ assert.ok(taskSchema.properties.status.enum.includes('pr_open'));
 assert.ok(taskSchema.properties.acceptance_criteria);
 assert.ok(taskSchema.properties.acceptance);
 assert.ok(!taskSchema.required.includes('stage'));
+assert.ok(taskSchema.properties.source.enum.includes('promotion'));
 assert.ok(taskSchema.properties.source.enum.includes('historical_corpus_backlog'));
 assert.ok(taskSchema.properties.output.properties.pr.type.includes('null'));
 assert.ok(taskSchema.anyOf.some((rule) => rule.required?.includes('acceptance_criteria')));
 assert.ok(taskSchema.anyOf.some((rule) => rule.required?.includes('acceptance')));
+assert.match(taskValidator, /const SOURCES = new Set\(\[[^\]]*'promotion'[^\]]*\]\);/);
 
 assert.match(reviewGateWorkflow, /coderabbitai/);
 assert.match(reviewGateScript, /'coderabbitai'/);

--- a/scripts/test-pipeline-orchestration-contracts.mjs
+++ b/scripts/test-pipeline-orchestration-contracts.mjs
@@ -67,6 +67,7 @@ assert.match(supplyChainValidationCommands, /node scripts\/test-pipeline-orchest
 
 const taskValidationPaths = taskValidationContract.on.pull_request.paths;
 assert.ok(taskValidationPaths.includes('.github/pipeline/schema/task-schema.json'));
+assert.ok(taskValidationPaths.includes('scripts/validate-pipeline-tasks.mjs'));
 const taskValidationCommands = taskValidationContract.jobs['validate-tasks'].steps
   .map((step) => step.run || '')
   .join('\n');

--- a/scripts/test-pipeline-orchestration-contracts.mjs
+++ b/scripts/test-pipeline-orchestration-contracts.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import yaml from 'js-yaml';
 
 const supplyChainWorkflow = readFileSync(new URL('../.github/workflows/supply-chain-live-discovery.yml', import.meta.url), 'utf8');
 const supplyChainValidationWorkflow = readFileSync(new URL('../.github/workflows/supply-chain-validate.yml', import.meta.url), 'utf8');
@@ -10,16 +11,18 @@ const reviewGateWorkflow = readFileSync(new URL('../.github/workflows/pipeline-r
 const reviewGateScript = readFileSync(new URL('./pipeline-review-gate.mjs', import.meta.url), 'utf8');
 const taskValidator = readFileSync(new URL('./validate-pipeline-tasks.mjs', import.meta.url), 'utf8');
 const taskSchema = JSON.parse(readFileSync(new URL('../.github/pipeline/schema/task-schema.json', import.meta.url), 'utf8'));
+const supplyChainWorkflowContract = yaml.load(supplyChainWorkflow, { schema: yaml.JSON_SCHEMA });
+const supplyChainValidationContract = yaml.load(supplyChainValidationWorkflow, { schema: yaml.JSON_SCHEMA });
+const taskValidationContract = yaml.load(taskValidationWorkflow, { schema: yaml.JSON_SCHEMA });
 
 assert.match(supplyChainWorkflow, /git checkout -B "\$BRANCH" origin\/main/);
 assert.doesNotMatch(supplyChainWorkflow, /git merge --no-edit origin\/main/);
 assert.match(supplyChainWorkflow, /DISCOVERY_REMOTE_HEAD/);
 assert.match(supplyChainWorkflow, /--force-with-lease=refs\/heads\/\$\{DISCOVERY_BRANCH\}/);
 assert.match(supplyChainWorkflow, /refs\/heads\/\$\{BRANCH\}:refs\/remotes\/origin\/\$\{BRANCH\}/);
-assert.ok(supplyChainWorkflow.includes('PREVIOUS_PACKET_DIR="$RUNNER_TEMP/supply-chain-previous-vulncheck-packets"'));
-assert.ok(supplyChainWorkflow.includes('git diff --name-only --diff-filter=A origin/main..."origin/${BRANCH}"'));
-assert.ok(supplyChainWorkflow.includes('git cat-file -e "origin/main:${packet_path}"'));
-assert.ok(supplyChainWorkflow.includes('cp -R "$PREVIOUS_PACKET_DIR"/. "$VULNCHECK_PACKET_DIR"/'));
+assert.deepEqual(supplyChainWorkflowContract.on.schedule, [{ cron: '17 */6 * * *' }]);
+assert.ok(!supplyChainWorkflow.includes('Run VulnCheck KEV source-packet intake'));
+assert.doesNotMatch(supplyChainWorkflow, /^\s+\.github\/pipeline\/source-packets\/vulncheck-kev\/\s*\\?$/m);
 assert.ok(supplyChainWorkflow.includes("replace(/\\|/g, '\\\\|')"));
 assert.ok(supplyChainWorkflow.includes("body += '\\n### Guardrails\\n\\n'"));
 assert.ok(!supplyChainWorkflow.includes("body += '\\\\n### Guardrails"));
@@ -44,17 +47,29 @@ assert.ok(supplyChainWorkflow.includes('site/public/supply-chain-graph.json'));
 assert.ok(supplyChainWorkflow.includes('site/public/supply-chain-malware-families-stix.json'));
 assert.ok(supplyChainWorkflow.includes('site/public/supply-chain-search-index.json'));
 
-assert.ok(supplyChainValidationWorkflow.includes('data/supply-chain-malware-families/**'));
-assert.ok(supplyChainValidationWorkflow.includes('scripts/build-supply-chain-graph.mjs'));
-assert.ok(supplyChainValidationWorkflow.includes('site/public/supply-chain-graph.json'));
-assert.ok(supplyChainValidationWorkflow.includes('site/public/supply-chain-malware-families-stix.json'));
-assert.ok(supplyChainValidationWorkflow.includes('site/public/supply-chain-search-index.json'));
-assert.ok(supplyChainValidationWorkflow.includes('node scripts/build-supply-chain-graph.mjs --check'));
-assert.ok(supplyChainValidationWorkflow.includes('.github/workflows/supply-chain-live-discovery.yml'));
-assert.ok(supplyChainValidationWorkflow.includes('node scripts/test-pipeline-orchestration-contracts.mjs'));
+const supplyChainValidationPaths = supplyChainValidationContract.on.pull_request.paths;
+for (const requiredPath of [
+  '.github/workflows/supply-chain-live-discovery.yml',
+  'data/supply-chain-malware-families/**',
+  'scripts/build-supply-chain-graph.mjs',
+  'site/public/supply-chain-graph.json',
+  'site/public/supply-chain-malware-families-stix.json',
+  'site/public/supply-chain-search-index.json',
+]) {
+  assert.ok(supplyChainValidationPaths.includes(requiredPath), `supply-chain validation trigger missing ${requiredPath}`);
+}
+const supplyChainValidationCommands = supplyChainValidationContract.jobs['validate-supply-chain'].steps
+  .map((step) => step.run || '')
+  .join('\n');
+assert.match(supplyChainValidationCommands, /node scripts\/build-supply-chain-graph\.mjs --check/);
+assert.match(supplyChainValidationCommands, /node scripts\/test-pipeline-orchestration-contracts\.mjs/);
 
-assert.ok(taskValidationWorkflow.includes('.github/pipeline/schema/task-schema.json'));
-assert.ok(taskValidationWorkflow.includes('node scripts/test-pipeline-orchestration-contracts.mjs'));
+const taskValidationPaths = taskValidationContract.on.pull_request.paths;
+assert.ok(taskValidationPaths.includes('.github/pipeline/schema/task-schema.json'));
+const taskValidationCommands = taskValidationContract.jobs['validate-tasks'].steps
+  .map((step) => step.run || '')
+  .join('\n');
+assert.match(taskValidationCommands, /node scripts\/test-pipeline-orchestration-contracts\.mjs/);
 
 assert.ok(taskSchema.properties.stage.enum.includes('generation'));
 assert.ok(taskSchema.properties.status.enum.includes('pr_open'));

--- a/scripts/test-pipeline-orchestration-contracts.mjs
+++ b/scripts/test-pipeline-orchestration-contracts.mjs
@@ -61,6 +61,7 @@ for (const requiredPath of [
 const supplyChainValidationCommands = supplyChainValidationContract.jobs['validate-supply-chain'].steps
   .map((step) => step.run || '')
   .join('\n');
+assert.match(supplyChainValidationCommands, /cd scripts && npm ci --no-audit --no-fund/);
 assert.match(supplyChainValidationCommands, /node scripts\/build-supply-chain-graph\.mjs --check/);
 assert.match(supplyChainValidationCommands, /node scripts\/test-pipeline-orchestration-contracts\.mjs/);
 

--- a/scripts/test-pipeline-orchestration-contracts.mjs
+++ b/scripts/test-pipeline-orchestration-contracts.mjs
@@ -5,6 +5,7 @@ import { readFileSync } from 'node:fs';
 const supplyChainWorkflow = readFileSync(new URL('../.github/workflows/supply-chain-live-discovery.yml', import.meta.url), 'utf8');
 const supplyChainValidationWorkflow = readFileSync(new URL('../.github/workflows/supply-chain-validate.yml', import.meta.url), 'utf8');
 const discoveryWorkflow = readFileSync(new URL('../.github/workflows/pipeline-discovery.yml', import.meta.url), 'utf8');
+const taskValidationWorkflow = readFileSync(new URL('../.github/workflows/pipeline-validate-tasks.yml', import.meta.url), 'utf8');
 const reviewGateWorkflow = readFileSync(new URL('../.github/workflows/pipeline-review-gate.yml', import.meta.url), 'utf8');
 const reviewGateScript = readFileSync(new URL('./pipeline-review-gate.mjs', import.meta.url), 'utf8');
 const taskValidator = readFileSync(new URL('./validate-pipeline-tasks.mjs', import.meta.url), 'utf8');
@@ -49,6 +50,11 @@ assert.ok(supplyChainValidationWorkflow.includes('site/public/supply-chain-graph
 assert.ok(supplyChainValidationWorkflow.includes('site/public/supply-chain-malware-families-stix.json'));
 assert.ok(supplyChainValidationWorkflow.includes('site/public/supply-chain-search-index.json'));
 assert.ok(supplyChainValidationWorkflow.includes('node scripts/build-supply-chain-graph.mjs --check'));
+assert.ok(supplyChainValidationWorkflow.includes('.github/workflows/supply-chain-live-discovery.yml'));
+assert.ok(supplyChainValidationWorkflow.includes('node scripts/test-pipeline-orchestration-contracts.mjs'));
+
+assert.ok(taskValidationWorkflow.includes('.github/pipeline/schema/task-schema.json'));
+assert.ok(taskValidationWorkflow.includes('node scripts/test-pipeline-orchestration-contracts.mjs'));
 
 assert.ok(taskSchema.properties.stage.enum.includes('generation'));
 assert.ok(taskSchema.properties.status.enum.includes('pr_open'));

--- a/scripts/test-pipeline-orchestration-contracts.mjs
+++ b/scripts/test-pipeline-orchestration-contracts.mjs
@@ -53,7 +53,10 @@ assert.ok(taskSchema.properties.source.enum.includes('historical_corpus_backlog'
 assert.ok(taskSchema.properties.output.properties.pr.type.includes('null'));
 assert.ok(taskSchema.anyOf.some((rule) => rule.required?.includes('acceptance_criteria')));
 assert.ok(taskSchema.anyOf.some((rule) => rule.required?.includes('acceptance')));
-assert.match(taskValidator, /const SOURCES = new Set\(\[[^\]]*'promotion'[^\]]*\]\);/);
+const taskSourceSetBody = taskValidator.match(/const SOURCES = new Set\(\[([\s\S]*?)\]\);/)?.[1] || '';
+for (const source of taskSchema.properties.source.enum) {
+  assert.ok(taskSourceSetBody.includes(`'${source}'`), `task validator SOURCES missing schema value: ${source}`);
+}
 
 assert.match(reviewGateWorkflow, /coderabbitai/);
 assert.match(reviewGateScript, /'coderabbitai'/);

--- a/scripts/test-pipeline-orchestration-contracts.mjs
+++ b/scripts/test-pipeline-orchestration-contracts.mjs
@@ -36,6 +36,13 @@ assert.ok(discoveryWorkflow.includes('OPEN_PREFILL_PAGE=$((OPEN_PREFILL_PAGE + 1
 
 assert.match(supplyChainWorkflow, /--retry 3 --retry-all-errors/);
 
+const liveDiscoveryGraphBuild = supplyChainWorkflow.indexOf('node scripts/build-supply-chain-graph.mjs');
+const liveDiscoveryCommit = supplyChainWorkflow.indexOf('- name: Commit candidate queue and public artifacts to branch');
+assert.ok(liveDiscoveryGraphBuild > 0 && liveDiscoveryGraphBuild < liveDiscoveryCommit);
+assert.ok(supplyChainWorkflow.includes('site/public/supply-chain-graph.json'));
+assert.ok(supplyChainWorkflow.includes('site/public/supply-chain-malware-families-stix.json'));
+assert.ok(supplyChainWorkflow.includes('site/public/supply-chain-search-index.json'));
+
 assert.ok(supplyChainValidationWorkflow.includes('data/supply-chain-malware-families/**'));
 assert.ok(supplyChainValidationWorkflow.includes('scripts/build-supply-chain-graph.mjs'));
 assert.ok(supplyChainValidationWorkflow.includes('site/public/supply-chain-graph.json'));

--- a/scripts/test-pipeline-orchestration-contracts.mjs
+++ b/scripts/test-pipeline-orchestration-contracts.mjs
@@ -7,6 +7,7 @@ const supplyChainValidationWorkflow = readFileSync(new URL('../.github/workflows
 const discoveryWorkflow = readFileSync(new URL('../.github/workflows/pipeline-discovery.yml', import.meta.url), 'utf8');
 const reviewGateWorkflow = readFileSync(new URL('../.github/workflows/pipeline-review-gate.yml', import.meta.url), 'utf8');
 const reviewGateScript = readFileSync(new URL('./pipeline-review-gate.mjs', import.meta.url), 'utf8');
+const taskSchema = JSON.parse(readFileSync(new URL('../.github/pipeline/schema/task-schema.json', import.meta.url), 'utf8'));
 
 assert.match(supplyChainWorkflow, /git checkout -B "\$BRANCH" origin\/main/);
 assert.doesNotMatch(supplyChainWorkflow, /git merge --no-edit origin\/main/);
@@ -40,6 +41,16 @@ assert.ok(supplyChainValidationWorkflow.includes('site/public/supply-chain-graph
 assert.ok(supplyChainValidationWorkflow.includes('site/public/supply-chain-malware-families-stix.json'));
 assert.ok(supplyChainValidationWorkflow.includes('site/public/supply-chain-search-index.json'));
 assert.ok(supplyChainValidationWorkflow.includes('node scripts/build-supply-chain-graph.mjs --check'));
+
+assert.ok(taskSchema.properties.stage.enum.includes('generation'));
+assert.ok(taskSchema.properties.status.enum.includes('pr_open'));
+assert.ok(taskSchema.properties.acceptance_criteria);
+assert.ok(taskSchema.properties.acceptance);
+assert.ok(!taskSchema.required.includes('stage'));
+assert.ok(taskSchema.properties.source.enum.includes('historical_corpus_backlog'));
+assert.ok(taskSchema.properties.output.properties.pr.type.includes('null'));
+assert.ok(taskSchema.anyOf.some((rule) => rule.required?.includes('acceptance_criteria')));
+assert.ok(taskSchema.anyOf.some((rule) => rule.required?.includes('acceptance')));
 
 assert.match(reviewGateWorkflow, /coderabbitai/);
 assert.match(reviewGateScript, /'coderabbitai'/);

--- a/scripts/test-pipeline-orchestration-contracts.mjs
+++ b/scripts/test-pipeline-orchestration-contracts.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
 const supplyChainWorkflow = readFileSync(new URL('../.github/workflows/supply-chain-live-discovery.yml', import.meta.url), 'utf8');
+const supplyChainValidationWorkflow = readFileSync(new URL('../.github/workflows/supply-chain-validate.yml', import.meta.url), 'utf8');
 const discoveryWorkflow = readFileSync(new URL('../.github/workflows/pipeline-discovery.yml', import.meta.url), 'utf8');
 const reviewGateWorkflow = readFileSync(new URL('../.github/workflows/pipeline-review-gate.yml', import.meta.url), 'utf8');
 const reviewGateScript = readFileSync(new URL('./pipeline-review-gate.mjs', import.meta.url), 'utf8');
@@ -32,6 +33,13 @@ assert.ok(discoveryWorkflow.includes('pulls?state=open&per_page=100&page=${OPEN_
 assert.ok(discoveryWorkflow.includes('OPEN_PREFILL_PAGE=$((OPEN_PREFILL_PAGE + 1))'));
 
 assert.match(supplyChainWorkflow, /--retry 3 --retry-all-errors/);
+
+assert.ok(supplyChainValidationWorkflow.includes('data/supply-chain-malware-families/**'));
+assert.ok(supplyChainValidationWorkflow.includes('scripts/build-supply-chain-graph.mjs'));
+assert.ok(supplyChainValidationWorkflow.includes('site/public/supply-chain-graph.json'));
+assert.ok(supplyChainValidationWorkflow.includes('site/public/supply-chain-malware-families-stix.json'));
+assert.ok(supplyChainValidationWorkflow.includes('site/public/supply-chain-search-index.json'));
+assert.ok(supplyChainValidationWorkflow.includes('node scripts/build-supply-chain-graph.mjs --check'));
 
 assert.match(reviewGateWorkflow, /coderabbitai/);
 assert.match(reviewGateScript, /'coderabbitai'/);

--- a/scripts/validate-pipeline-tasks.mjs
+++ b/scripts/validate-pipeline-tasks.mjs
@@ -23,7 +23,16 @@ const STAGES = new Set(['discovery', 'triage', 'draft', 'generation', 'validatio
 const TYPES = new Set(['incident', 'campaign', 'threat-actor', 'zero-day']);
 const PRIORITIES = new Set(['P0', 'P1', 'P2', 'P3']);
 const STATUSES = new Set(['pending', 'locked', 'pr_open', 'complete', 'failed', 'blocked', 'cancelled']);
-const SOURCES = new Set(['auto_discovery', 'promotion', 'manual_submission', 'enrichment', 'backfill']);
+const SOURCES = new Set([
+  'auto_discovery',
+  'promotion',
+  'manual_submission',
+  'enrichment',
+  'backfill',
+  'automated_submission',
+  'historical-corpus',
+  'historical_corpus_backlog',
+]);
 
 function parseArgs(argv) {
   const args = {

--- a/scripts/validate-pipeline-tasks.mjs
+++ b/scripts/validate-pipeline-tasks.mjs
@@ -23,7 +23,7 @@ const STAGES = new Set(['discovery', 'triage', 'draft', 'generation', 'validatio
 const TYPES = new Set(['incident', 'campaign', 'threat-actor', 'zero-day']);
 const PRIORITIES = new Set(['P0', 'P1', 'P2', 'P3']);
 const STATUSES = new Set(['pending', 'locked', 'pr_open', 'complete', 'failed', 'blocked', 'cancelled']);
-const SOURCES = new Set(['auto_discovery', 'manual_submission', 'enrichment', 'backfill']);
+const SOURCES = new Set(['auto_discovery', 'promotion', 'manual_submission', 'enrichment', 'backfill']);
 
 function parseArgs(argv) {
   const args = {

--- a/site/public/supply-chain-graph.json
+++ b/site/public/supply-chain-graph.json
@@ -8,11 +8,11 @@
     "candidate_queue": ".github/pipeline/supply-chain-candidates/latest.json"
   },
   "discovery_currency": {
-    "latest_corpus_incident_at": null,
-    "latest_discovery_signal_at": null,
-    "pending_candidate_count": 0,
-    "pending_current_count": 0,
-    "graph_latest_reflects": "corpus"
+    "latest_corpus_incident_at": "2026-05-28T00:00:00.000Z",
+    "latest_discovery_signal_at": "2026-07-09T23:47:01.172Z",
+    "pending_candidate_count": 40,
+    "pending_current_count": 40,
+    "graph_latest_reflects": "discovery"
   },
   "renderer_contract": {
     "g2_drawable_tiers": [


### PR DESCRIPTION
## Summary

- align the tracked task schema with the live validator and writers: canonical `acceptance_criteria`, legacy `acceptance` compatibility, `generation`, and `pr_open`
- retain explicit compatibility for legacy task source and output forms already present in the corpus
- regenerate the tracked supply-chain graph after the live candidate queue advanced
- make `Supply Chain: Validate Corpus` run the generator's deterministic `--check`
- cover the malware-family input, generator, and all tracked generated artifacts in workflow path filters
- pin both workflow and task-schema contracts in the orchestration test suite

## Why

Two independent contract gaps were allowing false-green pipeline state:

1. Clean `main` failed `node scripts/build-supply-chain-graph.mjs --check`, while deployment passed because Astro regenerated the graph only in its ephemeral workspace.
2. The runtime task validator and PR-state workflow use `pr_open` and canonical `acceptance_criteria`, but `.github/pipeline/schema/task-schema.json` still omitted `pr_open` and required legacy `acceptance`.

## Validation

- workflow YAML parse
- all 337 task files validate against the repaired JSON Schema
- all 337 task files pass the runtime validator with zero errors
- `node scripts/build-supply-chain-graph.mjs --check`
- supply-chain Python validators and 82 unit tests
- live-discovery and page-model tests
- full scripts test suite
- Astro production build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded task stage/status and added additional historical source options.
  * Added machine-checkable acceptance criteria (while remaining compatible with the legacy acceptance format).
  * Enhanced CI contract validation to cover orchestration behavior and generated supply-chain public artifacts.
* **Bug Fixes**
  * Improved supply-chain CI validation to ensure generated graph/search outputs are up to date.
  * Refreshed supply-chain graph metadata to reflect the latest discovery state.
* **Chores**
  * Updated live discovery scheduling and adjusted its outputs to focus on candidate review only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->